### PR TITLE
Expose ActuatorEnabled attr of matter DoorLock

### DIFF
--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -179,8 +179,9 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.BINARY_SENSOR,
         entity_description=MatterBinarySensorEntityDescription(
-            key="LockActuatorEnabled",
+            key="LockActuatorEnabledSensor",
             translation_key="actuator_enabled",
+            entity_category=EntityCategory.DIAGNOSTIC,
         ),
         entity_class=MatterBinarySensor,
         required_attributes=(clusters.DoorLock.Attributes.ActuatorEnabled,),

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -179,6 +179,15 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.BINARY_SENSOR,
         entity_description=MatterBinarySensorEntityDescription(
+            key="LockActuatorEnabled",
+            translation_key="actuator_enabled",
+        ),
+        entity_class=MatterBinarySensor,
+        required_attributes=(clusters.DoorLock.Attributes.ActuatorEnabled,),
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        entity_description=MatterBinarySensorEntityDescription(
             key="SmokeCoAlarmDeviceMutedSensor",
             device_to_ha=lambda x: (
                 x == clusters.SmokeCoAlarm.Enums.MuteStateEnum.kMuted

--- a/homeassistant/components/matter/binary_sensor.py
+++ b/homeassistant/components/matter/binary_sensor.py
@@ -180,7 +180,7 @@ DISCOVERY_SCHEMAS = [
         platform=Platform.BINARY_SENSOR,
         entity_description=MatterBinarySensorEntityDescription(
             key="LockActuatorEnabledSensor",
-            translation_key="actuator_enabled",
+            translation_key="actuator",
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         entity_class=MatterBinarySensor,

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -47,6 +47,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "actuator_enabled": {
+        "name": "Actuator enabled"
+      },
       "alarm_door": {
         "name": "Door alarm"
       },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -47,8 +47,8 @@
   },
   "entity": {
     "binary_sensor": {
-      "actuator_enabled": {
-        "name": "Actuator enabled"
+      "actuator": {
+        "name": "Actuator"
       },
       "alarm_door": {
         "name": "Door alarm"

--- a/tests/components/matter/snapshots/test_binary_sensor.ambr
+++ b/tests/components/matter/snapshots/test_binary_sensor.ambr
@@ -149,7 +149,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator_enabled-entry]
+# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -162,7 +162,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator_enabled',
+    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -170,28 +170,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Actuator enabled',
+    'object_id_base': 'Actuator',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Actuator enabled',
+    'original_name': 'Actuator',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'actuator_enabled',
+    'translation_key': 'actuator',
     'unique_id': '00000000000004D2-0000000000000014-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator_enabled-state]
+# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Aqara Smart Lock U200 Actuator enabled',
+      'friendly_name': 'Aqara Smart Lock U200 Actuator',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator_enabled',
+    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1094,7 +1094,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator_enabled-entry]
+# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1107,7 +1107,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.mock_door_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_door_lock_actuator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1115,28 +1115,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Actuator enabled',
+    'object_id_base': 'Actuator',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Actuator enabled',
+    'original_name': 'Actuator',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'actuator_enabled',
+    'translation_key': 'actuator',
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator_enabled-state]
+# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock Actuator enabled',
+      'friendly_name': 'Mock Door Lock Actuator',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.mock_door_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_door_lock_actuator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1193,7 +1193,7 @@
     'state': 'off',
   })
 # ---
-# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator_enabled-entry]
+# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1206,7 +1206,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1214,28 +1214,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Actuator enabled',
+    'object_id_base': 'Actuator',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Actuator enabled',
+    'original_name': 'Actuator',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'actuator_enabled',
+    'translation_key': 'actuator',
     'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator_enabled-state]
+# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock with unbolt Actuator enabled',
+      'friendly_name': 'Mock Door Lock with unbolt Actuator',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1392,7 +1392,7 @@
     'state': 'on',
   })
 # ---
-# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator_enabled-entry]
+# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1405,7 +1405,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.mock_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_lock_actuator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1413,28 +1413,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Actuator enabled',
+    'object_id_base': 'Actuator',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Actuator enabled',
+    'original_name': 'Actuator',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'actuator_enabled',
+    'translation_key': 'actuator',
     'unique_id': '00000000000004D2-0000000000000097-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator_enabled-state]
+# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Lock Actuator enabled',
+      'friendly_name': 'Mock Lock Actuator',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.mock_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.mock_lock_actuator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2338,7 +2338,7 @@
     'state': 'off',
   })
 # ---
-# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator_enabled-entry]
+# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2351,7 +2351,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2359,28 +2359,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Actuator enabled',
+    'object_id_base': 'Actuator',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Actuator enabled',
+    'original_name': 'Actuator',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'actuator_enabled',
+    'translation_key': 'actuator',
     'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator_enabled-state]
+# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Secuyou Smart Lock Actuator enabled',
+      'friendly_name': 'Secuyou Smart Lock Actuator',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator_enabled',
+    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_binary_sensor.ambr
+++ b/tests/components/matter/snapshots/test_binary_sensor.ambr
@@ -149,6 +149,55 @@
     'state': 'on',
   })
 # ---
+# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Actuator enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Actuator enabled',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actuator_enabled',
+    'unique_id': '00000000000004D2-0000000000000014-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[aqara_u200][binary_sensor.aqara_smart_lock_u200_actuator_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Aqara Smart Lock U200 Actuator enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.aqara_smart_lock_u200_actuator_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_binary_sensors[eve_contact_sensor][binary_sensor.eve_door_door-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1045,6 +1094,55 @@
     'state': 'on',
   })
 # ---
+# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mock_door_lock_actuator_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Actuator enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Actuator enabled',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actuator_enabled',
+    'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_actuator_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Door Lock Actuator enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mock_door_lock_actuator_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_binary_sensors[mock_door_lock][binary_sensor.mock_door_lock_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1093,6 +1191,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Actuator enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Actuator enabled',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actuator_enabled',
+    'unique_id': '00000000000004D2-0000000000000001-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_actuator_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Door Lock with unbolt Actuator enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mock_door_lock_with_unbolt_actuator_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensors[mock_door_lock_with_unbolt][binary_sensor.mock_door_lock_with_unbolt_battery-entry]
@@ -1239,6 +1386,55 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.water_leak_detector_water_leak',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.mock_lock_actuator_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Actuator enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Actuator enabled',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actuator_enabled',
+    'unique_id': '00000000000004D2-0000000000000097-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[mock_lock][binary_sensor.mock_lock_actuator_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Lock Actuator enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.mock_lock_actuator_enabled',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2140,6 +2336,55 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Actuator enabled',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Actuator enabled',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actuator_enabled',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-LockActuatorEnabledSensor-257-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[secuyou_smart_lock][binary_sensor.secuyou_smart_lock_actuator_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Secuyou Smart Lock Actuator enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.secuyou_smart_lock_actuator_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensors[silabs_dishwasher][binary_sensor.dishwasher_door_alarm-entry]

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -120,6 +120,29 @@ async def test_battery_sensor(
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+async def test_actuator_enabled_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test actuator enabled sensor."""
+    entity_id = "binary_sensor.mock_door_lock_actuator_enabled"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "on"
+
+    set_node_attribute(matter_node, 1, 257, 2, False)
+    await trigger_subscription_callback(
+        hass, matter_client, data=(matter_node.node_id, "1/257/2", False)
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "off"
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
 async def test_optional_sensor_from_featuremap(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/matter/test_binary_sensor.py
+++ b/tests/components/matter/test_binary_sensor.py
@@ -120,14 +120,14 @@ async def test_battery_sensor(
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
-async def test_actuator_enabled_sensor(
+async def test_actuator_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
     """Test actuator enabled sensor."""
-    entity_id = "binary_sensor.mock_door_lock_actuator_enabled"
+    entity_id = "binary_sensor.mock_door_lock_actuator"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
This PR aims to expose the ActuatorEnabled attribute of the Matter DoorLock cluster as a binary sensor entity. This attribute of the DoorLock cluster is mandatory and should (according to the spec) reflect whether the lock is currently capable of accepting lock/unlock requests.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards. (n.a.: no code was generated)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
