### PR TITLE
Handle 403 authentication errors in HomematicIP Cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -84,8 +84,12 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
                         HMIPC_NAME: self.auth.config.get(HMIPC_NAME),
                     },
                 )
-            return self.async_abort(reason="connection_aborted")
-        errors["base"] = "press_the_button"
+            if self.source == "reauth":
+                errors["base"] = "connection_aborted"
+            else:
+                return self.async_abort(reason="connection_aborted")
+        else:
+            errors["base"] = "press_the_button"
 
         return self.async_show_form(step_id="link", errors=errors)
 

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -70,6 +71,11 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
             authtoken = await self.auth.async_register()
             if authtoken:
                 _LOGGER.debug("Write config entry for HomematicIP Cloud")
+                if self.source == "reauth":
+                    return self.async_update_reload_and_abort(
+                        self._get_reauth_entry(),
+                        data_updates={HMIPC_AUTHTOKEN: authtoken},
+                    )
                 return self.async_create_entry(
                     title=self.auth.config[HMIPC_HAPID],
                     data={
@@ -82,6 +88,41 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
         errors["base"] = "press_the_button"
 
         return self.async_show_form(step_id="link", errors=errors)
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication when the auth token becomes invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauth confirmation and start link process."""
+        errors = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            config = {
+                HMIPC_HAPID: reauth_entry.data[HMIPC_HAPID],
+                HMIPC_PIN: user_input.get(HMIPC_PIN),
+                HMIPC_NAME: reauth_entry.data.get(HMIPC_NAME),
+            }
+            self.auth = HomematicipAuth(self.hass, config)
+            connected = await self.auth.async_setup()
+            if connected:
+                return await self.async_step_link()
+            errors["base"] = "invalid_sgtin_or_pin"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(HMIPC_PIN): str,
+                }
+            ),
+            errors=errors,
+        )
 
     async def async_step_import(self, import_data: dict[str, str]) -> ConfigFlowResult:
         """Import a new access point as a config entry."""

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -12,7 +12,10 @@ from homematicip.auth import Auth
 from homematicip.base.enums import EventType
 from homematicip.connection.connection_context import ConnectionContextBuilder
 from homematicip.connection.rest_connection import RestConnection
-from homematicip.exceptions.connection_exceptions import HmipConnectionError
+from homematicip.exceptions.connection_exceptions import (
+    HmipAuthenticationError,
+    HmipConnectionError,
+)
 
 import homeassistant
 from homeassistant.config_entries import ConfigEntry
@@ -186,6 +189,12 @@ class HomematicipHAP:
         while True:
             try:
                 await self.get_state()
+                break
+            except HmipAuthenticationError:
+                _LOGGER.error(
+                    "Authentication error from HomematicIP Cloud, triggering reauth"
+                )
+                self.config_entry.async_start_reauth(self.hass)
                 break
             except HmipConnectionError as err:
                 _LOGGER.warning(

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "connection_aborted": "[%key:common::config_flow::error::cannot_connect%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
@@ -24,6 +25,13 @@
       "link": {
         "description": "Press the blue button on the access point and the **Submit** button to register Homematic IP with Home Assistant.\n\n![Location of button on bridge](/static/images/config_flows/config_homematicip_cloud.png)",
         "title": "Link access point"
+      },
+      "reauth_confirm": {
+        "data": {
+          "pin": "[%key:common::config_flow::data::pin%]"
+        },
+        "description": "The authentication token for your HomematicIP access point is no longer valid. Press **Submit** and then press the blue button on your access point to re-register.",
+        "title": "Re-authenticate HomematicIP access point"
       }
     }
   },

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -7,6 +7,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
+      "connection_aborted": "Registration failed, please try again.",
       "invalid_sgtin_or_pin": "Invalid SGTIN or PIN code, please try again.",
       "press_the_button": "Please press the blue button.",
       "register_failed": "Failed to register, please try again.",

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -256,6 +256,53 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
     assert entry.data[HMIPC_AUTHTOKEN] == "new_token"
 
 
+async def test_reauth_flow_register_failure(hass: HomeAssistant) -> None:
+    """Test reauth flow keeps form alive when registration fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ABC123",
+        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "old_token", HMIPC_NAME: "hmip"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    # Submit reauth_confirm to get to link step
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+    assert result["step_id"] == "link"
+
+    # Button pressed but register fails -> should show error, not abort
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "link"
+    assert result["errors"] == {"base": "connection_aborted"}
+
+
 async def test_reauth_flow_connection_error(hass: HomeAssistant) -> None:
     """Test reauth flow with connection error shows form again."""
     entry = MockConfigEntry(

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -200,6 +200,88 @@ async def test_import_config(hass: HomeAssistant, simple_mock_home) -> None:
     assert result["result"].unique_id == "ABC123"
 
 
+async def test_reauth_flow(hass: HomeAssistant) -> None:
+    """Test reauth flow re-registers and updates the auth token."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ABC123",
+        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "old_token", HMIPC_NAME: "hmip"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    # Submit reauth_confirm, button not yet pressed -> link form shown
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "link"
+    assert result["errors"] == {"base": "press_the_button"}
+
+    # User presses button -> reauth completes
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+            return_value="new_token",
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[HMIPC_AUTHTOKEN] == "new_token"
+
+
+async def test_reauth_flow_connection_error(hass: HomeAssistant) -> None:
+    """Test reauth flow with connection error shows form again."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ABC123",
+        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "old_token", HMIPC_NAME: "hmip"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_sgtin_or_pin"}
+
+
 async def test_import_existing_config(hass: HomeAssistant) -> None:
     """Test abort of an existing accesspoint from config."""
     MockConfigEntry(domain=DOMAIN, unique_id="ABC123").add_to_hass(hass)

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -246,10 +246,15 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
             "homeassistant.components.homematicip_cloud.async_setup_entry",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_unload_entry",
+            return_value=True,
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -316,10 +321,15 @@ async def test_reauth_flow_register_failure(hass: HomeAssistant) -> None:
             "homeassistant.components.homematicip_cloud.async_setup_entry",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_unload_entry",
+            return_value=True,
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
@@ -369,10 +379,15 @@ async def test_reauth_flow_connection_error(hass: HomeAssistant) -> None:
             "homeassistant.components.homematicip_cloud.async_setup_entry",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_unload_entry",
+            return_value=True,
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={}
         )
+        await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -302,6 +302,29 @@ async def test_reauth_flow_register_failure(hass: HomeAssistant) -> None:
     assert result["step_id"] == "link"
     assert result["errors"] == {"base": "connection_aborted"}
 
+    # Retry succeeds -> reauth completes
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+            return_value="new_token",
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[HMIPC_AUTHTOKEN] == "new_token"
+
 
 async def test_reauth_flow_connection_error(hass: HomeAssistant) -> None:
     """Test reauth flow with connection error shows form again."""
@@ -327,6 +350,33 @@ async def test_reauth_flow_connection_error(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert result["errors"] == {"base": "invalid_sgtin_or_pin"}
+
+    # Retry succeeds -> reauth completes
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_setup",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_checkbutton",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.HomematicipAuth.async_register",
+            return_value="new_token",
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[HMIPC_AUTHTOKEN] == "new_token"
 
 
 async def test_import_existing_config(hass: HomeAssistant) -> None:

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -333,6 +333,7 @@ async def test_try_get_state_auth_error_triggers_reauth(
 ) -> None:
     """Test _try_get_state stops retrying on auth error and triggers reauth."""
     hass.config.components.add(DOMAIN)
+    hmip_config_entry.add_to_hass(hass)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
 
@@ -341,10 +342,14 @@ async def test_try_get_state_auth_error_triggers_reauth(
 
     hap.get_state = AsyncMock(side_effect=HmipAuthenticationError)
 
-    with patch.object(hmip_config_entry, "async_start_reauth") as mock_reauth:
-        await hap._try_get_state()
+    assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+
+    await hap._try_get_state()
+    await hass.async_block_till_done()
 
     # Should have called get_state only once (no retries)
     assert hap.get_state.call_count == 1
-    # Should have triggered reauth
-    mock_reauth.assert_called_once_with(hass)
+    # Should have triggered a reauth flow
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.auth import Auth
 from homematicip.connection.connection_context import ConnectionContext
-from homematicip.exceptions.connection_exceptions import HmipConnectionError
+from homematicip.exceptions.connection_exceptions import (
+    HmipAuthenticationError,
+    HmipConnectionError,
+)
 import pytest
 
 from homeassistant.components.homematicip_cloud import DOMAIN
@@ -323,3 +326,25 @@ async def test_async_connect(
     simple_mock_home.set_on_disconnected_handler.assert_called_once()
     simple_mock_home.set_on_reconnect_handler.assert_called_once()
     simple_mock_home.enable_events.assert_called_once()
+
+
+async def test_try_get_state_auth_error_triggers_reauth(
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
+) -> None:
+    """Test _try_get_state stops retrying on auth error and triggers reauth."""
+    hass.config.components.add(DOMAIN)
+    hap = HomematicipHAP(hass, hmip_config_entry)
+    assert hap
+
+    hap.home = MagicMock(spec=AsyncHome)
+    hap.home.websocket_is_connected = Mock(return_value=True)
+
+    hap.get_state = AsyncMock(side_effect=HmipAuthenticationError)
+
+    with patch.object(hmip_config_entry, "async_start_reauth") as mock_reauth:
+        await hap._try_get_state()
+
+    # Should have called get_state only once (no retries)
+    assert hap.get_state.call_count == 1
+    # Should have triggered reauth
+    mock_reauth.assert_called_once_with(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the HomematicIP cloud returns HTTP 403 `INVALID_AUTHORIZATION` during a state refresh (e.g. after a network change), `_try_get_state` currently retries forever with exponential backoff — the auth error is a permanent failure, not a transient connection issue.

This PR:
- Catches `HmipAuthenticationError` (new exception from hahn-th/homematicip-rest-api#629) separately from `HmipConnectionError` in `_try_get_state` and triggers a reauth flow instead of retrying
- Adds a reauth config flow that allows the user to re-register by pressing the blue button on the access point to obtain a new auth token

Uses `HmipAuthenticationError` from homematicip 2.6.0 (bumped in #162702).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #149538
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr