### PR TITLE
Catch AccessoryDisconnectedError in homekit pairing

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -496,6 +496,12 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
             except aiohomekit.AccessoryNotFoundError:
                 # Can no longer find the device on the network
                 return self.async_abort(reason="accessory_not_found_error")
+            except aiohomekit.AccessoryDisconnectedError as err:
+                # The accessory has disconnected from the network
+                return self.async_abort(
+                    reason="accessory_disconnected_error",
+                    description_placeholders={"error": str(err)},
+                )
             except IndexError:
                 # TLV error, usually not in pairing mode
                 _LOGGER.exception("Pairing communication failed")

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -460,6 +460,12 @@ class HomekitControllerFlowHandler(ConfigFlow, domain=DOMAIN):
             except aiohomekit.AccessoryNotFoundError:
                 # Can no longer find the device on the network
                 return self.async_abort(reason="accessory_not_found_error")
+            except aiohomekit.AccessoryDisconnectedError as err:
+                # The accessory has disconnected from the network
+                return self.async_abort(
+                    reason="accessory_disconnected_error",
+                    description_placeholders={"error": str(err)},
+                )
             except InsecureSetupCode:
                 errors["pairing_code"] = "insecure_setup_code"
             except Exception as err:

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "abort": {
-      "accessory_disconnected_error": "An connectivity error occurred while attempting to pair with this device.\n\n{error}",
+      "accessory_disconnected_error": "A connectivity error occurred while attempting to pair with this device.\n\n{error}",
       "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
       "already_configured": "Accessory is already configured with this controller.",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "accessory_disconnected_error": "An connectivity error occurred while attempting to pair with this device.\n\n{error}",
       "accessory_not_found_error": "Cannot add pairing as device can no longer be found.",
       "already_configured": "Accessory is already configured with this controller.",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -34,6 +34,7 @@ PAIRING_START_FORM_ERRORS = [
 ]
 
 PAIRING_START_ABORT_ERRORS = [
+    (aiohomekit.AccessoryDisconnectedError, "accessory_disconnected_error"),
     (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error"),
     (aiohomekit.UnavailableError, "already_paired"),
 ]

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -53,7 +53,8 @@ PAIRING_FINISH_FORM_ERRORS = [
 ]
 
 PAIRING_FINISH_ABORT_ERRORS = [
-    (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error")
+    (aiohomekit.AccessoryDisconnectedError, "accessory_disconnected_error"),
+    (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error"),
 ]
 
 


### PR DESCRIPTION
## Proposed change

The dismissal protection introduced in #162270 means that `AccessoryDisconnectedError` can now be thrown from `aiohomekit`. Handle this the same way as `AccessoryNotFoundError`.
 
## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
