### PR TITLE
Add charge state to Victron BLE

### DIFF
--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -246,7 +246,7 @@ SENSOR_DESCRIPTIONS = {
     Keys.CHARGE_STATE: VictronBLESensorEntityDescription(
         key=Keys.CHARGE_STATE,
         device_class=SensorDeviceClass.ENUM,
-        translation_key="device_state",
+        translation_key="charge_state",
         options=DEVICE_STATE_OPTIONS,
     ),
     Keys.CHARGER_ERROR: VictronBLESensorEntityDescription(

--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -243,6 +243,12 @@ SENSOR_DESCRIPTIONS = {
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    Keys.CHARGE_STATE: VictronBLESensorEntityDescription(
+        key=Keys.CHARGE_STATE,
+        device_class=SensorDeviceClass.ENUM,
+        translation_key="device_state",
+        options=DEVICE_STATE_OPTIONS,
+    ),
     Keys.CHARGER_ERROR: VictronBLESensorEntityDescription(
         key=Keys.CHARGER_ERROR,
         device_class=SensorDeviceClass.ENUM,

--- a/homeassistant/components/victron_ble/strings.json
+++ b/homeassistant/components/victron_ble/strings.json
@@ -87,6 +87,28 @@
       "cell_voltage": {
         "name": "Cell {cell} voltage"
       },
+      "charge_state": {
+        "name": "Charge state",
+        "state": {
+          "absorption": "[%key:component::victron_ble::entity::sensor::device_state::state::absorption%]",
+          "active": "[%key:component::victron_ble::entity::sensor::device_state::state::active%]",
+          "battery_safe": "[%key:component::victron_ble::entity::sensor::device_state::state::battery_safe%]",
+          "bulk": "[%key:component::victron_ble::entity::sensor::device_state::state::bulk%]",
+          "equalize_manual": "[%key:component::victron_ble::entity::sensor::device_state::state::equalize_manual%]",
+          "external_control": "[%key:component::victron_ble::entity::sensor::device_state::state::external_control%]",
+          "fault": "[%key:component::victron_ble::entity::sensor::device_state::state::fault%]",
+          "float": "[%key:component::victron_ble::entity::sensor::device_state::state::float%]",
+          "inverting": "[%key:component::victron_ble::entity::sensor::device_state::state::inverting%]",
+          "low_power": "[%key:component::victron_ble::entity::sensor::device_state::state::low_power%]",
+          "not_available": "[%key:component::victron_ble::entity::sensor::device_state::state::not_available%]",
+          "off": "[%key:common::state::off%]",
+          "power_supply": "[%key:component::victron_ble::entity::sensor::device_state::state::power_supply%]",
+          "recondition": "[%key:component::victron_ble::entity::sensor::device_state::state::recondition%]",
+          "repeated_absorption": "[%key:component::victron_ble::entity::sensor::device_state::state::repeated_absorption%]",
+          "starting_up": "[%key:component::victron_ble::entity::sensor::device_state::state::starting_up%]",
+          "storage": "[%key:component::victron_ble::entity::sensor::device_state::state::storage%]"
+        }
+      },
       "charger_error": {
         "name": "Charger error",
         "state": {

--- a/tests/components/victron_ble/snapshots/test_sensor.ambr
+++ b/tests/components/victron_ble/snapshots/test_sensor.ambr
@@ -1153,6 +1153,95 @@
     'state': '13.88',
   })
 # ---
+# name: test_sensors[solar_charger][sensor.solar_charger_charge_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'low_power',
+        'fault',
+        'bulk',
+        'absorption',
+        'float',
+        'storage',
+        'equalize_manual',
+        'inverting',
+        'power_supply',
+        'starting_up',
+        'repeated_absorption',
+        'recondition',
+        'battery_safe',
+        'active',
+        'external_control',
+        'not_available',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.solar_charger_charge_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charge state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charge state',
+    'platform': 'victron_ble',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_state',
+    'unique_id': '01:02:03:04:05:11-charge_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[solar_charger][sensor.solar_charger_charge_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Solar Charger Charge state',
+      'options': list([
+        'off',
+        'low_power',
+        'fault',
+        'bulk',
+        'absorption',
+        'float',
+        'storage',
+        'equalize_manual',
+        'inverting',
+        'power_supply',
+        'starting_up',
+        'repeated_absorption',
+        'recondition',
+        'battery_safe',
+        'active',
+        'external_control',
+        'not_available',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.solar_charger_charge_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'absorption',
+  })
+# ---
 # name: test_sensors[solar_charger][sensor.solar_charger_external_device_load-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the `charge_state` sensor (already exposed by `victron-ble-ha-parser` for [DC/DC chargers](https://github.com/rajlaud/victron-ble-ha-parser/blob/8f1a7b7b373f08b01de2e414053f82c5077d60c0/victron_ble_ha_parser/parser.py#L199) and [solar chargers](https://github.com/rajlaud/victron-ble-ha-parser/blob/8f1a7b7b373f08b01de2e414053f82c5077d60c0/victron_ble_ha_parser/parser.py#L346)).

`charge_type` uses the same enumeration as the other sensors that are exposed as `device_state`, so I've adopted that pattern, though I'm not sure it's particularly intuitive.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
