### PR TITLE
Fix conversion of data for todo.* actions

### DIFF
--- a/homeassistant/components/todoist/todo.py
+++ b/homeassistant/components/todoist/todo.py
@@ -45,9 +45,9 @@ def _task_api_data(item: TodoItem, api_data: Task | None = None) -> dict[str, An
     }
     if due := item.due:
         if isinstance(due, datetime.datetime):
-            item_data["due_datetime"] = due.isoformat()
+            item_data["due_datetime"] = due
         else:
-            item_data["due_date"] = due.isoformat()
+            item_data["due_date"] = due
         # In order to not lose any recurrence metadata for the task, we need to
         # ensure that we send the `due_string` param if the task has it set.
         # NOTE: It's ok to send stale data for non-recurring tasks. Any provided

--- a/tests/components/todoist/test_todo.py
+++ b/tests/components/todoist/test_todo.py
@@ -1,7 +1,9 @@
 """Unit tests for the Todoist todo platform."""
 
+from datetime import date, datetime
 from typing import Any
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 from todoist_api_python.models import Task
@@ -113,7 +115,7 @@ async def test_todo_item_state(
                     ),
                 )
             ],
-            {"description": "", "due_date": "2023-11-18"},
+            {"description": "", "due_date": date(2023, 11, 18)},
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -138,7 +140,9 @@ async def test_todo_item_state(
             ],
             {
                 "description": "",
-                "due_datetime": "2023-11-18T06:30:00-06:00",
+                "due_datetime": datetime(
+                    2023, 11, 18, 6, 30, tzinfo=ZoneInfo("US/Central")
+                ),
             },
             {
                 "uid": "task-id-1",
@@ -333,7 +337,7 @@ async def test_update_todo_item_status(
             {
                 "task_id": "task-id-1",
                 "content": "Soda",
-                "due_date": "2023-11-18",
+                "due_date": date(2023, 11, 18),
                 "description": "",
             },
             {
@@ -361,7 +365,9 @@ async def test_update_todo_item_status(
             {
                 "task_id": "task-id-1",
                 "content": "Soda",
-                "due_datetime": "2023-11-18T06:30:00-06:00",
+                "due_datetime": datetime(
+                    2023, 11, 18, 6, 30, tzinfo=ZoneInfo("US/Central")
+                ),
                 "description": "",
             },
             {
@@ -455,7 +461,7 @@ async def test_update_todo_item_status(
                 "task_id": "task-id-1",
                 "content": "Soda",
                 "description": "6-pack",
-                "due_date": "2024-02-01",
+                "due_date": date(2024, 2, 1),
                 "due_string": "every day",
             },
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes a bug where we were converting a `datetime` to a `str` when the action actually expected a `datetime` instance.  This was missed in the [previous PR ](https://github.com/home-assistant/core/pull/161811/changes/62b570e57f7e993dea7b53bc3813611cea2045ca)due to incorrect test fixture data, which has now been updated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162336
- This PR is related to issue: #162336
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
