### PR TITLE
Improve device information in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -160,10 +160,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, gateway.id)},
-            model=gateway.sub_type.beautify_name if gateway.sub_type else None,
+            model=gateway.type.beautify_name if gateway.type else None,
+            model_id=str(gateway.type),
             manufacturer=client.server.manufacturer,
             name=gateway.type.beautify_name if gateway.type else gateway.id,
             sw_version=gateway.connectivity.protocol_version,
+            hw_version=f"{gateway.type}:{gateway.sub_type}"
+            if gateway.type and gateway.sub_type
+            else None,
             configuration_url=client.server.configuration_url,
         )
 

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -82,7 +82,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
                 OverkizState.CORE_PRODUCT_MODEL_NAME,
                 OverkizState.IO_MODEL,
             )
-            or self.device.widget.value
+            or self.device.ui_class.value
         )
 
         suggested_area = (
@@ -100,6 +100,7 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
                 str,
                 self.executor.select_attribute(OverkizAttribute.CORE_FIRMWARE_REVISION),
             ),
+            model_id=self.device.widget,
             hw_version=self.device.controllable_name,
             suggested_area=suggested_area,
             via_device=(DOMAIN, self.executor.get_gateway_id()),

--- a/tests/components/overkiz/snapshots/test_diagnostics.ambr
+++ b/tests/components/overkiz/snapshots/test_diagnostics.ambr
@@ -6,7 +6,7 @@
       'controllable_name': 'rts:RollerShutterRTSComponent',
       'device_url': 'rts://****-****-6867/16756006',
       'firmware': None,
-      'model': 'UpDownRollerShutter',
+      'model': 'RollerShutter',
     }),
     'execution_history': list([
     ]),


### PR DESCRIPTION
## Proposed change
With the launch of the device database, I had a closer look to the entity setup for Overkiz. At the moment we are not exposing all information for the device and for the gateway we were only providing the subtype and not the type.

### Gateway

| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/2fb58d4b-ef4b-4509-9ee2-de67180f2e0e" width="500"/> | <img src="https://github.com/user-attachments/assets/a972cc47-6fce-496e-98f2-9e0e5fa1f5fc" width="500"/> |

Change:
- Change model to the GatewayType instead of the GatewaySubType (https://github.com/iMicknl/python-overkiz-api/blob/f3f867c605c86e23ea1c3e6e0e6b30bbf433b63f/pyoverkiz/enums/gateway.py#L89). GatewaySubType is not relevant here.
- Set model id to the value (int) of the GatewayType
- Add a concatenation of GatewayType + GatewaySubType as the hardware version 

---

### Device

| Before | After |
|-------|-------|
| <img src="https://github.com/user-attachments/assets/c0f03b6a-852a-4904-bea5-7cb930c5f440" width="500"/> | <img src="https://github.com/user-attachments/assets/95114e48-fd4d-4ff2-b684-5f7a2c8ad338" width="500"/> |

- Change the model to use the more generic `ui_class` instead of the `widget`
- Add the specific `widget` as the Model Id

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
