### PR TITLE
Limit actions on omada controller to one at a time

### DIFF
--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -32,6 +32,8 @@ from . import OmadaConfigEntry
 from .controller import OmadaGatewayCoordinator
 from .entity import OmadaDeviceEntity
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tplink_omada/device_tracker.py
+++ b/homeassistant/components/tplink_omada/device_tracker.py
@@ -1,7 +1,5 @@
 """Connected Wi-Fi device scanners for TP-Link Omada access points."""
 
-import logging
-
 from tplink_omada_client.clients import OmadaWirelessClient
 
 from homeassistant.components.device_tracker import ScannerEntity
@@ -13,7 +11,7 @@ from . import OmadaConfigEntry
 from .config_flow import CONF_SITE
 from .controller import OmadaClientsCoordinator
 
-_LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/tplink_omada/quality_scale.yaml
+++ b/homeassistant/components/tplink_omada/quality_scale.yaml
@@ -37,7 +37,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo
 

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -24,6 +24,8 @@ from .const import OmadaDeviceStatus
 from .coordinator import OmadaDevicesCoordinator
 from .entity import OmadaDeviceEntity
 
+PARALLEL_UPDATES = 0
+
 # Useful low level status categories, mapped to a more descriptive status.
 DEVICE_STATUS_MAP = {
     DeviceStatus.PROVISIONING: OmadaDeviceStatus.PENDING,

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -44,6 +44,8 @@ TPort = TypeVar("TPort")
 TDevice = TypeVar("TDevice", bound="OmadaDevice")
 TCoordinator = TypeVar("TCoordinator", bound="OmadaCoordinator[Any]")
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -44,7 +44,7 @@ TPort = TypeVar("TPort")
 TDevice = TypeVar("TDevice", bound="OmadaDevice")
 TCoordinator = TypeVar("TCoordinator", bound="OmadaCoordinator[Any]")
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -20,6 +20,8 @@ from . import OmadaConfigEntry
 from .coordinator import OmadaFirmwareUpdateCoordinator
 from .entity import OmadaDeviceEntity
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -20,7 +20,7 @@ from . import OmadaConfigEntry
 from .coordinator import OmadaFirmwareUpdateCoordinator
 from .entity import OmadaDeviceEntity
 
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add PARALLEL_UPDATES values for all domains. The domains all use coordinators, so zero is appropriate. I misunderstood what this setting did initially and tried a value of 1 for switches and update entities. This has no useful effect so I've changed them back to zero.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
