### PR TITLE
Fix Green Planet Energy price unit conversion

### DIFF
--- a/homeassistant/components/green_planet_energy/sensor.py
+++ b/homeassistant/components/green_planet_energy/sensor.py
@@ -43,7 +43,11 @@ SENSOR_DESCRIPTIONS: list[GreenPlanetEnergySensorEntityDescription] = [
         translation_key="highest_price_today",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=4,
-        value_fn=lambda api, data: api.get_highest_price_today(data),
+        value_fn=lambda api, data: (
+            price / 100
+            if (price := api.get_highest_price_today(data)) is not None
+            else None
+        ),
     ),
     GreenPlanetEnergySensorEntityDescription(
         key="gpe_highest_price_time",
@@ -61,7 +65,11 @@ SENSOR_DESCRIPTIONS: list[GreenPlanetEnergySensorEntityDescription] = [
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=4,
         translation_placeholders={"time_range": "(06:00-18:00)"},
-        value_fn=lambda api, data: api.get_lowest_price_day(data),
+        value_fn=lambda api, data: (
+            price / 100
+            if (price := api.get_lowest_price_day(data)) is not None
+            else None
+        ),
     ),
     GreenPlanetEnergySensorEntityDescription(
         key="gpe_lowest_price_day_time",
@@ -80,7 +88,11 @@ SENSOR_DESCRIPTIONS: list[GreenPlanetEnergySensorEntityDescription] = [
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=4,
         translation_placeholders={"time_range": "(18:00-06:00)"},
-        value_fn=lambda api, data: api.get_lowest_price_night(data),
+        value_fn=lambda api, data: (
+            price / 100
+            if (price := api.get_lowest_price_night(data)) is not None
+            else None
+        ),
     ),
     GreenPlanetEnergySensorEntityDescription(
         key="gpe_lowest_price_night_time",
@@ -98,7 +110,11 @@ SENSOR_DESCRIPTIONS: list[GreenPlanetEnergySensorEntityDescription] = [
         translation_key="current_price",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=4,
-        value_fn=lambda api, data: api.get_current_price(data, dt_util.now().hour),
+        value_fn=lambda api, data: (
+            price / 100
+            if (price := api.get_current_price(data, dt_util.now().hour)) is not None
+            else None
+        ),
     ),
 ]
 

--- a/tests/components/green_planet_energy/conftest.py
+++ b/tests/components/green_planet_energy/conftest.py
@@ -48,13 +48,14 @@ def mock_api() -> Generator[MagicMock]:
         mock_api_instance = MagicMock()
 
         # Mock the API response data
-        # Today's prices: 0.20 + (hour * 0.01)
+        # API returns prices in Cent/kWh (e.g., 25.0 Cent/kWh = 0.25 €/kWh)
+        # Today's prices: 20 + (hour * 1) Cent/kWh
         today_prices = {
-            f"gpe_price_{hour:02d}": 0.20 + (hour * 0.01) for hour in range(24)
+            f"gpe_price_{hour:02d}": 20.0 + (hour * 1.0) for hour in range(24)
         }
-        # Tomorrow's prices: 0.25 + (hour * 0.01) (slightly different for testing)
+        # Tomorrow's prices: 25 + (hour * 1) Cent/kWh (slightly different for testing)
         tomorrow_prices = {
-            f"gpe_price_{hour:02d}_tomorrow": 0.25 + (hour * 0.01) for hour in range(24)
+            f"gpe_price_{hour:02d}_tomorrow": 25.0 + (hour * 1.0) for hour in range(24)
         }
 
         # Combine all prices
@@ -63,24 +64,24 @@ def mock_api() -> Generator[MagicMock]:
         # Make get_electricity_prices async since coordinator uses it
         mock_api_instance.get_electricity_prices = AsyncMock(return_value=all_prices)
 
-        # Mock the calculation methods to return actual values (not coroutines)
-        # Highest price today: 0.20 + (23 * 0.01) = 0.43 at hour 23
-        mock_api_instance.get_highest_price_today.return_value = 0.43
-        mock_api_instance.get_highest_price_today_with_hour.return_value = (0.43, 23)
+        # Mock the calculation methods to return actual values in Cent/kWh (not coroutines)
+        # Highest price today: 20 + (23 * 1) = 43 Cent/kWh at hour 23
+        mock_api_instance.get_highest_price_today.return_value = 43.0
+        mock_api_instance.get_highest_price_today_with_hour.return_value = (43.0, 23)
 
-        # Lowest price day (6-22): 0.20 + (6 * 0.01) = 0.26 at hour 6
-        mock_api_instance.get_lowest_price_day.return_value = 0.26
-        mock_api_instance.get_lowest_price_day_with_hour.return_value = (0.26, 6)
+        # Lowest price day (6-22): 20 + (6 * 1) = 26 Cent/kWh at hour 6
+        mock_api_instance.get_lowest_price_day.return_value = 26.0
+        mock_api_instance.get_lowest_price_day_with_hour.return_value = (26.0, 6)
 
-        # Lowest price night (22-6): 0.20 + (0 * 0.01) = 0.20 at hour 0
-        mock_api_instance.get_lowest_price_night.return_value = 0.20
-        mock_api_instance.get_lowest_price_night_with_hour.return_value = (0.20, 0)
+        # Lowest price night (22-6): 20 + (0 * 1) = 20 Cent/kWh at hour 0
+        mock_api_instance.get_lowest_price_night.return_value = 20.0
+        mock_api_instance.get_lowest_price_night_with_hour.return_value = (20.0, 0)
 
         # Current price depends on the hour passed to the method
-        # Mock get_current_price to return the price for the requested hour
+        # Mock get_current_price to return the price for the requested hour in Cent/kWh
         def get_current_price_mock(data, hour):
-            """Return price for a specific hour."""
-            return 0.20 + (hour * 0.01)
+            """Return price for a specific hour in Cent/kWh."""
+            return 20.0 + (hour * 1.0)
 
         mock_api_instance.get_current_price.side_effect = get_current_price_mock
 


### PR DESCRIPTION
Convert prices from Cent/kWh (as returned by API) to €/kWh for proper display in Home Assistant and energy dashboard calculations. Fixing #162485

<img width="570" height="328" alt="image" src="https://github.com/user-attachments/assets/9c63a4c6-cb91-4794-a658-43a040e44ff7" />


- Divide price values by 100 in sensor value_fn lambdas using walrus operator
- Update test mocks to use realistic Cent/kWh values (e.g., 43.0 instead of 0.43)
- Fix mypy type errors by storing API result before division

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses the correct unit for the API now. See this bug: https://github.com/home-assistant/core/issues/162485


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162485
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
