### PR TITLE
Add timeout to B2 metadata downloads to prevent backup hang

### DIFF
--- a/homeassistant/components/backblaze_b2/b2_client.py
+++ b/homeassistant/components/backblaze_b2/b2_client.py
@@ -16,12 +16,18 @@ CONNECTION_TIMEOUT = 120  # 2 minutes
 # Default TIMEOUT_FOR_UPLOAD is 128 seconds, which is too short for large backups
 TIMEOUT_FOR_UPLOAD = 43200  # 12 hours
 
+# Reduced retry count for download operations
+# Default is 20 retries with exponential backoff, which can hang for 30+ minutes
+# when there are persistent connection errors (e.g., SSL failures)
+TRY_COUNT_DOWNLOAD = 3
+
 
 class B2Http(BaseB2Http):  # type: ignore[misc]
     """B2Http with extended timeouts for backup operations."""
 
     CONNECTION_TIMEOUT = CONNECTION_TIMEOUT
     TIMEOUT_FOR_UPLOAD = TIMEOUT_FOR_UPLOAD
+    TRY_COUNT_DOWNLOAD = TRY_COUNT_DOWNLOAD
 
 
 class B2Session(BaseB2Session):  # type: ignore[misc]

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -1031,3 +1031,123 @@ async def test_metadata_download_timeout_during_find_by_id(
         and "while searching for backup" in msg
         for msg in caplog.messages
     )
+
+
+async def test_metadata_timeout_does_not_block_healthy_backups(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a timed out metadata download doesn't prevent listing other backups."""
+    client = await hass_ws_client(hass)
+
+    mock_hanging_metadata = Mock()
+    mock_hanging_metadata.file_name = "testprefix/hanging_backup.metadata.json"
+    mock_hanging_metadata.download = Mock(side_effect=B2Error("SSL failure"))
+
+    mock_hanging_tar = Mock()
+    mock_hanging_tar.file_name = "testprefix/hanging_backup.tar"
+    mock_hanging_tar.size = 1000
+
+    mock_healthy_metadata = Mock()
+    mock_healthy_metadata.file_name = (
+        f"testprefix/{TEST_BACKUP.backup_id}.metadata.json"
+    )
+    mock_healthy_download = Mock()
+    mock_healthy_response = Mock()
+    mock_healthy_response.content = json.dumps(BACKUP_METADATA).encode()
+    mock_healthy_download.response = mock_healthy_response
+    mock_healthy_metadata.download = Mock(return_value=mock_healthy_download)
+
+    mock_healthy_tar = Mock()
+    mock_healthy_tar.file_name = f"testprefix/{TEST_BACKUP.backup_id}.tar"
+    mock_healthy_tar.size = TEST_BACKUP.size
+
+    def mock_ls(_self, _prefix=""):
+        return iter(
+            [
+                (mock_hanging_metadata, None),
+                (mock_hanging_tar, None),
+                (mock_healthy_metadata, None),
+                (mock_healthy_tar, None),
+            ]
+        )
+
+    call_count = 0
+    original_wait_for = asyncio.wait_for
+
+    async def wait_for_first_timeout(coro, *, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise TimeoutError
+        return await original_wait_for(coro, timeout=timeout)
+
+    with (
+        patch.object(BucketSimulator, "ls", mock_ls),
+        patch(
+            "homeassistant.components.backblaze_b2.backup.asyncio.wait_for",
+            wait_for_first_timeout,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        await client.send_json_auto_id({"type": "backup/info"})
+        response = await client.receive_json()
+
+    assert response["success"]
+    backups = response["result"]["backups"]
+    assert len(backups) == 1
+    assert backups[0]["backup_id"] == TEST_BACKUP.backup_id
+    assert any("Timeout downloading metadata file" in msg for msg in caplog.messages)
+
+
+async def test_metadata_download_timeout_during_get_backup(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test timeout on metadata re-download after file is found."""
+    client = await hass_ws_client(hass)
+
+    mock_metadata = Mock()
+    mock_metadata.file_name = f"testprefix/{TEST_BACKUP.backup_id}.metadata.json"
+    mock_download = Mock()
+    mock_response = Mock()
+    mock_response.content = json.dumps(BACKUP_METADATA).encode()
+    mock_download.response = mock_response
+    mock_metadata.download = Mock(return_value=mock_download)
+
+    mock_tar = Mock()
+    mock_tar.file_name = f"testprefix/{TEST_BACKUP.backup_id}.tar"
+    mock_tar.size = TEST_BACKUP.size
+
+    def mock_ls(_self, _prefix=""):
+        return iter([(mock_metadata, None), (mock_tar, None)])
+
+    call_count = 0
+    original_wait_for = asyncio.wait_for
+
+    async def wait_for_second_timeout(coro, *, timeout=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise TimeoutError
+        return await original_wait_for(coro, timeout=timeout)
+
+    with (
+        patch.object(BucketSimulator, "ls", mock_ls),
+        patch(
+            "homeassistant.components.backblaze_b2.backup.asyncio.wait_for",
+            wait_for_second_timeout,
+        ),
+        patch("homeassistant.components.backblaze_b2.backup.CACHE_TTL", 0),
+    ):
+        await client.send_json_auto_id(
+            {"type": "backup/details", "backup_id": TEST_BACKUP.backup_id}
+        )
+        response = await client.receive_json()
+
+    assert response["success"]
+    assert (
+        f"{DOMAIN}.{mock_config_entry.entry_id}" in response["result"]["agent_errors"]
+    )

--- a/tests/components/backblaze_b2/test_backup.py
+++ b/tests/components/backblaze_b2/test_backup.py
@@ -955,3 +955,79 @@ async def test_upload_cancelled(
     # CancelledError propagates up and causes a 500 error
     assert resp.status == 500
     assert any("cancelled" in msg for msg in caplog.messages)
+
+
+async def test_metadata_download_timeout_during_list(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that metadata download timeout during list is handled gracefully."""
+    client = await hass_ws_client(hass)
+
+    mock_metadata = Mock()
+    mock_metadata.file_name = "testprefix/slow.metadata.json"
+
+    mock_tar = Mock()
+    mock_tar.file_name = "testprefix/slow.tar"
+    mock_tar.size = TEST_BACKUP.size
+
+    def mock_ls(_self, _prefix=""):
+        return iter([(mock_metadata, None), (mock_tar, None)])
+
+    with (
+        patch.object(BucketSimulator, "ls", mock_ls),
+        patch(
+            "homeassistant.components.backblaze_b2.backup.asyncio.wait_for",
+            side_effect=TimeoutError,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        await client.send_json_auto_id({"type": "backup/info"})
+        response = await client.receive_json()
+
+    assert response["success"]
+    # The backup should not appear in the list due to timeout
+    assert len(response["result"]["backups"]) == 0
+    assert any("Timeout downloading metadata file" in msg for msg in caplog.messages)
+
+
+async def test_metadata_download_timeout_during_find_by_id(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that metadata download timeout during find by ID is handled gracefully."""
+    client = await hass_ws_client(hass)
+
+    mock_metadata = Mock()
+    mock_metadata.file_name = f"testprefix/{TEST_BACKUP.backup_id}.metadata.json"
+
+    mock_tar = Mock()
+    mock_tar.file_name = f"testprefix/{TEST_BACKUP.backup_id}.tar"
+    mock_tar.size = TEST_BACKUP.size
+
+    def mock_ls(_self, _prefix=""):
+        return iter([(mock_metadata, None), (mock_tar, None)])
+
+    with (
+        patch.object(BucketSimulator, "ls", mock_ls),
+        patch(
+            "homeassistant.components.backblaze_b2.backup.asyncio.wait_for",
+            side_effect=TimeoutError,
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        await client.send_json_auto_id(
+            {"type": "backup/details", "backup_id": TEST_BACKUP.backup_id}
+        )
+        response = await client.receive_json()
+
+    assert response["success"]
+    # The backup should not be found due to timeout
+    assert response["result"]["backup"] is None
+    assert any(
+        "Timeout downloading metadata file" in msg
+        and "while searching for backup" in msg
+        for msg in caplog.messages
+    )


### PR DESCRIPTION
## Proposed change

Fixes the backup system hanging when the Backblaze B2 integration encounters persistent connection errors (e.g., SSL failures).

The B2 SDK retries failed downloads up to 20 times with exponential backoff, which can block executor threads for 30+ minutes. Since the metadata download calls use `async_add_executor_job` with no timeout, they block indefinitely, freezing the entire backup system. Users can't view or create any backups until the integration is disabled.

This adds two layers of protection:

1. Reduced B2 SDK retry count (`TRY_COUNT_DOWNLOAD = 3` instead of 20) so persistent failures fail fast rather than retrying for 30+ minutes
2. `asyncio.wait_for` timeouts (60s) around all three metadata download call sites. If retries still block, the timeout cancels the operation and the backup system remains responsive.

On timeout, individual failing metadata files are skipped gracefully (with a warning log) rather than blocking the entire backup list.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #162553

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other open pull requests in this repository.