### PR TITLE
Fix HomematicIP heating group availability with unreachable members

### DIFF
--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -89,6 +89,17 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
             self._simple_heating = self._first_radiator_thermostat
 
     @property
+    def available(self) -> bool:
+        """Heating group available.
+
+        A heating group must be available, and should not be affected by the
+        individual availability of group members.
+        This allows controlling the temperature even when individual group
+        members are not available.
+        """
+        return True
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return DeviceInfo(

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -313,6 +313,17 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
         super().__init__(hap, device, post, is_multi_channel=False)
 
     @property
+    def available(self) -> bool:
+        """Cover shutter group available.
+
+        A cover shutter group must be available, and should not be affected by
+        the individual availability of group members.
+        This allows controlling the shutters even when individual group
+        members are not available.
+        """
+        return True
+
+    @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
         if self._device.shutterLevel is not None:

--- a/tests/components/homematicip_cloud/test_climate.py
+++ b/tests/components/homematicip_cloud/test_climate.py
@@ -23,6 +23,10 @@ from homeassistant.components.homematicip_cloud.climate import (
     ATTR_PRESET_END_TIME,
     PERMANENT_END_TIME,
 )
+from homeassistant.components.homematicip_cloud.entity import (
+    ATTR_GROUP_MEMBER_UNREACHABLE,
+)
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
@@ -426,6 +430,30 @@ async def test_hmip_heating_group_heat_with_radiator(
         PRESET_ECO,
         "Default",
     ]
+
+
+async def test_hmip_heating_group_availability(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test heating group stays available when group member is unreachable."""
+    entity_id = "climate.badezimmer"
+    entity_name = "Badezimmer"
+    device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_groups=[entity_name]
+    )
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert ha_state.state != STATE_UNAVAILABLE
+    assert not ha_state.attributes.get(ATTR_GROUP_MEMBER_UNREACHABLE)
+
+    await async_manipulate_test_data(hass, hmip_device, "unreach", True)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state != STATE_UNAVAILABLE
+    assert ha_state.attributes[ATTR_GROUP_MEMBER_UNREACHABLE]
 
 
 async def test_hmip_heating_profile_default_name(

--- a/tests/components/homematicip_cloud/test_cover.py
+++ b/tests/components/homematicip_cloud/test_cover.py
@@ -7,7 +7,10 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
     CoverState,
 )
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.components.homematicip_cloud.entity import (
+    ATTR_GROUP_MEMBER_UNREACHABLE,
+)
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
@@ -596,3 +599,25 @@ async def test_hmip_cover_slats_group(
     assert len(hmip_device.mock_calls) == service_call_counter + 9
     assert hmip_device.mock_calls[-1][0] == "set_shutter_stop_async"
     assert hmip_device.mock_calls[-1][1] == ()
+
+
+async def test_hmip_cover_shutter_group_availability(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test cover shutter group stays available when group member is unreachable."""
+    entity_id = "cover.rollos_shuttergroup"
+    entity_name = "Rollos ShutterGroup"
+    device_model = None
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(test_groups=["Rollos"])
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    assert ha_state.state != STATE_UNAVAILABLE
+    assert not ha_state.attributes.get(ATTR_GROUP_MEMBER_UNREACHABLE)
+
+    await async_manipulate_test_data(hass, hmip_device, "unreach", True)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state != STATE_UNAVAILABLE
+    assert ha_state.attributes[ATTR_GROUP_MEMBER_UNREACHABLE]


### PR DESCRIPTION
## Proposed change

When a HomematicIP group member (e.g., a window sensor with a dead battery) becomes unreachable, group-based entities in HA become unavailable — even though the group remains fully functional and controllable through the HomematicIP app.

The root cause is that `HomematicipHeatingGroup` and `HomematicipCoverShutterGroup` inherit their `available` property from `HomematicipGenericEntity`, which returns `not self._device.unreach`. For individual devices this is correct, but for groups `unreach` means "any group member is unreachable" (the integration even maps it to `group_member_unreachable` in state attributes), not "the group itself is non-functional."

This PR overrides the `available` property in both `HomematicipHeatingGroup` and `HomematicipCoverShutterGroup` to always return `True`, following the exact same pattern already used by two other group-based entities in the integration:

- `HomematicipGroupSwitch` (switch.py) — returns `True`
- `HomematicipSecurityZoneSensorGroup` (binary_sensor.py) — returns `True`

The unreachable member status continues to be exposed via the `group_member_unreachable` state attribute through the base class.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #143006

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
