### PR TITLE
Use direct DHW status for ViCare water heater state

### DIFF
--- a/tests/components/vicare/snapshots/test_water_heater.ambr
+++ b/tests/components/vicare/snapshots/test_water_heater.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[water_heater.model0-entry]
+# name: test_all_entities[water_heater.model0_domestic_hot_water-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'water_heater',
     'entity_category': None,
-    'entity_id': 'water_heater.model0',
+    'entity_id': 'water_heater.model0_domestic_hot_water',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,12 +23,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Domestic hot water',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Domestic hot water',
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -38,11 +38,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[water_heater.model0-state]
+# name: test_all_entities[water_heater.model0_domestic_hot_water-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'model0 None',
+      'friendly_name': 'model0 Domestic hot water',
       'max_temp': 60,
       'min_temp': 10,
       'supported_features': <WaterHeaterEntityFeature: 1>,
@@ -51,14 +51,14 @@
       'temperature': None,
     }),
     'context': <ANY>,
-    'entity_id': 'water_heater.model0',
+    'entity_id': 'water_heater.model0_domestic_hot_water',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_all_entities[water_heater.model0_2-entry]
+# name: test_all_entities[water_heater.model0_domestic_hot_water_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -74,7 +74,7 @@
     'disabled_by': None,
     'domain': 'water_heater',
     'entity_category': None,
-    'entity_id': 'water_heater.model0_2',
+    'entity_id': 'water_heater.model0_domestic_hot_water_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -82,12 +82,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Domestic hot water',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Domestic hot water',
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -97,11 +97,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[water_heater.model0_2-state]
+# name: test_all_entities[water_heater.model0_domestic_hot_water_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'model0 None',
+      'friendly_name': 'model0 Domestic hot water',
       'max_temp': 60,
       'min_temp': 10,
       'supported_features': <WaterHeaterEntityFeature: 1>,
@@ -110,7 +110,7 @@
       'temperature': None,
     }),
     'context': <ANY>,
-    'entity_id': 'water_heater.model0_2',
+    'entity_id': 'water_heater.model0_domestic_hot_water_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vicare/snapshots/test_water_heater.ambr
+++ b/tests/components/vicare/snapshots/test_water_heater.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[water_heater.model0_domestic_hot_water-entry]
+# name: test_all_entities[water_heater.model0-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'water_heater',
     'entity_category': None,
-    'entity_id': 'water_heater.model0_domestic_hot_water',
+    'entity_id': 'water_heater.model0',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,12 +23,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Domestic hot water',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Domestic hot water',
+    'original_name': None,
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -38,11 +38,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[water_heater.model0_domestic_hot_water-state]
+# name: test_all_entities[water_heater.model0-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'model0 Domestic hot water',
+      'friendly_name': 'model0 None',
       'max_temp': 60,
       'min_temp': 10,
       'supported_features': <WaterHeaterEntityFeature: 1>,
@@ -51,14 +51,14 @@
       'temperature': None,
     }),
     'context': <ANY>,
-    'entity_id': 'water_heater.model0_domestic_hot_water',
+    'entity_id': 'water_heater.model0',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_all_entities[water_heater.model0_domestic_hot_water_2-entry]
+# name: test_all_entities[water_heater.model0_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -74,7 +74,7 @@
     'disabled_by': None,
     'domain': 'water_heater',
     'entity_category': None,
-    'entity_id': 'water_heater.model0_domestic_hot_water_2',
+    'entity_id': 'water_heater.model0_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -82,12 +82,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Domestic hot water',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Domestic hot water',
+    'original_name': None,
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -97,11 +97,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[water_heater.model0_domestic_hot_water_2-state]
+# name: test_all_entities[water_heater.model0_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'current_temperature': None,
-      'friendly_name': 'model0 Domestic hot water',
+      'friendly_name': 'model0 None',
       'max_temp': 60,
       'min_temp': 10,
       'supported_features': <WaterHeaterEntityFeature: 1>,
@@ -110,7 +110,7 @@
       'temperature': None,
     }),
     'context': <ANY>,
-    'entity_id': 'water_heater.model0_domestic_hot_water_2',
+    'entity_id': 'water_heater.model0_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vicare/test_water_heater.py
+++ b/tests/components/vicare/test_water_heater.py
@@ -15,7 +15,7 @@ from .conftest import Fixture, MockPyViCare
 
 from tests.common import MockConfigEntry, snapshot_platform
 
-ENTITY_WATER_HEATER = "water_heater.model0"
+ENTITY_WATER_HEATER = "water_heater.model0_domestic_hot_water"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/vicare/test_water_heater.py
+++ b/tests/components/vicare/test_water_heater.py
@@ -8,11 +8,14 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
 
 from . import MODULE, setup_integration
 from .conftest import Fixture, MockPyViCare
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_WATER_HEATER = "water_heater.model0"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -31,3 +34,21 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dhw_active_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test water heater uses direct DHW status for on/off state."""
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
+    with (
+        patch(f"{MODULE}.login", return_value=MockPyViCare(fixtures)),
+        patch(f"{MODULE}.PLATFORMS", [Platform.WATER_HEATER]),
+    ):
+        await setup_integration(hass, mock_config_entry)
+        await async_update_entity(hass, ENTITY_WATER_HEATER)
+
+    state = hass.states.get(ENTITY_WATER_HEATER)
+    assert state.state == "on"


### PR DESCRIPTION
## Proposed change

Use `getDomesticHotWaterActive()` from PyViCare to determine the water heater on/off state instead of relying solely on the heating circuit's active mode.

On some Viessmann devices (e.g., Vitodens 300 0620), the circuit active mode can be `"heating"` while domestic hot water is independently active. The previous code derived the water heater state from `circuit.getActiveMode()`, which mapped `"heating"` to OFF — incorrectly showing the water heater as off.

PyViCare already provides `getDomesticHotWaterActive()` which checks the `heating.dhw` status property directly. This change uses that as the primary indicator, falling back to the circuit mode mapping for devices that don't expose the `heating.dhw` feature.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #160024
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr