### PR TITLE
Google Gen AI: Increase max iterations for AI Task

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/ai_task.py
+++ b/homeassistant/components/google_generative_ai_conversation/ai_task.py
@@ -80,7 +80,10 @@ class GoogleGenerativeAITaskEntity(
     ) -> ai_task.GenDataTaskResult:
         """Handle a generate data task."""
         await self._async_handle_chat_log(
-            chat_log, task.structure, default_max_tokens=RECOMMENDED_AI_TASK_MAX_TOKENS
+            chat_log,
+            task.structure,
+            default_max_tokens=RECOMMENDED_AI_TASK_MAX_TOKENS,
+            max_iterations=1000,
         )
 
         if not isinstance(chat_log.content[-1], conversation.AssistantContent):

--- a/homeassistant/components/google_generative_ai_conversation/entity.py
+++ b/homeassistant/components/google_generative_ai_conversation/entity.py
@@ -486,6 +486,7 @@ class GoogleGenerativeAILLMBaseEntity(Entity):
         chat_log: conversation.ChatLog,
         structure: vol.Schema | None = None,
         default_max_tokens: int | None = None,
+        max_iterations: int = MAX_TOOL_ITERATIONS,
     ) -> None:
         """Generate an answer for the chat log."""
         options = self.subentry.data
@@ -602,7 +603,7 @@ class GoogleGenerativeAILLMBaseEntity(Entity):
             )
 
         # To prevent infinite loops, we limit the number of iterations
-        for _iteration in range(MAX_TOOL_ITERATIONS):
+        for _iteration in range(max_iterations):
             try:
                 chat_response_generator = await chat.send_message_stream(
                     message=chat_request


### PR DESCRIPTION
## Proposed change

https://github.com/home-assistant/core/pull/162599 but for Google Gen AI.

When doing AI Task, we want the AI to do work. The limit on max iterations no longer makes sense. Increasing it, instead of removing it, for Google Gen AI to still make sure it cancels if it were to get in some bad loop.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This change improves flexibility in the Google Generative AI conversation component by allowing different iteration limits for different task types, while maintaining backward compatibility through sensible defaults.

https://claude.ai/code/session_015XZLXvtziawntyDyh5zZ3X