### PR TITLE
Fix absolute humidity sensor on HmIP-WGT glass thermostats

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -556,16 +556,8 @@ class HomematicipAbsoluteHumiditySensor(HomematicipGenericEntity, SensorEntity):
     @property
     def native_value(self) -> float | None:
         """Return the state."""
-        if self.functional_channel is None:
-            return None
-
-        value = self.functional_channel.vaporAmount
-
-        # Handle case where value might be None
-        if (
-            self.functional_channel.vaporAmount is None
-            or self.functional_channel.vaporAmount == ""
-        ):
+        value = self._device.vaporAmount
+        if value is None or value == "":
             return None
 
         return round(value, 3)


### PR DESCRIPTION
## Proposed change

Fix `HomematicipAbsoluteHumiditySensor` failing on HmIP-WGT (Wall Mounted Glass Thermostat) devices with `AttributeError: 'FunctionalChannel' object has no attribute 'vaporAmount'`.

The sensor was reading `vaporAmount` from `self.functional_channel`, which resolves to `functionalChannels[1]`. On HmIP-WGT devices, channel 1 is `INPUT_QUICK_ACTION_DISPLAY_CHANNEL` (a base `FunctionalChannel` without `vaporAmount`), while the actual thermostat data is on channel 3 (`WALL_MOUNTED_THERMOSTAT_PRO_CHANNEL`).

The fix reads from `self._device.vaporAmount` instead, which is populated from the correct channel in the device's `from_json()`. This is consistent with how `HomematicipTemperatureSensor` and `HomematicipHumiditySensor` already access their values.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr