### PR TITLE
GIOS quality scale fixes to platinum

### DIFF
--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -8,11 +8,10 @@ from aiohttp.client_exceptions import ClientConnectorError
 from gios import Gios
 from gios.exceptions import GiosError
 
-from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_STATION_ID, DOMAIN
@@ -59,15 +58,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiosConfigEntry) -> bool
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Remove air_quality entities from registry if they exist
-    ent_reg = er.async_get(hass)
-    unique_id = str(coordinator.gios.station_id)
-    if entity_id := ent_reg.async_get_entity_id(
-        AIR_QUALITY_PLATFORM, DOMAIN, unique_id
-    ):
-        _LOGGER.debug("Removing deprecated air_quality entity %s", entity_id)
-        ent_reg.async_remove(entity_id)
 
     return True
 

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_STATION_ID, DOMAIN
-from .coordinator import GiosConfigEntry, GiosData, GiosDataUpdateCoordinator
+from .coordinator import GiosConfigEntry, GiosDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GiosConfigEntry) -> bool
     coordinator = GiosDataUpdateCoordinator(hass, entry, gios)
     await coordinator.async_config_entry_first_refresh()
 
-    entry.runtime_data = GiosData(coordinator)
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/gios/coordinator.py
+++ b/homeassistant/components/gios/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING
 
@@ -22,14 +21,7 @@ from .const import API_TIMEOUT, DOMAIN, MANUFACTURER, SCAN_INTERVAL, URL
 
 _LOGGER = logging.getLogger(__name__)
 
-type GiosConfigEntry = ConfigEntry[GiosData]
-
-
-@dataclass
-class GiosData:
-    """Data for GIOS integration."""
-
-    coordinator: GiosDataUpdateCoordinator
+type GiosConfigEntry = ConfigEntry[GiosDataUpdateCoordinator]
 
 
 class GiosDataUpdateCoordinator(DataUpdateCoordinator[GiosSensors]):

--- a/homeassistant/components/gios/diagnostics.py
+++ b/homeassistant/components/gios/diagnostics.py
@@ -14,7 +14,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: GiosConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = config_entry.runtime_data.coordinator
+    coordinator = config_entry.runtime_data
 
     return {
         "config_entry": config_entry.as_dict(),

--- a/homeassistant/components/gios/manifest.json
+++ b/homeassistant/components/gios/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["dacite", "gios"],
+  "quality_scale": "platinum",
   "requirements": ["gios==7.0.0"]
 }

--- a/homeassistant/components/gios/quality_scale.yaml
+++ b/homeassistant/components/gios/quality_scale.yaml
@@ -9,14 +9,8 @@ rules:
   appropriate-polling: done
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment:
-      We should have the happy flow as the first test, which can be merged with test_show_form.
-      The config flow tests are missing adding a duplicate entry test.
-  config-flow:
-    status: todo
-    comment: Limit the scope of the try block in the user step
+  config-flow-test-coverage: done
+  config-flow: done
   dependency-transparency: done
   docs-actions:
     status: exempt
@@ -27,9 +21,7 @@ rules:
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
-  runtime-data:
-    status: todo
-    comment: No direct need to wrap the coordinator in a dataclass to store in the config entry
+  runtime-data: done
   test-before-configure: done
   test-before-setup: done
   unique-config-entry: done
@@ -50,11 +42,7 @@ rules:
   reauthentication-flow:
     status: exempt
     comment: This integration does not require authentication.
-  test-coverage:
-    status: todo
-    comment:
-      The `test_async_setup_entry` should test the state of the mock config entry, instead of an entity state
-      The `test_availability` doesn't really do what it says it does, and this is now already tested via the snapshot tests.
+  test-coverage: done
 
   # Gold
   devices: done
@@ -78,13 +66,9 @@ rules:
     status: exempt
     comment: This integration does not have devices.
   entity-category: done
-  entity-device-class:
-    status: todo
-    comment: We can use the CO device class for the carbon monoxide sensor
+  entity-device-class: done
   entity-disabled-by-default: done
-  entity-translations:
-    status: todo
-    comment: We can remove the options state_attributes.
+  entity-translations: done
   exception-translations: done
   icon-translations: done
   reconfiguration-flow:

--- a/homeassistant/components/gios/quality_scale.yaml
+++ b/homeassistant/components/gios/quality_scale.yaml
@@ -1,7 +1,4 @@
 rules:
-  # Other comments:
-  # - we could consider removing the air quality entity removal
-
   # Bronze
   action-setup:
     status: exempt

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -72,9 +72,9 @@ SENSOR_TYPES: tuple[GiosSensorEntityDescription, ...] = (
         key=ATTR_CO,
         value=lambda sensors: sensors.co.value if sensors.co else None,
         suggested_display_precision=0,
+        device_class=SensorDeviceClass.CO,
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         state_class=SensorStateClass.MEASUREMENT,
-        translation_key="co",
     ),
     GiosSensorEntityDescription(
         key=ATTR_NO,

--- a/homeassistant/components/gios/sensor.py
+++ b/homeassistant/components/gios/sensor.py
@@ -181,7 +181,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Add a GIOS entities from a config_entry."""
-    coordinator = entry.runtime_data.coordinator
+    coordinator = entry.runtime_data
     # Due to the change of the attribute name of one sensor, it is necessary to migrate
     # the unique_id to the new name.
     entity_registry = er.async_get(hass)

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -31,18 +31,6 @@
           "sufficient": "Sufficient",
           "very_bad": "Very bad",
           "very_good": "Very good"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       },
       "c6h6": {
@@ -57,18 +45,6 @@
           "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       },
       "nox": {
@@ -83,18 +59,6 @@
           "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       },
       "pm10_index": {
@@ -106,18 +70,6 @@
           "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       },
       "pm25_index": {
@@ -129,18 +81,6 @@
           "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       },
       "so2_index": {
@@ -152,18 +92,6 @@
           "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
           "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
           "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-        },
-        "state_attributes": {
-          "options": {
-            "state": {
-              "bad": "[%key:component::gios::entity::sensor::aqi::state::bad%]",
-              "good": "[%key:component::gios::entity::sensor::aqi::state::good%]",
-              "moderate": "[%key:component::gios::entity::sensor::aqi::state::moderate%]",
-              "sufficient": "[%key:component::gios::entity::sensor::aqi::state::sufficient%]",
-              "very_bad": "[%key:component::gios::entity::sensor::aqi::state::very_bad%]",
-              "very_good": "[%key:component::gios::entity::sensor::aqi::state::very_good%]"
-            }
-          }
         }
       }
     }

--- a/homeassistant/components/gios/strings.json
+++ b/homeassistant/components/gios/strings.json
@@ -48,9 +48,6 @@
       "c6h6": {
         "name": "Benzene"
       },
-      "co": {
-        "name": "[%key:component::sensor::entity_component::carbon_monoxide::name%]"
-      },
       "no2_index": {
         "name": "Nitrogen dioxide index",
         "state": {

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -1404,7 +1404,6 @@ INTEGRATIONS_WITHOUT_SCALE = [
     "geofency",
     "geonetnz_quakes",
     "geonetnz_volcano",
-    "gios",
     "github",
     "gitlab_ci",
     "gitter",

--- a/tests/components/gios/snapshots/test_sensor.ambr
+++ b/tests/components/gios/snapshots/test_sensor.ambr
@@ -153,14 +153,14 @@
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.CO: 'carbon_monoxide'>,
     'original_icon': None,
     'original_name': 'Carbon monoxide',
     'platform': 'gios',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'co',
+    'translation_key': None,
     'unique_id': '123-co',
     'unit_of_measurement': 'μg/m³',
   })
@@ -169,6 +169,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by GIOŚ',
+      'device_class': 'carbon_monoxide',
       'friendly_name': 'Home Carbon monoxide',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'μg/m³',

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -4,11 +4,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.components.gios.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
@@ -90,26 +89,3 @@ async def test_migrate_unique_id_to_str(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.unique_id == "123"
-
-
-async def test_remove_air_quality_entities(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
-    mock_gios: MagicMock,
-) -> None:
-    """Test remove air_quality entities from registry."""
-    mock_config_entry.add_to_hass(hass)
-    entity_registry.async_get_or_create(
-        AIR_QUALITY_PLATFORM,
-        DOMAIN,
-        "123",
-        suggested_object_id="home",
-        disabled_by=None,
-    )
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    entry = entity_registry.async_get("air_quality.home")
-    assert entry is None

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -7,7 +7,6 @@ import pytest
 from homeassistant.components.air_quality import DOMAIN as AIR_QUALITY_PLATFORM
 from homeassistant.components.gios.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -19,12 +18,10 @@ from tests.common import MockConfigEntry
 @pytest.mark.usefixtures("init_integration")
 async def test_async_setup_entry(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test a successful setup entry."""
-    state = hass.states.get("sensor.home_pm2_5")
-    assert state is not None
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "4"
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_config_not_ready(

--- a/tests/components/gios/test_sensor.py
+++ b/tests/components/gios/test_sensor.py
@@ -38,22 +38,6 @@ async def test_sensor(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_availability(hass: HomeAssistant) -> None:
-    """Ensure that we mark the entities unavailable correctly when service causes an error."""
-    state = hass.states.get("sensor.home_pm2_5")
-    assert state
-    assert state.state == "4"
-
-    state = hass.states.get("sensor.home_pm2_5_index")
-    assert state
-    assert state.state == "good"
-
-    state = hass.states.get("sensor.home_air_quality_index")
-    assert state
-    assert state.state == "good"
-
-
-@pytest.mark.usefixtures("init_integration")
 async def test_availability_api_error(
     hass: HomeAssistant,
     mock_gios: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add duplicate entry test and merge happy flow test in config flow tests
- Limit try block scope in config flow user step
- Store coordinator directly in runtime_data instead of wrapping in dataclass
- Fix `test_async_setup_entry` to test config entry state and remove redundant `test_availability`
- Use `SensorDeviceClass.CO` for carbon monoxide sensor
- Remove redundant `state_attributes.options` from strings
- Mark all quality scale items as done and set platinum in manifest
- Remove legacy air quality entity cleanup 

Depends on: https://github.com/home-assistant/core/pull/155603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
