### PR TITLE
Create device registry entries for ZHA group entities

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -132,6 +132,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             return DeviceInfo(
                 identifiers={(DOMAIN, group_proxy.group_device_identifier)},
                 name=group_proxy.group.name,
+                manufacturer="Zigbee",
+                model="Zigbee group",
                 via_device=(DOMAIN, coordinator_ieee),
             )
 

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -19,7 +19,11 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import State, callback
-from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_ZIGBEE,
+    DeviceEntryType,
+    DeviceInfo,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.group import IntegrationSpecificGroup
@@ -133,7 +137,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
                 identifiers={(DOMAIN, group_proxy.group_device_identifier)},
                 name=group_proxy.group.name,
                 manufacturer="Zigbee",
-                model="Zigbee group",
+                model="Group",
+                entry_type=DeviceEntryType.SERVICE,
                 via_device=(DOMAIN, coordinator_ieee),
             )
 

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -120,9 +120,23 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
+        zha_gateway = self.entity_data.device_proxy.gateway_proxy.gateway
+        coordinator_ieee = str(zha_gateway.state.node_info.ieee)
+
+        # Group entities have their own device linked via the coordinator
+        if (
+            self.entity_data.is_group_entity
+            and self.entity_data.group_proxy is not None
+        ):
+            group_proxy = self.entity_data.group_proxy
+            return DeviceInfo(
+                identifiers={(DOMAIN, group_proxy.group_device_identifier)},
+                name=group_proxy.group.name,
+                via_device=(DOMAIN, coordinator_ieee),
+            )
+
         zha_device_info = self.entity_data.device_proxy.device_info
         ieee = zha_device_info["ieee"]
-        zha_gateway = self.entity_data.device_proxy.gateway_proxy.gateway
 
         device_info = DeviceInfo(
             connections={(CONNECTION_ZIGBEE, ieee)},
@@ -131,11 +145,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             model=zha_device_info[ATTR_MODEL],
             name=zha_device_info[ATTR_NAME],
         )
-        if ieee != str(zha_gateway.state.node_info.ieee):
-            device_info[ATTR_VIA_DEVICE] = (
-                DOMAIN,
-                str(zha_gateway.state.node_info.ieee),
-            )
+        if ieee != coordinator_ieee:
+            device_info[ATTR_VIA_DEVICE] = (DOMAIN, coordinator_ieee)
         return device_info
 
     @callback

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -19,11 +19,7 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import State, callback
-from homeassistant.helpers.device_registry import (
-    CONNECTION_ZIGBEE,
-    DeviceEntryType,
-    DeviceInfo,
-)
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.group import IntegrationSpecificGroup
@@ -132,15 +128,7 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self.entity_data.is_group_entity
             and self.entity_data.group_proxy is not None
         ):
-            group_proxy = self.entity_data.group_proxy
-            return DeviceInfo(
-                identifiers={(DOMAIN, group_proxy.group_device_identifier)},
-                name=group_proxy.group.name,
-                manufacturer="Zigbee",
-                model="Group",
-                entry_type=DeviceEntryType.SERVICE,
-                via_device=(DOMAIN, coordinator_ieee),
-            )
+            return self.entity_data.group_proxy.get_device_info(coordinator_ieee)
 
         zha_device_info = self.entity_data.device_proxy.device_info
         ieee = zha_device_info["ieee"]

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -87,6 +87,13 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
         If a device class is set but no translation key,
         the device class name is used.
         """
+        # Group entities use device name since they have their own device
+        if (
+            self.entity_data.is_group_entity
+            and self.entity_data.group_proxy is not None
+        ):
+            return None
+
         meta = self.entity_data.entity.info_object
         if meta.primary:
             self._attr_name = None

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -17,7 +17,11 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import State, callback
-from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_ZIGBEE,
+    DeviceEntryType,
+    DeviceInfo,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.group import IntegrationSpecificGroup
@@ -136,7 +140,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
                 identifiers={(DOMAIN, group_proxy.group_device_identifier)},
                 name=group_proxy.group.name,
                 manufacturer="Zigbee",
-                model="Zigbee group",
+                model="Group",
+                entry_type=DeviceEntryType.SERVICE,
                 via_device=(DOMAIN, coordinator_ieee),
             )
 

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -123,9 +123,23 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return a device description for device registry."""
+        zha_gateway = self.entity_data.device_proxy.gateway_proxy.gateway
+        coordinator_ieee = str(zha_gateway.state.node_info.ieee)
+
+        # Group entities have their own device linked via the coordinator
+        if (
+            self.entity_data.is_group_entity
+            and self.entity_data.group_proxy is not None
+        ):
+            group_proxy = self.entity_data.group_proxy
+            return DeviceInfo(
+                identifiers={(DOMAIN, group_proxy.group_device_identifier)},
+                name=group_proxy.group.name,
+                via_device=(DOMAIN, coordinator_ieee),
+            )
+
         zha_device_info = self.entity_data.device_proxy.device_info
         ieee = zha_device_info["ieee"]
-        zha_gateway = self.entity_data.device_proxy.gateway_proxy.gateway
 
         device_info = DeviceInfo(
             connections={(CONNECTION_ZIGBEE, ieee)},
@@ -134,11 +148,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             model=zha_device_info[ATTR_MODEL],
             name=zha_device_info[ATTR_NAME],
         )
-        if ieee != str(zha_gateway.state.node_info.ieee):
-            device_info[ATTR_VIA_DEVICE] = (
-                DOMAIN,
-                str(zha_gateway.state.node_info.ieee),
-            )
+        if ieee != coordinator_ieee:
+            device_info[ATTR_VIA_DEVICE] = (DOMAIN, coordinator_ieee)
         return device_info
 
     @callback

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -17,11 +17,7 @@ from homeassistant.const import (
     EntityCategory,
 )
 from homeassistant.core import State, callback
-from homeassistant.helpers.device_registry import (
-    CONNECTION_ZIGBEE,
-    DeviceEntryType,
-    DeviceInfo,
-)
+from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.group import IntegrationSpecificGroup
@@ -135,15 +131,7 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             self.entity_data.is_group_entity
             and self.entity_data.group_proxy is not None
         ):
-            group_proxy = self.entity_data.group_proxy
-            return DeviceInfo(
-                identifiers={(DOMAIN, group_proxy.group_device_identifier)},
-                name=group_proxy.group.name,
-                manufacturer="Zigbee",
-                model="Group",
-                entry_type=DeviceEntryType.SERVICE,
-                via_device=(DOMAIN, coordinator_ieee),
-            )
+            return self.entity_data.group_proxy.get_device_info(coordinator_ieee)
 
         zha_device_info = self.entity_data.device_proxy.device_info
         ieee = zha_device_info["ieee"]

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -90,6 +90,13 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
         If a device class is set but no translation key,
         the device class name is used.
         """
+        # Group entities use device name since they have their own device
+        if (
+            self.entity_data.is_group_entity
+            and self.entity_data.group_proxy is not None
+        ):
+            return None
+
         meta = self.entity_data.entity.info_object
         if meta.primary:
             self._attr_name = None

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -135,6 +135,8 @@ class ZHAEntity(LogMixin, RestoreEntity, Entity):
             return DeviceInfo(
                 identifiers={(DOMAIN, group_proxy.group_device_identifier)},
                 name=group_proxy.group.name,
+                manufacturer="Zigbee",
+                model="Zigbee group",
                 via_device=(DOMAIN, coordinator_ieee),
             )
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -623,6 +623,16 @@ class ZHAGatewayProxy(EventBase):
 
         # Group devices use synthetic identifiers, not real IEEE addresses
         if ieee_address.startswith("zha_group_"):
+            group_id = int(ieee_address.removeprefix("zha_group_"), 16)
+            if (group_proxy := self.group_proxies.get(group_id)) is None:
+                return
+            if entity_entry.unique_id not in group_proxy.group.group_entities:
+                return
+            group_entity = group_proxy.group.group_entities[entity_entry.unique_id]
+            if entity_entry.disabled:
+                group_entity.disable()
+            else:
+                group_entity.enable()
             return
 
         ieee = EUI64.convert(ieee_address)
@@ -897,16 +907,15 @@ class ZHAGatewayProxy(EventBase):
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
 
-            # Only create a device for groups that have entities
-            if zha_group_proxy.group.group_entities:
-                device_registry = dr.async_get(self.hass)
-                coordinator_ieee = str(self.gateway.state.node_info.ieee)
-                device_info = zha_group_proxy.get_device_info(coordinator_ieee)
-                device_registry_device = device_registry.async_get_or_create(
-                    config_entry_id=self.config_entry.entry_id,
-                    **device_info,
-                )
-                zha_group_proxy.device_id = device_registry_device.id
+        if zha_group_proxy.device_id is None and zha_group_proxy.group.group_entities:
+            device_registry = dr.async_get(self.hass)
+            coordinator_ieee = str(self.gateway.state.node_info.ieee)
+            device_info = zha_group_proxy.get_device_info(coordinator_ieee)
+            device_registry_device = device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                **device_info,
+            )
+            zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -953,7 +962,8 @@ class ZHAGatewayProxy(EventBase):
             entity_registry.deleted_entities.pop(
                 (entry.domain, entry.platform, entry.unique_id), None
             )
-        device_registry.async_remove_device(device_id)
+        if device_registry.async_get(device_id) is not None:
+            device_registry.async_remove_device(device_id)
         device_registry.deleted_devices.pop(device_id, None)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -890,6 +890,8 @@ class ZHAGatewayProxy(EventBase):
                     config_entry_id=self.config_entry.entry_id,
                     identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
                     name=zha_group_proxy.group.name,
+                    manufacturer="Zigbee",
+                    model="Zigbee group",
                     via_device=(DOMAIN, coordinator_ieee),
                 )
                 zha_group_proxy.device_id = device_registry_device.id

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -935,19 +935,22 @@ class ZHAGatewayProxy(EventBase):
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
         """Remove device and entity registry entries for group when the group is removed."""
-        if zha_group_proxy.device_id is not None:
-            device_registry = dr.async_get(self.hass)
-            entity_registry = er.async_get(self.hass)
-            device_id = zha_group_proxy.device_id
-            # Fully clean up entity and device registries because group IDs can be
-            # reused, and we don't want old cached data to persist
-            for entry in er.async_entries_for_device(
-                entity_registry, device_id, include_disabled_entities=True
-            ):
-                entity_registry.async_remove(entry.entity_id)
-            device_registry.async_remove_device(device_id)
-            if device_id in device_registry.deleted_devices:
-                del device_registry.deleted_devices[device_id]
+        if (device_id := zha_group_proxy.device_id) is None:
+            return
+
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+        # Fully clean up entity and device registries because group IDs can be
+        # reused, and we don't want old cached data to persist
+        for entry in er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=True
+        ):
+            entity_registry.async_remove(entry.entity_id)
+            entity_registry.deleted_entities.pop(
+                (entry.domain, entry.platform, entry.unique_id), None
+            )
+        device_registry.async_remove_device(device_id)
+        device_registry.deleted_devices.pop(device_id, None)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -953,18 +953,25 @@ class ZHAGatewayProxy(EventBase):
 
         device_registry = dr.async_get(self.hass)
         entity_registry = er.async_get(self.hass)
-        # Fully clean up entity and device registries because group IDs can be
-        # reused, and we don't want old cached data to persist
+        entity_keys = []
         for entry in er.async_entries_for_device(
             entity_registry, device_id, include_disabled_entities=True
         ):
+            entity_keys.append((entry.domain, entry.platform, entry.unique_id))
             entity_registry.async_remove(entry.entity_id)
-            entity_registry.deleted_entities.pop(
-                (entry.domain, entry.platform, entry.unique_id), None
-            )
         if device_registry.async_get(device_id) is not None:
             device_registry.async_remove_device(device_id)
-        device_registry.deleted_devices.pop(device_id, None)
+        # Purge deleted-entry caches so a new group reusing the same zigpy
+        # group ID is not restored with stale settings from the old group.
+        purged = False
+        for key in entity_keys:
+            if entity_registry.deleted_entities.pop(key, None) is not None:
+                purged = True
+        if device_registry.deleted_devices.pop(device_id, None) is not None:
+            purged = True
+        if purged:
+            entity_registry.async_schedule_save()
+            device_registry.async_schedule_save()
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -934,12 +934,20 @@ class ZHAGatewayProxy(EventBase):
     def _cleanup_group_entity_registry_entries(
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
-        """Remove device and entity registry entries for group when the group is removed from HA."""
-        # Only remove the device if one was created (groups with entities have devices)
+        """Remove device and entity registry entries for group when the group is removed."""
         if zha_group_proxy.device_id is not None:
             device_registry = dr.async_get(self.hass)
-            # Remove the group device, which will also remove associated entities
-            device_registry.async_remove_device(zha_group_proxy.device_id)
+            entity_registry = er.async_get(self.hass)
+            device_id = zha_group_proxy.device_id
+            # Fully clean up entity and device registries because group IDs can be
+            # reused, and we don't want old cached data to persist
+            for entry in er.async_entries_for_device(
+                entity_registry, device_id, include_disabled_entities=True
+            ):
+                entity_registry.async_remove(entry.entity_id)
+            device_registry.async_remove_device(device_id)
+            if device_id in device_registry.deleted_devices:
+                del device_registry.deleted_devices[device_id]
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -238,10 +238,27 @@ class GroupEntityReference(NamedTuple):
 class ZHAGroupProxy(LogMixin):
     """Proxy class to interact with the ZHA group instances."""
 
+    _ha_device_id: str
+
     def __init__(self, group: Group, gateway_proxy: ZHAGatewayProxy) -> None:
         """Initialize the gateway proxy."""
         self.group: Group = group
         self.gateway_proxy: ZHAGatewayProxy = gateway_proxy
+
+    @property
+    def device_id(self) -> str:
+        """Return the HA device registry device id."""
+        return self._ha_device_id
+
+    @device_id.setter
+    def device_id(self, device_id: str) -> None:
+        """Set the HA device registry device id."""
+        self._ha_device_id = device_id
+
+    @property
+    def group_device_identifier(self) -> str:
+        """Return unique identifier for the group device."""
+        return f"zha_group_0x{self.group.group_id:04x}"
 
     @property
     def group_info(self) -> dict[str, Any]:
@@ -863,6 +880,16 @@ class ZHAGatewayProxy(EventBase):
                 self.gateway.groups[group_info.group_id], self
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
+
+            device_registry = dr.async_get(self.hass)
+            coordinator_ieee = str(self.gateway.state.node_info.ieee)
+            device_registry_device = device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
+                name=zha_group_proxy.group.name,
+                via_device=(DOMAIN, coordinator_ieee),
+            )
+            zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -894,39 +921,10 @@ class ZHAGatewayProxy(EventBase):
     def _cleanup_group_entity_registry_entries(
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
-        """Remove entity registry entries for group entities when the groups are removed from HA."""
-        # first we collect the potential unique ids for entities that could be created from this group
-        possible_entity_unique_ids = [
-            f"{domain}_zha_group_0x{zha_group_proxy.group.group_id:04x}"
-            for domain in GROUP_ENTITY_DOMAINS
-        ]
-
-        # then we get all group entity entries tied to the coordinator
-        entity_registry = er.async_get(self.hass)
-        assert self.gateway.coordinator_zha_device
-        coordinator_proxy = self.device_proxies[
-            self.gateway.coordinator_zha_device.ieee
-        ]
-        all_group_entity_entries = er.async_entries_for_device(
-            entity_registry,
-            coordinator_proxy.device_id,
-            include_disabled_entities=True,
-        )
-
-        # then we get the entity entries for this specific group
-        # by getting the entries that match
-        entries_to_remove = [
-            entry
-            for entry in all_group_entity_entries
-            if entry.unique_id in possible_entity_unique_ids
-        ]
-
-        # then we remove the entries from the entity registry
-        for entry in entries_to_remove:
-            _LOGGER.debug(
-                "cleaning up entity registry entry for entity: %s", entry.entity_id
-            )
-            entity_registry.async_remove(entry.entity_id)
+        """Remove device and entity registry entries for group when the group is removed from HA."""
+        device_registry = dr.async_get(self.hass)
+        # Remove the group device, which will also remove associated entities
+        device_registry.async_remove_device(zha_group_proxy.device_id)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -621,6 +621,10 @@ class ZHAGatewayProxy(EventBase):
         )
         assert ieee_address
 
+        # Group devices use synthetic identifiers, not real IEEE addresses
+        if ieee_address.startswith("zha_group_"):
+            return
+
         ieee = EUI64.convert(ieee_address)
 
         assert ieee in self.device_proxies

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -261,6 +261,17 @@ class ZHAGroupProxy(LogMixin):
         """Return unique identifier for the group device."""
         return f"zha_group_0x{self.group.group_id:04x}"
 
+    def get_device_info(self, coordinator_ieee: str) -> dr.DeviceInfo:
+        """Return device info for this group."""
+        return dr.DeviceInfo(
+            identifiers={(DOMAIN, self.group_device_identifier)},
+            name=self.group.name,
+            manufacturer="Zigbee",
+            model="Group",
+            entry_type=dr.DeviceEntryType.SERVICE,
+            via_device=(DOMAIN, coordinator_ieee),
+        )
+
     @property
     def group_info(self) -> dict[str, Any]:
         """Return a group description for group."""
@@ -886,14 +897,10 @@ class ZHAGatewayProxy(EventBase):
             if zha_group_proxy.group.group_entities:
                 device_registry = dr.async_get(self.hass)
                 coordinator_ieee = str(self.gateway.state.node_info.ieee)
+                device_info = zha_group_proxy.get_device_info(coordinator_ieee)
                 device_registry_device = device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,
-                    identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
-                    name=zha_group_proxy.group.name,
-                    manufacturer="Zigbee",
-                    model="Group",
-                    entry_type=dr.DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, coordinator_ieee),
+                    **device_info,
                 )
                 zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -238,15 +238,16 @@ class GroupEntityReference(NamedTuple):
 class ZHAGroupProxy(LogMixin):
     """Proxy class to interact with the ZHA group instances."""
 
-    _ha_device_id: str
+    _ha_device_id: str | None
 
     def __init__(self, group: Group, gateway_proxy: ZHAGatewayProxy) -> None:
         """Initialize the gateway proxy."""
         self.group: Group = group
         self.gateway_proxy: ZHAGatewayProxy = gateway_proxy
+        self._ha_device_id = None
 
     @property
-    def device_id(self) -> str:
+    def device_id(self) -> str | None:
         """Return the HA device registry device id."""
         return self._ha_device_id
 
@@ -881,15 +882,17 @@ class ZHAGatewayProxy(EventBase):
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
 
-            device_registry = dr.async_get(self.hass)
-            coordinator_ieee = str(self.gateway.state.node_info.ieee)
-            device_registry_device = device_registry.async_get_or_create(
-                config_entry_id=self.config_entry.entry_id,
-                identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
-                name=zha_group_proxy.group.name,
-                via_device=(DOMAIN, coordinator_ieee),
-            )
-            zha_group_proxy.device_id = device_registry_device.id
+            # Only create a device for groups that have entities
+            if zha_group_proxy.group.group_entities:
+                device_registry = dr.async_get(self.hass)
+                coordinator_ieee = str(self.gateway.state.node_info.ieee)
+                device_registry_device = device_registry.async_get_or_create(
+                    config_entry_id=self.config_entry.entry_id,
+                    identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
+                    name=zha_group_proxy.group.name,
+                    via_device=(DOMAIN, coordinator_ieee),
+                )
+                zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -922,9 +925,11 @@ class ZHAGatewayProxy(EventBase):
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
         """Remove device and entity registry entries for group when the group is removed from HA."""
-        device_registry = dr.async_get(self.hass)
-        # Remove the group device, which will also remove associated entities
-        device_registry.async_remove_device(zha_group_proxy.device_id)
+        # Only remove the device if one was created (groups with entities have devices)
+        if zha_group_proxy.device_id is not None:
+            device_registry = dr.async_get(self.hass)
+            # Remove the group device, which will also remove associated entities
+            device_registry.async_remove_device(zha_group_proxy.device_id)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -891,7 +891,8 @@ class ZHAGatewayProxy(EventBase):
                     identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
                     name=zha_group_proxy.group.name,
                     manufacturer="Zigbee",
-                    model="Zigbee group",
+                    model="Group",
+                    entry_type=dr.DeviceEntryType.SERVICE,
                     via_device=(DOMAIN, coordinator_ieee),
                 )
                 zha_group_proxy.device_id = device_registry_device.id

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -233,10 +233,27 @@ class GroupEntityReference(NamedTuple):
 class ZHAGroupProxy(LogMixin):
     """Proxy class to interact with the ZHA group instances."""
 
+    _ha_device_id: str
+
     def __init__(self, group: Group, gateway_proxy: ZHAGatewayProxy) -> None:
         """Initialize the gateway proxy."""
         self.group: Group = group
         self.gateway_proxy: ZHAGatewayProxy = gateway_proxy
+
+    @property
+    def device_id(self) -> str:
+        """Return the HA device registry device id."""
+        return self._ha_device_id
+
+    @device_id.setter
+    def device_id(self, device_id: str) -> None:
+        """Set the HA device registry device id."""
+        self._ha_device_id = device_id
+
+    @property
+    def group_device_identifier(self) -> str:
+        """Return unique identifier for the group device."""
+        return f"zha_group_0x{self.group.group_id:04x}"
 
     @property
     def group_info(self) -> dict[str, Any]:
@@ -894,6 +911,16 @@ class ZHAGatewayProxy(EventBase):
                 self.gateway.groups[group_info.group_id], self
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
+
+            device_registry = dr.async_get(self.hass)
+            coordinator_ieee = str(self.gateway.state.node_info.ieee)
+            device_registry_device = device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
+                name=zha_group_proxy.group.name,
+                via_device=(DOMAIN, coordinator_ieee),
+            )
+            zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -931,40 +958,10 @@ class ZHAGatewayProxy(EventBase):
     def _cleanup_group_entity_registry_entries(
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
-        """Remove entity registry entries for removed group entities."""
-        # first we collect the potential unique ids for
-        # entities that could be created from this group
-        possible_entity_unique_ids = [
-            f"{domain}_zha_group_0x{zha_group_proxy.group.group_id:04x}"
-            for domain in GROUP_ENTITY_DOMAINS
-        ]
-
-        # then we get all group entity entries tied to the coordinator
-        entity_registry = er.async_get(self.hass)
-        assert self.gateway.coordinator_zha_device
-        coordinator_proxy = self.device_proxies[
-            self.gateway.coordinator_zha_device.ieee
-        ]
-        all_group_entity_entries = er.async_entries_for_device(
-            entity_registry,
-            coordinator_proxy.device_id,
-            include_disabled_entities=True,
-        )
-
-        # then we get the entity entries for this specific group
-        # by getting the entries that match
-        entries_to_remove = [
-            entry
-            for entry in all_group_entity_entries
-            if entry.unique_id in possible_entity_unique_ids
-        ]
-
-        # then we remove the entries from the entity registry
-        for entry in entries_to_remove:
-            _LOGGER.debug(
-                "cleaning up entity registry entry for entity: %s", entry.entity_id
-            )
-            entity_registry.async_remove(entry.entity_id)
+        """Remove device and entity registry entries for group when the group is removed from HA."""
+        device_registry = dr.async_get(self.hass)
+        # Remove the group device, which will also remove associated entities
+        device_registry.async_remove_device(zha_group_proxy.device_id)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -921,6 +921,8 @@ class ZHAGatewayProxy(EventBase):
                     config_entry_id=self.config_entry.entry_id,
                     identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
                     name=zha_group_proxy.group.name,
+                    manufacturer="Zigbee",
+                    model="Zigbee group",
                     via_device=(DOMAIN, coordinator_ieee),
                 )
                 zha_group_proxy.device_id = device_registry_device.id

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -233,15 +233,16 @@ class GroupEntityReference(NamedTuple):
 class ZHAGroupProxy(LogMixin):
     """Proxy class to interact with the ZHA group instances."""
 
-    _ha_device_id: str
+    _ha_device_id: str | None
 
     def __init__(self, group: Group, gateway_proxy: ZHAGatewayProxy) -> None:
         """Initialize the gateway proxy."""
         self.group: Group = group
         self.gateway_proxy: ZHAGatewayProxy = gateway_proxy
+        self._ha_device_id = None
 
     @property
-    def device_id(self) -> str:
+    def device_id(self) -> str | None:
         """Return the HA device registry device id."""
         return self._ha_device_id
 
@@ -912,15 +913,17 @@ class ZHAGatewayProxy(EventBase):
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
 
-            device_registry = dr.async_get(self.hass)
-            coordinator_ieee = str(self.gateway.state.node_info.ieee)
-            device_registry_device = device_registry.async_get_or_create(
-                config_entry_id=self.config_entry.entry_id,
-                identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
-                name=zha_group_proxy.group.name,
-                via_device=(DOMAIN, coordinator_ieee),
-            )
-            zha_group_proxy.device_id = device_registry_device.id
+            # Only create a device for groups that have entities
+            if zha_group_proxy.group.group_entities:
+                device_registry = dr.async_get(self.hass)
+                coordinator_ieee = str(self.gateway.state.node_info.ieee)
+                device_registry_device = device_registry.async_get_or_create(
+                    config_entry_id=self.config_entry.entry_id,
+                    identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
+                    name=zha_group_proxy.group.name,
+                    via_device=(DOMAIN, coordinator_ieee),
+                )
+                zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -959,9 +962,11 @@ class ZHAGatewayProxy(EventBase):
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
         """Remove device and entity registry entries for group when the group is removed from HA."""
-        device_registry = dr.async_get(self.hass)
-        # Remove the group device, which will also remove associated entities
-        device_registry.async_remove_device(zha_group_proxy.device_id)
+        # Only remove the device if one was created (groups with entities have devices)
+        if zha_group_proxy.device_id is not None:
+            device_registry = dr.async_get(self.hass)
+            # Remove the group device, which will also remove associated entities
+            device_registry.async_remove_device(zha_group_proxy.device_id)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -971,12 +971,20 @@ class ZHAGatewayProxy(EventBase):
     def _cleanup_group_entity_registry_entries(
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
-        """Remove device and entity registry entries for group when the group is removed from HA."""
-        # Only remove the device if one was created (groups with entities have devices)
+        """Remove device and entity registry entries for group when the group is removed."""
         if zha_group_proxy.device_id is not None:
             device_registry = dr.async_get(self.hass)
-            # Remove the group device, which will also remove associated entities
-            device_registry.async_remove_device(zha_group_proxy.device_id)
+            entity_registry = er.async_get(self.hass)
+            device_id = zha_group_proxy.device_id
+            # Fully clean up entity and device registries because group IDs can be
+            # reused, and we don't want old cached data to persist
+            for entry in er.async_entries_for_device(
+                entity_registry, device_id, include_disabled_entities=True
+            ):
+                entity_registry.async_remove(entry.entity_id)
+            device_registry.async_remove_device(device_id)
+            if device_id in device_registry.deleted_devices:
+                del device_registry.deleted_devices[device_id]
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -256,6 +256,17 @@ class ZHAGroupProxy(LogMixin):
         """Return unique identifier for the group device."""
         return f"zha_group_0x{self.group.group_id:04x}"
 
+    def get_device_info(self, coordinator_ieee: str) -> dr.DeviceInfo:
+        """Return device info for this group."""
+        return dr.DeviceInfo(
+            identifiers={(DOMAIN, self.group_device_identifier)},
+            name=self.group.name,
+            manufacturer="Zigbee",
+            model="Group",
+            entry_type=dr.DeviceEntryType.SERVICE,
+            via_device=(DOMAIN, coordinator_ieee),
+        )
+
     @property
     def group_info(self) -> dict[str, Any]:
         """Return a group description for group."""
@@ -917,14 +928,10 @@ class ZHAGatewayProxy(EventBase):
             if zha_group_proxy.group.group_entities:
                 device_registry = dr.async_get(self.hass)
                 coordinator_ieee = str(self.gateway.state.node_info.ieee)
+                device_info = zha_group_proxy.get_device_info(coordinator_ieee)
                 device_registry_device = device_registry.async_get_or_create(
                     config_entry_id=self.config_entry.entry_id,
-                    identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
-                    name=zha_group_proxy.group.name,
-                    manufacturer="Zigbee",
-                    model="Group",
-                    entry_type=dr.DeviceEntryType.SERVICE,
-                    via_device=(DOMAIN, coordinator_ieee),
+                    **device_info,
                 )
                 zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -201,7 +201,6 @@ ZHA_GW_MSG_LOG_ENTRY = "log_entry"
 ZHA_GW_MSG_LOG_OUTPUT = "log_output"
 SIGNAL_REMOVE_ENTITIES = "zha_remove_entities"
 SIGNAL_REMOVE_ENTITY = "zha_remove_entity"
-GROUP_ENTITY_DOMAINS = [Platform.LIGHT, Platform.SWITCH, Platform.FAN]
 SIGNAL_ADD_ENTITIES = "zha_add_entities"
 ENTITIES = "entities"
 

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -922,7 +922,8 @@ class ZHAGatewayProxy(EventBase):
                     identifiers={(DOMAIN, zha_group_proxy.group_device_identifier)},
                     name=zha_group_proxy.group.name,
                     manufacturer="Zigbee",
-                    model="Zigbee group",
+                    model="Group",
+                    entry_type=dr.DeviceEntryType.SERVICE,
                     via_device=(DOMAIN, coordinator_ieee),
                 )
                 zha_group_proxy.device_id = device_registry_device.id

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -655,6 +655,16 @@ class ZHAGatewayProxy(EventBase):
 
         # Group devices use synthetic identifiers, not real IEEE addresses
         if ieee_address.startswith("zha_group_"):
+            group_id = int(ieee_address.removeprefix("zha_group_"), 16)
+            if (group_proxy := self.group_proxies.get(group_id)) is None:
+                return
+            if entity_entry.unique_id not in group_proxy.group.group_entities:
+                return
+            group_entity = group_proxy.group.group_entities[entity_entry.unique_id]
+            if entity_entry.disabled:
+                group_entity.disable()
+            else:
+                group_entity.enable()
             return
 
         ieee = EUI64.convert(ieee_address)
@@ -928,16 +938,15 @@ class ZHAGatewayProxy(EventBase):
             )
             self.group_proxies[group_info.group_id] = zha_group_proxy
 
-            # Only create a device for groups that have entities
-            if zha_group_proxy.group.group_entities:
-                device_registry = dr.async_get(self.hass)
-                coordinator_ieee = str(self.gateway.state.node_info.ieee)
-                device_info = zha_group_proxy.get_device_info(coordinator_ieee)
-                device_registry_device = device_registry.async_get_or_create(
-                    config_entry_id=self.config_entry.entry_id,
-                    **device_info,
-                )
-                zha_group_proxy.device_id = device_registry_device.id
+        if zha_group_proxy.device_id is None and zha_group_proxy.group.group_entities:
+            device_registry = dr.async_get(self.hass)
+            coordinator_ieee = str(self.gateway.state.node_info.ieee)
+            device_info = zha_group_proxy.get_device_info(coordinator_ieee)
+            device_registry_device = device_registry.async_get_or_create(
+                config_entry_id=self.config_entry.entry_id,
+                **device_info,
+            )
+            zha_group_proxy.device_id = device_registry_device.id
         return zha_group_proxy
 
     def _create_entity_metadata(
@@ -990,7 +999,8 @@ class ZHAGatewayProxy(EventBase):
             entity_registry.deleted_entities.pop(
                 (entry.domain, entry.platform, entry.unique_id), None
             )
-        device_registry.async_remove_device(device_id)
+        if device_registry.async_get(device_id) is not None:
+            device_registry.async_remove_device(device_id)
         device_registry.deleted_devices.pop(device_id, None)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -990,18 +990,25 @@ class ZHAGatewayProxy(EventBase):
 
         device_registry = dr.async_get(self.hass)
         entity_registry = er.async_get(self.hass)
-        # Fully clean up entity and device registries because group IDs can be
-        # reused, and we don't want old cached data to persist
+        entity_keys = []
         for entry in er.async_entries_for_device(
             entity_registry, device_id, include_disabled_entities=True
         ):
+            entity_keys.append((entry.domain, entry.platform, entry.unique_id))
             entity_registry.async_remove(entry.entity_id)
-            entity_registry.deleted_entities.pop(
-                (entry.domain, entry.platform, entry.unique_id), None
-            )
         if device_registry.async_get(device_id) is not None:
             device_registry.async_remove_device(device_id)
-        device_registry.deleted_devices.pop(device_id, None)
+        # Purge deleted-entry caches so a new group reusing the same zigpy
+        # group ID is not restored with stale settings from the old group.
+        purged = False
+        for key in entity_keys:
+            if entity_registry.deleted_entities.pop(key, None) is not None:
+                purged = True
+        if device_registry.deleted_devices.pop(device_id, None) is not None:
+            purged = True
+        if purged:
+            entity_registry.async_schedule_save()
+            device_registry.async_schedule_save()
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -653,6 +653,10 @@ class ZHAGatewayProxy(EventBase):
         )
         assert ieee_address
 
+        # Group devices use synthetic identifiers, not real IEEE addresses
+        if ieee_address.startswith("zha_group_"):
+            return
+
         ieee = EUI64.convert(ieee_address)
 
         assert ieee in self.device_proxies

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -972,19 +972,22 @@ class ZHAGatewayProxy(EventBase):
         self, zha_group_proxy: ZHAGroupProxy
     ) -> None:
         """Remove device and entity registry entries for group when the group is removed."""
-        if zha_group_proxy.device_id is not None:
-            device_registry = dr.async_get(self.hass)
-            entity_registry = er.async_get(self.hass)
-            device_id = zha_group_proxy.device_id
-            # Fully clean up entity and device registries because group IDs can be
-            # reused, and we don't want old cached data to persist
-            for entry in er.async_entries_for_device(
-                entity_registry, device_id, include_disabled_entities=True
-            ):
-                entity_registry.async_remove(entry.entity_id)
-            device_registry.async_remove_device(device_id)
-            if device_id in device_registry.deleted_devices:
-                del device_registry.deleted_devices[device_id]
+        if (device_id := zha_group_proxy.device_id) is None:
+            return
+
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+        # Fully clean up entity and device registries because group IDs can be
+        # reused, and we don't want old cached data to persist
+        for entry in er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=True
+        ):
+            entity_registry.async_remove(entry.entity_id)
+            entity_registry.deleted_entities.pop(
+                (entry.domain, entry.platform, entry.unique_id), None
+            )
+        device_registry.async_remove_device(device_id)
+        device_registry.deleted_devices.pop(device_id, None)
 
     def _update_group_entities(self, group_event: GroupEvent) -> None:
         """Update group entities when a group event is received."""

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -162,7 +162,7 @@ def find_entity_ids(
 
 def async_find_group_entity_id(hass: HomeAssistant, domain, group):
     """Find the group entity id under test."""
-    entity_id = f"{domain}.coordinator_manufacturer_coordinator_model_{group.name.lower().replace(' ', '_')}"
+    entity_id = f"{domain}.{group.name.lower().replace(' ', '_')}"
 
     entity_ids = hass.states.async_entity_ids(domain)
     assert entity_id in entity_ids

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -162,10 +162,7 @@ def find_entity_ids(
 
 def async_find_group_entity_id(hass: HomeAssistant, domain, group):
     """Find the group entity id under test."""
-    entity_id = (
-        f"{domain}.coordinator_manufacturer_coordinator_model"
-        f"_{group.name.lower().replace(' ', '_')}"
-    )
+    entity_id = f"{domain}.{group.name.lower().replace(' ', '_')}"
 
     entity_ids = hass.states.async_entity_ids(domain)
     assert entity_id in entity_ids

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -22,7 +22,7 @@ import zigpy.quirks
 import zigpy.state
 import zigpy.types
 import zigpy.util
-from zigpy.zcl.clusters.general import Basic, Groups
+from zigpy.zcl.clusters.general import Basic, Groups, OnOff
 from zigpy.zcl.foundation import Status
 import zigpy.zdo.types as zdo_t
 
@@ -37,6 +37,8 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
+FIXTURE_GRP_WITH_ENTITIES_ID = 0x2001
+FIXTURE_GRP_WITH_ENTITIES_NAME = "Test Group"
 COUNTER_NAMES = ["counter_1", "counter_2", "counter_3"]
 
 
@@ -419,3 +421,38 @@ def zigpy_device_mock(zigpy_app_controller) -> Callable[..., zigpy.device.Device
         return device
 
     return _mock_dev
+
+
+@pytest.fixture
+def zigpy_app_controller_with_group(
+    zigpy_app_controller: ControllerApplication,
+    zigpy_device_mock: Callable[..., zigpy.device.Device],
+) -> ControllerApplication:
+    """Add two switch devices and a group with members to the app controller."""
+    endpoint_config = {
+        1: {
+            SIG_EP_INPUT: [
+                OnOff.cluster_id,
+                Basic.cluster_id,
+                Groups.cluster_id,
+            ],
+            SIG_EP_OUTPUT: [],
+            SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+            SIG_EP_PROFILE: zha.PROFILE_ID,
+        }
+    }
+    device_1 = zigpy_device_mock(endpoint_config, ieee="01:2d:6f:00:0a:90:69:e1")
+    device_2 = zigpy_device_mock(endpoint_config, ieee="01:2d:6f:00:0a:90:69:e2")
+
+    zigpy_app_controller.devices[device_1.ieee] = device_1
+    zigpy_app_controller.devices[device_2.ieee] = device_2
+
+    group = zigpy_app_controller.groups.add_group(
+        FIXTURE_GRP_WITH_ENTITIES_ID,
+        FIXTURE_GRP_WITH_ENTITIES_NAME,
+        suppress_event=True,
+    )
+    group.add_member(device_1.endpoints[1], suppress_event=True)
+    group.add_member(device_2.endpoints[1], suppress_event=True)
+
+    return zigpy_app_controller

--- a/tests/components/zha/test_entity.py
+++ b/tests/components/zha/test_entity.py
@@ -1,16 +1,25 @@
 """Test ZHA entities."""
 
 from collections.abc import Callable, Coroutine
+from typing import Any
 
+from zigpy.application import ControllerApplication
 from zigpy.device import Device
 from zigpy.profiles import zha
 from zigpy.zcl.clusters import general
 
-from homeassistant.components.zha.helpers import get_zha_gateway
+from homeassistant.components.zha.helpers import get_zha_gateway, get_zha_gateway_proxy
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+from .conftest import (
+    FIXTURE_GRP_WITH_ENTITIES_ID,
+    FIXTURE_GRP_WITH_ENTITIES_NAME,
+    SIG_EP_INPUT,
+    SIG_EP_OUTPUT,
+    SIG_EP_PROFILE,
+    SIG_EP_TYPE,
+)
 
 
 async def test_device_registry_via_device(
@@ -48,3 +57,40 @@ async def test_device_registry_via_device(
     )
 
     assert reg_device.via_device_id == reg_coordinator_device.id
+
+
+async def test_group_entity_name_and_device_info(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[Any, Any, None]],
+    zigpy_app_controller_with_group: ControllerApplication,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that group entities use group device info and return None for name."""
+    await setup_zha()
+
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    group_proxy = gateway_proxy.group_proxies[FIXTURE_GRP_WITH_ENTITIES_ID]
+    assert group_proxy.device_id is not None
+
+    # Find the group entity
+    entity_entries = er.async_entries_for_device(
+        entity_registry, group_proxy.device_id, include_disabled_entities=True
+    )
+    assert len(entity_entries) > 0
+
+    # The entity should use the group device name (friendly name = group name)
+    entity = hass.states.get(entity_entries[0].entity_id)
+    assert entity is not None
+    assert entity.name == FIXTURE_GRP_WITH_ENTITIES_NAME
+
+    # Verify device info points to the group device
+    device = device_registry.async_get(group_proxy.device_id)
+    assert device is not None
+    assert (
+        "zha",
+        f"zha_group_0x{FIXTURE_GRP_WITH_ENTITIES_ID:04x}",
+    ) in device.identifiers
+    assert device.manufacturer == "Zigbee"
+    assert device.model == "Group"
+    assert device.entry_type == dr.DeviceEntryType.SERVICE

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -238,22 +238,19 @@ def test_zha_group_proxy_group_device_identifier(
     group_id: int, expected_identifier: str
 ) -> None:
     """Test ZHAGroupProxy group_device_identifier property."""
-    mock_group = MagicMock()
-    mock_group.group_id = group_id
-    group_proxy = ZHAGroupProxy(mock_group, MagicMock())
-
+    group_proxy = ZHAGroupProxy(MagicMock(group_id=group_id), MagicMock())
     assert group_proxy.group_device_identifier == expected_identifier
 
 
 def test_zha_group_proxy_get_device_info() -> None:
     """Test ZHAGroupProxy get_device_info returns correct DeviceInfo."""
-    mock_group = MagicMock()
-    mock_group.group_id = 0x1001
+    mock_group = MagicMock(group_id=0x1001)
     mock_group.name = "Test Group"
     coordinator_ieee = "00:15:8d:00:02:32:4f:32"
 
-    group_proxy = ZHAGroupProxy(mock_group, MagicMock())
-    device_info = group_proxy.get_device_info(coordinator_ieee)
+    device_info = ZHAGroupProxy(mock_group, MagicMock()).get_device_info(
+        coordinator_ieee
+    )
 
     assert device_info == {
         "identifiers": {(zha_const.DOMAIN, "zha_group_0x1001")},
@@ -267,35 +264,25 @@ def test_zha_group_proxy_get_device_info() -> None:
 
 def test_zha_group_proxy_device_id_property() -> None:
     """Test ZHAGroupProxy device_id property getter and setter."""
-    group_proxy = ZHAGroupProxy(MagicMock(), MagicMock())
+    group_proxy = ZHAGroupProxy(MagicMock(group_id=0x1001), MagicMock())
 
     assert group_proxy.device_id is None
-
     group_proxy.device_id = "test_device_id"
     assert group_proxy.device_id == "test_device_id"
 
 
-async def test_zha_group_proxy_device_created_for_group_with_entities(
+async def test_zha_group_proxy_no_device_for_group_without_entities(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[Any, Any, None]],
 ) -> None:
-    """Test that a device is created for groups with entities."""
+    """Test that no device is created for groups without entities."""
     await setup_zha()
 
     gateway_proxy = get_zha_gateway_proxy(hass)
-    device_registry = dr.async_get(hass)
 
     group_proxy = gateway_proxy.group_proxies.get(FIXTURE_GRP_ID)
     assert group_proxy is not None
     assert group_proxy.group.name == FIXTURE_GRP_NAME
-
-    if group_proxy.group.group_entities:
-        assert group_proxy.device_id is not None
-        device = device_registry.async_get(group_proxy.device_id)
-        assert device is not None
-        assert device.name == FIXTURE_GRP_NAME
-        assert device.manufacturer == "Zigbee"
-        assert device.model == "Group"
-        assert device.entry_type == dr.DeviceEntryType.SERVICE
-    else:
-        assert group_proxy.device_id is None
+    # Fixture group has no members, so no entities, so no device
+    assert not group_proxy.group.group_entities
+    assert group_proxy.device_id is None

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -1,7 +1,9 @@
 """Tests for ZHA helpers."""
 
+from collections.abc import Callable, Coroutine
 import logging
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import voluptuous_serialize
@@ -11,15 +13,19 @@ from zigpy.zcl.clusters import lighting
 
 from homeassistant.components.zha import const as zha_const
 from homeassistant.components.zha.helpers import (
+    ZHAGroupProxy,
     cluster_command_schema_to_vol_schema,
     convert_to_zcl_values,
     create_zha_config,
     exclude_none_values,
     get_zha_data,
+    get_zha_gateway_proxy,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
+
+from .conftest import FIXTURE_GRP_ID, FIXTURE_GRP_NAME
 
 from tests.common import MockConfigEntry
 
@@ -218,3 +224,78 @@ async def test_create_zha_config_remove_unused(
 
     # Does not error out
     create_zha_config(hass, ha_zha_data)
+
+
+@pytest.mark.parametrize(
+    ("group_id", "expected_identifier"),
+    [
+        (0x0001, "zha_group_0x0001"),
+        (0x1001, "zha_group_0x1001"),
+        (0xFFFF, "zha_group_0xffff"),
+    ],
+)
+def test_zha_group_proxy_group_device_identifier(
+    group_id: int, expected_identifier: str
+) -> None:
+    """Test ZHAGroupProxy group_device_identifier property."""
+    mock_group = MagicMock()
+    mock_group.group_id = group_id
+    group_proxy = ZHAGroupProxy(mock_group, MagicMock())
+
+    assert group_proxy.group_device_identifier == expected_identifier
+
+
+def test_zha_group_proxy_get_device_info() -> None:
+    """Test ZHAGroupProxy get_device_info returns correct DeviceInfo."""
+    mock_group = MagicMock()
+    mock_group.group_id = 0x1001
+    mock_group.name = "Test Group"
+    coordinator_ieee = "00:15:8d:00:02:32:4f:32"
+
+    group_proxy = ZHAGroupProxy(mock_group, MagicMock())
+    device_info = group_proxy.get_device_info(coordinator_ieee)
+
+    assert device_info == {
+        "identifiers": {(zha_const.DOMAIN, "zha_group_0x1001")},
+        "name": "Test Group",
+        "manufacturer": "Zigbee",
+        "model": "Group",
+        "entry_type": dr.DeviceEntryType.SERVICE,
+        "via_device": (zha_const.DOMAIN, coordinator_ieee),
+    }
+
+
+def test_zha_group_proxy_device_id_property() -> None:
+    """Test ZHAGroupProxy device_id property getter and setter."""
+    group_proxy = ZHAGroupProxy(MagicMock(), MagicMock())
+
+    assert group_proxy.device_id is None
+
+    group_proxy.device_id = "test_device_id"
+    assert group_proxy.device_id == "test_device_id"
+
+
+async def test_zha_group_proxy_device_created_for_group_with_entities(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[Any, Any, None]],
+) -> None:
+    """Test that a device is created for groups with entities."""
+    await setup_zha()
+
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    device_registry = dr.async_get(hass)
+
+    group_proxy = gateway_proxy.group_proxies.get(FIXTURE_GRP_ID)
+    assert group_proxy is not None
+    assert group_proxy.group.name == FIXTURE_GRP_NAME
+
+    if group_proxy.group.group_entities:
+        assert group_proxy.device_id is not None
+        device = device_registry.async_get(group_proxy.device_id)
+        assert device is not None
+        assert device.name == FIXTURE_GRP_NAME
+        assert device.manufacturer == "Zigbee"
+        assert device.model == "Group"
+        assert device.entry_type == dr.DeviceEntryType.SERVICE
+    else:
+        assert group_proxy.device_id is None

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -19,13 +19,23 @@ from homeassistant.components.zha.helpers import (
     create_zha_config,
     exclude_none_values,
     get_zha_data,
+    get_zha_gateway,
     get_zha_gateway_proxy,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.setup import async_setup_component
 
-from .conftest import FIXTURE_GRP_ID, FIXTURE_GRP_NAME
+from .conftest import (
+    FIXTURE_GRP_ID,
+    FIXTURE_GRP_NAME,
+    FIXTURE_GRP_WITH_ENTITIES_ID,
+    FIXTURE_GRP_WITH_ENTITIES_NAME,
+)
 
 from tests.common import MockConfigEntry
 
@@ -286,3 +296,73 @@ async def test_zha_group_proxy_no_device_for_group_without_entities(
     # Fixture group has no members, so no entities, so no device
     assert not group_proxy.group.group_entities
     assert group_proxy.device_id is None
+
+
+async def test_zha_group_device_creation_with_entities(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[Any, Any, None]],
+    zigpy_app_controller_with_group: ControllerApplication,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a device is created for groups with entities."""
+    await setup_zha()
+
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    group_proxy = gateway_proxy.group_proxies[FIXTURE_GRP_WITH_ENTITIES_ID]
+
+    assert group_proxy.group.group_entities
+    assert group_proxy.device_id is not None
+
+    device = device_registry.async_get(group_proxy.device_id)
+    assert device is not None
+    assert device.name == FIXTURE_GRP_WITH_ENTITIES_NAME
+    assert device.manufacturer == "Zigbee"
+    assert device.model == "Group"
+    assert device.entry_type == dr.DeviceEntryType.SERVICE
+
+    # Verify via_device points to coordinator
+    gateway = get_zha_gateway(hass)
+    coordinator_ieee = str(gateway.state.node_info.ieee)
+    coordinator_device = device_registry.async_get_device(
+        identifiers={("zha", coordinator_ieee)}
+    )
+    assert device.via_device_id == coordinator_device.id
+
+
+async def test_zha_group_cleanup_on_removal(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[Any, Any, None]],
+    zigpy_app_controller_with_group: ControllerApplication,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that device and entities are cleaned up when a group is removed."""
+    await setup_zha()
+
+    gateway = get_zha_gateway(hass)
+    gateway_proxy = get_zha_gateway_proxy(hass)
+    group_proxy = gateway_proxy.group_proxies[FIXTURE_GRP_WITH_ENTITIES_ID]
+    device_id = group_proxy.device_id
+    assert device_id is not None
+
+    # Collect entity entries for the group device before removal
+    entity_entries = er.async_entries_for_device(
+        entity_registry, device_id, include_disabled_entities=True
+    )
+    assert len(entity_entries) > 0
+    entity_keys = [
+        (entry.domain, entry.platform, entry.unique_id) for entry in entity_entries
+    ]
+
+    # Remove the group
+    await gateway.async_remove_zigpy_group(FIXTURE_GRP_WITH_ENTITIES_ID)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Device should be removed from device registry
+    assert device_registry.async_get(device_id) is None
+    # Deleted devices cache should not contain the removed device
+    assert device_id not in device_registry.deleted_devices
+
+    # Entities should be removed and not in deleted cache
+    for key in entity_keys:
+        assert key not in entity_registry.deleted_entities


### PR DESCRIPTION
## Proposed change

This PR improves the handling of ZHA group entities by creating proper device registry entries for groups. Previously, group entities were linked to the coordinator device. Now, each group gets its own device in the device registry, with entities properly associated to that group device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr