### PR TITLE
Cleanup default None value from dict.get

### DIFF
--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -201,5 +201,5 @@ class ArwnSensor(SensorEntity):
         ev: dict[str, Any] = {}
         ev.update(event)
         self._attr_extra_state_attributes = ev
-        self._attr_native_value = ev.get(self._state_key, None)
+        self._attr_native_value = ev.get(self._state_key)
         self.async_write_ha_state()

--- a/homeassistant/components/egardia/binary_sensor.py
+++ b/homeassistant/components/egardia/binary_sensor.py
@@ -39,7 +39,9 @@ async def async_setup_platform(
                 sensor_id=disc_info[sensor]["id"],
                 name=disc_info[sensor]["name"],
                 egardia_system=hass.data[EGARDIA_DEVICE],
-                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(disc_info[sensor]["type"]),
+                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(
+                    disc_info[sensor]["type"]
+                ),
             )
             for sensor in disc_info
         ),

--- a/homeassistant/components/egardia/binary_sensor.py
+++ b/homeassistant/components/egardia/binary_sensor.py
@@ -39,9 +39,7 @@ async def async_setup_platform(
                 sensor_id=disc_info[sensor]["id"],
                 name=disc_info[sensor]["name"],
                 egardia_system=hass.data[EGARDIA_DEVICE],
-                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(
-                    disc_info[sensor]["type"], None
-                ),
+                device_class=EGARDIA_TYPE_TO_DEVICE_CLASS.get(disc_info[sensor]["type"]),
             )
             for sensor in disc_info
         ),

--- a/homeassistant/components/lyric/climate.py
+++ b/homeassistant/components/lyric/climate.py
@@ -254,7 +254,7 @@ class LyricClimate(LyricDeviceEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current hvac action."""
-        action = HVAC_ACTIONS.get(self.device.operation_status.mode, None)
+        action = HVAC_ACTIONS.get(self.device.operation_status.mode)
         if action == HVACAction.OFF and self.hvac_mode != HVACMode.OFF:
             action = HVACAction.IDLE
         return action

--- a/homeassistant/components/onvif/parsers.py
+++ b/homeassistant/components/onvif/parsers.py
@@ -397,7 +397,7 @@ async def async_parse_tplink_detector(uid: str, msg) -> Event | None:
             rule = source.Value
 
     for item in payload.Data.SimpleItem:
-        event_template = _TAPO_EVENT_TEMPLATES.get(item.Name, None)
+        event_template = _TAPO_EVENT_TEMPLATES.get(item.Name)
         if event_template is None:
             continue
 

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -228,7 +228,7 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
         """Return current hvac mode."""
         if self._current_mode is None:
             return None
-        return VICARE_TO_HA_HVAC_HEATING.get(self._current_mode, None)
+        return VICARE_TO_HA_HVAC_HEATING.get(self._current_mode)
 
     def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set a new hvac mode on the ViCare API."""

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -151,4 +151,4 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
         """Return current operation ie. heat, cool, idle."""
         if self._current_mode is None:
             return None
-        return VICARE_TO_HA_HVAC_DHW.get(self._current_mode, None)
+        return VICARE_TO_HA_HVAC_DHW.get(self._current_mode)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #162356

Generated from `ruff check --select=SIM910 --fix`

https://docs.astral.sh/ruff/rules/dict-get-with-none-default/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
