### PR TITLE
Fix Venstar integration crash when thermostat is unreachable

### DIFF
--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     """Set up Vensar device binary_sensors based on a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    if coordinator.client.alerts is None:
+    if not isinstance(coordinator.client.alerts, list):
         return
     async_add_entities(
         VenstarBinarySensor(coordinator, config_entry, alert["name"])
@@ -43,6 +43,8 @@ class VenstarBinarySensor(VenstarEntity, BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
+        if not isinstance(self._client.alerts, list):
+            return None
         for alert in self._client.alerts:
             if alert["name"] == self.alert:
                 return alert["active"]

--- a/homeassistant/components/venstar/binary_sensor.py
+++ b/homeassistant/components/venstar/binary_sensor.py
@@ -20,7 +20,7 @@ async def async_setup_entry(
     """Set up Vensar device binary_sensors based on a config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    if not isinstance(coordinator.client.alerts, list):
+    if coordinator.client.alerts is None:
         return
     async_add_entities(
         VenstarBinarySensor(coordinator, config_entry, alert["name"])
@@ -43,7 +43,7 @@ class VenstarBinarySensor(VenstarEntity, BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
-        if not isinstance(self._client.alerts, list):
+        if self._client.alerts is None:
             return None
         for alert in self._client.alerts:
             if alert["name"] == self.alert:

--- a/homeassistant/components/venstar/coordinator.py
+++ b/homeassistant/components/venstar/coordinator.py
@@ -81,20 +81,22 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
         await asyncio.sleep(VENSTAR_SLEEP)
 
         try:
-            await self.hass.async_add_executor_job(self.client.update_alerts)
+            alerts_success = await self.hass.async_add_executor_job(
+                self.client.update_alerts
+            )
         except (OSError, RequestException) as ex:
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar alert update: {ex}"
             ) from ex
 
-        if not isinstance(self.client.alerts, list):
+        if not alerts_success:
             raise update_coordinator.UpdateFailed("Unable to update Venstar alert data")
 
         # older venstars sometimes cannot handle rapid sequential connections
         await asyncio.sleep(VENSTAR_SLEEP)
 
         try:
-            self.runtimes = await self.hass.async_add_executor_job(
+            runtimes_result = await self.hass.async_add_executor_job(
                 self.client.get_runtimes
             )
         except (OSError, RequestException) as ex:
@@ -102,7 +104,9 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
                 f"Exception during Venstar runtime update: {ex}"
             ) from ex
 
-        if self.runtimes is False:
+        if not runtimes_result:
             raise update_coordinator.UpdateFailed(
                 "Unable to update Venstar runtime data"
             )
+
+        self.runtimes = runtimes_result

--- a/homeassistant/components/venstar/coordinator.py
+++ b/homeassistant/components/venstar/coordinator.py
@@ -38,23 +38,44 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
         self.runtimes: list[dict[str, int]] = []
 
     async def _async_update_data(self) -> None:
-        """Update the state."""
+        """Update the state.
+
+        The venstarcolortouch library catches all exceptions internally and
+        returns False on failure instead of raising.  This means the
+        OSError / RequestException handlers below will rarely fire, so we
+        also check return values to detect silent failures and properly
+        signal UpdateFailed to the coordinator.
+        """
         try:
-            await self.hass.async_add_executor_job(self.client.update_info)
+            info_success = await self.hass.async_add_executor_job(
+                self.client.update_info
+            )
         except (OSError, RequestException) as ex:
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar info update: {ex}"
             ) from ex
 
+        if not info_success:
+            raise update_coordinator.UpdateFailed(
+                "Unable to update Venstar thermostat info"
+            )
+
         # older venstars sometimes cannot handle rapid sequential connections
         await asyncio.sleep(VENSTAR_SLEEP)
 
         try:
-            await self.hass.async_add_executor_job(self.client.update_sensors)
+            sensor_success = await self.hass.async_add_executor_job(
+                self.client.update_sensors
+            )
         except (OSError, RequestException) as ex:
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar sensor update: {ex}"
             ) from ex
+
+        if not sensor_success:
+            raise update_coordinator.UpdateFailed(
+                "Unable to update Venstar sensor data"
+            )
 
         # older venstars sometimes cannot handle rapid sequential connections
         await asyncio.sleep(VENSTAR_SLEEP)
@@ -65,6 +86,9 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar alert update: {ex}"
             ) from ex
+
+        if not isinstance(self.client.alerts, list):
+            raise update_coordinator.UpdateFailed("Unable to update Venstar alert data")
 
         # older venstars sometimes cannot handle rapid sequential connections
         await asyncio.sleep(VENSTAR_SLEEP)
@@ -77,3 +101,8 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
             raise update_coordinator.UpdateFailed(
                 f"Exception during Venstar runtime update: {ex}"
             ) from ex
+
+        if self.runtimes is False:
+            raise update_coordinator.UpdateFailed(
+                "Unable to update Venstar runtime data"
+            )

--- a/tests/components/venstar/__init__.py
+++ b/tests/components/venstar/__init__.py
@@ -20,11 +20,11 @@ class VenstarColorTouchMock:
         self.status = {}
         self.model = "COLORTOUCH"
         self._api_ver = 7
-        self._firmware_ver = tuple(5, 28)
+        self._firmware_ver = (5, 28)
         self.name = "TestVenstar"
         self._info = {}
         self._sensors = {}
-        self.alerts = {}
+        self.alerts = []
         self.MODE_OFF = 0
         self.MODE_HEAT = 1
         self.MODE_COOL = 2
@@ -52,9 +52,17 @@ class VenstarColorTouchMock:
         """Mock a update_info that raises Exception."""
         raise RequestException
 
+    def failed_update_info(self):
+        """Mock update_info returning False (silent failure)."""
+        return False
+
     def update_sensors(self):
         """Mock update_sensors."""
         return True
+
+    def failed_update_sensors(self):
+        """Mock update_sensors returning False (silent failure)."""
+        return False
 
     def update_runtimes(self):
         """Mock update_runtimes."""
@@ -62,8 +70,17 @@ class VenstarColorTouchMock:
 
     def update_alerts(self):
         """Mock update_alerts."""
+        self.alerts = []
         return True
+
+    def failed_update_alerts(self):
+        """Mock update_alerts setting alerts to False (silent failure)."""
+        self.alerts = False
 
     def get_runtimes(self):
         """Mock get runtimes."""
         return {}
+
+    def failed_get_runtimes(self):
+        """Mock get_runtimes returning False (silent failure)."""
+        return False

--- a/tests/components/venstar/__init__.py
+++ b/tests/components/venstar/__init__.py
@@ -74,12 +74,12 @@ class VenstarColorTouchMock:
         return True
 
     def failed_update_alerts(self):
-        """Mock update_alerts setting alerts to False (silent failure)."""
-        self.alerts = False
+        """Mock update_alerts returning False (silent failure)."""
+        return False
 
     def get_runtimes(self):
         """Mock get runtimes."""
-        return {}
+        return [{"heat1": 100, "cool1": 200}]
 
     def failed_get_runtimes(self):
         """Mock get_runtimes returning False (silent failure)."""

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -98,3 +98,175 @@ async def test_setup_entry_exception(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_info_returns_false(hass: HomeAssistant) -> None:
+    """Validate coordinator handles update_info returning False."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_SSL: False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch._request",
+            new=VenstarColorTouchMock._request,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
+            new=VenstarColorTouchMock.update_sensors,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_info",
+            new=VenstarColorTouchMock.failed_update_info,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+            new=VenstarColorTouchMock.update_alerts,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
+            new=VenstarColorTouchMock.get_runtimes,
+        ),
+        patch(
+            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
+            new=0,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_sensors_returns_false(hass: HomeAssistant) -> None:
+    """Validate coordinator handles update_sensors returning False."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_SSL: False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch._request",
+            new=VenstarColorTouchMock._request,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
+            new=VenstarColorTouchMock.failed_update_sensors,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_info",
+            new=VenstarColorTouchMock.update_info,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+            new=VenstarColorTouchMock.update_alerts,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
+            new=VenstarColorTouchMock.get_runtimes,
+        ),
+        patch(
+            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
+            new=0,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_alerts_returns_false(hass: HomeAssistant) -> None:
+    """Validate coordinator handles update_alerts setting alerts to False."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_SSL: False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch._request",
+            new=VenstarColorTouchMock._request,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
+            new=VenstarColorTouchMock.update_sensors,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_info",
+            new=VenstarColorTouchMock.update_info,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+            new=VenstarColorTouchMock.failed_update_alerts,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
+            new=VenstarColorTouchMock.get_runtimes,
+        ),
+        patch(
+            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
+            new=0,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_get_runtimes_returns_false(hass: HomeAssistant) -> None:
+    """Validate coordinator handles get_runtimes returning False."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_SSL: False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch._request",
+            new=VenstarColorTouchMock._request,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
+            new=VenstarColorTouchMock.update_sensors,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_info",
+            new=VenstarColorTouchMock.update_info,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
+            new=VenstarColorTouchMock.update_alerts,
+        ),
+        patch(
+            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
+            new=VenstarColorTouchMock.failed_get_runtimes,
+        ),
+        patch(
+            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
+            new=0,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.components.venstar.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_SSL
@@ -100,8 +102,19 @@ async def test_setup_entry_exception(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_update_info_returns_false(hass: HomeAssistant) -> None:
-    """Validate coordinator handles update_info returning False."""
+@pytest.mark.parametrize(
+    ("failed_method", "target_method"),
+    [
+        ("failed_update_info", "update_info"),
+        ("failed_update_sensors", "update_sensors"),
+        ("failed_update_alerts", "update_alerts"),
+        ("failed_get_runtimes", "get_runtimes"),
+    ],
+)
+async def test_silent_failure_triggers_retry(
+    hass: HomeAssistant, failed_method: str, target_method: str
+) -> None:
+    """Validate coordinator handles library methods returning False."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -111,48 +124,15 @@ async def test_update_info_returns_false(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch._request",
-            new=VenstarColorTouchMock._request,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
-            new=VenstarColorTouchMock.update_sensors,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_info",
-            new=VenstarColorTouchMock.failed_update_info,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
-            new=VenstarColorTouchMock.update_alerts,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
-            new=VenstarColorTouchMock.get_runtimes,
-        ),
-        patch(
-            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
-            new=0,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_update_sensors_returns_false(hass: HomeAssistant) -> None:
-    """Validate coordinator handles update_sensors returning False."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_SSL: False,
-        },
-    )
-    config_entry.add_to_hass(hass)
+    # Map method names to their default (successful) mocks
+    methods = {
+        "update_info": VenstarColorTouchMock.update_info,
+        "update_sensors": VenstarColorTouchMock.update_sensors,
+        "update_alerts": VenstarColorTouchMock.update_alerts,
+        "get_runtimes": VenstarColorTouchMock.get_runtimes,
+    }
+    # Override the target method with its failed variant
+    methods[target_method] = getattr(VenstarColorTouchMock, failed_method)
 
     with (
         patch(
@@ -160,106 +140,20 @@ async def test_update_sensors_returns_false(hass: HomeAssistant) -> None:
             new=VenstarColorTouchMock._request,
         ),
         patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
-            new=VenstarColorTouchMock.failed_update_sensors,
-        ),
-        patch(
             "homeassistant.components.venstar.VenstarColorTouch.update_info",
-            new=VenstarColorTouchMock.update_info,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
-            new=VenstarColorTouchMock.update_alerts,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
-            new=VenstarColorTouchMock.get_runtimes,
-        ),
-        patch(
-            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
-            new=0,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_update_alerts_returns_false(hass: HomeAssistant) -> None:
-    """Validate coordinator handles update_alerts setting alerts to False."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_SSL: False,
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch._request",
-            new=VenstarColorTouchMock._request,
+            new=methods["update_info"],
         ),
         patch(
             "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
-            new=VenstarColorTouchMock.update_sensors,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_info",
-            new=VenstarColorTouchMock.update_info,
+            new=methods["update_sensors"],
         ),
         patch(
             "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
-            new=VenstarColorTouchMock.failed_update_alerts,
+            new=methods["update_alerts"],
         ),
         patch(
             "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
-            new=VenstarColorTouchMock.get_runtimes,
-        ),
-        patch(
-            "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",
-            new=0,
-        ),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_get_runtimes_returns_false(hass: HomeAssistant) -> None:
-    """Validate coordinator handles get_runtimes returning False."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_HOST: TEST_HOST,
-            CONF_SSL: False,
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch._request",
-            new=VenstarColorTouchMock._request,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_sensors",
-            new=VenstarColorTouchMock.update_sensors,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_info",
-            new=VenstarColorTouchMock.update_info,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.update_alerts",
-            new=VenstarColorTouchMock.update_alerts,
-        ),
-        patch(
-            "homeassistant.components.venstar.VenstarColorTouch.get_runtimes",
-            new=VenstarColorTouchMock.failed_get_runtimes,
+            new=methods["get_runtimes"],
         ),
         patch(
             "homeassistant.components.venstar.coordinator.VENSTAR_SLEEP",

--- a/tests/components/venstar/util.py
+++ b/tests/components/venstar/util.py
@@ -40,6 +40,12 @@ def mock_venstar_devices(f):
                     f"http://venstar-{model}.localdomain/query/alerts",
                     text=await async_load_fixture(hass, f"{model}_alerts.json", DOMAIN),
                 )
+                m.get(
+                    f"http://venstar-{model}.localdomain/query/runtimes",
+                    text=await async_load_fixture(
+                        hass, f"{model}_runtimes.json", DOMAIN
+                    ),
+                )
             await f(hass)
 
     return wrapper


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `venstarcolortouch` library's `_request()` method catches all exceptions internally and returns `False` instead of raising. This means the coordinator's `except (OSError, RequestException)` handlers never fire on connection failures — the calls silently return `False`.

When a thermostat becomes unreachable, `client.alerts` gets set to `False` (not a list), causing `binary_sensor.py` to crash with `TypeError: 'bool' object is not iterable`.

This PR:
- Checks return values from the library in the coordinator and raises `UpdateFailed` on silent failures, so HA properly marks entities as unavailable and retries automatically.
- Adds tests for all four silent-failure paths (`update_info`, `update_sensors`, `update_alerts`, `get_runtimes` each returning `False`).
- Fixed `update_alerts` mock to set `self.alerts = []` on success, matching the real library's behavior. The previous mock only returned `True` without populating the alerts attribute. I believe this was a bug — the old coordinator never inspected `client.alerts` after calling `update_alerts()`, so it went unnoticed. With the new return-value checks, the mock must accurately reflect what the library does on success.
- Fixes two pre-existing bugs in the test mock: `alerts` was initialized as `dict` instead of `list`, and `_firmware_ver = tuple(5, 28)` which raises `TypeError` (should be a tuple literal `(5, 28)`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136605
- This PR is related to issue: #112673
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr