### PR TITLE
Add vacuum's activity table to LG ThinQ

### DIFF
--- a/homeassistant/components/lg_thinq/vacuum.py
+++ b/homeassistant/components/lg_thinq/vacuum.py
@@ -57,6 +57,11 @@ ROBOT_STATUS_TO_HA = {
     "sleep": VacuumActivity.IDLE,
     "standby": VacuumActivity.IDLE,
     "working": VacuumActivity.CLEANING,
+    "station_dry": VacuumActivity.CLEANING,
+    "water_removal": VacuumActivity.CLEANING,
+    "water_injection": VacuumActivity.CLEANING,
+    "clean_select": VacuumActivity.CLEANING,
+    "clean_select_gozone": VacuumActivity.CLEANING,
     "error": VacuumActivity.ERROR,
 }
 ROBOT_BATT_TO_HA = {
@@ -111,7 +116,9 @@ class ThinQStateVacuumEntity(ThinQEntity, StateVacuumEntity):
         super()._update_status()
 
         # Update state.
-        self._attr_activity = ROBOT_STATUS_TO_HA[self.data.current_state]
+        self._attr_activity = ROBOT_STATUS_TO_HA.get(
+            self.data.current_state, VacuumActivity.CLEANING
+        )
 
         # Update battery.
         if (level := self.data.battery) is not None:

--- a/homeassistant/components/lg_thinq/vacuum.py
+++ b/homeassistant/components/lg_thinq/vacuum.py
@@ -57,7 +57,9 @@ ROBOT_STATUS_TO_HA = {
     "sleep": VacuumActivity.IDLE,
     "standby": VacuumActivity.IDLE,
     "working": VacuumActivity.CLEANING,
+    "station": VacuumActivity.CLEANING,
     "station_dry": VacuumActivity.CLEANING,
+    "station_mop": VacuumActivity.CLEANING,
     "water_removal": VacuumActivity.CLEANING,
     "water_injection": VacuumActivity.CLEANING,
     "clean_select": VacuumActivity.CLEANING,
@@ -116,8 +118,10 @@ class ThinQStateVacuumEntity(ThinQEntity, StateVacuumEntity):
         super()._update_status()
 
         # Update state.
-        self._attr_activity = ROBOT_STATUS_TO_HA.get(
-            self.data.current_state, VacuumActivity.CLEANING
+        self._attr_activity = (
+            ROBOT_STATUS_TO_HA.get(self.data.current_state, VacuumActivity.CLEANING)
+            if self.data.current_state is not None
+            else None
         )
 
         # Update battery.

--- a/homeassistant/components/lg_thinq/vacuum.py
+++ b/homeassistant/components/lg_thinq/vacuum.py
@@ -59,6 +59,7 @@ ROBOT_STATUS_TO_HA = {
     "working": VacuumActivity.CLEANING,
     "station": VacuumActivity.CLEANING,
     "station_dry": VacuumActivity.CLEANING,
+    "clean_learning": VacuumActivity.CLEANING,
     "station_mop": VacuumActivity.CLEANING,
     "water_removal": VacuumActivity.CLEANING,
     "water_injection": VacuumActivity.CLEANING,
@@ -118,11 +119,7 @@ class ThinQStateVacuumEntity(ThinQEntity, StateVacuumEntity):
         super()._update_status()
 
         # Update state.
-        self._attr_activity = (
-            ROBOT_STATUS_TO_HA.get(self.data.current_state, VacuumActivity.CLEANING)
-            if self.data.current_state is not None
-            else None
-        )
+        self._attr_activity = ROBOT_STATUS_TO_HA.get(self.data.current_state)
 
         # Update battery.
         if (level := self.data.battery) is not None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Currently, LG robot vacuum cleaners have a variety of cleaning functions, and more states may be added in the future.
>     "station_dry": VacuumActivity.CLEANING,
>     "water_removal": VacuumActivity.CLEANING,
>     "water_injection": VacuumActivity.CLEANING,
>     "clean_select": VacuumActivity.CLEANING,
>     "clean_select_gozone": VacuumActivity.CLEANING,

- A fix is ​​also needed to prevent KeyError.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
