### PR TITLE
WIP: Add set_state service to Hue

### DIFF
--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .bridge import HueConfigEntry
 from .const import (
+    CONF_ALL,
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
     CONF_IGNORE_AVAILABILITY,
@@ -396,6 +397,13 @@ class HueV2OptionsFlowHandler(OptionsFlow):
             for identifier in entry.identifiers
             if identifier[0] == DOMAIN
         }
+        room_ids = {
+            identifier[1]: entry.name
+            for entry in entries
+            if entry.entry_type == dr.DeviceEntryType.SERVICE
+            for identifier in entry.identifiers
+            if identifier[0] == DOMAIN
+        }
         # filter any non existing device id's from the list
         cur_ids = [
             item
@@ -411,6 +419,10 @@ class HueV2OptionsFlowHandler(OptionsFlow):
                         CONF_IGNORE_AVAILABILITY,
                         default=cur_ids,
                     ): cv.multi_select(dev_ids),
+                    vol.Optional(
+                        CONF_ALL,
+                        default=self.config_entry.options.get(CONF_ALL, []),
+                    ): cv.multi_select(room_ids),
                 }
             ),
         )

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -11,14 +11,20 @@ DOMAIN = "hue"
 CONF_IGNORE_AVAILABILITY = "ignore_availability"
 
 CONF_SUBTYPE = "subtype"
+CONF_ALL = "all"
+
+SERVICE_HUE_GROUP_SET_STATE = "set_group_state"
+SERVICE_HUE_LIGHT_SET_STATE = "set_light_state"
 
 ATTR_HUE_EVENT = "hue_event"
+
 SERVICE_HUE_ACTIVATE_SCENE = "hue_activate_scene"
 ATTR_GROUP_NAME = "group_name"
 ATTR_SCENE_NAME = "scene_name"
 ATTR_TRANSITION = "transition"
 ATTR_DYNAMIC = "dynamic"
 
+ATTR_POWER = "power"
 
 # V1 API SPECIFIC CONSTANTS ##################
 

--- a/homeassistant/components/hue/icons.json
+++ b/homeassistant/components/hue/icons.json
@@ -29,6 +29,12 @@
     },
     "hue_activate_scene": {
       "service": "mdi:palette"
+    },
+    "set_group_state": {
+      "service": "mdi:palette"
+    },
+    "set_light_state": {
+      "service": "mdi:palette"
     }
   }
 }

--- a/homeassistant/components/hue/services.yaml
+++ b/homeassistant/components/hue/services.yaml
@@ -43,3 +43,57 @@ activate_scene:
         number:
           min: 1
           max: 255
+
+set_group_state:
+  target:
+    entity:
+      domain: light
+      integration: hue
+  fields:
+    transition:
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+    brightness:
+      selector:
+        number:
+          min: 1
+          max: 255
+    color_temp_kelvin:
+      selector:
+        color_temp:
+          unit: "kelvin"
+          min: 2000
+          max: 10000
+    power:
+      selector:
+        boolean:
+
+set_light_state:
+  target:
+    entity:
+      domain: light
+      integration: hue
+  fields:
+    transition:
+      selector:
+        number:
+          min: 0
+          max: 3600
+          unit_of_measurement: seconds
+    brightness:
+      selector:
+        number:
+          min: 1
+          max: 255
+    color_temp_kelvin:
+      selector:
+        color_temp:
+          unit: "kelvin"
+          min: 2000
+          max: 10000
+    power:
+      selector:
+        boolean:

--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -155,6 +155,7 @@
     "step": {
       "init": {
         "data": {
+          "all": "Select light groups that should only 'turn on' if all lights in the group are on",
           "allow_hue_groups": "Allow Hue groups",
           "allow_hue_scenes": "Allow Hue scenes",
           "allow_unreachable": "Allow unreachable bulbs to report their state correctly",
@@ -203,6 +204,50 @@
         }
       },
       "name": "Activate scene"
+    },
+    "set_group_state": {
+      "description": "Update the color/brightness of a group without requiring a power state to be communicated at the same time. Useful to adjust the state of a group that contains powered off entities without unintentionally powering them all on.",
+      "fields": {
+        "brightness": {
+          "description": "Set brightness for the light.",
+          "name": "Brightness"
+        },
+        "color_temp_kelvin": {
+          "description": "Set color temperature of the lights in the group.",
+          "name": "Color temperature (Kelvin)"
+        },
+        "power": {
+          "description": "Turn the light on or off. Leave out to keep the power as it is.",
+          "name": "Power"
+        },
+        "transition": {
+          "description": "Duration it takes to get to the final state.",
+          "name": "Transition"
+        }
+      },
+      "name": "Set Hue group state"
+    },
+    "set_light_state": {
+      "description": "Update the color/brightness of a light without requiring a power state to be communicated at the same time. Useful to 'pre-stage' the state of a light before it's turned on, eliminating initial color transition flicker.",
+      "fields": {
+        "brightness": {
+          "description": "Set brightness for the light.",
+          "name": "Brightness"
+        },
+        "color_temp_kelvin": {
+          "description": "Set color temperature of the light.",
+          "name": "Color temperature (Kelvin)"
+        },
+        "power": {
+          "description": "Turn the light on or off. Leave out to keep the power as it is.",
+          "name": "Power"
+        },
+        "transition": {
+          "description": "Duration it takes to get to the final state.",
+          "name": "Transition"
+        }
+      },
+      "name": "Set Hue light state"
     }
   }
 }

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from functools import reduce
 from typing import Any
 
 from aiohue.v2 import HueBridgeV2
@@ -18,25 +19,36 @@ from homeassistant.components.light import (
     ATTR_TRANSITION,
     ATTR_XY_COLOR,
     FLASH_SHORT,
+    LIGHT_TURN_ON_SCHEMA,
     ColorMode,
     LightEntity,
     LightEntityDescription,
     LightEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_platform as ep,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util import color as color_util
 
 from ..bridge import HueBridge, HueConfigEntry
-from ..const import DOMAIN
+from ..const import ATTR_POWER, DOMAIN, SERVICE_HUE_GROUP_SET_STATE
 from .entity import HueBaseEntity
 from .helpers import (
     normalize_hue_brightness,
     normalize_hue_colortemp,
     normalize_hue_transition,
 )
+
+HUE_GROUP_SET_STATE_SCHEMA: VolDictType = {
+    **LIGHT_TURN_ON_SCHEMA,
+    ATTR_POWER: cv.boolean,
+}
 
 
 async def async_setup_entry(
@@ -47,6 +59,10 @@ async def async_setup_entry(
     """Set up Hue groups on light platform."""
     bridge = config_entry.runtime_data
     api: HueBridgeV2 = bridge.api
+    platform = ep.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_HUE_GROUP_SET_STATE, HUE_GROUP_SET_STATE_SCHEMA, "set_state"
+    )
 
     async def async_add_light(event_type: EventType, resource: GroupedLight) -> None:
         """Add Grouped Light for Hue Room/Zone."""
@@ -134,8 +150,14 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return true if light is on."""
-        return self.resource.on.on
+        """Return if `all` config property is enabled, returns true if all lights within hue group are on. Otherwise, returns the underlying Hue group state where any turned on light within a room will accordingly indicate the group as turned on."""
+        # how should a best hue group opt into this behavior via configuration? config flow at integration level?
+        return reduce(
+            lambda x, y: x and y,
+            [x.on.on for x in self.controller.get_lights(self.resource.id)],
+            True,
+        )
+        # return self.resource.on.on
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -212,6 +234,28 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
             self.controller.set_state,
             id=self.resource.id,
             on=False,
+            transition_time=transition,
+        )
+
+    async def set_state(self, **kwargs: Any) -> None:
+        """Update the color of a group while optionally turning the lights within on or off."""
+        power = kwargs.get(ATTR_POWER)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
+        xy_color = kwargs.get(ATTR_XY_COLOR)
+        color_temp = normalize_hue_colortemp(
+            kwargs.get(ATTR_COLOR_TEMP_KELVIN),
+            color_util.color_temperature_kelvin_to_mired(self.max_color_temp_kelvin),
+            color_util.color_temperature_kelvin_to_mired(self.min_color_temp_kelvin),
+        )
+
+        await self.bridge.async_request_call(
+            self.controller.set_state,
+            id=self.resource.id,
+            on=power,
+            brightness=brightness,
+            color_xy=xy_color,
+            color_temp=color_temp,
             transition_time=transition,
         )
 

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -20,6 +20,7 @@ from homeassistant.components.light import (
     ATTR_XY_COLOR,
     EFFECT_OFF,
     FLASH_SHORT,
+    LIGHT_TURN_ON_SCHEMA,
     ColorMode,
     LightEntity,
     LightEntityDescription,
@@ -27,12 +28,14 @@ from homeassistant.components.light import (
     filter_supported_color_modes,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_platform as ep
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util import color as color_util
 
 from ..bridge import HueBridge, HueConfigEntry
-from ..const import DOMAIN
+from ..const import ATTR_POWER, DOMAIN, SERVICE_HUE_LIGHT_SET_STATE
 from .entity import HueBaseEntity
 from .helpers import (
     normalize_hue_brightness,
@@ -46,6 +49,11 @@ FALLBACK_KELVIN = 5800  # halfway
 
 # HA 2025.4 replaced the deprecated effect "None" with HA default "off"
 DEPRECATED_EFFECT_NONE = "None"
+
+HUE_LIGHT_SET_STATE_SCHEMA: VolDictType = {
+    **LIGHT_TURN_ON_SCHEMA,
+    ATTR_POWER: cv.boolean,
+}
 
 
 async def async_setup_entry(
@@ -69,6 +77,10 @@ async def async_setup_entry(
     # register listener for new lights
     config_entry.async_on_unload(
         controller.subscribe(async_add_light, event_filter=EventType.RESOURCE_ADDED)
+    )
+    platform = ep.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_HUE_LIGHT_SET_STATE, HUE_LIGHT_SET_STATE_SCHEMA, "set_state"
     )
 
 
@@ -327,4 +339,26 @@ class HueLight(HueBaseEntity, LightEntity):
             self.controller.set_flash,
             id=self.resource.id,
             short=flash == FLASH_SHORT,
+        )
+
+    async def set_state(self, **kwargs: Any) -> None:
+        """Update the color of a light while optionally turning it on or off."""
+        power = kwargs.get(ATTR_POWER)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+        transition = normalize_hue_transition(kwargs.get(ATTR_TRANSITION))
+        xy_color = kwargs.get(ATTR_XY_COLOR)
+        color_temp = normalize_hue_colortemp(
+            kwargs.get(ATTR_COLOR_TEMP_KELVIN),
+            color_util.color_temperature_kelvin_to_mired(self.max_color_temp_kelvin),
+            color_util.color_temperature_kelvin_to_mired(self.min_color_temp_kelvin),
+        )
+
+        await self.bridge.async_request_call(
+            self.controller.set_state,
+            id=self.resource.id,
+            on=power,
+            brightness=brightness,
+            color_xy=xy_color,
+            color_temp=color_temp,
+            transition_time=transition,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Need to remove tangential change to Hue group behavior from branch before merging. 

## Proposed change
I am proposing two new service calls to the Hue integration, `set_group_state` & `set_light_state`. These service calls, similar to the `set_state` call within the LIFX integration, allow a caller to modify the state of a light or group without requiring the light to also turn on or off, as required by the HA `light` entity.

When using `set_group_state`, a room of lights can be smoothly transitioned to a new state as a unified group, without also forcing every light in the room to turn on. This is mentioned as a complaint here https://github.com/home-assistant/core/issues/139312 and I've seen it mentioned in other community chatter regarding the Hue integration.

When using `set_light_state`, a light that is currently off (but still powered and connected to the Hub) can be "pre-staged" with a state so that, upon the next simple "turn on" command, it turns on to the intended state immediately. Previously, even when using the `intercept` option from the Adaptive Lighting integration (which adds a brightness & color tempt to each light.turn_on) with a transition time of 0, there would be a visible transition from the prior state (potentially related to https://github.com/home-assistant/core/issues/155775). With an automation running in the background calling `set_light_state`, those flickers of the previous state are gone.

Together, these allow me to use the community `Adaptive Lighting` integration (with `only_once`) to manage the lighting configuration, calculations, and the "manual override" state for each light, while an automation runs alongside it calling these service calls. This way, I get the best of adaptive lighting while avoiding the edge cases of an entire room turning on on each adaptation tick, or a room turning on initially in its old state. 

My automation to transition all rooms that are turned on and prestage all the lights inside the off rooms looks like: 
```
alias: Adaptive Lighting Set State Ticker
description: ""
triggers:
  - trigger: state
    entity_id:
      - timer.adaptive_lighting_set_state_next_tick_timer
    to:
      - idle
conditions: []
actions:
  - repeat:
      for_each: >-
        {{ state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
        'configuration').lights }}
      sequence:
        - if:
            - condition: template
              value_template: >-
                {{ not
                state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                'manual_control') | contains(repeat.item) }}
          then:
            - if:
                - condition: template
                  value_template: "{{ states(repeat.item) == \"on\" }}"
              then:
                - action: hue.set_group_state
                  metadata: {}
                  target:
                    entity_id: "{{ repeat.item }}"
                  data:
                    brightness: >-
                      {{
                      state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                      'brightness_pct') }}
                    color_temp_kelvin: >-
                      {{
                      state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                      'color_temp_kelvin') }}
                    transition: >-
                      {{
                      state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                      'configuration').transition }}
              else:
                - repeat:
                    for_each: "{{ state_attr(repeat.item, 'entity_id') | list }}"
                    sequence:
                      - action: hue.set_light_state
                        target:
                          entity_id: "{{ repeat.item }}"
                        data:
                          brightness: >-
                            {{
                            state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                            'brightness_pct') }}
                          color_temp_kelvin: >-
                            {{
                            state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
                            'color_temp_kelvin') }}
  - action: timer.start
    metadata: {}
    target:
      entity_id: timer.adaptive_lighting_set_state_next_tick_timer
    data:
      duration: >-
        {{ state_attr('switch.adaptive_lighting_adaptive_hue_lighting',
        'configuration').interval | int(0) | timestamp_custom('%H:%M:%S', false)
        }}
mode: single
```

I'd also included as part of this branch a prospective change to add an "all entities" option to Hue light groups, comparable to the "all entities" option on native HA light groups. This would work around an edge case in my current setup where turning on a single light within a room causes the whole room to turn on via the `only_once` adaptation from Adaptive Lighting that runs when it notices the state of the room change to `on`. This functionality is tangential to the new service calls, and this edge case may best be resolved by other means. I'll remove that change before this PR is finalized, but wanted to mention this shortcoming to anyone reading who tries to emulate my setup as described.

Lastly, it's a limitation of the Hue API but trying to `set_state` on an `off` group will have no effect on the lights within it. Each off light needs to have `set_state` called for "pre-staging" to be applied.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue:
- This PR is related to issue: #139312 #155775
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
