### PR TITLE
Fix JSON serialization of time objects in OpenAI tool results

### DIFF
--- a/homeassistant/components/openai_conversation/entity.py
+++ b/homeassistant/components/openai_conversation/entity.py
@@ -64,6 +64,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, issue_registry as ir, llm
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import json_dumps
 from homeassistant.util import slugify
 
 from .const import (
@@ -183,7 +184,7 @@ def _convert_content_to_param(
                     FunctionCallOutput(
                         type="function_call_output",
                         call_id=content.tool_call_id,
-                        output=json.dumps(content.tool_result),
+                        output=json_dumps(content.tool_result),
                     )
                 )
             continue
@@ -217,7 +218,7 @@ def _convert_content_to_param(
                             ResponseFunctionToolCallParam(
                                 type="function_call",
                                 name=tool_call.tool_name,
-                                arguments=json.dumps(tool_call.tool_args),
+                                arguments=json_dumps(tool_call.tool_args),
                                 call_id=tool_call.id,
                             )
                         )

--- a/tests/components/openai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/openai_conversation/snapshots/test_conversation.ambr
@@ -7,14 +7,14 @@
       'type': 'message',
     }),
     dict({
-      'arguments': '{"code": "import math\\nmath.sqrt(55555)", "container": "cntr_A"}',
+      'arguments': '{"code":"import math\\nmath.sqrt(55555)","container":"cntr_A"}',
       'call_id': 'ci_A',
       'name': 'code_interpreter',
       'type': 'function_call',
     }),
     dict({
       'call_id': 'ci_A',
-      'output': '{"output": [{"logs": "235.70108188126758\\n", "type": "logs"}]}',
+      'output': '{"output":[{"logs":"235.70108188126758\\n","type":"logs"}]}',
       'type': 'function_call_output',
     }),
     dict({
@@ -146,7 +146,7 @@
       'type': 'reasoning',
     }),
     dict({
-      'arguments': '{"param1": "call1"}',
+      'arguments': '{"param1":"call1"}',
       'call_id': 'call_call_1',
       'name': 'test_tool',
       'type': 'function_call',
@@ -157,7 +157,7 @@
       'type': 'function_call_output',
     }),
     dict({
-      'arguments': '{"param1": "call2"}',
+      'arguments': '{"param1":"call2"}',
       'call_id': 'call_call_2',
       'name': 'test_tool',
       'type': 'function_call',

--- a/tests/components/openai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/openai_conversation/snapshots/test_conversation.ambr
@@ -38,6 +38,65 @@
   list([
     dict({
       'attachments': None,
+      'content': 'What time is it?',
+      'created': HAFakeDatetime(2025, 10, 31, 12, 0, tzinfo=datetime.timezone.utc),
+      'role': 'user',
+    }),
+    dict({
+      'agent_id': 'conversation.openai_conversation',
+      'content': None,
+      'created': HAFakeDatetime(2025, 10, 31, 12, 0, tzinfo=datetime.timezone.utc),
+      'native': None,
+      'role': 'assistant',
+      'thinking_content': None,
+      'tool_calls': list([
+        dict({
+          'external': True,
+          'id': 'mock-tool-call-id',
+          'tool_args': dict({
+          }),
+          'tool_name': 'HassGetCurrentTime',
+        }),
+      ]),
+    }),
+    dict({
+      'agent_id': 'conversation.openai_conversation',
+      'created': HAFakeDatetime(2025, 10, 31, 12, 0, tzinfo=datetime.timezone.utc),
+      'role': 'tool_result',
+      'tool_call_id': 'mock-tool-call-id',
+      'tool_name': 'HassGetCurrentTime',
+      'tool_result': dict({
+        'data': dict({
+          'failed': list([
+          ]),
+          'success': list([
+          ]),
+          'targets': list([
+          ]),
+        }),
+        'response_type': 'action_done',
+        'speech': dict({
+          'plain': dict({
+            'extra_data': None,
+            'speech': '12:00 PM',
+          }),
+        }),
+        'speech_slots': dict({
+          'time': datetime.time(12, 0),
+        }),
+      }),
+    }),
+    dict({
+      'agent_id': 'conversation.openai_conversation',
+      'content': '12:00 PM',
+      'created': HAFakeDatetime(2025, 10, 31, 12, 0, tzinfo=datetime.timezone.utc),
+      'native': None,
+      'role': 'assistant',
+      'thinking_content': None,
+      'tool_calls': None,
+    }),
+    dict({
+      'attachments': None,
       'content': 'Please call the test function',
       'created': HAFakeDatetime(2025, 10, 31, 12, 0, tzinfo=datetime.timezone.utc),
       'role': 'user',
@@ -125,6 +184,27 @@
 # ---
 # name: test_function_call.1
   list([
+    dict({
+      'content': 'What time is it?',
+      'role': 'user',
+      'type': 'message',
+    }),
+    dict({
+      'arguments': '{}',
+      'call_id': 'mock-tool-call-id',
+      'name': 'HassGetCurrentTime',
+      'type': 'function_call',
+    }),
+    dict({
+      'call_id': 'mock-tool-call-id',
+      'output': '{"speech":{"plain":{"speech":"12:00 PM","extra_data":null}},"response_type":"action_done","speech_slots":{"time":"12:00:00"},"data":{"targets":[],"success":[],"failed":[]}}',
+      'type': 'function_call_output',
+    }),
+    dict({
+      'content': '12:00 PM',
+      'role': 'assistant',
+      'type': 'message',
+    }),
     dict({
       'content': 'Please call the test function',
       'role': 'user',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the json serialization of time objects in the tool calls history after the `GetCurrentTimeIntentHandler` intent.
This is a port of https://github.com/home-assistant/core/pull/160459 from anthropic integration to openai.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/160078
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
