### PR TITLE
Increase max tasks retrieved per page to prevent timeout

### DIFF
--- a/homeassistant/components/todoist/const.py
+++ b/homeassistant/components/todoist/const.py
@@ -93,4 +93,7 @@ COLLABORATORS: Final = "collaborators"
 
 DOMAIN: Final = "todoist"
 
+# Maximum number of items per page for Todoist API requests
+MAX_PAGE_SIZE: Final = 200
+
 SERVICE_NEW_TASK: Final = "new_task"

--- a/homeassistant/components/todoist/coordinator.py
+++ b/homeassistant/components/todoist/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the Todoist component."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from datetime import timedelta
 import logging
@@ -11,6 +12,8 @@ from todoist_api_python.models import Label, Project, Section, Task
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import MAX_PAGE_SIZE
 
 T = TypeVar("T")
 
@@ -53,26 +56,30 @@ class TodoistCoordinator(DataUpdateCoordinator[list[Task]]):
     async def _async_update_data(self) -> list[Task]:
         """Fetch tasks from the Todoist API."""
         try:
-            tasks_async = await self.api.get_tasks(limit=200)
+            tasks_async = await self.api.get_tasks(limit=MAX_PAGE_SIZE)
             return await flatten_async_pages(tasks_async)
+        except asyncio.CancelledError:
+            raise
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     async def async_get_projects(self) -> list[Project]:
         """Return todoist projects fetched at most once."""
         if self._projects is None:
-            projects_async = await self.api.get_projects(limit=200)
+            projects_async = await self.api.get_projects(limit=MAX_PAGE_SIZE)
             self._projects = await flatten_async_pages(projects_async)
         return self._projects
 
     async def async_get_sections(self, project_id: str) -> list[Section]:
         """Return todoist sections for a given project ID."""
-        sections_async = await self.api.get_sections(project_id=project_id, limit=200)
+        sections_async = await self.api.get_sections(
+            project_id=project_id, limit=MAX_PAGE_SIZE
+        )
         return await flatten_async_pages(sections_async)
 
     async def async_get_labels(self) -> list[Label]:
         """Return todoist labels fetched at most once."""
         if self._labels is None:
-            labels_async = await self.api.get_labels(limit=200)
+            labels_async = await self.api.get_labels(limit=MAX_PAGE_SIZE)
             self._labels = await flatten_async_pages(labels_async)
         return self._labels

--- a/homeassistant/components/todoist/coordinator.py
+++ b/homeassistant/components/todoist/coordinator.py
@@ -53,26 +53,26 @@ class TodoistCoordinator(DataUpdateCoordinator[list[Task]]):
     async def _async_update_data(self) -> list[Task]:
         """Fetch tasks from the Todoist API."""
         try:
-            tasks_async = await self.api.get_tasks()
+            tasks_async = await self.api.get_tasks(limit=200)
+            return await flatten_async_pages(tasks_async)
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
-        return await flatten_async_pages(tasks_async)
 
     async def async_get_projects(self) -> list[Project]:
         """Return todoist projects fetched at most once."""
         if self._projects is None:
-            projects_async = await self.api.get_projects()
+            projects_async = await self.api.get_projects(limit=200)
             self._projects = await flatten_async_pages(projects_async)
         return self._projects
 
     async def async_get_sections(self, project_id: str) -> list[Section]:
         """Return todoist sections for a given project ID."""
-        sections_async = await self.api.get_sections(project_id=project_id)
+        sections_async = await self.api.get_sections(project_id=project_id, limit=200)
         return await flatten_async_pages(sections_async)
 
     async def async_get_labels(self) -> list[Label]:
         """Return todoist labels fetched at most once."""
         if self._labels is None:
-            labels_async = await self.api.get_labels()
+            labels_async = await self.api.get_labels(limit=200)
             self._labels = await flatten_async_pages(labels_async)
         return self._labels

--- a/tests/components/todoist/conftest.py
+++ b/tests/components/todoist/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from requests.exceptions import HTTPError
 from requests.models import Response
+from todoist_api_python.api_async import TodoistAPIAsync
 from todoist_api_python.models import Collaborator, Due, Label, Project, Section, Task
 
 from homeassistant.components.todoist import DOMAIN
@@ -126,7 +127,7 @@ def mock_tasks(due: Due) -> list[Task]:
 @pytest.fixture(name="api")
 def mock_api(tasks: list[Task]) -> AsyncMock:
     """Mock the api state."""
-    api = AsyncMock()
+    api = AsyncMock(spec=TodoistAPIAsync)
     api.get_projects.side_effect = make_api_response(
         [
             Project(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default limit of tasks per page is 50, this change increases that amount to the maximum allowed (200) in order to try to avoid global timeouts for users with a large number of tasks.

Unfortunately the python sdk ends up firing off blocking http requests wrapped in an async generator which can lead to timeouts like in https://github.com/home-assistant/core/issues/162539

There is an open issue upstream: https://github.com/Doist/todoist-api-python/issues/162  But it's not currently in progress.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162539 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
