### PR TITLE
Improve SmartTub integration quality scale toward Bronze

### DIFF
--- a/homeassistant/components/smarttub/binary_sensor.py
+++ b/homeassistant/components/smarttub/binary_sensor.py
@@ -49,6 +49,8 @@ SNOOZE_REMINDER_SCHEMA: VolDictType = {
     )
 }
 
+PARALLEL_UPDATES = 0
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/homeassistant/components/smarttub/climate.py
+++ b/homeassistant/components/smarttub/climate.py
@@ -40,6 +40,8 @@ HVAC_ACTIONS = {
     "ON": HVACAction.HEATING,
 }
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/smarttub/entity.py
+++ b/homeassistant/components/smarttub/entity.py
@@ -17,6 +17,8 @@ from .helpers import get_spa_name
 class SmartTubEntity(CoordinatorEntity):
     """Base class for SmartTub entities."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[dict[str, Any]],
@@ -36,9 +38,9 @@ class SmartTubEntity(CoordinatorEntity):
             identifiers={(DOMAIN, spa.id)},
             manufacturer=spa.brand,
             model=spa.model,
+            name=get_spa_name(spa),
         )
-        spa_name = get_spa_name(self.spa)
-        self._attr_name = f"{spa_name} {entity_name}"
+        self._attr_name = entity_name
 
     @property
     def spa_status(self) -> SpaState:
@@ -77,12 +79,13 @@ class SmartTubExternalSensorBase(SmartTubEntity):
         sensor: SpaSensor,
     ) -> None:
         """Initialize the external sensor entity."""
+        super().__init__(coordinator, spa, self._human_readable_name(sensor))
         self.sensor_address = sensor.address
         self._attr_unique_id = f"{spa.id}-externalsensor-{sensor.address}"
-        super().__init__(coordinator, spa, self._human_readable_name(sensor))
 
     @staticmethod
     def _human_readable_name(sensor: SpaSensor) -> str:
+        """Return a human-readable name for the sensor."""
         return " ".join(
             word.capitalize() for word in sensor.name.strip("{}").split("-")
         )

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -19,7 +19,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import ATTR_LIGHTS, DEFAULT_LIGHT_BRIGHTNESS, DEFAULT_LIGHT_EFFECT
 from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
-from .helpers import get_spa_name
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -54,8 +55,7 @@ class SmartTubLight(SmartTubEntity, LightEntity):
         super().__init__(coordinator, light.spa, "light")
         self.light_zone = light.zone
         self._attr_unique_id = f"{super().unique_id}-{light.zone}"
-        spa_name = get_spa_name(self.spa)
-        self._attr_name = f"{spa_name} Light {light.zone}"
+        self._attr_name = f"Light {light.zone}"
 
     @property
     def light(self) -> SpaLight:

--- a/homeassistant/components/smarttub/quality_scale.yaml
+++ b/homeassistant/components/smarttub/quality_scale.yaml
@@ -1,0 +1,74 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency: done
+  docs-actions: todo
+  docs-high-level-description: todo
+  docs-installation-instructions: todo
+  docs-removal-instructions: todo
+  entity-event-setup:
+    status: exempt
+    comment: Entities use coordinator polling, no explicit event subscriptions.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration does not have configuration parameters.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery:
+    status: exempt
+    comment: This is a cloud-only service with no local discovery mechanism.
+  discovery-update-info:
+    status: exempt
+    comment: This is a cloud-only service with no local discovery mechanism.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: Spa devices are fixed to the account and cannot be dynamically added or removed.
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: done
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: This integration does not raise any repairable issues.
+  stale-devices:
+    status: exempt
+    comment: Spa devices are fixed to the account and cannot be removed.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -33,6 +33,8 @@ SET_PRIMARY_FILTRATION_SCHEMA = vol.All(
     ),
 )
 
+PARALLEL_UPDATES = 0
+
 SET_SECONDARY_FILTRATION_SCHEMA: VolDictType = {
     vol.Required(ATTR_MODE): vol.In(
         {

--- a/homeassistant/components/smarttub/strings.json
+++ b/homeassistant/components/smarttub/strings.json
@@ -9,6 +9,14 @@
     },
     "step": {
       "reauth_confirm": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "[%key:component::smarttub::config::step::user::data_description::email%]",
+          "password": "[%key:component::smarttub::config::step::user::data_description::password%]"
+        },
         "description": "The SmartTub integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
@@ -16,6 +24,10 @@
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "The email address associated with your SmartTub account.",
+          "password": "The password for your SmartTub account."
         },
         "description": "Enter your SmartTub email address and password to log in",
         "title": "Login"

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -13,7 +13,8 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import API_TIMEOUT, ATTR_PUMPS
 from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
-from .helpers import get_spa_name
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -54,12 +55,11 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
     @property
     def name(self) -> str:
         """Return a name for this pump entity."""
-        spa_name = get_spa_name(self.spa)
         if self.pump_type == SpaPump.PumpType.CIRCULATION:
-            return f"{spa_name} Circulation Pump"
+            return "Circulation Pump"
         if self.pump_type == SpaPump.PumpType.JET:
-            return f"{spa_name} Jet {self.pump_id}"
-        return f"{spa_name} pump {self.pump_id}"
+            return f"Jet {self.pump_id}"
+        return f"Pump {self.pump_id}"
 
     @property
     def is_on(self) -> bool:

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -877,7 +877,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "sma",
     "smappee",
     "smart_meter_texas",
-    "smarttub",
     "smarty",
     "smhi",
     "sms",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Begin working toward Bronze quality scale compliance for the SmartTub integration:

- Add `_attr_has_entity_name = True` to all entities, using the device name as prefix instead of manual name construction in each entity
- Add `quality_scale.yaml` tracking the status of all integration quality scale rules
- Add `PARALLEL_UPDATES = 0` to all platform files (coordinator-based, no serialization needed)
- Add `data_description` entries for config flow steps (now required by the framework)
- Fix `SmartTubExternalSensorBase` unique_id being overwritten by parent `__init__` (was set before `super().__init__()` which then overwrote it)
- Remove `smarttub` from the hassfest `INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE` list

Entity IDs are unchanged since the device name + entity name pattern produces the same slugified result as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr