### PR TITLE
Make bad entity ID detection more lenient

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -829,7 +829,7 @@ class EntityPlatform:
                         "In most cases, entities should not set entity_id,"
                         " but if they do, it should be a valid entity ID.",
                         integration_domain=self.platform_name,
-                        breaks_in_ha_version="2026.8.0",
+                        breaks_in_ha_version="2027.2.0",
                     )
                 else:
                     entity.add_to_platform_abort()

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -42,6 +42,7 @@ from . import device_registry as dr, entity_registry as er, service, translation
 from .deprecation import deprecated_function
 from .entity_registry import EntityRegistry, RegistryEntryDisabler, RegistryEntryHider
 from .event import async_call_later
+from .frame import report_usage
 from .issue_registry import IssueSeverity, async_create_issue
 from .typing import UNDEFINED, ConfigType, DiscoveryInfoType, VolDictType, VolSchemaType
 
@@ -822,13 +823,28 @@ class EntityPlatform:
         # An entity may suggest the entity_id by setting entity_id itself
         if not hasattr(entity, "internal_integration_suggested_object_id"):
             if entity.entity_id is not None and not valid_entity_id(entity.entity_id):
+                if entity.unique_id is not None:
+                    report_usage(
+                        f"sets an invalid entity ID: '{entity.entity_id}'. "
+                        "In most cases, entities should not set entity_id,"
+                        " but if they do, it should be a valid entity ID.",
+                        integration_domain=self.platform_name,
+                        breaks_in_ha_version="2026.8.0",
+                    )
+                else:
+                    entity.add_to_platform_abort()
+                    raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
+            try:
+                entity.internal_integration_suggested_object_id = (
+                    split_entity_id(entity.entity_id)[1]
+                    if entity.entity_id is not None
+                    else None
+                )
+            except ValueError:
                 entity.add_to_platform_abort()
-                raise HomeAssistantError(f"Invalid entity ID: {entity.entity_id}")
-            entity.internal_integration_suggested_object_id = (
-                split_entity_id(entity.entity_id)[1]
-                if entity.entity_id is not None
-                else None
-            )
+                raise HomeAssistantError(
+                    f"Invalid entity ID: {entity.entity_id}"
+                ) from None
 
         # Get entity_id from unique ID registration
         if entity.unique_id is not None:

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1967,6 +1967,7 @@ async def test_invalid_entity_id(
     assert entity.hass is None
     assert entity.platform is None
     assert "Invalid entity ID: invalid_entity_id" in caplog.text
+
     # Ensure the valid entity was still added
     assert entity2.hass is not None
     assert entity2.platform is not None
@@ -1977,7 +1978,7 @@ async def test_invalid_entity_id_report_usage(
 ) -> None:
     """Test that setting an invalid entity_id reports usage."""
     platform = MockEntityPlatform(hass)
-    entity = MockEntity(entity_id="invalid_entity_id", unique_id="unique")
+    entity = MockEntity(entity_id="test_domain.INVALID-ENTITY-ID", unique_id="unique")
 
     mock_integration = Mock(is_built_in=True, domain="test_platform")
     with (
@@ -1991,8 +1992,12 @@ async def test_invalid_entity_id_report_usage(
 
     assert (
         "Detected that integration 'test_platform' "
-        "sets an invalid entity ID: 'invalid_entity_id'"
+        "sets an invalid entity ID: 'test_domain.INVALID-ENTITY-ID'"
     ) in caplog.text
+
+    # Ensure the valid entity was still added
+    assert entity.hass is not None
+    assert entity.platform is not None
 
 
 class MockBlockingEntity(MockEntity):

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1972,6 +1972,29 @@ async def test_invalid_entity_id(
     assert entity2.platform is not None
 
 
+async def test_invalid_entity_id_report_usage(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that setting an invalid entity_id reports usage."""
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(entity_id="invalid_entity_id", unique_id="unique")
+
+    mock_integration = Mock(is_built_in=True, domain="test_platform")
+    with (
+        caplog.at_level(logging.WARNING),
+        patch(
+            "homeassistant.helpers.frame.async_get_issue_integration",
+            return_value=mock_integration,
+        ),
+    ):
+        await platform.async_add_entities([entity])
+
+    assert (
+        "Detected that integration 'test_platform' "
+        "sets an invalid entity ID: 'invalid_entity_id'"
+    ) in caplog.text
+
+
 class MockBlockingEntity(MockEntity):
     """Class to mock an entity that will block adding entities."""
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1995,7 +1995,7 @@ async def test_invalid_entity_id_report_usage(
         "sets an invalid entity ID: 'test_domain.INVALID-ENTITY-ID'"
     ) in caplog.text
 
-    # Ensure the valid entity was still added
+    # Ensure the entity was still added
     assert entity.hass is not None
     assert entity.platform is not None
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make bad entity ID detection more lenient.

Prior to #160302, bad entity IDs were mistakenly accepted in the code path with `unique_id` set. This was intentionally fixed in that PR, but the impact turned out to be bigger than expected, as many custom integrations seem to set `entity_id` for no good reason (and do it incorrectly).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162345
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
