### PR TITLE
2026.2.1

### DIFF
--- a/homeassistant/components/alexa_devices/manifest.json
+++ b/homeassistant/components/alexa_devices/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aioamazondevices"],
   "quality_scale": "platinum",
-  "requirements": ["aioamazondevices==11.1.1"]
+  "requirements": ["aioamazondevices==11.1.3"]
 }

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -26,10 +26,9 @@ from homeassistant.const import (
     UnitOfVolumetricFlux,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import AmbientStation, AmbientStationConfigEntry
+from . import AmbientStationConfigEntry
 from .const import ATTR_LAST_DATA, TYPE_SOLARRADIATION, TYPE_SOLARRADIATION_LX
 from .entity import AmbientWeatherEntity
 
@@ -682,22 +681,6 @@ async def async_setup_entry(
 
 class AmbientWeatherSensor(AmbientWeatherEntity, SensorEntity):
     """Define an Ambient sensor."""
-
-    def __init__(
-        self,
-        ambient: AmbientStation,
-        mac_address: str,
-        station_name: str,
-        description: EntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(ambient, mac_address, station_name, description)
-
-        if description.key == TYPE_SOLARRADIATION_LX:
-            # Since TYPE_SOLARRADIATION and TYPE_SOLARRADIATION_LX will have the same
-            # name in the UI, we influence the entity ID of TYPE_SOLARRADIATION_LX here
-            # to differentiate them:
-            self.entity_id = f"sensor.{station_name}_solar_rad_lx"
 
     @callback
     def update_from_latest_data(self) -> None:

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["denonavr"],
-  "requirements": ["denonavr==1.3.1"],
+  "requirements": ["denonavr==1.3.2"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -17,6 +17,7 @@ from denonavr.const import (
     STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_STOPPED,
 )
 from denonavr.exceptions import (
     AvrCommandError,
@@ -103,6 +104,7 @@ DENON_STATE_MAPPING = {
     STATE_OFF: MediaPlayerState.OFF,
     STATE_PLAYING: MediaPlayerState.PLAYING,
     STATE_PAUSED: MediaPlayerState.PAUSED,
+    STATE_STOPPED: MediaPlayerState.IDLE,
 }
 
 

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "quality_scale": "platinum",
-  "requirements": ["pyenphase==2.4.3"],
+  "requirements": ["pyenphase==2.4.5"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@zxdavb"],
   "documentation": "https://www.home-assistant.io/integrations/evohome",
   "iot_class": "cloud_polling",
-  "loggers": ["evohome", "evohomeasync", "evohomeasync2"],
+  "loggers": ["evohomeasync", "evohomeasync2"],
   "quality_scale": "legacy",
-  "requirements": ["evohome-async==1.0.6"]
+  "requirements": ["evohome-async==1.1.3"]
 }

--- a/homeassistant/components/google_air_quality/manifest.json
+++ b/homeassistant/components/google_air_quality/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["google_air_quality_api"],
   "quality_scale": "bronze",
-  "requirements": ["google_air_quality_api==3.0.0"]
+  "requirements": ["google_air_quality_api==3.0.1"]
 }

--- a/homeassistant/components/libre_hardware_monitor/manifest.json
+++ b/homeassistant/components/libre_hardware_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["librehardwaremonitor-api==1.8.4"]
+  "requirements": ["librehardwaremonitor-api==1.9.1"]
 }

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -110,7 +110,7 @@ async def create_server(
         return [
             types.TextContent(
                 type="text",
-                text=json.dumps(tool_response),
+                text=json.dumps(tool_response, ensure_ascii=False),
             )
         ]
 

--- a/homeassistant/components/nintendo_parental_controls/manifest.json
+++ b/homeassistant/components/nintendo_parental_controls/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pynintendoauth", "pynintendoparental"],
   "quality_scale": "bronze",
-  "requirements": ["pynintendoauth==1.0.2", "pynintendoparental==2.3.2"]
+  "requirements": ["pynintendoauth==1.0.2", "pynintendoparental==2.3.2.1"]
 }

--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -104,7 +104,6 @@ class RpcLinkedgoThermostatClimate(ShellyRpcAttributeEntity, ClimateEntity):
         )
 
         config = coordinator.device.config
-        self._status = coordinator.device.status
 
         self._attr_min_temp = config[key]["min"]
         self._attr_max_temp = config[key]["max"]
@@ -141,6 +140,11 @@ class RpcLinkedgoThermostatClimate(ShellyRpcAttributeEntity, ClimateEntity):
             self._attr_hvac_modes = [HVACMode.OFF] + [
                 THERMOSTAT_TO_HA_MODE[mode] for mode in modes
             ]
+
+    @property
+    def _status(self) -> dict[str, Any]:
+        """Return the full device status."""
+        return self.coordinator.device.status
 
     @property
     def current_humidity(self) -> float | None:

--- a/homeassistant/components/smarttub/manifest.json
+++ b/homeassistant/components/smarttub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/smarttub",
   "iot_class": "cloud_polling",
   "loggers": ["smarttub"],
-  "requirements": ["python-smarttub==0.0.46"]
+  "requirements": ["python-smarttub==0.0.47"]
 }

--- a/homeassistant/components/smarttub/strings.json
+++ b/homeassistant/components/smarttub/strings.json
@@ -9,6 +9,14 @@
     },
     "step": {
       "reauth_confirm": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "[%key:component::smarttub::config::step::user::data_description::email%]",
+          "password": "[%key:component::smarttub::config::step::user::data_description::password%]"
+        },
         "description": "The SmartTub integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
@@ -16,6 +24,10 @@
         "data": {
           "email": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "The email address associated with your SmartTub account",
+          "password": "The password for your SmartTub account"
         },
         "description": "Enter your SmartTub email address and password to log in",
         "title": "Login"

--- a/homeassistant/components/tesla_fleet/sensor.py
+++ b/homeassistant/components/tesla_fleet/sensor.py
@@ -436,7 +436,6 @@ ENERGY_INFO_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="vpp_backup_reserve_percent",
         entity_category=EntityCategory.DIAGNOSTIC,
-        device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
     ),
     SensorEntityDescription(key="version"),

--- a/homeassistant/components/todoist/todo.py
+++ b/homeassistant/components/todoist/todo.py
@@ -45,9 +45,9 @@ def _task_api_data(item: TodoItem, api_data: Task | None = None) -> dict[str, An
     }
     if due := item.due:
         if isinstance(due, datetime.datetime):
-            item_data["due_datetime"] = due.isoformat()
+            item_data["due_datetime"] = due
         else:
-            item_data["due_date"] = due.isoformat()
+            item_data["due_date"] = due
         # In order to not lose any recurrence metadata for the task, we need to
         # ensure that we send the `due_string` param if the task has it set.
         # NOTE: It's ok to send stale data for non-recurring tasks. Any provided

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -48,6 +48,7 @@ TUYA_HVAC_TO_HA = {
     "heat": HVACMode.HEAT,
     "hot": HVACMode.HEAT,
     "manual": HVACMode.HEAT_COOL,
+    "off": HVACMode.OFF,
     "wet": HVACMode.DRY,
     "wind": HVACMode.FAN_ONLY,
 }
@@ -442,7 +443,9 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
         if hvac_mode_wrapper:
             self._attr_hvac_modes = [HVACMode.OFF]
             for mode in hvac_mode_wrapper.options:
-                self._attr_hvac_modes.append(HVACMode(mode))
+                if mode != HVACMode.OFF:
+                    # OFF is always added first
+                    self._attr_hvac_modes.append(HVACMode(mode))
 
         elif switch_wrapper:
             self._attr_hvac_modes = [

--- a/homeassistant/components/yardian/sensor.py
+++ b/homeassistant/components/yardian/sensor.py
@@ -61,7 +61,6 @@ SENSOR_DESCRIPTIONS: tuple[YardianSensorEntityDescription, ...] = (
     YardianSensorEntityDescription(
         key="active_zone_count",
         translation_key="active_zone_count",
-        native_unit_of_measurement="zones",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda coordinator: len(coordinator.data.active_zones),
     ),

--- a/homeassistant/components/yardian/strings.json
+++ b/homeassistant/components/yardian/strings.json
@@ -38,7 +38,7 @@
     "sensor": {
       "active_zone_count": {
         "name": "Active zones",
-        "unit_of_measurement": "Zones"
+        "unit_of_measurement": "zones"
       },
       "rain_delay": {
         "name": "Rain delay"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2026
 MINOR_VERSION: Final = 2
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 13, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2026.2.0"
+version = "2026.2.1"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2597,7 +2597,7 @@ python-ripple-api==0.0.3
 python-roborock==4.8.0
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.46
+python-smarttub==0.0.47
 
 # homeassistant.components.snoo
 python-snoo==0.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2251,7 +2251,7 @@ pynina==1.0.2
 pynintendoauth==1.0.2
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==2.3.2
+pynintendoparental==2.3.2.1
 
 # homeassistant.components.nobo_hub
 pynobo==1.8.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.8.4
+librehardwaremonitor-api==1.9.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -797,7 +797,7 @@ deluge-client==1.10.2
 demetriek==1.3.0
 
 # homeassistant.components.denonavr
-denonavr==1.3.1
+denonavr==1.3.2
 
 # homeassistant.components.devialet
 devialet==1.5.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1105,7 +1105,7 @@ google-nest-sdm==9.1.2
 google-photos-library-api==0.12.1
 
 # homeassistant.components.google_air_quality
-google_air_quality_api==3.0.0
+google_air_quality_api==3.0.1
 
 # homeassistant.components.slide
 # homeassistant.components.slide_local

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2032,7 +2032,7 @@ pyegps==0.2.5
 pyemoncms==0.1.3
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.4.3
+pyenphase==2.4.5
 
 # homeassistant.components.envisalink
 pyenvisalink==4.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -938,7 +938,7 @@ eufylife-ble-client==0.1.8
 # evdev==1.6.1
 
 # homeassistant.components.evohome
-evohome-async==1.0.6
+evohome-async==1.1.3
 
 # homeassistant.components.bryant_evolution
 evolutionhttp==0.0.18

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -190,7 +190,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.5
 
 # homeassistant.components.alexa_devices
-aioamazondevices==11.1.1
+aioamazondevices==11.1.3
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -826,7 +826,7 @@ eternalegypt==0.0.18
 eufylife-ble-client==0.1.8
 
 # homeassistant.components.evohome
-evohome-async==1.0.6
+evohome-async==1.1.3
 
 # homeassistant.components.bryant_evolution
 evolutionhttp==0.0.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -981,7 +981,7 @@ google-nest-sdm==9.1.2
 google-photos-library-api==0.12.1
 
 # homeassistant.components.google_air_quality
-google_air_quality_api==3.0.0
+google_air_quality_api==3.0.1
 
 # homeassistant.components.slide
 # homeassistant.components.slide_local

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1228,7 +1228,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.8.4
+librehardwaremonitor-api==1.9.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -706,7 +706,7 @@ deluge-client==1.10.2
 demetriek==1.3.0
 
 # homeassistant.components.denonavr
-denonavr==1.3.1
+denonavr==1.3.2
 
 # homeassistant.components.devialet
 devialet==1.5.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2187,7 +2187,7 @@ python-rabbitair==0.0.8
 python-roborock==4.8.0
 
 # homeassistant.components.smarttub
-python-smarttub==0.0.46
+python-smarttub==0.0.47
 
 # homeassistant.components.snoo
 python-snoo==0.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1907,7 +1907,7 @@ pynina==1.0.2
 pynintendoauth==1.0.2
 
 # homeassistant.components.nintendo_parental_controls
-pynintendoparental==2.3.2
+pynintendoparental==2.3.2.1
 
 # homeassistant.components.nobo_hub
 pynobo==1.8.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1730,7 +1730,7 @@ pyegps==0.2.5
 pyemoncms==0.1.3
 
 # homeassistant.components.enphase_envoy
-pyenphase==2.4.3
+pyenphase==2.4.5
 
 # homeassistant.components.everlights
 pyeverlights==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -181,7 +181,7 @@ aioairzone-cloud==0.7.2
 aioairzone==1.0.5
 
 # homeassistant.components.alexa_devices
-aioamazondevices==11.1.1
+aioamazondevices==11.1.3
 
 # homeassistant.components.ambient_network
 # homeassistant.components.ambient_station

--- a/tests/components/evohome/conftest.py
+++ b/tests/components/evohome/conftest.py
@@ -168,7 +168,7 @@ async def setup_evohome(
             "evohomeasync2.auth.CredentialsManagerBase._post_request",
             mock_post_request(install),
         ),
-        patch("evohome.auth.AbstractAuth._make_request", mock_make_request(install)),
+        patch("_evohome.auth.AbstractAuth._make_request", mock_make_request(install)),
     ):
         evo: EvohomeClient | None = None
 

--- a/tests/components/evohome/test_init.py
+++ b/tests/components/evohome/test_init.py
@@ -31,13 +31,9 @@ _MSG_USR = (
     "special characters accepted via the vendor's website are not valid here."
 )
 
-LOG_HINT_429_CREDS = ("evohome.credentials", logging.ERROR, _MSG_429)
-LOG_HINT_OTH_CREDS = ("evohome.credentials", logging.ERROR, _MSG_OTH)
-LOG_HINT_USR_CREDS = ("evohome.credentials", logging.ERROR, _MSG_USR)
-
-LOG_HINT_429_AUTH = ("evohome.auth", logging.ERROR, _MSG_429)
-LOG_HINT_OTH_AUTH = ("evohome.auth", logging.ERROR, _MSG_OTH)
-LOG_HINT_USR_AUTH = ("evohome.auth", logging.ERROR, _MSG_USR)
+LOG_HINT_429_AUTH = ("evohomeasync2.auth", logging.ERROR, _MSG_429)
+LOG_HINT_OTH_AUTH = ("evohomeasync2.auth", logging.ERROR, _MSG_OTH)
+LOG_HINT_USR_AUTH = ("evohomeasync2.auth", logging.ERROR, _MSG_USR)
 
 LOG_FAIL_CONNECTION = (
     "homeassistant.components.evohome",
@@ -110,10 +106,10 @@ EXC_BAD_GATEWAY = aiohttp.ClientResponseError(
 )
 
 AUTHENTICATION_TESTS: dict[Exception, list] = {
-    EXC_BAD_CONNECTION: [LOG_HINT_OTH_CREDS, LOG_FAIL_CONNECTION, LOG_SETUP_FAILED],
-    EXC_BAD_CREDENTIALS: [LOG_HINT_USR_CREDS, LOG_FAIL_CREDENTIALS, LOG_SETUP_FAILED],
-    EXC_BAD_GATEWAY: [LOG_HINT_OTH_CREDS, LOG_FAIL_GATEWAY, LOG_SETUP_FAILED],
-    EXC_TOO_MANY_REQUESTS: [LOG_HINT_429_CREDS, LOG_FAIL_TOO_MANY, LOG_SETUP_FAILED],
+    EXC_BAD_CONNECTION: [LOG_HINT_OTH_AUTH, LOG_FAIL_CONNECTION, LOG_SETUP_FAILED],
+    EXC_BAD_CREDENTIALS: [LOG_HINT_USR_AUTH, LOG_FAIL_CREDENTIALS, LOG_SETUP_FAILED],
+    EXC_BAD_GATEWAY: [LOG_HINT_OTH_AUTH, LOG_FAIL_GATEWAY, LOG_SETUP_FAILED],
+    EXC_TOO_MANY_REQUESTS: [LOG_HINT_429_AUTH, LOG_FAIL_TOO_MANY, LOG_SETUP_FAILED],
 }
 
 CLIENT_REQUEST_TESTS: dict[Exception, list] = {
@@ -137,7 +133,8 @@ async def test_authentication_failure_v2(
 
     with (
         patch(
-            "evohome.credentials.CredentialsManagerBase._request", side_effect=exception
+            "_evohome.credentials.CredentialsManagerBase._request",
+            side_effect=exception,
         ),
         caplog.at_level(logging.WARNING),
     ):
@@ -165,7 +162,7 @@ async def test_client_request_failure_v2(
             "evohomeasync2.auth.CredentialsManagerBase._post_request",
             mock_post_request("default"),
         ),
-        patch("evohome.auth.AbstractAuth._request", side_effect=exception),
+        patch("_evohome.auth.AbstractAuth._request", side_effect=exception),
         caplog.at_level(logging.WARNING),
     ):
         result = await async_setup_component(hass, DOMAIN, {DOMAIN: config})

--- a/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
+++ b/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
@@ -439,7 +439,7 @@
     'state': '5.030',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -454,7 +454,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -462,12 +462,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'CPU Fan Fan',
+    'object_id_base': 'CPU Fan Speed',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'CPU Fan Fan',
+    'original_name': 'CPU Fan Speed',
     'platform': 'libre_hardware_monitor',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -477,17 +477,17 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Speed',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -549,7 +549,7 @@
     'state': '55.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -564,7 +564,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -572,12 +572,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Pump Fan Fan',
+    'object_id_base': 'Pump Fan Speed',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Pump Fan Fan',
+    'original_name': 'Pump Fan Speed',
     'platform': 'libre_hardware_monitor',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -587,24 +587,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Speed',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -619,7 +619,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -627,12 +627,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'System Fan #1 Fan',
+    'object_id_base': 'System Fan #1 Speed',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'System Fan #1 Fan',
+    'original_name': 'System Fan #1 Speed',
     'platform': 'libre_hardware_monitor',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -642,16 +642,16 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+      'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Speed',
       'max_value': None,
       'min_value': None,
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -933,7 +933,7 @@
     'state': '36.0',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -948,7 +948,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -956,12 +956,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'GPU Fan 1 Fan',
+    'object_id_base': 'GPU Fan 1 Speed',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'GPU Fan 1 Fan',
+    'original_name': 'GPU Fan 1 Speed',
     'platform': 'libre_hardware_monitor',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -971,24 +971,24 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Speed',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-entry]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1003,7 +1003,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1011,12 +1011,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'GPU Fan 2 Fan',
+    'object_id_base': 'GPU Fan 2 Speed',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'GPU Fan 2 Fan',
+    'original_name': 'GPU Fan 2 Speed',
     'platform': 'libre_hardware_monitor',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1026,17 +1026,17 @@
     'unit_of_measurement': 'RPM',
   })
 # ---
-# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan-state]
+# name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+      'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Speed',
       'max_value': '0',
       'min_value': '0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'RPM',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+    'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1452,14 +1452,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1467,14 +1467,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1482,13 +1482,13 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Speed',
         'max_value': None,
         'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1706,14 +1706,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1721,14 +1721,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1830,14 +1830,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) CPU Fan Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_cpu_fan_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1845,14 +1845,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) Pump Fan Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_pump_fan_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -1860,13 +1860,13 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Fan',
+        'friendly_name': '[GAMING-PC] MSI MAG B650M MORTAR WIFI (MS-7D76) System Fan #1 Speed',
         'max_value': None,
         'min_value': None,
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_msi_mag_b650m_mortar_wifi_ms_7d76_system_fan_1_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2084,14 +2084,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 1 Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_1_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
@@ -2099,14 +2099,14 @@
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({
-        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Fan',
+        'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU Fan 2 Speed',
         'max_value': '0',
         'min_value': '0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
         'unit_of_measurement': 'RPM',
       }),
       'context': <ANY>,
-      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_fan',
+      'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_fan_2_speed',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -57,6 +57,7 @@ from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 from . import (
     MOCK_MAC,
     init_integration,
+    mutate_rpc_device_status,
     patch_platforms,
     register_device,
     register_entity,
@@ -1046,6 +1047,16 @@ async def test_rpc_linkedgo_st802_thermostat(
     mock_rpc_device.boolean_set.assert_called_once_with(201, False)
     assert (state := hass.states.get(entity_id))
     assert state.state == HVACMode.OFF
+
+    # Test current temperature update
+    assert (state := hass.states.get(entity_id))
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 25.1
+
+    mutate_rpc_device_status(monkeypatch, mock_rpc_device, "number:201", "value", 22.4)
+    mock_rpc_device.mock_update()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.4
 
 
 async def test_rpc_linkedgo_st1820_thermostat(

--- a/tests/components/tesla_fleet/snapshots/test_sensor.ambr
+++ b/tests/components/tesla_fleet/snapshots/test_sensor.ambr
@@ -2448,7 +2448,7 @@
     'object_id_base': 'VPP backup reserve',
     'options': dict({
     }),
-    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_device_class': None,
     'original_icon': None,
     'original_name': 'VPP backup reserve',
     'platform': 'tesla_fleet',
@@ -2463,7 +2463,6 @@
 # name: test_sensors[sensor.energy_site_vpp_backup_reserve-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'Energy Site VPP backup reserve',
       'unit_of_measurement': '%',
     }),
@@ -2478,7 +2477,6 @@
 # name: test_sensors[sensor.energy_site_vpp_backup_reserve-statealt]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
       'friendly_name': 'Energy Site VPP backup reserve',
       'unit_of_measurement': '%',
     }),

--- a/tests/components/todoist/test_todo.py
+++ b/tests/components/todoist/test_todo.py
@@ -1,7 +1,9 @@
 """Unit tests for the Todoist todo platform."""
 
+from datetime import date, datetime
 from typing import Any
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 from todoist_api_python.models import Task
@@ -113,7 +115,7 @@ async def test_todo_item_state(
                     ),
                 )
             ],
-            {"description": "", "due_date": "2023-11-18"},
+            {"description": "", "due_date": date(2023, 11, 18)},
             {
                 "uid": "task-id-1",
                 "summary": "Soda",
@@ -138,7 +140,9 @@ async def test_todo_item_state(
             ],
             {
                 "description": "",
-                "due_datetime": "2023-11-18T06:30:00-06:00",
+                "due_datetime": datetime(
+                    2023, 11, 18, 6, 30, tzinfo=ZoneInfo("US/Central")
+                ),
             },
             {
                 "uid": "task-id-1",
@@ -333,7 +337,7 @@ async def test_update_todo_item_status(
             {
                 "task_id": "task-id-1",
                 "content": "Soda",
-                "due_date": "2023-11-18",
+                "due_date": date(2023, 11, 18),
                 "description": "",
             },
             {
@@ -361,7 +365,9 @@ async def test_update_todo_item_status(
             {
                 "task_id": "task-id-1",
                 "content": "Soda",
-                "due_datetime": "2023-11-18T06:30:00-06:00",
+                "due_datetime": datetime(
+                    2023, 11, 18, 6, 30, tzinfo=ZoneInfo("US/Central")
+                ),
                 "description": "",
             },
             {
@@ -455,7 +461,7 @@ async def test_update_todo_item_status(
                 "task_id": "task-id-1",
                 "content": "Soda",
                 "description": "6-pack",
-                "due_date": "2024-02-01",
+                "due_date": date(2024, 2, 1),
                 "due_string": "every day",
             },
             {

--- a/tests/components/tuya/snapshots/test_climate.ambr
+++ b/tests/components/tuya/snapshots/test_climate.ambr
@@ -90,7 +90,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'target_temp_step': 1.0,
     }),
@@ -137,7 +136,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'supported_features': <ClimateEntityFeature: 17>,
       'target_temp_step': 1.0,
@@ -460,7 +458,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'target_temp_step': 1.0,
     }),
@@ -509,7 +506,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'supported_features': <ClimateEntityFeature: 17>,
       'target_temp_step': 1.0,
@@ -538,7 +534,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'target_temp_step': 1.0,
     }),
@@ -587,7 +582,6 @@
       'preset_modes': list([
         'auto',
         'manual',
-        'off',
       ]),
       'supported_features': <ClimateEntityFeature: 401>,
       'target_temp_step': 1.0,

--- a/tests/components/yardian/snapshots/test_sensor.ambr
+++ b/tests/components/yardian/snapshots/test_sensor.ambr
@@ -1,4 +1,57 @@
 # serializer version: 1
+# name: test_sensor_entities[sensor.yardian_smart_sprinkler_active_zones-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.yardian_smart_sprinkler_active_zones',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active zones',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Active zones',
+    'platform': 'yardian',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_zone_count',
+    'unique_id': 'yid123_active_zone_count',
+    'unit_of_measurement': 'zones',
+  })
+# ---
+# name: test_sensor_entities[sensor.yardian_smart_sprinkler_active_zones-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Yardian Smart Sprinkler Active zones',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'zones',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.yardian_smart_sprinkler_active_zones',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
 # name: test_sensor_entities[sensor.yardian_smart_sprinkler_rain_delay-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
- Fix redundant `off` preset in Tuya climate ([@epenet] - [#161040]) ([tuya docs]) (breaking-change)
- Fix device_class of backup reserve sensor ([@jonootto] - [#161178]) ([tesla_fleet docs])
- Bump evohome-async to 1.1.3 ([@zxdavb] - [#162232]) ([evohome docs]) (dependency)
- Bump google_air_quality_api to 3.0.1 ([@Thomas55555] - [#162233]) ([google_air_quality docs]) (dependency)
- Bump denonavr to 1.3.2 ([@ol-iver] - [#162271]) ([denonavr docs]) (dependency)
- Fix multipart upload to use consistent part sizes for R2/S3 ([@corrreia] - [#162278]) ([cloudflare_r2 docs])
- Add mapping for `stopped` state to `denonavr` media player ([@ol-iver] - [#162283]) ([denonavr docs])
- Fix unicode escaping in MCP server tool response ([@luochen1990] - [#162319]) ([mcp_server docs])
- Bump pyenphase to 2.4.5 ([@catsmanac] - [#162324]) ([enphase_envoy docs]) (dependency)
- Fix Shelly Linkedgo Thermostat status update ([@thecode] - [#162339]) ([shelly docs])
- Update pynintendoparental requirement to version 2.3.2.1 ([@pantherale0] - [#162362]) ([nintendo_parental_controls docs]) (dependency)
- Fix conversion of data for todo.* actions ([@boralyl] - [#162366]) ([todoist docs])
- Bump python-smarttub to 0.0.47 ([@mdz] - [#162367]) ([smarttub docs]) (dependency)
- Add missing config flow strings to SmartTub ([@mdz] - [#162375]) ([smarttub docs])
- Remove entity id overwrite for ambient station ([@joostlek] - [#162403]) ([ambient_station docs])
- Bump librehardwaremonitor-api to version 1.9.1 ([@Sab44] - [#162409]) ([libre_hardware_monitor docs]) (dependency)
- Remove double unit of measurement for yardian ([@joostlek] - [#162412]) ([yardian docs])
- Fix invalid yardian snaphots ([@epenet] - [#162422]) ([yardian docs])
- Make bad entity ID detection more lenient ([@arturpragacz] - [#162425])
- dep: bump aioamazondevices to 11.1.3 ([@jamesonuk] - [#162437]) ([alexa_devices docs]) (dependency)

[#161040]: https://github.com/home-assistant/core/pull/161040
[#161178]: https://github.com/home-assistant/core/pull/161178
[#162224]: https://github.com/home-assistant/core/pull/162224
[#162232]: https://github.com/home-assistant/core/pull/162232
[#162233]: https://github.com/home-assistant/core/pull/162233
[#162271]: https://github.com/home-assistant/core/pull/162271
[#162278]: https://github.com/home-assistant/core/pull/162278
[#162283]: https://github.com/home-assistant/core/pull/162283
[#162319]: https://github.com/home-assistant/core/pull/162319
[#162324]: https://github.com/home-assistant/core/pull/162324
[#162339]: https://github.com/home-assistant/core/pull/162339
[#162362]: https://github.com/home-assistant/core/pull/162362
[#162366]: https://github.com/home-assistant/core/pull/162366
[#162367]: https://github.com/home-assistant/core/pull/162367
[#162375]: https://github.com/home-assistant/core/pull/162375
[#162403]: https://github.com/home-assistant/core/pull/162403
[#162409]: https://github.com/home-assistant/core/pull/162409
[#162412]: https://github.com/home-assistant/core/pull/162412
[#162422]: https://github.com/home-assistant/core/pull/162422
[#162425]: https://github.com/home-assistant/core/pull/162425
[#162437]: https://github.com/home-assistant/core/pull/162437
[@Sab44]: https://github.com/Sab44
[@Thomas55555]: https://github.com/Thomas55555
[@arturpragacz]: https://github.com/arturpragacz
[@boralyl]: https://github.com/boralyl
[@catsmanac]: https://github.com/catsmanac
[@corrreia]: https://github.com/corrreia
[@epenet]: https://github.com/epenet
[@frenck]: https://github.com/frenck
[@jamesonuk]: https://github.com/jamesonuk
[@jonootto]: https://github.com/jonootto
[@joostlek]: https://github.com/joostlek
[@luochen1990]: https://github.com/luochen1990
[@mdz]: https://github.com/mdz
[@ol-iver]: https://github.com/ol-iver
[@pantherale0]: https://github.com/pantherale0
[@thecode]: https://github.com/thecode
[@zxdavb]: https://github.com/zxdavb
[abode docs]: https://www.home-assistant.io/integrations/abode/
[alexa_devices docs]: https://www.home-assistant.io/integrations/alexa_devices/
[ambient_station docs]: https://www.home-assistant.io/integrations/ambient_station/
[cloudflare_r2 docs]: https://www.home-assistant.io/integrations/cloudflare_r2/
[denonavr docs]: https://www.home-assistant.io/integrations/denonavr/
[enphase_envoy docs]: https://www.home-assistant.io/integrations/enphase_envoy/
[evohome docs]: https://www.home-assistant.io/integrations/evohome/
[google_air_quality docs]: https://www.home-assistant.io/integrations/google_air_quality/
[libre_hardware_monitor docs]: https://www.home-assistant.io/integrations/libre_hardware_monitor/
[mcp_server docs]: https://www.home-assistant.io/integrations/mcp_server/
[nintendo_parental_controls docs]: https://www.home-assistant.io/integrations/nintendo_parental_controls/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[smarttub docs]: https://www.home-assistant.io/integrations/smarttub/
[tesla_fleet docs]: https://www.home-assistant.io/integrations/tesla_fleet/
[todoist docs]: https://www.home-assistant.io/integrations/todoist/
[tuya docs]: https://www.home-assistant.io/integrations/tuya/
[yardian docs]: https://www.home-assistant.io/integrations/yardian/