### PR TITLE
Add trigger for timer events

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -153,6 +153,7 @@ _EXPERIMENTAL_TRIGGER_PLATFORMS = {
     "siren",
     "switch",
     "text",
+    "timer",
     "update",
     "vacuum",
 }

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -20,8 +20,20 @@
     }
   },
   "triggers": {
-    "events": {
-      "trigger": "mdi:timer"
+    "cancel": {
+      "trigger": "mdi:timer-cancel-outline"
+    },
+    "finish": {
+      "trigger": "mdi:timer-check-outline"
+    },
+    "pause": {
+      "trigger": "mdi:timer-pause-outline"
+    },
+    "restart": {
+      "trigger": "mdi:timer-refresh-outline"
+    },
+    "start": {
+      "trigger": "mdi:timer-play-outline"
     }
   }
 }

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -18,5 +18,10 @@
     "start": {
       "service": "mdi:play"
     }
+  },
+  "triggers": {
+    "events": {
+      "trigger": "mdi:timer"
+    }
   }
 }

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -20,7 +20,7 @@
     }
   },
   "triggers": {
-    "canceled": {
+    "cancelled": {
       "trigger": "mdi:timer-cancel-outline"
     },
     "finished": {

--- a/homeassistant/components/timer/icons.json
+++ b/homeassistant/components/timer/icons.json
@@ -20,19 +20,19 @@
     }
   },
   "triggers": {
-    "cancel": {
+    "canceled": {
       "trigger": "mdi:timer-cancel-outline"
     },
-    "finish": {
+    "finished": {
       "trigger": "mdi:timer-check-outline"
     },
-    "pause": {
+    "paused": {
       "trigger": "mdi:timer-pause-outline"
     },
-    "restart": {
+    "restarted": {
       "trigger": "mdi:timer-refresh-outline"
     },
-    "start": {
+    "started": {
       "trigger": "mdi:timer-play-outline"
     }
   }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -70,23 +70,23 @@
   },
   "title": "Timer",
   "triggers": {
-    "cancel": {
+    "canceled": {
       "description": "Triggers when the timer gets canceled.",
       "name": "Timer canceled"
     },
-    "finish": {
+    "finished": {
       "description": "Triggers when the timer finishes.",
       "name": "Timer finished"
     },
-    "pause": {
+    "paused": {
       "description": "Triggers when the timer pauses.",
       "name": "Timer paused"
     },
-    "restart": {
+    "restarted": {
       "description": "Triggers when the timer restarts.",
       "name": "Timer restarted"
     },
-    "start": {
+    "started": {
       "description": "Triggers when the timer starts.",
       "name": "Timer started"
     }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -1,9 +1,4 @@
 {
-  "common": {
-    "trigger_events_description": "Triggers when the selected events of a timer fire.",
-    "trigger_events_field_events_description": "Possible events that a timer can fire",
-    "trigger_events_field_events_name": "Events"
-  },
   "entity_component": {
     "_": {
       "name": "Timer",
@@ -32,17 +27,6 @@
         "restore": {
           "name": "Restore"
         }
-      }
-    }
-  },
-  "selector": {
-    "timer_events": {
-      "options": {
-        "cancel": "[%key:component::timer::services::cancel::name%]",
-        "finish": "[%key:component::timer::services::finish::name%]",
-        "pause": "[%key:common::action::pause%]",
-        "restart": "[%key:common::action::restart%]",
-        "start": "[%key:common::action::start%]"
       }
     }
   },
@@ -86,15 +70,25 @@
   },
   "title": "Timer",
   "triggers": {
-    "events": {
-      "description": "[%key:component::timer::common::trigger_events_description%]",
-      "fields": {
-        "events": {
-          "description": "[%key:component::timer::common::trigger_events_field_events_description%]",
-          "name": "[%key:component::timer::common::trigger_events_field_events_name%]"
-        }
-      },
-      "name": "Timer event"
+    "cancel": {
+      "description": "Triggers when the timer gets canceled.",
+      "name": "Timer canceled"
+    },
+    "finish": {
+      "description": "Triggers when the timer finishes.",
+      "name": "Timer finished"
+    },
+    "pause": {
+      "description": "Triggers when the timer pauses.",
+      "name": "Timer paused"
+    },
+    "restart": {
+      "description": "Triggers when the timer restarts.",
+      "name": "Timer restarted"
+    },
+    "start": {
+      "description": "Triggers when the timer starts.",
+      "name": "Timer started"
     }
   }
 }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -1,4 +1,9 @@
 {
+  "common": {
+    "trigger_events_description": "Triggers when the selected events of a timer fire.",
+    "trigger_events_field_events_description": "Possible events that a timer can fire",
+    "trigger_events_field_events_name": "Events"
+  },
   "entity_component": {
     "_": {
       "name": "Timer",
@@ -27,6 +32,17 @@
         "restore": {
           "name": "Restore"
         }
+      }
+    }
+  },
+  "selector": {
+    "timer_events": {
+      "options": {
+        "cancel": "[%key:component::timer::services::cancel::name%]",
+        "finish": "[%key:component::timer::services::finish::name%]",
+        "pause": "[%key:common::action::pause%]",
+        "restart": "[%key:common::action::restart%]",
+        "start": "[%key:common::action::start%]"
       }
     }
   },
@@ -68,5 +84,17 @@
       "name": "[%key:common::action::start%]"
     }
   },
-  "title": "Timer"
+  "title": "Timer",
+  "triggers": {
+    "events": {
+      "description": "[%key:component::timer::common::trigger_events_description%]",
+      "fields": {
+        "events": {
+          "description": "[%key:component::timer::common::trigger_events_field_events_description%]",
+          "name": "[%key:component::timer::common::trigger_events_field_events_name%]"
+        }
+      },
+      "name": "Timer event"
+    }
+  }
 }

--- a/homeassistant/components/timer/strings.json
+++ b/homeassistant/components/timer/strings.json
@@ -70,9 +70,9 @@
   },
   "title": "Timer",
   "triggers": {
-    "canceled": {
-      "description": "Triggers when the timer gets canceled.",
-      "name": "Timer canceled"
+    "cancelled": {
+      "description": "Triggers when the timer gets cancelled.",
+      "name": "Timer cancelled"
     },
     "finished": {
       "description": "Triggers when the timer finishes.",

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -44,7 +44,6 @@ class BaseTimerEventTrigger(Trigger):
         super().__init__(hass, config)
         assert config.target is not None
         self._target = config.target
-        self._unsub_listener: CALLBACK_TYPE | None = None
 
     async def async_attach_runner(
         self, run_action: TriggerActionRunner
@@ -52,12 +51,6 @@ class BaseTimerEventTrigger(Trigger):
         """Attach the trigger."""
 
         tracked_entities = self._target[CONF_ENTITY_ID]
-
-        @callback
-        def async_remove() -> None:
-            """Remove trigger."""
-            if self._unsub_listener:
-                self._unsub_listener()
 
         @callback
         def async_on_event(event: Event) -> None:
@@ -75,13 +68,11 @@ class BaseTimerEventTrigger(Trigger):
             entity_id = data.get("entity_id")
             return isinstance(entity_id, str) and entity_id in tracked_entities
 
-        self._unsub_listener = self._hass.bus.async_listen(
+        return self._hass.bus.async_listen(
             event_type=self._event_type,
             event_filter=filter_event,
             listener=async_on_event,
         )
-
-        return async_remove
 
 
 class TimerStartEventTrigger(BaseTimerEventTrigger):
@@ -115,11 +106,11 @@ class TimerRestartEventTrigger(BaseTimerEventTrigger):
 
 
 TRIGGERS: dict[str, type[Trigger]] = {
-    "start": TimerStartEventTrigger,
-    "finish": TimerFinishEventTrigger,
-    "pause": TimerPauseEventTrigger,
-    "cancel": TimerCancelEventTrigger,
-    "restart": TimerRestartEventTrigger,
+    "started": TimerStartEventTrigger,
+    "finished": TimerFinishEventTrigger,
+    "paused": TimerPauseEventTrigger,
+    "canceled": TimerCancelEventTrigger,
+    "restarted": TimerRestartEventTrigger,
 }
 
 

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -1,15 +1,13 @@
 """Timer trigger configuration."""
 
 from collections.abc import Mapping
-import logging
 from typing import Any, cast
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_ENTITY_ID, CONF_OPTIONS, CONF_TARGET
+from homeassistant.const import CONF_ENTITY_ID, CONF_TARGET
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
 from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
 from homeassistant.helpers.typing import ConfigType
 
@@ -21,61 +19,18 @@ from . import (
     EVENT_TIMER_STARTED,
 )
 
-CONF_EVENTS = "events"
-
-TRIGGER_EVENT_START = "start"
-TRIGGER_EVENT_FINISH = "finish"
-TRIGGER_EVENT_PAUSE = "pause"
-TRIGGER_EVENT_CANCEL = "cancel"
-TRIGGER_EVENT_RESTART = "restart"
-
-_LOGGER = logging.getLogger(__name__)
-
-_TRIGGER_EVENT_TIMER_MAP = {
-    TRIGGER_EVENT_START: EVENT_TIMER_STARTED,
-    TRIGGER_EVENT_FINISH: EVENT_TIMER_FINISHED,
-    TRIGGER_EVENT_PAUSE: EVENT_TIMER_PAUSED,
-    TRIGGER_EVENT_CANCEL: EVENT_TIMER_CANCELLED,
-    TRIGGER_EVENT_RESTART: EVENT_TIMER_RESTARTED,
-}
-
-_OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
-    vol.Required(CONF_EVENTS): cv.multi_select(
-        [
-            TRIGGER_EVENT_START,
-            TRIGGER_EVENT_FINISH,
-            TRIGGER_EVENT_PAUSE,
-            TRIGGER_EVENT_CANCEL,
-            TRIGGER_EVENT_RESTART,
-        ]
-    ),
-}
-
 _EVENT_TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_OPTIONS): vol.All(
-            _OPTIONS_SCHEMA_DICT,
-        ),
         vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
     }
 )
 
 
-class TimerEventTrigger(Trigger):
+class BaseTimerEventTrigger(Trigger):
     """Trigger on events."""
 
-    _options: dict[str, Any]
     _target: dict[str, Any]
-
-    @classmethod
-    async def async_validate_complete_config(
-        cls, hass: HomeAssistant, complete_config: ConfigType
-    ) -> ConfigType:
-        """Validate complete config."""
-        complete_config = move_top_level_schema_fields_to_options(
-            complete_config, _OPTIONS_SCHEMA_DICT
-        )
-        return await super().async_validate_complete_config(hass, complete_config)
+    _event_type: str
 
     @classmethod
     async def async_validate_config(
@@ -87,10 +42,8 @@ class TimerEventTrigger(Trigger):
     def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize trigger."""
         super().__init__(hass, config)
-        assert config.options is not None
         assert config.target is not None
         self._target = config.target
-        self._options = config.options
         self._unsubs: list[CALLBACK_TYPE] = []
 
     async def async_attach_runner(
@@ -114,30 +67,64 @@ class TimerEventTrigger(Trigger):
                 "data": event.data,
             }
             description = f"Event {event.event_type} detected"
-            run_action(payload, description)
+            run_action(payload, description, context=event.context)
 
         @callback
-        def filter_event(data: Mapping[str, str]) -> bool:
+        def filter_event(data: Mapping[str, Any]) -> bool:
             """Filter events that match the configured entity."""
-            return data["entity_id"] in tracked_entities
+            entity_id = data.get("entity_id")
+            return isinstance(entity_id, str) and entity_id in tracked_entities
 
-        for track_event in self._options[CONF_EVENTS]:
-            event = _TRIGGER_EVENT_TIMER_MAP[track_event]
-            unsub = self._hass.bus.async_listen(
-                event_type=event,
-                event_filter=filter_event,
-                listener=async_on_event,
-            )
-            self._unsubs.append(unsub)
+        event = self._event_type
+        unsub = self._hass.bus.async_listen(
+            event_type=event,
+            event_filter=filter_event,
+            listener=async_on_event,
+        )
+        self._unsubs.append(unsub)
 
         return async_remove
 
 
-TRIGGER: dict[str, type[Trigger]] = {
-    "events": TimerEventTrigger,
+class TimerStartEventTrigger(BaseTimerEventTrigger):
+    """Trigger for start event."""
+
+    _event_type = EVENT_TIMER_STARTED
+
+
+class TimerFinishEventTrigger(BaseTimerEventTrigger):
+    """Trigger for finish event."""
+
+    _event_type = EVENT_TIMER_FINISHED
+
+
+class TimerPauseEventTrigger(BaseTimerEventTrigger):
+    """Trigger for pause event."""
+
+    _event_type = EVENT_TIMER_PAUSED
+
+
+class TimerCancelEventTrigger(BaseTimerEventTrigger):
+    """Trigger for cancel event."""
+
+    _event_type = EVENT_TIMER_CANCELLED
+
+
+class TimerRestartEventTrigger(BaseTimerEventTrigger):
+    """Trigger for restart event."""
+
+    _event_type = EVENT_TIMER_RESTARTED
+
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    "start": TimerStartEventTrigger,
+    "finish": TimerFinishEventTrigger,
+    "pause": TimerPauseEventTrigger,
+    "cancel": TimerCancelEventTrigger,
+    "restart": TimerRestartEventTrigger,
 }
 
 
 async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
     """Return triggers provided by this integration."""
-    return TRIGGER
+    return TRIGGERS

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -109,7 +109,7 @@ TRIGGERS: dict[str, type[Trigger]] = {
     "started": TimerStartEventTrigger,
     "finished": TimerFinishEventTrigger,
     "paused": TimerPauseEventTrigger,
-    "canceled": TimerCancelEventTrigger,
+    "cancelled": TimerCancelEventTrigger,
     "restarted": TimerRestartEventTrigger,
 }
 

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -44,7 +44,7 @@ class BaseTimerEventTrigger(Trigger):
         super().__init__(hass, config)
         assert config.target is not None
         self._target = config.target
-        self._unsubs: list[CALLBACK_TYPE] = []
+        self._unsub_listener: CALLBACK_TYPE | None = None
 
     async def async_attach_runner(
         self, run_action: TriggerActionRunner
@@ -56,8 +56,8 @@ class BaseTimerEventTrigger(Trigger):
         @callback
         def async_remove() -> None:
             """Remove trigger."""
-            for unsub in self._unsubs:
-                unsub()
+            if self._unsub_listener:
+                self._unsub_listener()
 
         @callback
         def async_on_event(event: Event) -> None:
@@ -75,13 +75,11 @@ class BaseTimerEventTrigger(Trigger):
             entity_id = data.get("entity_id")
             return isinstance(entity_id, str) and entity_id in tracked_entities
 
-        event = self._event_type
-        unsub = self._hass.bus.async_listen(
-            event_type=event,
+        self._unsub_listener = self._hass.bus.async_listen(
+            event_type=self._event_type,
             event_filter=filter_event,
             listener=async_on_event,
         )
-        self._unsubs.append(unsub)
 
         return async_remove
 

--- a/homeassistant/components/timer/trigger.py
+++ b/homeassistant/components/timer/trigger.py
@@ -1,0 +1,143 @@
+"""Timer trigger configuration."""
+
+from collections.abc import Mapping
+import logging
+from typing import Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_ENTITY_ID, CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.automation import move_top_level_schema_fields_to_options
+from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
+from homeassistant.helpers.typing import ConfigType
+
+from . import (
+    EVENT_TIMER_CANCELLED,
+    EVENT_TIMER_FINISHED,
+    EVENT_TIMER_PAUSED,
+    EVENT_TIMER_RESTARTED,
+    EVENT_TIMER_STARTED,
+)
+
+CONF_EVENTS = "events"
+
+TRIGGER_EVENT_START = "start"
+TRIGGER_EVENT_FINISH = "finish"
+TRIGGER_EVENT_PAUSE = "pause"
+TRIGGER_EVENT_CANCEL = "cancel"
+TRIGGER_EVENT_RESTART = "restart"
+
+_LOGGER = logging.getLogger(__name__)
+
+_TRIGGER_EVENT_TIMER_MAP = {
+    TRIGGER_EVENT_START: EVENT_TIMER_STARTED,
+    TRIGGER_EVENT_FINISH: EVENT_TIMER_FINISHED,
+    TRIGGER_EVENT_PAUSE: EVENT_TIMER_PAUSED,
+    TRIGGER_EVENT_CANCEL: EVENT_TIMER_CANCELLED,
+    TRIGGER_EVENT_RESTART: EVENT_TIMER_RESTARTED,
+}
+
+_OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
+    vol.Required(CONF_EVENTS): cv.multi_select(
+        [
+            TRIGGER_EVENT_START,
+            TRIGGER_EVENT_FINISH,
+            TRIGGER_EVENT_PAUSE,
+            TRIGGER_EVENT_CANCEL,
+            TRIGGER_EVENT_RESTART,
+        ]
+    ),
+}
+
+_EVENT_TRIGGER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OPTIONS): vol.All(
+            _OPTIONS_SCHEMA_DICT,
+        ),
+        vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
+    }
+)
+
+
+class TimerEventTrigger(Trigger):
+    """Trigger on events."""
+
+    _options: dict[str, Any]
+    _target: dict[str, Any]
+
+    @classmethod
+    async def async_validate_complete_config(
+        cls, hass: HomeAssistant, complete_config: ConfigType
+    ) -> ConfigType:
+        """Validate complete config."""
+        complete_config = move_top_level_schema_fields_to_options(
+            complete_config, _OPTIONS_SCHEMA_DICT
+        )
+        return await super().async_validate_complete_config(hass, complete_config)
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate trigger-specific config."""
+        return cast(ConfigType, _EVENT_TRIGGER_SCHEMA(config))
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize trigger."""
+        super().__init__(hass, config)
+        assert config.options is not None
+        assert config.target is not None
+        self._target = config.target
+        self._options = config.options
+        self._unsubs: list[CALLBACK_TYPE] = []
+
+    async def async_attach_runner(
+        self, run_action: TriggerActionRunner
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger."""
+
+        tracked_entities = self._target[CONF_ENTITY_ID]
+
+        @callback
+        def async_remove() -> None:
+            """Remove trigger."""
+            for unsub in self._unsubs:
+                unsub()
+
+        @callback
+        def async_on_event(event: Event) -> None:
+            """Handle event."""
+            payload = {
+                "event_type": event.event_type,
+                "data": event.data,
+            }
+            description = f"Event {event.event_type} detected"
+            run_action(payload, description)
+
+        @callback
+        def filter_event(data: Mapping[str, str]) -> bool:
+            """Filter events that match the configured entity."""
+            return data["entity_id"] in tracked_entities
+
+        for track_event in self._options[CONF_EVENTS]:
+            event = _TRIGGER_EVENT_TIMER_MAP[track_event]
+            unsub = self._hass.bus.async_listen(
+                event_type=event,
+                event_filter=filter_event,
+                listener=async_on_event,
+            )
+            self._unsubs.append(unsub)
+
+        return async_remove
+
+
+TRIGGER: dict[str, type[Trigger]] = {
+    "events": TimerEventTrigger,
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return triggers provided by this integration."""
+    return TRIGGER

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -3,8 +3,8 @@
     entity:
       domain: timer
 
-start: *trigger_common
-finish: *trigger_common
-pause: *trigger_common
-cancel: *trigger_common
-restart: *trigger_common
+started: *trigger_common
+finished: *trigger_common
+paused: *trigger_common
+canceled: *trigger_common
+restarted: *trigger_common

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -6,5 +6,5 @@
 started: *trigger_common
 finished: *trigger_common
 paused: *trigger_common
-canceled: *trigger_common
+cancelled: *trigger_common
 restarted: *trigger_common

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -2,18 +2,9 @@
   target:
     entity:
       domain: timer
-  fields:
-    events:
-      required: true
-      selector:
-        select:
-          options:
-            - start
-            - finish
-            - pause
-            - cancel
-            - restart
-          translation_key: timer_events
-          multiple: true
 
-events: *trigger_common
+start: *trigger_common
+finish: *trigger_common
+pause: *trigger_common
+cancel: *trigger_common
+restart: *trigger_common

--- a/homeassistant/components/timer/triggers.yaml
+++ b/homeassistant/components/timer/triggers.yaml
@@ -1,0 +1,19 @@
+.trigger_common: &trigger_common
+  target:
+    entity:
+      domain: timer
+  fields:
+    events:
+      required: true
+      selector:
+        select:
+          options:
+            - start
+            - finish
+            - pause
+            - cancel
+            - restart
+          translation_key: timer_events
+          multiple: true
+
+events: *trigger_common

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
+from tests.components import arm_trigger
 
 
 @pytest.fixture
@@ -69,6 +70,30 @@ async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
 
 
 @pytest.mark.parametrize(
+    "trigger_key",
+    [
+        "timer.start",
+        "timer.finish",
+        "timer.pause",
+        "timer.cancel",
+        "timer.restart",
+    ],
+)
+async def test_light_triggers_gated_by_labs_flag(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, trigger_key: str
+) -> None:
+    """Test the light triggers are gated by the labs flag."""
+    await arm_trigger(hass, trigger_key, None, {})
+    assert (
+        "Unnamed automation failed to setup triggers and has been disabled: Trigger "
+        f"'{trigger_key}' requires the experimental 'New triggers and conditions' "
+        "feature to be enabled in Home Assistant Labs settings (feature flag: "
+        "'new_triggers_conditions')"
+    ) in caplog.text
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
     ("timer", "steps", "timer_event"),
     [
         ("start", [SERVICE_START], "timer.started"),
@@ -101,6 +126,7 @@ async def test_timer_type_event(
     assert test_calls[0]["event_type"] == timer_event
 
 
+@pytest.mark.usefixtures("enable_labs_preview_features")
 async def test_full_usage(
     hass: HomeAssistant, automation_test_calls, service_calls: list[ServiceCall]
 ) -> None:
@@ -135,6 +161,7 @@ async def test_full_usage(
         assert test_calls[index]["entity_id"] == "timer.test"
 
 
+@pytest.mark.usefixtures("enable_labs_preview_features")
 async def test_exception_bad_trigger(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -1,0 +1,151 @@
+"""Support for timer triggers."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from homeassistant.components import automation
+from homeassistant.components.timer import (
+    CONF_DURATION,
+    DOMAIN,
+    SERVICE_CANCEL,
+    SERVICE_FINISH,
+    SERVICE_PAUSE,
+    SERVICE_START,
+)
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_mock_service
+
+
+@pytest.fixture
+def automation_test_calls(hass: HomeAssistant) -> Callable[[], list[dict[str, Any]]]:
+    """Fixture to return payload data for automation calls."""
+    service_calls = async_mock_service(hass, "test", "automation")
+
+    def get_trigger_data() -> list[dict[str, Any]]:
+        return [c.data for c in service_calls]
+
+    return get_trigger_data
+
+
+async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
+    """Common initialization for timer and automation."""
+    assert await async_setup_component(
+        hass, DOMAIN, {DOMAIN: {"test": {CONF_DURATION: 10}}}
+    )
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "test",
+                    "trigger": {
+                        "platform": f"{DOMAIN}.events",
+                        "target": {
+                            "entity_id": "timer.test",
+                        },
+                        "options": {
+                            "events": events,
+                        },
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "entity_id": "{{ trigger.data.entity_id }}",
+                            "event_type": "{{ trigger.event_type }}",
+                            "message": "service called",
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+
+async def test_triggers(
+    hass: HomeAssistant, automation_test_calls, service_calls: list[ServiceCall]
+) -> None:
+    """Test timer triggers."""
+
+    await config_setup(hass, ["start", "pause", "finish", "restart", "cancel"])
+
+    steps = [
+        {"call": SERVICE_START},
+        {"call": SERVICE_PAUSE},
+        {"call": SERVICE_START},
+        {"call": SERVICE_CANCEL},
+        {"call": SERVICE_START},
+        {"call": SERVICE_FINISH},
+        {"call": SERVICE_START},
+        {"call": SERVICE_START},  # restart event
+    ]
+    for index, step in enumerate(steps):
+        await hass.services.async_call(
+            DOMAIN,
+            step["call"],
+            {CONF_ENTITY_ID: "timer.test"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        test_calls = automation_test_calls()
+
+        assert len(service_calls) == 2 * (index + 1)
+        assert len(test_calls) == index + 1
+        assert service_calls[2 * index].data["entity_id"] == "timer.test"
+        assert test_calls[index]["entity_id"] == "timer.test"
+
+
+async def test_restart_event(hass: HomeAssistant, automation_test_calls) -> None:
+    """Test timer triggers."""
+
+    await config_setup(hass, ["restart"])
+
+    steps = [
+        {"call": SERVICE_START},
+        {"call": SERVICE_START},  # restart event
+    ]
+    for step in steps:
+        await hass.services.async_call(
+            DOMAIN,
+            step["call"],
+            {CONF_ENTITY_ID: "timer.test"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    test_calls = automation_test_calls()
+    assert len(test_calls) == 1
+    assert test_calls[0]["entity_id"] == "timer.test"
+    assert test_calls[0]["event_type"] == "timer.restarted"
+
+
+async def test_exception_bad_trigger(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test for exception on event triggers firing."""
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"trigger": {"platform": DOMAIN, "oops": "abc123"}},
+                    "action": {
+                        "service": "test.automation",
+                        "data": {"message": "service called"},
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert "Unnamed automation could not be validated" in caplog.text

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -37,44 +37,76 @@ async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {CONF_DURATION: 10}}}
     )
+
+    automations = [
+        {
+            "alias": f"test_{event}",
+            "trigger": {
+                "platform": f"{DOMAIN}.{event}",
+                "target": {
+                    "entity_id": "timer.test",
+                },
+            },
+            "action": {
+                "service": "test.automation",
+                "data_template": {
+                    "entity_id": "{{ trigger.data.entity_id }}",
+                    "event_type": "{{ trigger.event_type }}",
+                    "message": "service called",
+                    "id": "{{ trigger.id }}",
+                },
+            },
+        }
+        for event in events
+    ]
+
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
-        {
-            automation.DOMAIN: [
-                {
-                    "alias": "test",
-                    "trigger": {
-                        "platform": f"{DOMAIN}.events",
-                        "target": {
-                            "entity_id": "timer.test",
-                        },
-                        "options": {
-                            "events": events,
-                        },
-                    },
-                    "action": {
-                        "service": "test.automation",
-                        "data_template": {
-                            "entity_id": "{{ trigger.data.entity_id }}",
-                            "event_type": "{{ trigger.event_type }}",
-                            "message": "service called",
-                            "id": "{{ trigger.id }}",
-                        },
-                    },
-                }
-            ]
-        },
+        {automation.DOMAIN: automations},
     )
     await hass.async_block_till_done()
 
 
-async def test_triggers(
+@pytest.mark.parametrize(
+    ("timer", "steps", "timer_event"),
+    [
+        ("start", [SERVICE_START], "timer.started"),
+        ("finish", [SERVICE_START, SERVICE_FINISH], "timer.finished"),
+        ("pause", [SERVICE_START, SERVICE_PAUSE], "timer.paused"),
+        ("cancel", [SERVICE_START, SERVICE_CANCEL], "timer.cancelled"),
+        ("restart", [SERVICE_START, SERVICE_PAUSE, SERVICE_START], "timer.restarted"),
+        ("restart", [SERVICE_START, SERVICE_START], "timer.restarted"),
+    ],
+)
+async def test_timer_type_event(
+    hass: HomeAssistant, timer, steps, timer_event, automation_test_calls
+) -> None:
+    """Test timer triggers."""
+
+    await config_setup(hass, [timer])
+
+    for step in steps:
+        await hass.services.async_call(
+            DOMAIN,
+            step,
+            {CONF_ENTITY_ID: "timer.test"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    test_calls = automation_test_calls()
+    assert len(test_calls) == 1
+    assert test_calls[0]["entity_id"] == "timer.test"
+    assert test_calls[0]["event_type"] == timer_event
+
+
+async def test_full_usage(
     hass: HomeAssistant, automation_test_calls, service_calls: list[ServiceCall]
 ) -> None:
     """Test timer triggers."""
 
-    await config_setup(hass, ["start", "pause", "finish", "restart", "cancel"])
+    await config_setup(hass, ["start", "pause", "finish", "cancel", "restart"])
 
     steps = [
         {"call": SERVICE_START},
@@ -84,7 +116,7 @@ async def test_triggers(
         {"call": SERVICE_START},
         {"call": SERVICE_FINISH},
         {"call": SERVICE_START},
-        {"call": SERVICE_START},  # restart event
+        {"call": SERVICE_START},
     ]
     for index, step in enumerate(steps):
         await hass.services.async_call(
@@ -101,30 +133,6 @@ async def test_triggers(
         assert len(test_calls) == index + 1
         assert service_calls[2 * index].data["entity_id"] == "timer.test"
         assert test_calls[index]["entity_id"] == "timer.test"
-
-
-async def test_restart_event(hass: HomeAssistant, automation_test_calls) -> None:
-    """Test timer triggers."""
-
-    await config_setup(hass, ["restart"])
-
-    steps = [
-        {"call": SERVICE_START},
-        {"call": SERVICE_START},  # restart event
-    ]
-    for step in steps:
-        await hass.services.async_call(
-            DOMAIN,
-            step["call"],
-            {CONF_ENTITY_ID: "timer.test"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-    test_calls = automation_test_calls()
-    assert len(test_calls) == 1
-    assert test_calls[0]["entity_id"] == "timer.test"
-    assert test_calls[0]["event_type"] == "timer.restarted"
 
 
 async def test_exception_bad_trigger(

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -33,7 +33,7 @@ def automation_test_calls(hass: HomeAssistant) -> Callable[[], list[dict[str, An
     return get_trigger_data
 
 
-async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
+async def config_setup(hass: HomeAssistant, triggers: list[str]) -> None:
     """Common initialization for timer and automation."""
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {"test": {CONF_DURATION: 10}}}
@@ -41,9 +41,9 @@ async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
 
     automations = [
         {
-            "alias": f"test_{event}",
+            "alias": f"test_{trigger}",
             "trigger": {
-                "platform": f"{DOMAIN}.{event}",
+                "platform": f"{DOMAIN}.{trigger}",
                 "target": {
                     "entity_id": "timer.test",
                 },
@@ -58,7 +58,7 @@ async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
                 },
             },
         }
-        for event in events
+        for trigger in triggers
     ]
 
     assert await async_setup_component(
@@ -72,17 +72,17 @@ async def config_setup(hass: HomeAssistant, events: list[str]) -> None:
 @pytest.mark.parametrize(
     "trigger_key",
     [
-        "timer.start",
-        "timer.finish",
-        "timer.pause",
-        "timer.cancel",
-        "timer.restart",
+        "timer.started",
+        "timer.finished",
+        "timer.paused",
+        "timer.canceled",
+        "timer.restarted",
     ],
 )
-async def test_light_triggers_gated_by_labs_flag(
+async def test_timer_triggers_gated_by_labs_flag(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, trigger_key: str
 ) -> None:
-    """Test the light triggers are gated by the labs flag."""
+    """Test the timer triggers are gated by the labs flag."""
     await arm_trigger(hass, trigger_key, None, {})
     assert (
         "Unnamed automation failed to setup triggers and has been disabled: Trigger "
@@ -96,12 +96,12 @@ async def test_light_triggers_gated_by_labs_flag(
 @pytest.mark.parametrize(
     ("timer", "steps", "timer_event"),
     [
-        ("start", [SERVICE_START], "timer.started"),
-        ("finish", [SERVICE_START, SERVICE_FINISH], "timer.finished"),
-        ("pause", [SERVICE_START, SERVICE_PAUSE], "timer.paused"),
-        ("cancel", [SERVICE_START, SERVICE_CANCEL], "timer.cancelled"),
-        ("restart", [SERVICE_START, SERVICE_PAUSE, SERVICE_START], "timer.restarted"),
-        ("restart", [SERVICE_START, SERVICE_START], "timer.restarted"),
+        ("started", [SERVICE_START], "timer.started"),
+        ("finished", [SERVICE_START, SERVICE_FINISH], "timer.finished"),
+        ("paused", [SERVICE_START, SERVICE_PAUSE], "timer.paused"),
+        ("canceled", [SERVICE_START, SERVICE_CANCEL], "timer.cancelled"),
+        ("restarted", [SERVICE_START, SERVICE_PAUSE, SERVICE_START], "timer.restarted"),
+        ("restarted", [SERVICE_START, SERVICE_START], "timer.restarted"),
     ],
 )
 async def test_timer_type_event(
@@ -130,9 +130,9 @@ async def test_timer_type_event(
 async def test_full_usage(
     hass: HomeAssistant, automation_test_calls, service_calls: list[ServiceCall]
 ) -> None:
-    """Test timer triggers."""
+    """Test timer triggers by attaching to all kind of events."""
 
-    await config_setup(hass, ["start", "pause", "finish", "cancel", "restart"])
+    await config_setup(hass, ["started", "paused", "finished", "canceled", "restarted"])
 
     steps = [
         {"call": SERVICE_START},
@@ -162,10 +162,21 @@ async def test_full_usage(
 
 
 @pytest.mark.usefixtures("enable_labs_preview_features")
-async def test_exception_bad_trigger(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+@pytest.mark.parametrize(
+    "trigger_key",
+    [
+        DOMAIN,
+        "timer.started",
+        "timer.finished",
+        "timer.paused",
+        "timer.canceled",
+        "timer.restarted",
+    ],
+)
+async def test_exception_bad_timer_trigger(
+    hass: HomeAssistant, trigger_key, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test for exception on event triggers firing."""
+    """Test bad timer configuration."""
 
     await async_setup_component(
         hass,
@@ -173,7 +184,7 @@ async def test_exception_bad_trigger(
         {
             automation.DOMAIN: [
                 {
-                    "trigger": {"trigger": {"platform": DOMAIN, "oops": "abc123"}},
+                    "trigger": {"trigger": {"platform": trigger_key, "oops": "abc123"}},
                     "action": {
                         "service": "test.automation",
                         "data": {"message": "service called"},

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -75,7 +75,7 @@ async def config_setup(hass: HomeAssistant, triggers: list[str]) -> None:
         "timer.started",
         "timer.finished",
         "timer.paused",
-        "timer.canceled",
+        "timer.cancelled",
         "timer.restarted",
     ],
 )
@@ -99,7 +99,7 @@ async def test_timer_triggers_gated_by_labs_flag(
         ("started", [SERVICE_START], "timer.started"),
         ("finished", [SERVICE_START, SERVICE_FINISH], "timer.finished"),
         ("paused", [SERVICE_START, SERVICE_PAUSE], "timer.paused"),
-        ("canceled", [SERVICE_START, SERVICE_CANCEL], "timer.cancelled"),
+        ("cancelled", [SERVICE_START, SERVICE_CANCEL], "timer.cancelled"),
         ("restarted", [SERVICE_START, SERVICE_PAUSE, SERVICE_START], "timer.restarted"),
         ("restarted", [SERVICE_START, SERVICE_START], "timer.restarted"),
     ],
@@ -132,7 +132,9 @@ async def test_full_usage(
 ) -> None:
     """Test timer triggers by attaching to all kind of events."""
 
-    await config_setup(hass, ["started", "paused", "finished", "canceled", "restarted"])
+    await config_setup(
+        hass, ["started", "paused", "finished", "cancelled", "restarted"]
+    )
 
     steps = [
         {"call": SERVICE_START},
@@ -169,7 +171,7 @@ async def test_full_usage(
         "timer.started",
         "timer.finished",
         "timer.paused",
-        "timer.canceled",
+        "timer.cancelled",
         "timer.restarted",
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enables a new timer trigger, avoiding having to use a manual event trigger for them.

The final result is this:
<img width="1637" height="827" alt="Screenshot 2026-02-14 at 11 59 21 PM" src="https://github.com/user-attachments/assets/30c7e668-d1ac-4778-99fb-4431c34e3df3" />


> [!NOTE]
> This feature is behind `new_triggers_conditions` feature flag.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes #164029
  - fixes #164033
  - fixes #164030
  - fixes #164032
  - fixes #164031
- This PR is related to issue: #158350 
- Link to documentation pull request: home-assistant/home-assistant.io#43456
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
