### PR TITLE
Fix Tesla Fleet partner registration to use all regions

### DIFF
--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -307,12 +307,9 @@ async def test_domain_registration_errors(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
         # Enter domain - this should fail and stay on domain_registration
-        with patch(
-            "homeassistant.helpers.translation.async_get_translations", return_value={}
-        ):
-            result = await hass.config_entries.flow.async_configure(
-                result["flow_id"], {CONF_DOMAIN: "example.com"}
-            )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_registration"
         assert result["errors"] == {"base": expected_error}

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -251,7 +251,7 @@ async def test_domain_input_invalid_domain(
     ("side_effect", "expected_error"),
     [
         (InvalidResponse, "invalid_response"),
-        (TeslaFleetError("Custom error"), "unknown_error"),
+        (TeslaFleetError("Custom error"), "invalid_response"),
     ],
 )
 @pytest.mark.usefixtures("current_request_with_host")
@@ -495,6 +495,159 @@ async def test_domain_registration_public_key_mismatch(
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "domain_registration"
         assert result["errors"] == {"base": "public_key_mismatch"}
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_partial_failure(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key,
+) -> None:
+    """Test domain registration succeeds when one region fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    public_key = "0404112233445566778899aabbccddeeff112233445566778899aabbccddeeff112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122"
+
+    # Create two separate mocks for NA and EU
+    mock_api_na = AsyncMock()
+    mock_api_na.private_key = mock_private_key
+    mock_api_na.get_private_key = AsyncMock()
+    mock_api_na.partner_login = AsyncMock()
+    mock_api_na.public_pem = "test_pem"
+    mock_api_na.public_uncompressed_point = public_key
+    mock_api_na.partner.register.return_value = {"response": {"public_key": public_key}}
+
+    mock_api_eu = AsyncMock()
+    mock_api_eu.private_key = mock_private_key
+    mock_api_eu.get_private_key = AsyncMock()
+    mock_api_eu.partner_login = AsyncMock()
+    mock_api_eu.public_pem = "test_pem"
+    mock_api_eu.public_uncompressed_point = public_key
+    mock_api_eu.server = "https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    mock_api_eu.partner.register.side_effect = TeslaFleetError("EU registration failed")
+
+    with (
+        patch(
+            "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+            side_effect=[mock_api_na, mock_api_eu],
+        ),
+        patch(
+            "homeassistant.components.tesla_fleet.async_setup_entry", return_value=True
+        ),
+    ):
+        # Complete OAuth
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+
+        # Enter domain - NA succeeds, EU fails, should still proceed
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "registration_complete"
+
+        # Complete flow
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_domain_registration_all_regions_fail(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key,
+) -> None:
+    """Test domain registration fails when all regions fail."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    mock_api_na = AsyncMock()
+    mock_api_na.private_key = mock_private_key
+    mock_api_na.get_private_key = AsyncMock()
+    mock_api_na.partner_login = AsyncMock()
+    mock_api_na.public_pem = "test_pem"
+    mock_api_na.public_uncompressed_point = "test_point"
+    mock_api_na.server = "https://fleet-api.prd.na.vn.cloud.tesla.com"
+    mock_api_na.partner.register.side_effect = TeslaFleetError("NA registration failed")
+
+    mock_api_eu = AsyncMock()
+    mock_api_eu.private_key = mock_private_key
+    mock_api_eu.get_private_key = AsyncMock()
+    mock_api_eu.partner_login = AsyncMock()
+    mock_api_eu.public_pem = "test_pem"
+    mock_api_eu.public_uncompressed_point = "test_point"
+    mock_api_eu.server = "https://fleet-api.prd.eu.vn.cloud.tesla.com"
+    mock_api_eu.partner.register.side_effect = TeslaFleetError("EU registration failed")
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[mock_api_na, mock_api_eu],
+    ):
+        # Complete OAuth
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+        # Enter domain - both regions fail
+        with patch(
+            "homeassistant.helpers.translation.async_get_translations", return_value={}
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], {CONF_DOMAIN: "example.com"}
+            )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_registration"
+        assert result["errors"] == {"base": "invalid_response"}
 
 
 @pytest.mark.usefixtures("current_request_with_host")


### PR DESCRIPTION
## Proposed change

Fix "Unable to Grant Third-Party Access" error during Tesla Fleet setup caused by Tesla's OAuth JWT containing an `ou_code` that doesn't match the user's actual region.

Previously, the config flow used the `ou_code` from the JWT to select a single regional server for partner registration. If the region was wrong, registration only existed on the wrong server, and virtual key installation would fail.

This change registers the partner domain on both NA and EU servers (skipping CN) during the config flow, so registration exists regardless of region mismatch. If at least one region succeeds, the flow proceeds. `PreconditionFailed` remains fatal since it indicates a configuration issue rather than a regional one.

Changes:
- Replace single-region `self.api` with `self.apis` list containing NA and EU API instances
- Loop over all regions in `async_oauth_create_entry` to set up partner API connections
- In `async_step_domain_registration`, register on all regions -- if at least one succeeds, proceed
- Added `test_domain_registration_partial_failure` and `test_domain_registration_all_regions_fail` tests

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #161678
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr