### PR TITLE
Add audio volume level support to SmartThings integration

### DIFF
--- a/homeassistant/components/smartthings/entity.py
+++ b/homeassistant/components/smartthings/entity.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.entity import Entity
 from . import FullDevice
 from .const import DOMAIN, MAIN
 
+type CommandArgument = int | str | list[Any] | dict[str, Any] | None
+
 
 class SmartThingsEntity(Entity):
     """Defines a SmartThings entity."""
@@ -100,7 +102,7 @@ class SmartThingsEntity(Entity):
         self,
         capability: Capability,
         command: Command,
-        argument: int | str | list[Any] | dict[str, Any] | None = None,
+        argument: CommandArgument = None,
     ) -> None:
         """Execute a command on the device."""
         kwargs = {}

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -60,14 +60,14 @@ CAPABILITY_TO_NUMBER_RANGE_DESCRIPTIONS: dict[
         range_attribute=Attribute.VOLUME_LEVEL_RANGE,
         command=Command.SET_VOLUME_LEVEL,
         exists_fn=lambda device, component: (
-            get_range_options_count(
+            Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
+            and get_range_options_count(
                 device,
                 component,
                 Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
                 Attribute.VOLUME_LEVEL_RANGE,
             )
             >= 2
-            and Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
         ),
     ),
 }
@@ -251,6 +251,7 @@ class SmartThingsRangeNumberEntity(SmartThingsEntity, NumberEntity):
             )
         else:
             self._attr_translation_key = description.key
+        self._attr_suggested_object_id = self._attr_translation_key
 
     @property
     def range(self) -> dict[str, int]:

--- a/homeassistant/components/smartthings/number.py
+++ b/homeassistant/components/smartthings/number.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from pysmartthings import Attribute, Capability, Command, SmartThings
 
-from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -12,6 +20,57 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import FullDevice, SmartThingsConfigEntry
 from .const import MAIN, UNIT_MAP
 from .entity import SmartThingsEntity
+from .util import get_range_options_count
+
+
+@dataclass(frozen=True, kw_only=True)
+class SmartThingsNumberRangeEntityDescription(NumberEntityDescription):
+    """Describe a SmartThings number range entity."""
+
+    status_attribute: Attribute
+    range_attribute: Attribute
+    command: Command
+    component_translation_key: dict[str, str] | None = None
+    exists_fn: Callable[[FullDevice, str], bool] = lambda device, component: True
+
+
+CAPABILITY_TO_NUMBER_RANGE_DESCRIPTIONS: dict[
+    Capability, SmartThingsNumberRangeEntityDescription
+] = {
+    Capability.THERMOSTAT_COOLING_SETPOINT: SmartThingsNumberRangeEntityDescription(
+        key=Capability.THERMOSTAT_COOLING_SETPOINT,
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        status_attribute=Attribute.COOLING_SETPOINT,
+        range_attribute=Attribute.COOLING_SETPOINT_RANGE,
+        command=Command.SET_COOLING_SETPOINT,
+        exists_fn=lambda device, component: (
+            component in ("cooler", "freezer", "onedoor")
+        ),
+        component_translation_key={
+            "cooler": "cooler_temperature",
+            "freezer": "freezer_temperature",
+            "onedoor": "target_temperature",
+        },
+    ),
+    Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL: SmartThingsNumberRangeEntityDescription(
+        key="audio_volume_level",
+        entity_category=EntityCategory.CONFIG,
+        status_attribute=Attribute.VOLUME_LEVEL,
+        range_attribute=Attribute.VOLUME_LEVEL_RANGE,
+        command=Command.SET_VOLUME_LEVEL,
+        exists_fn=lambda device, component: (
+            get_range_options_count(
+                device,
+                component,
+                Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
+                Attribute.VOLUME_LEVEL_RANGE,
+            )
+            >= 2
+            and Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
+        ),
+    ),
+}
 
 
 async def async_setup_entry(
@@ -35,15 +94,22 @@ async def async_setup_entry(
             and Capability.SAMSUNG_CE_CONNECTION_STATE not in hood_component
         )
     )
+
     entities.extend(
-        SmartThingsRefrigeratorTemperatureNumberEntity(
-            entry_data.client, device, component
+        SmartThingsRangeNumberEntity(
+            entry_data.client,
+            device,
+            description,
+            capability,
+            component,
         )
         for device in entry_data.devices.values()
         for component in device.status
-        if component in ("cooler", "freezer", "onedoor")
-        and Capability.THERMOSTAT_COOLING_SETPOINT in device.status[component]
+        for capability, description in CAPABILITY_TO_NUMBER_RANGE_DESCRIPTIONS.items()
+        if capability in device.status[component]
+        and description.exists_fn(device, component)
     )
+
     async_add_entities(entities)
 
 
@@ -153,38 +219,45 @@ class SmartThingsHoodNumberEntity(SmartThingsEntity, NumberEntity):
         )
 
 
-class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEntity):
+class SmartThingsRangeNumberEntity(SmartThingsEntity, NumberEntity):
     """Define a SmartThings number."""
 
-    _attr_entity_category = EntityCategory.CONFIG
-    _attr_device_class = NumberDeviceClass.TEMPERATURE
+    entity_description: SmartThingsNumberRangeEntityDescription
 
-    def __init__(self, client: SmartThings, device: FullDevice, component: str) -> None:
+    def __init__(
+        self,
+        client: SmartThings,
+        device: FullDevice,
+        description: SmartThingsNumberRangeEntityDescription,
+        capability: Capability,
+        component: str = MAIN,
+    ) -> None:
         """Initialize the instance."""
         super().__init__(
             client,
             device,
-            {Capability.THERMOSTAT_COOLING_SETPOINT},
+            {capability},
             component=component,
         )
-        self._attr_unique_id = f"{device.device.device_id}_{component}_{Capability.THERMOSTAT_COOLING_SETPOINT}_{Attribute.COOLING_SETPOINT}_{Attribute.COOLING_SETPOINT}"
-        unit = self._internal_state[Capability.THERMOSTAT_COOLING_SETPOINT][
-            Attribute.COOLING_SETPOINT
-        ].unit
-        assert unit is not None
-        self._attr_native_unit_of_measurement = UNIT_MAP[unit]
-        self._attr_translation_key = {
-            "cooler": "cooler_temperature",
-            "freezer": "freezer_temperature",
-            "onedoor": "target_temperature",
-        }.get(component)
+        self.entity_description = description
+        self._attr_unique_id = f"{device.device.device_id}_{component}_{description.key}_{description.status_attribute}_{description.status_attribute}"
+        unit = self._internal_state[capability][description.status_attribute].unit
+        if unit is not None:
+            self._attr_native_unit_of_measurement = UNIT_MAP[unit]
+        self.number_capability = capability
+        if description.component_translation_key:
+            self._attr_translation_key = description.component_translation_key.get(
+                component, description.key
+            )
+        else:
+            self._attr_translation_key = description.key
 
     @property
     def range(self) -> dict[str, int]:
         """Return the list of options."""
         return self.get_attribute_value(
-            Capability.THERMOSTAT_COOLING_SETPOINT,
-            Attribute.COOLING_SETPOINT_RANGE,
+            self.number_capability,
+            self.entity_description.range_attribute,
         )
 
     @property
@@ -192,7 +265,8 @@ class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEn
         """Return the current value."""
         return int(
             self.get_attribute_value(
-                Capability.THERMOSTAT_COOLING_SETPOINT, Attribute.COOLING_SETPOINT
+                self.number_capability,
+                self.entity_description.status_attribute,
             )
         )
 
@@ -214,7 +288,7 @@ class SmartThingsRefrigeratorTemperatureNumberEntity(SmartThingsEntity, NumberEn
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         await self.execute_device_command(
-            Capability.THERMOSTAT_COOLING_SETPOINT,
-            Command.SET_COOLING_SETPOINT,
+            self.number_capability,
+            self.entity_description.command,
             int(value),
         )

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -154,6 +154,9 @@
       }
     },
     "number": {
+      "audio_volume_level": {
+        "name": "Audio volume level"
+      },
       "cool_select_plus_temperature": {
         "name": "CoolSelect+ temperature"
       },
@@ -766,6 +769,9 @@
       },
       "keep_fresh_mode": {
         "name": "Keep fresh mode"
+      },
+      "mute": {
+        "name": "Mute"
       },
       "power_cool": {
         "name": "Power cool"

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -19,8 +20,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import FullDevice, SmartThingsConfigEntry
 from .const import INVALID_SWITCH_CATEGORIES, MAIN
-from .entity import SmartThingsEntity
-from .util import deprecate_entity
+from .entity import CommandArgument, SmartThingsEntity
+from .util import deprecate_entity, get_range_options_count
 
 CAPABILITIES = (
     Capability.SWITCH_LEVEL,
@@ -48,9 +49,12 @@ class SmartThingsSwitchEntityDescription(SwitchEntityDescription):
 
     status_attribute: Attribute
     component_translation_key: dict[str, str] | None = None
-    on_key: str = "on"
+    on_key: str | int = "on"
     on_command: Command = Command.ON
+    on_command_argument: CommandArgument = None
     off_command: Command = Command.OFF
+    off_command_argument: CommandArgument = None
+    exists_fn: Callable[[FullDevice, str], bool] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -58,6 +62,8 @@ class SmartThingsCommandSwitchEntityDescription(SmartThingsSwitchEntityDescripti
     """Describe a SmartThings switch entity."""
 
     command: Command
+    on_command_argument: CommandArgument = "on"
+    off_command_argument: CommandArgument = "off"
 
 
 SWITCH = SmartThingsSwitchEntityDescription(
@@ -88,6 +94,28 @@ CAPABILITY_TO_COMMAND_SWITCHES: dict[
         status_attribute=Attribute.STEAM_CLOSET_AUTO_CYCLE_LINK,
         command=Command.SET_STEAM_CLOSET_AUTO_CYCLE_LINK,
         entity_category=EntityCategory.CONFIG,
+    ),
+    Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL: SmartThingsCommandSwitchEntityDescription(
+        key=Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
+        translation_key="mute",
+        status_attribute=Attribute.VOLUME_LEVEL,
+        command=Command.SET_VOLUME_LEVEL,
+        on_key=0,
+        on_command_argument=0,
+        off_command_argument=1,
+        entity_category=EntityCategory.CONFIG,
+        exists_fn=lambda device, component: (
+            # Only create mute switch if volume level has 2 options (muted and unmuted)
+            # For other cases, we rely on the volume level number entity to set volume
+            get_range_options_count(
+                device,
+                component,
+                Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
+                Attribute.VOLUME_LEVEL_RANGE,
+            )
+            == 2
+            and Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
+        ),
     ),
 }
 CAPABILITY_TO_SWITCHES: dict[Capability | str, SmartThingsSwitchEntityDescription] = {
@@ -170,6 +198,7 @@ async def async_setup_entry(
         for device in entry_data.devices.values()
         for capability, description in CAPABILITY_TO_COMMAND_SWITCHES.items()
         if capability in device.status[MAIN]
+        and (description.exists_fn is None or description.exists_fn(device, MAIN))
     ]
     entities.extend(
         SmartThingsSwitch(
@@ -190,6 +219,7 @@ async def async_setup_entry(
                 and component in description.component_translation_key
             )
         )
+        and (description.exists_fn is None or description.exists_fn(device, component))
     )
     entity_registry = er.async_get(hass)
     for device in entry_data.devices.values():
@@ -279,6 +309,7 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         await self.execute_device_command(
             self.switch_capability,
             self.entity_description.off_command,
+            self.entity_description.off_command_argument,
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -286,6 +317,7 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         await self.execute_device_command(
             self.switch_capability,
             self.entity_description.on_command,
+            self.entity_description.on_command_argument,
         )
 
     @property
@@ -309,7 +341,7 @@ class SmartThingsCommandSwitch(SmartThingsSwitch):
         await self.execute_device_command(
             self.switch_capability,
             self.entity_description.command,
-            "off",
+            self.entity_description.off_command_argument,
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -317,5 +349,5 @@ class SmartThingsCommandSwitch(SmartThingsSwitch):
         await self.execute_device_command(
             self.switch_capability,
             self.entity_description.command,
-            "on",
+            self.entity_description.on_command_argument,
         )

--- a/homeassistant/components/smartthings/switch.py
+++ b/homeassistant/components/smartthings/switch.py
@@ -107,14 +107,14 @@ CAPABILITY_TO_COMMAND_SWITCHES: dict[
         exists_fn=lambda device, component: (
             # Only create mute switch if volume level has 2 options (muted and unmuted)
             # For other cases, we rely on the volume level number entity to set volume
-            get_range_options_count(
+            Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
+            and get_range_options_count(
                 device,
                 component,
                 Capability.SAMSUNG_CE_AUDIO_VOLUME_LEVEL,
                 Attribute.VOLUME_LEVEL_RANGE,
             )
             == 2
-            and Capability.ROBOT_CLEANER_MOVEMENT not in device.status[component]
         ),
     ),
 }
@@ -303,6 +303,7 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
             translation_key := translation_keys.get(component)
         ) is not None:
             self._attr_translation_key = translation_key
+        self._attr_suggested_object_id = entity_description.translation_key
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""

--- a/homeassistant/components/smartthings/util.py
+++ b/homeassistant/components/smartthings/util.py
@@ -1,5 +1,7 @@
 """Utility functions for SmartThings integration."""
 
+from pysmartthings import Attribute, Capability
+
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity
 from homeassistant.core import HomeAssistant
@@ -10,6 +12,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 
+from . import FullDevice
 from .const import DOMAIN
 
 
@@ -82,3 +85,21 @@ def get_automations_and_scripts_using_entity(
         for entity_id in entities
         if (item := entity_reg.async_get(entity_id))
     ]
+
+
+def get_range_options_count(
+    device: FullDevice, component: str, capability: Capability, attribute: Attribute
+) -> int:
+    """Get the number of options in a range attribute."""
+    value = device.status[component][capability][attribute].value
+    assert isinstance(value, dict)
+    minimum = value.get("minimum", None)
+    maximum = value.get("maximum", None)
+    step = value.get("step", None)
+    if minimum is None or maximum is None or step is None:
+        raise ValueError("Missing range options")
+    assert isinstance(minimum, int)
+    assert isinstance(maximum, int)
+    assert isinstance(step, int)
+
+    return len(range(minimum, maximum + 1, step))

--- a/homeassistant/components/smartthings/util.py
+++ b/homeassistant/components/smartthings/util.py
@@ -90,16 +90,38 @@ def get_automations_and_scripts_using_entity(
 def get_range_options_count(
     device: FullDevice, component: str, capability: Capability, attribute: Attribute
 ) -> int:
-    """Get the number of options in a range attribute."""
-    value = device.status[component][capability][attribute].value
-    assert isinstance(value, dict)
-    minimum = value.get("minimum", None)
-    maximum = value.get("maximum", None)
-    step = value.get("step", None)
-    if minimum is None or maximum is None or step is None:
-        raise ValueError("Missing range options")
-    assert isinstance(minimum, int)
-    assert isinstance(maximum, int)
-    assert isinstance(step, int)
+    """Get the number of options in a range attribute.
 
-    return len(range(minimum, maximum + 1, step))
+    This helper is intentionally non-throwing. If the underlying status payload
+    is missing or malformed, it will return 0 so callers can skip creating the
+    related entity instead of failing platform setup.
+    """
+    try:
+        status = device.status
+        value = status[component][capability][attribute].value
+    except KeyError, TypeError, AttributeError:
+        # Missing component/capability/attribute or unexpected structure
+        return 0
+
+    if not isinstance(value, dict):
+        return 0
+
+    minimum = value.get("minimum")
+    maximum = value.get("maximum")
+    step = value.get("step")
+
+    if (
+        not isinstance(minimum, int)
+        or not isinstance(maximum, int)
+        or not isinstance(step, int)
+    ):
+        return 0
+
+    if step <= 0 or maximum < minimum:
+        return 0
+
+    try:
+        return len(range(minimum, maximum + 1, step))
+    except ValueError:
+        # range() can still raise ValueError for invalid arguments
+        return 0

--- a/tests/components/smartthings/snapshots/test_number.ambr
+++ b/tests/components/smartthings/snapshots/test_number.ambr
@@ -477,6 +477,122 @@
     'state': '3',
   })
 # ---
+# name: test_all_entities[da_wm_dw_01011][number.dishwasher-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.dishwasher',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '7ff318f3-3772-524d-3c9f-72fcd26413ed_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_dw_01011][number.dishwasher-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dishwasher',
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.dishwasher',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1',
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.trockner',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': '3d39866c-7716-5259-44f0-fd7025efd85f_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wd_01011][number.trockner-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Trockner',
+      'max': 3,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.trockner',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3',
+  })
+# ---
 # name: test_all_entities[da_wm_wm_000001][number.washer_rinse_cycles-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -593,6 +709,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.machine_a_laver',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_volume_level',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_audio_volume_level_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver',
+      'max': 1,
+      'min': 0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.machine_a_laver',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
   })
 # ---
 # name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_rinse_cycles-entry]

--- a/tests/components/smartthings/snapshots/test_number.ambr
+++ b/tests/components/smartthings/snapshots/test_number.ambr
@@ -477,7 +477,7 @@
     'state': '3',
   })
 # ---
-# name: test_all_entities[da_wm_dw_01011][number.dishwasher-entry]
+# name: test_all_entities[da_wm_dw_01011][number.dishwasher_audio_volume_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -495,7 +495,7 @@
     'disabled_by': None,
     'domain': 'number',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'number.dishwasher',
+    'entity_id': 'number.dishwasher_audio_volume_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -503,12 +503,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Audio volume level',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Audio volume level',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -518,24 +518,24 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_wm_dw_01011][number.dishwasher-state]
+# name: test_all_entities[da_wm_dw_01011][number.dishwasher_audio_volume_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Dishwasher',
+      'friendly_name': 'Dishwasher Audio volume level',
       'max': 1,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
       'step': 1,
     }),
     'context': <ANY>,
-    'entity_id': 'number.dishwasher',
+    'entity_id': 'number.dishwasher_audio_volume_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1',
   })
 # ---
-# name: test_all_entities[da_wm_wd_01011][number.trockner-entry]
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -553,7 +553,7 @@
     'disabled_by': None,
     'domain': 'number',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'number.trockner',
+    'entity_id': 'number.trockner_audio_volume_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -561,12 +561,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Audio volume level',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Audio volume level',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -576,17 +576,17 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_wm_wd_01011][number.trockner-state]
+# name: test_all_entities[da_wm_wd_01011][number.trockner_audio_volume_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Trockner',
+      'friendly_name': 'Trockner Audio volume level',
       'max': 3,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
       'step': 1,
     }),
     'context': <ANY>,
-    'entity_id': 'number.trockner',
+    'entity_id': 'number.trockner_audio_volume_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -711,7 +711,7 @@
     'state': '2',
   })
 # ---
-# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver-entry]
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -729,7 +729,7 @@
     'disabled_by': None,
     'domain': 'number',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'number.machine_a_laver',
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -737,12 +737,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Audio volume level',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Audio volume level',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -752,17 +752,17 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver-state]
+# name: test_all_entities[da_wm_wm_01011][number.machine_a_laver_audio_volume_level-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Machine à Laver',
+      'friendly_name': 'Machine à Laver Audio volume level',
       'max': 1,
       'min': 0,
       'mode': <NumberMode.AUTO: 'auto'>,
       'step': 1,
     }),
     'context': <ANY>,
-    'entity_id': 'number.machine_a_laver',
+    'entity_id': 'number.machine_a_laver_audio_volume_level',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -1028,6 +1028,55 @@
     'state': 'off',
   })
 # ---
+# name: test_all_entities[da_wm_dw_01011][switch.dishwasher-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.dishwasher',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mute',
+    'unique_id': '7ff318f3-3772-524d-3c9f-72fcd26413ed_main_samsungce.audioVolumeLevel_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_dw_01011][switch.dishwasher-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Dishwasher',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.dishwasher',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_entities[da_wm_sc_000001][switch.airdresser_auto_cycle_link-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1369,6 +1418,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.machine_a_laver',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mute',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_samsungce.audioVolumeLevel_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.machine_a_laver',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_bubble_soak-entry]

--- a/tests/components/smartthings/snapshots/test_switch.ambr
+++ b/tests/components/smartthings/snapshots/test_switch.ambr
@@ -1028,7 +1028,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_wm_dw_01011][switch.dishwasher-entry]
+# name: test_all_entities[da_wm_dw_01011][switch.dishwasher_mute-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1041,7 +1041,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.dishwasher',
+    'entity_id': 'switch.dishwasher_mute',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1049,12 +1049,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Mute',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Mute',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1064,13 +1064,13 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_wm_dw_01011][switch.dishwasher-state]
+# name: test_all_entities[da_wm_dw_01011][switch.dishwasher_mute-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Dishwasher',
+      'friendly_name': 'Dishwasher Mute',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.dishwasher',
+    'entity_id': 'switch.dishwasher_mute',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1420,55 +1420,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.machine_a_laver',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'smartthings',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'mute',
-    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_samsungce.audioVolumeLevel_volumeLevel_volumeLevel',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Machine à Laver',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.machine_a_laver',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
 # name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_bubble_soak-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1516,6 +1467,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_mute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.machine_a_laver_mute',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mute',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Mute',
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mute',
+    'unique_id': 'b854ca5f-dc54-140d-6349-758b4d973c41_main_samsungce.audioVolumeLevel_volumeLevel_volumeLevel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_wm_wm_01011][switch.machine_a_laver_mute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Machine à Laver Mute',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.machine_a_laver_mute',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[generic_ef00_v1][switch.thermostat_kuche-entry]


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Add number entity for audio volume level control
- Add mute switch for devices with binary volume (0/1)
- Refactor refrigerator temperature entities to use generic SmartThingsRangeNumberEntity
- Add get_range_options_count utility to determine entity type
- Add CommandArgument type alias to reduce duplication
- Excluder robot cleaners as it causes unknown problems (see: https://github.com/home-assistant/core/pull/156642#pullrequestreview-3468100318)
- Update translations and test snapshots

Supersede: https://github.com/home-assistant/core/pull/156642


Tests on: DA-WM-DW-01011 (Samsung Model: [DW60BG850B00ET](https://www.samsung.com/pl/dishwashers/built-in/60cm-built-in-dishwasher-14-place-settings-white-dw60bg850b00et/)). I don't have another device to check it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/41787
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
