### PR TITLE
Add switch platform to nrgkick integration for enabling or pausing car charging

### DIFF
--- a/homeassistant/components/nrgkick/__init__.py
+++ b/homeassistant/components/nrgkick/__init__.py
@@ -12,6 +12,7 @@ from .coordinator import NRGkickConfigEntry, NRGkickDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable
-from typing import TypeVar
 
 import aiohttp
 from nrgkick_api import (
@@ -17,7 +16,6 @@ from nrgkick_api import (
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
-
 
 
 class NRGkickApiClientError(HomeAssistantError):

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -56,7 +56,7 @@ class NRGkickApiClientInvalidResponseError(NRGkickApiClientError):
     translation_key = "invalid_response"
 
 
-async def async_api_call(awaitable: Awaitable[_T]) -> _T:
+async def async_api_call[_T](awaitable: Awaitable[_T]) -> _T:
     """Call the NRGkick API and map common library errors.
 
     This helper is intended for one-off API calls outside the coordinator,

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -9,7 +9,9 @@ import aiohttp
 from nrgkick_api import (
     NRGkickAPIDisabledError,
     NRGkickAuthenticationError,
+    NRGkickCommandRejectedError,
     NRGkickConnectionError,
+    NRGkickInvalidResponseError,
 )
 
 from homeassistant.exceptions import HomeAssistantError
@@ -63,10 +65,18 @@ async def async_api_call(awaitable: Awaitable[_T]) -> _T:
     """
     try:
         return await awaitable
+    except NRGkickCommandRejectedError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="command_rejected",
+            translation_placeholders={"reason": err.reason},
+        ) from err
     except NRGkickAuthenticationError as err:
         raise NRGkickApiClientAuthenticationError from err
     except NRGkickAPIDisabledError as err:
         raise NRGkickApiClientApiDisabledError from err
+    except NRGkickInvalidResponseError as err:
+        raise NRGkickApiClientInvalidResponseError from err
     except NRGkickConnectionError as err:
         raise NRGkickApiClientCommunicationError(
             translation_placeholders={"error": str(err)}

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -59,9 +59,10 @@ class NRGkickApiClientInvalidResponseError(NRGkickApiClientError):
 async def async_api_call(awaitable: Awaitable[_T]) -> _T:
     """Call the NRGkick API and map common library errors.
 
-    This helper is intended for command-style calls (switch/number/etc.), where
-    errors should surface as user-facing `HomeAssistantError` exceptions.
-    Polling/setup error mapping is handled by the coordinator.
+    This helper is intended for one-off API calls outside the coordinator,
+    such as command-style calls (switch/number/etc.) and config flow
+    validation, where errors should surface as user-facing `HomeAssistantError`
+    exceptions. Regular polling is handled by the coordinator.
     """
     try:
         return await awaitable

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -18,7 +18,6 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
-_T = TypeVar("_T")
 
 
 class NRGkickApiClientError(HomeAssistantError):

--- a/homeassistant/components/nrgkick/api.py
+++ b/homeassistant/components/nrgkick/api.py
@@ -1,10 +1,22 @@
-"""Home Assistant exceptions for the NRGkick integration."""
+"""API helpers and Home Assistant exceptions for the NRGkick integration."""
 
 from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import TypeVar
+
+import aiohttp
+from nrgkick_api import (
+    NRGkickAPIDisabledError,
+    NRGkickAuthenticationError,
+    NRGkickConnectionError,
+)
 
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
+
+_T = TypeVar("_T")
 
 
 class NRGkickApiClientError(HomeAssistantError):
@@ -37,3 +49,29 @@ class NRGkickApiClientApiDisabledError(NRGkickApiClientError):
 
 class NRGkickApiClientInvalidResponseError(NRGkickApiClientError):
     """Exception for invalid responses from the device."""
+
+    translation_domain = DOMAIN
+    translation_key = "invalid_response"
+
+
+async def async_api_call(awaitable: Awaitable[_T]) -> _T:
+    """Call the NRGkick API and map common library errors.
+
+    This helper is intended for command-style calls (switch/number/etc.), where
+    errors should surface as user-facing `HomeAssistantError` exceptions.
+    Polling/setup error mapping is handled by the coordinator.
+    """
+    try:
+        return await awaitable
+    except NRGkickAuthenticationError as err:
+        raise NRGkickApiClientAuthenticationError from err
+    except NRGkickAPIDisabledError as err:
+        raise NRGkickApiClientApiDisabledError from err
+    except NRGkickConnectionError as err:
+        raise NRGkickApiClientCommunicationError(
+            translation_placeholders={"error": str(err)}
+        ) from err
+    except (TimeoutError, aiohttp.ClientError, OSError) as err:
+        raise NRGkickApiClientCommunicationError(
+            translation_placeholders={"error": str(err)}
+        ) from err

--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -5,13 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-import aiohttp
-from nrgkick_api import (
-    NRGkickAPI,
-    NRGkickAPIDisabledError,
-    NRGkickAuthenticationError,
-    NRGkickConnectionError,
-)
+from nrgkick_api import NRGkickAPI
 import voluptuous as vol
 import yarl
 
@@ -33,6 +27,7 @@ from .api import (
     NRGkickApiClientCommunicationError,
     NRGkickApiClientError,
     NRGkickApiClientInvalidResponseError,
+    async_api_call,
 )
 from .const import DOMAIN
 
@@ -96,15 +91,8 @@ async def validate_input(
         session=session,
     )
 
-    try:
-        await api.test_connection()
-        info = await api.get_info(["general"], raw=True)
-    except NRGkickAuthenticationError as err:
-        raise NRGkickApiClientAuthenticationError from err
-    except NRGkickAPIDisabledError as err:
-        raise NRGkickApiClientApiDisabledError from err
-    except (NRGkickConnectionError, TimeoutError, aiohttp.ClientError, OSError) as err:
-        raise NRGkickApiClientCommunicationError from err
+    await async_api_call(api.test_connection())
+    info = await async_api_call(api.get_info(["general"], raw=True))
 
     device_name = info.get("general", {}).get("device_name")
     if not device_name:

--- a/homeassistant/components/nrgkick/coordinator.py
+++ b/homeassistant/components/nrgkick/coordinator.py
@@ -13,6 +13,7 @@ from nrgkick_api import (
     NRGkickAPIDisabledError,
     NRGkickAuthenticationError,
     NRGkickConnectionError,
+    NRGkickInvalidResponseError,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -78,6 +79,11 @@ class NRGkickDataUpdateCoordinator(DataUpdateCoordinator[NRGkickData]):
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
                 translation_placeholders={"error": str(error)},
+            ) from error
+        except NRGkickInvalidResponseError as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_response",
             ) from error
         except (TimeoutError, aiohttp.ClientError, OSError) as error:
             raise UpdateFailed(

--- a/homeassistant/components/nrgkick/coordinator.py
+++ b/homeassistant/components/nrgkick/coordinator.py
@@ -87,3 +87,18 @@ class NRGkickDataUpdateCoordinator(DataUpdateCoordinator[NRGkickData]):
             ) from error
 
         return NRGkickData(info=info, control=control, values=values)
+
+    def async_update_control_cache(self, updates: dict[str, Any]) -> None:
+        """Update the cached control data.
+
+        This is intended for optimistic updates after successful commands.
+        """
+        data = self.data
+        assert data is not None
+
+        control = dict(data.control)
+        control.update(updates)
+
+        self.async_set_updated_data(
+            NRGkickData(info=data.info, control=control, values=data.values)
+        )

--- a/homeassistant/components/nrgkick/coordinator.py
+++ b/homeassistant/components/nrgkick/coordinator.py
@@ -93,18 +93,3 @@ class NRGkickDataUpdateCoordinator(DataUpdateCoordinator[NRGkickData]):
             ) from error
 
         return NRGkickData(info=info, control=control, values=values)
-
-    def async_update_control_cache(self, updates: dict[str, Any]) -> None:
-        """Update the cached control data.
-
-        This is intended for optimistic updates after successful commands.
-        """
-        data = self.data
-        assert data is not None
-
-        control = dict(data.control)
-        control.update(updates)
-
-        self.async_set_updated_data(
-            NRGkickData(info=data.info, control=control, values=data.values)
-        )

--- a/homeassistant/components/nrgkick/entity.py
+++ b/homeassistant/components/nrgkick/entity.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from typing import Any
 
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api import async_api_call
 from .const import DOMAIN
 from .coordinator import NRGkickDataUpdateCoordinator
 
@@ -55,3 +57,9 @@ class NRGkickEntity(CoordinatorEntity[NRGkickDataUpdateCoordinator]):
             device_info_typed["connections"] = connections
 
         self._attr_device_info = device_info_typed
+
+    async def _async_call_api[_T](self, awaitable: Awaitable[_T]) -> _T:
+        """Call the API, map errors, and refresh coordinator data."""
+        result = await async_api_call(awaitable)
+        await self.coordinator.async_refresh()
+        return result

--- a/homeassistant/components/nrgkick/strings.json
+++ b/homeassistant/components/nrgkick/strings.json
@@ -286,6 +286,11 @@
           "unsupported_charging_mode": "Unsupported charging mode"
         }
       }
+    },
+    "switch": {
+      "charging_enabled": {
+        "name": "Charging enabled"
+      }
     }
   },
   "exceptions": {
@@ -294,6 +299,9 @@
     },
     "authentication_error": {
       "message": "Authentication failed. Please check your credentials."
+    },
+    "command_rejected": {
+      "message": "The device rejected the request: {reason}"
     },
     "communication_error": {
       "message": "Communication error with NRGkick device: {error}"

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -2,53 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .api import async_api_call
 from .coordinator import NRGkickConfigEntry, NRGkickData, NRGkickDataUpdateCoordinator
 from .entity import NRGkickEntity
 
 PARALLEL_UPDATES = 0
 
-
-@dataclass(frozen=True, kw_only=True)
-class NRGkickSwitchEntityDescription(SwitchEntityDescription):
-    """Class describing NRGkick switch entities."""
-
-    is_on_fn: Callable[[NRGkickData], bool]
-    set_is_on_fn: Callable[[NRGkickDataUpdateCoordinator, bool], Awaitable[None]]
+CHARGING_ENABLED_KEY = "charging_enabled"
 
 
 def _is_charging_enabled(data: NRGkickData) -> bool:
     """Return True if charging is enabled (not paused)."""
     return bool(data.control.get("charge_pause") == 0)
-
-
-async def _async_set_charging_enabled(
-    coordinator: NRGkickDataUpdateCoordinator, is_on: bool
-) -> None:
-    """Enable or pause charging.
-
-    The NRGkick API uses a pause flag (pause=True means charging is paused).
-    """
-    await async_api_call(coordinator.api.set_charge_pause(not is_on))
-    await coordinator.async_refresh()
-
-
-SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (
-    NRGkickSwitchEntityDescription(
-        key="charging_enabled",
-        translation_key="charging_enabled",
-        is_on_fn=_is_charging_enabled,
-        set_is_on_fn=_async_set_charging_enabled,
-    ),
-)
 
 
 async def async_setup_entry(
@@ -59,36 +29,29 @@ async def async_setup_entry(
     """Set up NRGkick switches based on a config entry."""
     coordinator = entry.runtime_data
 
-    async_add_entities(
-        NRGkickSwitch(coordinator, description) for description in SWITCHES
-    )
+    async_add_entities([NRGkickChargingEnabledSwitch(coordinator)])
 
 
-class NRGkickSwitch(NRGkickEntity, SwitchEntity):
-    """Representation of a NRGkick switch."""
+class NRGkickChargingEnabledSwitch(NRGkickEntity, SwitchEntity):
+    """Representation of the NRGkick charging enabled switch."""
 
-    entity_description: NRGkickSwitchEntityDescription
+    _attr_translation_key = CHARGING_ENABLED_KEY
 
-    def __init__(
-        self,
-        coordinator: NRGkickDataUpdateCoordinator,
-        entity_description: NRGkickSwitchEntityDescription,
-    ) -> None:
+    def __init__(self, coordinator: NRGkickDataUpdateCoordinator) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator, entity_description.key)
-        self.entity_description = entity_description
+        super().__init__(coordinator, CHARGING_ENABLED_KEY)
 
     @property
     def is_on(self) -> bool:
         """Return the state of the switch."""
         data = self.coordinator.data
         assert data is not None
-        return self.entity_description.is_on_fn(data)
+        return _is_charging_enabled(data)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on (enable charging)."""
-        await self.entity_description.set_is_on_fn(self.coordinator, True)
+        await self._async_call_api(self.coordinator.api.set_charge_pause(False))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off (pause charging)."""
-        await self.entity_description.set_is_on_fn(self.coordinator, False)
+        await self._async_call_api(self.coordinator.api.set_charge_pause(True))

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -8,11 +8,9 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .api import NRGkickApiClientInvalidResponseError, async_api_call
-from .const import DOMAIN
+from .api import async_api_call
 from .coordinator import NRGkickConfigEntry, NRGkickData, NRGkickDataUpdateCoordinator
 from .entity import NRGkickEntity
 
@@ -24,9 +22,7 @@ class NRGkickSwitchEntityDescription(SwitchEntityDescription):
     """Class describing NRGkick switch entities."""
 
     is_on_fn: Callable[[NRGkickData], bool]
-    set_pause_fn: Callable[
-        [NRGkickDataUpdateCoordinator, bool], Awaitable[dict[str, Any]]
-    ]
+    set_pause_fn: Callable[[NRGkickDataUpdateCoordinator, bool], Awaitable[int]]
 
 
 def _is_charging_enabled(data: NRGkickData) -> bool:
@@ -37,36 +33,9 @@ def _is_charging_enabled(data: NRGkickData) -> bool:
 
 async def _async_set_charge_pause(
     coordinator: NRGkickDataUpdateCoordinator, pause: bool
-) -> dict[str, Any]:
+) -> int:
     """Set the charge pause state."""
-    response = await async_api_call(coordinator.api.set_charge_pause(pause))
-
-    if (reason := response.get("Response")) and isinstance(reason, str):
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="command_rejected",
-            translation_placeholders={"reason": reason},
-        )
-
-    if "charge_pause" not in response:
-        raise NRGkickApiClientInvalidResponseError
-
-    try:
-        charge_pause = int(response["charge_pause"])
-    except (TypeError, ValueError) as err:
-        raise NRGkickApiClientInvalidResponseError from err
-
-    expected = 1 if pause else 0
-    if charge_pause != expected:
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="command_rejected",
-            translation_placeholders={
-                "reason": f"Unexpected charge_pause value: {charge_pause}",
-            },
-        )
-
-    return response
+    return await async_api_call(coordinator.api.set_charge_pause(pause))
 
 
 SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -39,7 +39,7 @@ async def _async_set_charging_enabled(
     The NRGkick API uses a pause flag (pause=True means charging is paused).
     """
     await async_api_call(coordinator.api.set_charge_pause(not is_on))
-    coordinator.async_update_control_cache({"charge_pause": 0 if is_on else 1})
+    await coordinator.async_refresh()
 
 
 SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -27,8 +27,7 @@ class NRGkickSwitchEntityDescription(SwitchEntityDescription):
 
 def _is_charging_enabled(data: NRGkickData) -> bool:
     """Return True if charging is enabled (not paused)."""
-    charge_pause = data.control.get("charge_pause")
-    return charge_pause == 0
+    return bool(data.control.get("charge_pause") == 0)
 
 
 async def _async_set_charging_enabled(
@@ -58,7 +57,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up NRGkick switches based on a config entry."""
-    coordinator: NRGkickDataUpdateCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
 
     async_add_entities(
         NRGkickSwitch(coordinator, description) for description in SWITCHES

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -22,7 +22,7 @@ class NRGkickSwitchEntityDescription(SwitchEntityDescription):
     """Class describing NRGkick switch entities."""
 
     is_on_fn: Callable[[NRGkickData], bool]
-    set_pause_fn: Callable[[NRGkickDataUpdateCoordinator, bool], Awaitable[int]]
+    set_is_on_fn: Callable[[NRGkickDataUpdateCoordinator, bool], Awaitable[None]]
 
 
 def _is_charging_enabled(data: NRGkickData) -> bool:
@@ -31,11 +31,15 @@ def _is_charging_enabled(data: NRGkickData) -> bool:
     return charge_pause == 0
 
 
-async def _async_set_charge_pause(
-    coordinator: NRGkickDataUpdateCoordinator, pause: bool
-) -> int:
-    """Set the charge pause state."""
-    return await async_api_call(coordinator.api.set_charge_pause(pause))
+async def _async_set_charging_enabled(
+    coordinator: NRGkickDataUpdateCoordinator, is_on: bool
+) -> None:
+    """Enable or pause charging.
+
+    The NRGkick API uses a pause flag (pause=True means charging is paused).
+    """
+    await async_api_call(coordinator.api.set_charge_pause(not is_on))
+    coordinator.async_update_control_cache({"charge_pause": 0 if is_on else 1})
 
 
 SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (
@@ -43,8 +47,7 @@ SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (
         key="charging_enabled",
         translation_key="charging_enabled",
         is_on_fn=_is_charging_enabled,
-        # API expects pause=True to stop charging
-        set_pause_fn=_async_set_charge_pause,
+        set_is_on_fn=_async_set_charging_enabled,
     ),
 )
 
@@ -83,20 +86,10 @@ class NRGkickSwitch(NRGkickEntity, SwitchEntity):
         assert data is not None
         return self.entity_description.is_on_fn(data)
 
-    def _optimistic_set_charge_pause(self, pause: bool) -> None:
-        """Optimistically update the cached control data.
-
-        This makes state changes visible immediately after a successful command,
-        while a background coordinator refresh verifies the actual device state.
-        """
-        self.coordinator.async_update_control_cache({"charge_pause": 1 if pause else 0})
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on (enable charging)."""
-        await self.entity_description.set_pause_fn(self.coordinator, False)
-        self._optimistic_set_charge_pause(False)
+        await self.entity_description.set_is_on_fn(self.coordinator, True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off (pause charging)."""
-        await self.entity_description.set_pause_fn(self.coordinator, True)
-        self._optimistic_set_charge_pause(True)
+        await self.entity_description.set_is_on_fn(self.coordinator, False)

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from nrgkick_api.const import CONTROL_KEY_CHARGE_PAUSE
+
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -18,7 +20,7 @@ CHARGING_ENABLED_KEY = "charging_enabled"
 
 def _is_charging_enabled(data: NRGkickData) -> bool:
     """Return True if charging is enabled (not paused)."""
-    return bool(data.control.get("charge_pause") == 0)
+    return bool(data.control.get(CONTROL_KEY_CHARGE_PAUSE) == 0)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/nrgkick/switch.py
+++ b/homeassistant/components/nrgkick/switch.py
@@ -1,0 +1,133 @@
+"""Switch platform for NRGkick."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .api import NRGkickApiClientInvalidResponseError, async_api_call
+from .const import DOMAIN
+from .coordinator import NRGkickConfigEntry, NRGkickData, NRGkickDataUpdateCoordinator
+from .entity import NRGkickEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class NRGkickSwitchEntityDescription(SwitchEntityDescription):
+    """Class describing NRGkick switch entities."""
+
+    is_on_fn: Callable[[NRGkickData], bool]
+    set_pause_fn: Callable[
+        [NRGkickDataUpdateCoordinator, bool], Awaitable[dict[str, Any]]
+    ]
+
+
+def _is_charging_enabled(data: NRGkickData) -> bool:
+    """Return True if charging is enabled (not paused)."""
+    charge_pause = data.control.get("charge_pause")
+    return charge_pause == 0
+
+
+async def _async_set_charge_pause(
+    coordinator: NRGkickDataUpdateCoordinator, pause: bool
+) -> dict[str, Any]:
+    """Set the charge pause state."""
+    response = await async_api_call(coordinator.api.set_charge_pause(pause))
+
+    if (reason := response.get("Response")) and isinstance(reason, str):
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="command_rejected",
+            translation_placeholders={"reason": reason},
+        )
+
+    if "charge_pause" not in response:
+        raise NRGkickApiClientInvalidResponseError
+
+    try:
+        charge_pause = int(response["charge_pause"])
+    except (TypeError, ValueError) as err:
+        raise NRGkickApiClientInvalidResponseError from err
+
+    expected = 1 if pause else 0
+    if charge_pause != expected:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="command_rejected",
+            translation_placeholders={
+                "reason": f"Unexpected charge_pause value: {charge_pause}",
+            },
+        )
+
+    return response
+
+
+SWITCHES: tuple[NRGkickSwitchEntityDescription, ...] = (
+    NRGkickSwitchEntityDescription(
+        key="charging_enabled",
+        translation_key="charging_enabled",
+        is_on_fn=_is_charging_enabled,
+        # API expects pause=True to stop charging
+        set_pause_fn=_async_set_charge_pause,
+    ),
+)
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: NRGkickConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up NRGkick switches based on a config entry."""
+    coordinator: NRGkickDataUpdateCoordinator = entry.runtime_data
+
+    async_add_entities(
+        NRGkickSwitch(coordinator, description) for description in SWITCHES
+    )
+
+
+class NRGkickSwitch(NRGkickEntity, SwitchEntity):
+    """Representation of a NRGkick switch."""
+
+    entity_description: NRGkickSwitchEntityDescription
+
+    def __init__(
+        self,
+        coordinator: NRGkickDataUpdateCoordinator,
+        entity_description: NRGkickSwitchEntityDescription,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, entity_description.key)
+        self.entity_description = entity_description
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the switch."""
+        data = self.coordinator.data
+        assert data is not None
+        return self.entity_description.is_on_fn(data)
+
+    def _optimistic_set_charge_pause(self, pause: bool) -> None:
+        """Optimistically update the cached control data.
+
+        This makes state changes visible immediately after a successful command,
+        while a background coordinator refresh verifies the actual device state.
+        """
+        self.coordinator.async_update_control_cache({"charge_pause": 1 if pause else 0})
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on (enable charging)."""
+        await self.entity_description.set_pause_fn(self.coordinator, False)
+        self._optimistic_set_charge_pause(False)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off (pause charging)."""
+        await self.entity_description.set_pause_fn(self.coordinator, True)
+        self._optimistic_set_charge_pause(True)

--- a/tests/components/nrgkick/__init__.py
+++ b/tests/components/nrgkick/__init__.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from unittest.mock import patch
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
-async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    platforms: Iterable[Platform] | None = None,
+) -> None:
     """Set up the component for tests."""
     config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    if platforms is None:
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        return
+
+    with patch("homeassistant.components.nrgkick.PLATFORMS", list(platforms)):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/nrgkick/conftest.py
+++ b/tests/components/nrgkick/conftest.py
@@ -48,10 +48,10 @@ def mock_nrgkick_api(
         api.get_control.return_value = mock_control_data
         api.get_values.return_value = mock_values_data
 
-        api.set_current.return_value = {"current_set": 16.0}
-        api.set_charge_pause.return_value = {"charge_pause": 0}
-        api.set_energy_limit.return_value = {"energy_limit": 0}
-        api.set_phase_count.return_value = {"phase_count": 3}
+        api.set_current.return_value = 16.0
+        api.set_charge_pause.return_value = 0
+        api.set_energy_limit.return_value = 0
+        api.set_phase_count.return_value = 3
 
         yield api
 

--- a/tests/components/nrgkick/conftest.py
+++ b/tests/components/nrgkick/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from nrgkick_api import ConnectorType, GridPhases
@@ -75,7 +75,7 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 def mock_info_data() -> dict[str, Any]:
     """Mock device info data."""
-    res = cast(dict[str, Any], load_json_object_fixture("info.json", DOMAIN))
+    res = load_json_object_fixture("info.json", DOMAIN)
     res["connector"]["type"] = ConnectorType.TYPE2
     res["grid"]["phases"] = GridPhases.L1_L2_L3
     return res

--- a/tests/components/nrgkick/conftest.py
+++ b/tests/components/nrgkick/conftest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 from nrgkick_api import ConnectorType, GridPhases
@@ -75,7 +75,7 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 def mock_info_data() -> dict[str, Any]:
     """Mock device info data."""
-    res = load_json_object_fixture("info.json", DOMAIN)
+    res = cast(dict[str, Any], load_json_object_fixture("info.json", DOMAIN))
     res["connector"]["type"] = ConnectorType.TYPE2
     res["grid"]["phases"] = GridPhases.L1_L2_L3
     return res

--- a/tests/components/nrgkick/snapshots/test_switch.ambr
+++ b/tests/components/nrgkick/snapshots/test_switch.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_switch_entities[switch.nrgkick_test_charging_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.nrgkick_test_charging_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charging enabled',
+    'platform': 'nrgkick',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_enabled',
+    'unique_id': 'TEST123456_charging_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.nrgkick_test_charging_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'NRGkick Test Charging enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.nrgkick_test_charging_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/nrgkick/test_init.py
+++ b/tests/components/nrgkick/test_init.py
@@ -23,7 +23,9 @@ from tests.common import MockConfigEntry
 
 
 async def test_load_unload_entry(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_nrgkick_api: AsyncMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
 ) -> None:
     """Test successful load and unload of entry."""
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/nrgkick/test_sensor.py
+++ b/tests/components/nrgkick/test_sensor.py
@@ -1,12 +1,14 @@
 """Tests for the NRGkick sensor platform."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock
 
 from nrgkick_api import ChargingStatus, ConnectorType
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -26,7 +28,7 @@ async def test_sensor_entities(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test sensor entities."""
-    await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SENSOR])
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -43,10 +45,12 @@ async def test_mapped_unknown_values_become_state_unknown(
         ChargingStatus.UNKNOWN
     )
 
-    await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SENSOR])
 
-    assert hass.states.get("sensor.nrgkick_test_connector_type").state == STATE_UNKNOWN
-    assert hass.states.get("sensor.nrgkick_test_status").state == STATE_UNKNOWN
+    assert (state := hass.states.get("sensor.nrgkick_test_connector_type"))
+    assert state.state == STATE_UNKNOWN
+    assert (state := hass.states.get("sensor.nrgkick_test_status"))
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_cellular_and_gps_entities_are_gated_by_model_type(
@@ -58,7 +62,7 @@ async def test_cellular_and_gps_entities_are_gated_by_model_type(
 
     mock_nrgkick_api.get_info.return_value["general"]["model_type"] = "NRGkick Gen2"
 
-    await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SENSOR])
 
     assert hass.states.get("sensor.nrgkick_test_cellular_mode") is None
     assert hass.states.get("sensor.nrgkick_test_cellular_signal_strength") is None

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, call
 
 from nrgkick_api import NRGkickCommandRejectedError
+from nrgkick_api.const import CONTROL_KEY_CHARGE_PAUSE
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -55,7 +56,7 @@ async def test_charge_switch_service_calls_update_state(
     # Pause charging
     # Simulate the device reporting the new paused state after the command.
     control_data = mock_nrgkick_api.get_control.return_value.copy()
-    control_data["charge_pause"] = 1
+    control_data[CONTROL_KEY_CHARGE_PAUSE] = 1
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -69,7 +70,7 @@ async def test_charge_switch_service_calls_update_state(
     # Resume charging
     # Simulate the device reporting the resumed state after the command.
     control_data = mock_nrgkick_api.get_control.return_value.copy()
-    control_data["charge_pause"] = 0
+    control_data[CONTROL_KEY_CHARGE_PAUSE] = 0
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -109,7 +110,10 @@ async def test_charge_switch_rejected_by_device(
             blocking=True,
         )
 
-    assert "blocked by solar-charging" in str(err.value)
+    assert err.value.translation_key == "command_rejected"
+    assert err.value.translation_placeholders == {
+        "reason": "Charging pause is blocked by solar-charging"
+    }
 
     # State should reflect actual device control data (still not paused).
     assert (state := hass.states.get(entity_id))

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -47,14 +47,7 @@ async def test_charge_switch_service_calls_update_state(
 
     mock_nrgkick_api.set_charge_pause.side_effect = set_charge_pause
 
-    entity_entry = next(
-        entry
-        for entry in er.async_entries_for_config_entry(
-            entity_registry, mock_config_entry.entry_id
-        )
-        if entry.domain == "switch" and entry.translation_key == "charging_enabled"
-    )
-    entity_id = entity_entry.entity_id
+    entity_id = "switch.nrgkick_test_charging_enabled"
 
     assert (state := hass.states.get(entity_id))
     assert state.state == "on"
@@ -104,14 +97,7 @@ async def test_charge_switch_rejected_by_device(
     """Test the switch surfaces device rejection messages and keeps state."""
     await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
 
-    entity_entry = next(
-        entry
-        for entry in er.async_entries_for_config_entry(
-            entity_registry, mock_config_entry.entry_id
-        )
-        if entry.domain == "switch" and entry.translation_key == "charging_enabled"
-    )
-    entity_id = entity_entry.entity_id
+    entity_id = "switch.nrgkick_test_charging_enabled"
 
     # Device refuses the command and the library raises an exception.
     mock_nrgkick_api.set_charge_pause.side_effect = NRGkickCommandRejectedError(

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, call
 
+from nrgkick_api import NRGkickCommandRejectedError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -41,8 +42,8 @@ async def test_charge_switch_service_calls_update_state(
     """Test the charge switch calls the API and updates state."""
     await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
 
-    async def set_charge_pause(pause: bool) -> dict[str, int]:
-        return {"charge_pause": 1 if pause else 0}
+    async def set_charge_pause(pause: bool) -> int:
+        return 1 if pause else 0
 
     mock_nrgkick_api.set_charge_pause.side_effect = set_charge_pause
 
@@ -102,10 +103,10 @@ async def test_charge_switch_rejected_by_device(
     )
     entity_id = entity_entry.entity_id
 
-    # Device refuses the command and returns a textual response.
-    mock_nrgkick_api.set_charge_pause.return_value = {
-        "Response": "Charging pause is blocked by solar-charging"
-    }
+    # Device refuses the command and the library raises an exception.
+    mock_nrgkick_api.set_charge_pause.side_effect = NRGkickCommandRejectedError(
+        "Charging pause is blocked by solar-charging"
+    )
 
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -8,7 +8,13 @@ from nrgkick_api import NRGkickCommandRejectedError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -53,9 +59,9 @@ async def test_charge_switch_service_calls_update_state(
     control_data["charge_pause"] = 1
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
-        "switch",
-        "turn_off",
-        {"entity_id": entity_id},
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert (state := hass.states.get(entity_id))
@@ -67,9 +73,9 @@ async def test_charge_switch_service_calls_update_state(
     control_data["charge_pause"] = 0
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
-        "switch",
-        "turn_on",
-        {"entity_id": entity_id},
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert (state := hass.states.get(entity_id))
@@ -99,9 +105,9 @@ async def test_charge_switch_rejected_by_device(
 
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
-            "switch",
-            "turn_off",
-            {"entity_id": entity_id},
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
 

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -43,7 +43,6 @@ async def test_charge_switch_service_calls_update_state(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nrgkick_api: AsyncMock,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the charge switch calls the API and updates state."""
     await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
@@ -91,7 +90,6 @@ async def test_charge_switch_rejected_by_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nrgkick_api: AsyncMock,
-    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test the switch surfaces device rejection messages and keeps state."""
     await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -1,0 +1,122 @@
+"""Tests for the NRGkick switch platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
+
+
+async def test_switch_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test switch entities."""
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_charge_switch_service_calls_update_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the charge switch calls the API and updates state."""
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
+
+    async def set_charge_pause(pause: bool) -> dict[str, int]:
+        return {"charge_pause": 1 if pause else 0}
+
+    mock_nrgkick_api.set_charge_pause.side_effect = set_charge_pause
+
+    entity_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.domain == "switch" and entry.translation_key == "charging_enabled"
+    )
+    entity_id = entity_entry.entity_id
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "on"
+
+    # Pause charging
+    mock_nrgkick_api.get_control.return_value["charge_pause"] = 1
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+
+    # Resume charging
+    mock_nrgkick_api.get_control.return_value["charge_pause"] = 0
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+
+    assert mock_nrgkick_api.set_charge_pause.await_args_list == [
+        call(True),
+        call(False),
+    ]
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "on"
+
+
+async def test_charge_switch_rejected_by_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the switch surfaces device rejection messages and keeps state."""
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
+
+    entity_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.domain == "switch" and entry.translation_key == "charging_enabled"
+    )
+    entity_id = entity_entry.entity_id
+
+    # Device refuses the command and returns a textual response.
+    mock_nrgkick_api.set_charge_pause.return_value = {
+        "Response": "Charging pause is blocked by solar-charging"
+    }
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": entity_id},
+            blocking=True,
+        )
+
+    assert "blocked by solar-charging" in str(err.value)
+
+    # State should reflect actual device control data (still not paused).
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "on"

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -60,29 +60,36 @@ async def test_charge_switch_service_calls_update_state(
     assert state.state == "on"
 
     # Pause charging
-    mock_nrgkick_api.get_control.return_value["charge_pause"] = 1
+    # The device (mock) still says "not paused" (0) immediately, but our optimistic
+    # update should make the entity report "off".
+    mock_nrgkick_api.get_control.return_value["charge_pause"] = 0
     await hass.services.async_call(
         "switch",
         "turn_off",
         {"entity_id": entity_id},
         blocking=True,
     )
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "off"
+
+    # Now we simulate the device eventually catching up for the next poll
+    mock_nrgkick_api.get_control.return_value["charge_pause"] = 1
 
     # Resume charging
-    mock_nrgkick_api.get_control.return_value["charge_pause"] = 0
+    # Device implies it is paused (1), but optimistic update should make it "on".
     await hass.services.async_call(
         "switch",
         "turn_on",
         {"entity_id": entity_id},
         blocking=True,
     )
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "on"
 
     assert mock_nrgkick_api.set_charge_pause.await_args_list == [
         call(True),
         call(False),
     ]
-    assert (state := hass.states.get(entity_id))
-    assert state.state == "on"
 
 
 async def test_charge_switch_rejected_by_device(

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -60,29 +60,32 @@ async def test_charge_switch_service_calls_update_state(
     assert state.state == "on"
 
     # Pause charging
-    # The device (mock) still says "not paused" (0) immediately, but our optimistic
-    # update should make the entity report "off".
-    mock_nrgkick_api.get_control.return_value["charge_pause"] = 0
+    # Simulate the device reporting the new paused state after the command.
+    control_data = dict(mock_nrgkick_api.get_control.return_value)
+    control_data["charge_pause"] = 1
+    mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
         "switch",
         "turn_off",
         {"entity_id": entity_id},
         blocking=True,
     )
+    await hass.async_block_till_done()
     assert (state := hass.states.get(entity_id))
     assert state.state == "off"
 
-    # Now we simulate the device eventually catching up for the next poll
-    mock_nrgkick_api.get_control.return_value["charge_pause"] = 1
-
     # Resume charging
-    # Device implies it is paused (1), but optimistic update should make it "on".
+    # Simulate the device reporting the resumed state after the command.
+    control_data = dict(mock_nrgkick_api.get_control.return_value)
+    control_data["charge_pause"] = 0
+    mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
         "switch",
         "turn_on",
         {"entity_id": entity_id},
         blocking=True,
     )
+    await hass.async_block_till_done()
     assert (state := hass.states.get(entity_id))
     assert state.state == "on"
 

--- a/tests/components/nrgkick/test_switch.py
+++ b/tests/components/nrgkick/test_switch.py
@@ -42,11 +42,6 @@ async def test_charge_switch_service_calls_update_state(
     """Test the charge switch calls the API and updates state."""
     await setup_integration(hass, mock_config_entry, platforms=[Platform.SWITCH])
 
-    async def set_charge_pause(pause: bool) -> int:
-        return 1 if pause else 0
-
-    mock_nrgkick_api.set_charge_pause.side_effect = set_charge_pause
-
     entity_id = "switch.nrgkick_test_charging_enabled"
 
     assert (state := hass.states.get(entity_id))
@@ -54,7 +49,7 @@ async def test_charge_switch_service_calls_update_state(
 
     # Pause charging
     # Simulate the device reporting the new paused state after the command.
-    control_data = dict(mock_nrgkick_api.get_control.return_value)
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data["charge_pause"] = 1
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
@@ -63,13 +58,12 @@ async def test_charge_switch_service_calls_update_state(
         {"entity_id": entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert (state := hass.states.get(entity_id))
     assert state.state == "off"
 
     # Resume charging
     # Simulate the device reporting the resumed state after the command.
-    control_data = dict(mock_nrgkick_api.get_control.return_value)
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data["charge_pause"] = 0
     mock_nrgkick_api.get_control.return_value = control_data
     await hass.services.async_call(
@@ -78,7 +72,6 @@ async def test_charge_switch_service_calls_update_state(
         {"entity_id": entity_id},
         blocking=True,
     )
-    await hass.async_block_till_done()
     assert (state := hass.states.get(entity_id))
     assert state.state == "on"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds the "charge enabled" control as new switch platform.

Implementation notes:
- The device API allows setting the charge pause. For the HA user interface, I decided inverting this to have a switch that *enables charging* instead of *enabling the charge pause*.
- The device API returns the updated value if successful, or a message with info if switching is not allowed. With upcoming number entities in mind, I updated the nrgkick-api library (therefore also a dependency update) to parse the message and translate it into new exceptions for disallowed settings with a reason. This simplifies the HA integration, as such checks logically belong to the API wrapper. New nrgkick API library release: https://github.com/andijakl/nrgkick-api/releases/tag/v1.7.1 (includes link to diff)
- The translation of nrgkick-api library exceptions into HA integration exceptions is now centralized in `api.py`'s `async_api_call()` for better code re-use (also used in config flow)
- Adds tests to cover both successful + rejected set command. Extended `setup_integration()` in `__init__.py` to switch the platform for snapshot testing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43455
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
