### PR TITLE
Use has_entity_name in SmartTub entities

### DIFF
--- a/homeassistant/components/smarttub/binary_sensor.py
+++ b/homeassistant/components/smarttub/binary_sensor.py
@@ -98,6 +98,7 @@ class SmartTubOnline(SmartTubOnboardSensorBase, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     # This seems to be very noisy and not generally useful, so disable by default.
     _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "online"
 
     def __init__(
         self, coordinator: DataUpdateCoordinator[dict[str, Any]], spa: Spa
@@ -115,6 +116,7 @@ class SmartTubReminder(SmartTubEntity, BinarySensorEntity):
     """Reminders for maintenance actions."""
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "reminder"
 
     def __init__(
         self,
@@ -130,6 +132,9 @@ class SmartTubReminder(SmartTubEntity, BinarySensorEntity):
         )
         self.reminder_id = reminder.id
         self._attr_unique_id = f"{spa.id}-reminder-{reminder.id}"
+        self._attr_translation_placeholders = {
+            "reminder_name": reminder.name.title(),
+        }
 
     @property
     def reminder(self) -> SpaReminder:
@@ -167,6 +172,7 @@ class SmartTubError(SmartTubEntity, BinarySensorEntity):
     """
 
     _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_translation_key = "error"
 
     def __init__(
         self, coordinator: DataUpdateCoordinator[dict[str, Any]], spa: Spa
@@ -211,6 +217,7 @@ class SmartTubCoverSensor(SmartTubExternalSensorBase, BinarySensorEntity):
     """Wireless magnetic cover sensor."""
 
     _attr_device_class = BinarySensorDeviceClass.OPENING
+    _attr_translation_key = "cover_sensor"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/smarttub/climate.py
+++ b/homeassistant/components/smarttub/climate.py
@@ -72,6 +72,7 @@ class SmartTubThermostat(SmartTubEntity, ClimateEntity):
     _attr_min_temp = DEFAULT_MIN_TEMP
     _attr_max_temp = DEFAULT_MAX_TEMP
     _attr_preset_modes = list(PRESET_MODES.values())
+    _attr_translation_key = "thermostat"
 
     def __init__(
         self, coordinator: DataUpdateCoordinator[dict[str, Any]], spa: Spa

--- a/homeassistant/components/smarttub/entity.py
+++ b/homeassistant/components/smarttub/entity.py
@@ -17,6 +17,8 @@ from .helpers import get_spa_name
 class SmartTubEntity(CoordinatorEntity):
     """Base class for SmartTub entities."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[dict[str, Any]],
@@ -36,9 +38,9 @@ class SmartTubEntity(CoordinatorEntity):
             identifiers={(DOMAIN, spa.id)},
             manufacturer=spa.brand,
             model=spa.model,
+            name=get_spa_name(spa),
         )
-        spa_name = get_spa_name(self.spa)
-        self._attr_name = f"{spa_name} {entity_name}"
+        self._attr_name = entity_name
 
     @property
     def spa_status(self) -> SpaState:
@@ -77,12 +79,13 @@ class SmartTubExternalSensorBase(SmartTubEntity):
         sensor: SpaSensor,
     ) -> None:
         """Initialize the external sensor entity."""
+        super().__init__(coordinator, spa, self._human_readable_name(sensor))
         self.sensor_address = sensor.address
         self._attr_unique_id = f"{spa.id}-externalsensor-{sensor.address}"
-        super().__init__(coordinator, spa, self._human_readable_name(sensor))
 
     @staticmethod
     def _human_readable_name(sensor: SpaSensor) -> str:
+        """Return a human-readable name for the sensor."""
         return " ".join(
             word.capitalize() for word in sensor.name.strip("{}").split("-")
         )

--- a/homeassistant/components/smarttub/entity.py
+++ b/homeassistant/components/smarttub/entity.py
@@ -40,7 +40,6 @@ class SmartTubEntity(CoordinatorEntity):
             model=spa.model,
             name=get_spa_name(spa),
         )
-        self._attr_name = entity_name
 
     @property
     def spa_status(self) -> SpaState:
@@ -72,6 +71,8 @@ class SmartTubOnboardSensorBase(SmartTubEntity):
 class SmartTubExternalSensorBase(SmartTubEntity):
     """Class for additional BLE wireless sensors sold separately."""
 
+    _attr_translation_key = "external_sensor"
+
     def __init__(
         self,
         coordinator: DataUpdateCoordinator[dict[str, Any]],
@@ -79,9 +80,17 @@ class SmartTubExternalSensorBase(SmartTubEntity):
         sensor: SpaSensor,
     ) -> None:
         """Initialize the external sensor entity."""
-        super().__init__(coordinator, spa, self._human_readable_name(sensor))
+        super().__init__(coordinator, spa, self._sensor_key(sensor))
         self.sensor_address = sensor.address
         self._attr_unique_id = f"{spa.id}-externalsensor-{sensor.address}"
+        self._attr_translation_placeholders = {
+            "sensor_name": self._human_readable_name(sensor),
+        }
+
+    @staticmethod
+    def _sensor_key(sensor: SpaSensor) -> str:
+        """Return a key for the sensor suitable for unique_id generation."""
+        return sensor.name.strip("{}").replace("-", "_")
 
     @staticmethod
     def _human_readable_name(sensor: SpaSensor) -> str:

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -53,7 +53,9 @@ class SmartTubLight(SmartTubEntity, LightEntity):
         super().__init__(coordinator, light.spa, "light")
         self.light_zone = light.zone
         self._attr_unique_id = f"{super().unique_id}-{light.zone}"
-        self._attr_name = f"Light {light.zone}"
+        del self._attr_name
+        self._attr_translation_key = "light_zone"
+        self._attr_translation_placeholders = {"zone": str(light.zone)}
 
     @property
     def light(self) -> SpaLight:

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -53,6 +53,7 @@ class SmartTubLight(SmartTubEntity, LightEntity):
         super().__init__(coordinator, light.spa, "light")
         self.light_zone = light.zone
         self._attr_unique_id = f"{super().unique_id}-{light.zone}"
+        # Remove _attr_name set by base class so translation_key takes effect
         del self._attr_name
         self._attr_translation_key = "light_zone"
         self._attr_translation_placeholders = {"zone": str(light.zone)}

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -53,8 +53,6 @@ class SmartTubLight(SmartTubEntity, LightEntity):
         super().__init__(coordinator, light.spa, "light")
         self.light_zone = light.zone
         self._attr_unique_id = f"{super().unique_id}-{light.zone}"
-        # Remove _attr_name set by base class so translation_key takes effect
-        del self._attr_name
         self._attr_translation_key = "light_zone"
         self._attr_translation_placeholders = {"zone": str(light.zone)}
 

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -21,7 +21,6 @@ from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
 
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: SmartTubConfigEntry,

--- a/homeassistant/components/smarttub/light.py
+++ b/homeassistant/components/smarttub/light.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import ATTR_LIGHTS, DEFAULT_LIGHT_BRIGHTNESS, DEFAULT_LIGHT_EFFECT
 from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
-from .helpers import get_spa_name
+
 
 
 async def async_setup_entry(
@@ -54,8 +54,7 @@ class SmartTubLight(SmartTubEntity, LightEntity):
         super().__init__(coordinator, light.spa, "light")
         self.light_zone = light.zone
         self._attr_unique_id = f"{super().unique_id}-{light.zone}"
-        spa_name = get_spa_name(self.spa)
-        self._attr_name = f"{spa_name} Light {light.zone}"
+        self._attr_name = f"Light {light.zone}"
 
     @property
     def light(self) -> SpaLight:

--- a/homeassistant/components/smarttub/sensor.py
+++ b/homeassistant/components/smarttub/sensor.py
@@ -93,6 +93,17 @@ async def async_setup_entry(
 class SmartTubBuiltinSensor(SmartTubOnboardSensorBase, SensorEntity):
     """Generic class for SmartTub status sensors."""
 
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[dict[str, Any]],
+        spa: smarttub.Spa,
+        sensor_name: str,
+        state_key: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator, spa, sensor_name, state_key)
+        self._attr_translation_key = state_key
+
     @property
     def native_value(self) -> str | None:
         """Return the current state of the sensor."""
@@ -115,6 +126,7 @@ class SmartTubPrimaryFiltrationCycle(SmartTubBuiltinSensor):
         super().__init__(
             coordinator, spa, "Primary Filtration Cycle", "primary_filtration"
         )
+        self._attr_translation_key = "primary_filtration_cycle"
 
     @property
     def cycle(self) -> smarttub.SpaPrimaryFiltrationCycle:
@@ -155,6 +167,7 @@ class SmartTubSecondaryFiltrationCycle(SmartTubBuiltinSensor):
         super().__init__(
             coordinator, spa, "Secondary Filtration Cycle", "secondary_filtration"
         )
+        self._attr_translation_key = "secondary_filtration_cycle"
 
     @property
     def cycle(self) -> smarttub.SpaSecondaryFiltrationCycle:

--- a/homeassistant/components/smarttub/strings.json
+++ b/homeassistant/components/smarttub/strings.json
@@ -23,9 +23,54 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "cover_sensor": {
+        "name": "Cover sensor"
+      },
+      "error": {
+        "name": "Error"
+      },
+      "online": {
+        "name": "Online"
+      },
+      "reminder": {
+        "name": "{reminder_name} reminder"
+      }
+    },
+    "climate": {
+      "thermostat": {
+        "name": "Thermostat"
+      }
+    },
     "light": {
       "light_zone": {
         "name": "Light {zone}"
+      }
+    },
+    "sensor": {
+      "blowout_cycle": {
+        "name": "Blowout cycle"
+      },
+      "cleanup_cycle": {
+        "name": "Cleanup cycle"
+      },
+      "flow_switch": {
+        "name": "Flow switch"
+      },
+      "ozone": {
+        "name": "Ozone"
+      },
+      "primary_filtration_cycle": {
+        "name": "Primary filtration cycle"
+      },
+      "secondary_filtration_cycle": {
+        "name": "Secondary filtration cycle"
+      },
+      "state": {
+        "name": "State"
+      },
+      "uv": {
+        "name": "UV"
       }
     },
     "switch": {

--- a/homeassistant/components/smarttub/strings.json
+++ b/homeassistant/components/smarttub/strings.json
@@ -22,6 +22,24 @@
       }
     }
   },
+  "entity": {
+    "light": {
+      "light_zone": {
+        "name": "Light {zone}"
+      }
+    },
+    "switch": {
+      "circulation_pump": {
+        "name": "Circulation pump"
+      },
+      "jet": {
+        "name": "Jet {pump_id}"
+      },
+      "pump": {
+        "name": "Pump {pump_id}"
+      }
+    }
+  },
   "services": {
     "reset_reminder": {
       "description": "Resets the maintenance reminder on a hot tub.",

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -44,8 +44,6 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
         self.pump_id = pump.id
         self.pump_type = pump.type
         self._attr_unique_id = f"{super().unique_id}-{pump.id}"
-        # Remove _attr_name set by base class so translation_key takes effect
-        del self._attr_name
         if pump.type == SpaPump.PumpType.CIRCULATION:
             self._attr_translation_key = "circulation_pump"
         elif pump.type == SpaPump.PumpType.JET:

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -15,7 +15,6 @@ from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
 
 
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: SmartTubConfigEntry,

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -44,20 +44,20 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
         self.pump_id = pump.id
         self.pump_type = pump.type
         self._attr_unique_id = f"{super().unique_id}-{pump.id}"
+        del self._attr_name
+        if pump.type == SpaPump.PumpType.CIRCULATION:
+            self._attr_translation_key = "circulation_pump"
+        elif pump.type == SpaPump.PumpType.JET:
+            self._attr_translation_key = "jet"
+            self._attr_translation_placeholders = {"pump_id": str(pump.id)}
+        else:
+            self._attr_translation_key = "pump"
+            self._attr_translation_placeholders = {"pump_id": str(pump.id)}
 
     @property
     def pump(self) -> SpaPump:
         """Return the underlying SpaPump object for this entity."""
         return self.coordinator.data[self.spa.id][ATTR_PUMPS][self.pump_id]
-
-    @property
-    def name(self) -> str:
-        """Return a name for this pump entity."""
-        if self.pump_type == SpaPump.PumpType.CIRCULATION:
-            return "Circulation Pump"
-        if self.pump_type == SpaPump.PumpType.JET:
-            return f"Jet {self.pump_id}"
-        return f"Pump {self.pump_id}"
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -44,6 +44,7 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
         self.pump_id = pump.id
         self.pump_type = pump.type
         self._attr_unique_id = f"{super().unique_id}-{pump.id}"
+        # Remove _attr_name set by base class so translation_key takes effect
         del self._attr_name
         if pump.type == SpaPump.PumpType.CIRCULATION:
             self._attr_translation_key = "circulation_pump"

--- a/homeassistant/components/smarttub/switch.py
+++ b/homeassistant/components/smarttub/switch.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import API_TIMEOUT, ATTR_PUMPS
 from .controller import SmartTubConfigEntry
 from .entity import SmartTubEntity
-from .helpers import get_spa_name
+
 
 
 async def async_setup_entry(
@@ -54,12 +54,11 @@ class SmartTubPump(SmartTubEntity, SwitchEntity):
     @property
     def name(self) -> str:
         """Return a name for this pump entity."""
-        spa_name = get_spa_name(self.spa)
         if self.pump_type == SpaPump.PumpType.CIRCULATION:
-            return f"{spa_name} Circulation Pump"
+            return "Circulation Pump"
         if self.pump_type == SpaPump.PumpType.JET:
-            return f"{spa_name} Jet {self.pump_id}"
-        return f"{spa_name} pump {self.pump_id}"
+            return f"Jet {self.pump_id}"
+        return f"Pump {self.pump_id}"
 
     @property
     def is_on(self) -> bool:

--- a/tests/components/smarttub/test_binary_sensor.py
+++ b/tests/components/smarttub/test_binary_sensor.py
@@ -109,7 +109,7 @@ async def test_reset_reminder(spa, setup_entry, hass: HomeAssistant) -> None:
 async def test_cover_sensor(hass: HomeAssistant, spa, setup_entry) -> None:
     """Test cover sensor."""
 
-    entity_id = f"binary_sensor.{spa.brand}_{spa.model}_cover_sensor_1"
+    entity_id = f"binary_sensor.{spa.brand}_{spa.model}_cover_sensor"
 
     state = hass.states.get(entity_id)
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Set `_attr_has_entity_name = True` in the `SmartTubEntity` base class. Move the device name into `DeviceInfo` and simplify entity names to only contain the entity-specific part (e.g. "Light 1" instead of "My Spa Light 1"). This follows the Home Assistant entity naming guidelines.

Also fix the initialization order in `SmartTubExternalSensorBase` so that `super().__init__` is called before overriding `_attr_unique_id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code I am submitting and can explain how it works.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Made with [Cursor](https://cursor.com)