### PR TITLE
Remove legacy fallback in light support_color_modes property

### DIFF
--- a/homeassistant/components/deako/light.py
+++ b/homeassistant/components/deako/light.py
@@ -89,8 +89,5 @@ class DeakoLightEntity(LightEntity):
         assert self._attr_unique_id is not None
         state = self.client.get_state(self._attr_unique_id) or {}
         self._attr_is_on = bool(state.get("power", False))
-        if (
-            self._attr_supported_color_modes is not None
-            and ColorMode.BRIGHTNESS in self._attr_supported_color_modes
-        ):
+        if ColorMode.BRIGHTNESS in self._attr_supported_color_modes:
             self._attr_brightness = int(round(state.get("dim", 0) * 2.55))

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -74,9 +74,11 @@ def filter_supported_color_modes(color_modes: Iterable[ColorMode]) -> set[ColorM
 
 
 def valid_supported_color_modes(
-    color_modes: Iterable[ColorMode],
+    color_modes: Iterable[ColorMode] | None,
 ) -> set[ColorMode]:
     """Validate the given color modes."""
+    if color_modes is None:
+        raise vol.Error(f"Invalid supported_color_modes {color_modes}")
     color_modes = set(color_modes)
     if (
         not color_modes

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -283,9 +283,7 @@ def filter_turn_on_params(light: LightEntity, params: dict[str, Any]) -> dict[st
     if LightEntityFeature.TRANSITION not in supported_features:
         params.pop(ATTR_TRANSITION, None)
 
-    supported_color_modes = (
-        light._light_internal_supported_color_modes  # noqa: SLF001
-    )
+    supported_color_modes = valid_supported_color_modes(light.supported_color_modes)
     if not brightness_supported(supported_color_modes):
         params.pop(ATTR_BRIGHTNESS, None)
     if ColorMode.COLOR_TEMP not in supported_color_modes:
@@ -363,8 +361,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         ):
             profiles.apply_default(light.entity_id, light.is_on, params)
 
-        legacy_supported_color_modes = light._light_internal_supported_color_modes  # noqa: SLF001
-        supported_color_modes = light.supported_color_modes
+        supported_color_modes = valid_supported_color_modes(light.supported_color_modes)
 
         # If a color temperature is specified, emulate it if not supported by the light
         if ATTR_COLOR_TEMP_KELVIN in params:
@@ -381,9 +378,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
                     light.min_color_temp_kelvin,
                     light.max_color_temp_kelvin,
                 )
-            elif ColorMode.COLOR_TEMP not in legacy_supported_color_modes:
+            elif ColorMode.COLOR_TEMP not in supported_color_modes:
                 color_temp = params.pop(ATTR_COLOR_TEMP_KELVIN)
-                if color_supported(legacy_supported_color_modes):
+                if color_supported(supported_color_modes):
                     params[ATTR_HS_COLOR] = color_util.color_temperature_to_hs(
                         color_temp
                     )
@@ -793,8 +790,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_supported_features: LightEntityFeature = LightEntityFeature(0)
     _attr_xy_color: tuple[float, float] | None = None
 
-    __color_mode_reported = False
-
     @cached_property
     def brightness(self) -> int | None:
         """Return the brightness of this light between 0..255."""
@@ -895,7 +890,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return capability attributes."""
         data: dict[str, Any] = {}
         supported_features = self.supported_features
-        supported_color_modes = self._light_internal_supported_color_modes
+        supported_color_modes = valid_supported_color_modes(self.supported_color_modes)
 
         if ColorMode.COLOR_TEMP in supported_color_modes:
             min_color_temp_kelvin = self.min_color_temp_kelvin
@@ -988,39 +983,13 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             f"of {effect_color_modes}"
         )
 
-    def __validate_supported_color_modes(
-        self,
-        supported_color_modes: set[ColorMode],
-    ) -> None:
-        """Validate the supported color modes."""
-        if self.__color_mode_reported:
-            return
-
-        try:
-            valid_supported_color_modes(supported_color_modes)
-        except vol.Error:
-            # Warning added in 2024.3, reject in 2025.3
-            if not self.__color_mode_reported and self.__should_report_light_issue():
-                self.__color_mode_reported = True
-                report_issue = self._suggest_report_issue()
-                _LOGGER.warning(
-                    (
-                        "%s (%s) sets invalid supported color modes %s, this will stop "
-                        "working in Home Assistant Core 2025.3, please %s"
-                    ),
-                    self.entity_id,
-                    type(self),
-                    supported_color_modes,
-                    report_issue,
-                )
-
     @final
     @property
     def state_attributes(self) -> dict[str, Any] | None:
         """Return state attributes."""
         data: dict[str, Any] = {}
         supported_features = self.supported_features
-        supported_color_modes = self.supported_color_modes
+        supported_color_modes = valid_supported_color_modes(self.supported_color_modes)
 
         _is_on = self.is_on
         color_mode = self.color_mode if _is_on else None
@@ -1062,12 +1031,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
         return data
 
-    @property
-    def _light_internal_supported_color_modes(self) -> set[ColorMode]:
-        """Calculate supported color modes with backwards compatibility."""
-        self.__validate_supported_color_modes(color_modes := self.supported_color_modes)
-        return color_modes
-
     @cached_property
     def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
@@ -1077,10 +1040,3 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def supported_features(self) -> LightEntityFeature:
         """Flag supported features."""
         return self._attr_supported_features
-
-    def __should_report_light_issue(self) -> bool:
-        """Return if light color mode issues should be reported."""
-        if not self.platform:
-            return True
-        # philips_js has known issues, we don't need users to open issues
-        return self.platform.platform_name != "philips_js"

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -1021,9 +1021,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         data: dict[str, Any] = {}
         supported_features = self.supported_features
         supported_color_modes = self.supported_color_modes
-        legacy_supported_color_modes = (
-            supported_color_modes or self._light_internal_supported_color_modes
-        )
 
         _is_on = self.is_on
         color_mode = self.color_mode if _is_on else None
@@ -1034,7 +1031,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 effect = self.effect
             data[ATTR_EFFECT] = effect
 
-        self.__validate_color_mode(color_mode, legacy_supported_color_modes, effect)
+        self.__validate_color_mode(color_mode, supported_color_modes, effect)
 
         data[ATTR_COLOR_MODE] = color_mode
 
@@ -1050,15 +1047,15 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             else:
                 data[ATTR_COLOR_TEMP_KELVIN] = None
 
-        if color_supported(legacy_supported_color_modes) or color_temp_supported(
-            legacy_supported_color_modes
+        if color_supported(supported_color_modes) or color_temp_supported(
+            supported_color_modes
         ):
             data[ATTR_HS_COLOR] = None
             data[ATTR_RGB_COLOR] = None
             data[ATTR_XY_COLOR] = None
-            if ColorMode.RGBW in legacy_supported_color_modes:
+            if ColorMode.RGBW in supported_color_modes:
                 data[ATTR_RGBW_COLOR] = None
-            if ColorMode.RGBWW in legacy_supported_color_modes:
+            if ColorMode.RGBWW in supported_color_modes:
                 data[ATTR_RGBWW_COLOR] = None
             if color_mode:
                 data.update(self._light_internal_convert_color(color_mode))

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -74,7 +74,7 @@ def filter_supported_color_modes(color_modes: Iterable[ColorMode]) -> set[ColorM
 
 
 def valid_supported_color_modes(
-    color_modes: Iterable[ColorMode] | None,
+    color_modes: Iterable[ColorMode],
 ) -> set[ColorMode]:
     """Validate the given color modes."""
     if color_modes is None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -789,7 +789,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_rgb_color: tuple[int, int, int] | None = None
     _attr_rgbw_color: tuple[int, int, int, int] | None = None
     _attr_rgbww_color: tuple[int, int, int, int, int] | None = None
-    _attr_supported_color_modes: set[ColorMode] | None = None
+    _attr_supported_color_modes: set[ColorMode]
     _attr_supported_features: LightEntityFeature = LightEntityFeature(0)
     _attr_xy_color: tuple[float, float] | None = None
 
@@ -1068,29 +1068,11 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @property
     def _light_internal_supported_color_modes(self) -> set[ColorMode]:
         """Calculate supported color modes with backwards compatibility."""
-        if (_supported_color_modes := self.supported_color_modes) is not None:
-            self.__validate_supported_color_modes(_supported_color_modes)
-            return _supported_color_modes
-
-        # Backwards compatibility for supported_color_modes added in 2021.4
-        # Warning added in 2024.3, remove in 2025.3
-        if not self.__color_mode_reported and self.__should_report_light_issue():
-            self.__color_mode_reported = True
-            report_issue = self._suggest_report_issue()
-            _LOGGER.warning(
-                (
-                    "%s (%s) does not set supported color modes, this will stop working"
-                    " in Home Assistant Core 2025.3, please %s"
-                ),
-                self.entity_id,
-                type(self),
-                report_issue,
-            )
-
-        return {ColorMode.ONOFF}
+        self.__validate_supported_color_modes(color_modes := self.supported_color_modes)
+        return color_modes
 
     @cached_property
-    def supported_color_modes(self) -> set[ColorMode] | None:
+    def supported_color_modes(self) -> set[ColorMode]:
         """Flag supported color modes."""
         return self._attr_supported_color_modes
 

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -332,7 +332,7 @@ class MatterLight(MatterEntity, LightEntity):
     @callback
     def _update_from_device(self) -> None:
         """Update from device."""
-        if self._attr_supported_color_modes is None:
+        if not hasattr(self, "_attr_supported_color_modes"):
             # work out what (color)features are supported
             supported_color_modes = {ColorMode.ONOFF}
             # brightness support

--- a/homeassistant/components/tasmota/light.py
+++ b/homeassistant/components/tasmota/light.py
@@ -216,11 +216,11 @@ class TasmotaLight(
 
         attributes: dict[str, Any] = {}
 
-        if ATTR_HS_COLOR in kwargs and ColorMode.HS in supported_color_modes:  # type: ignore[operator]
+        if ATTR_HS_COLOR in kwargs and ColorMode.HS in supported_color_modes:
             hs_color = kwargs[ATTR_HS_COLOR]
             attributes["color_hs"] = [hs_color[0], hs_color[1]]
 
-        if ATTR_WHITE in kwargs and ColorMode.WHITE in supported_color_modes:  # type: ignore[operator]
+        if ATTR_WHITE in kwargs and ColorMode.WHITE in supported_color_modes:
             attributes["white_value"] = scale_brightness(kwargs[ATTR_WHITE])
 
         if ATTR_TRANSITION in kwargs:
@@ -231,7 +231,7 @@ class TasmotaLight(
 
         if (
             ATTR_COLOR_TEMP_KELVIN in kwargs
-            and ColorMode.COLOR_TEMP in supported_color_modes  # type: ignore[operator]
+            and ColorMode.COLOR_TEMP in supported_color_modes
         ):
             attributes["color_temp"] = color_util.color_temperature_kelvin_to_mired(
                 kwargs[ATTR_COLOR_TEMP_KELVIN]

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -1892,7 +1892,7 @@ _INHERITANCE_MATCH: dict[str, list[ClassTypeHintMatch]] = {
                 ),
                 TypeHintMatch(
                     function_name="supported_color_modes",
-                    return_type=["set[ColorMode]", None],
+                    return_type=["set[ColorMode]"],
                     mandatory=True,
                 ),
                 TypeHintMatch(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -2354,7 +2354,7 @@ def test_filter_supported_color_modes() -> None:
 
 
 @pytest.mark.parametrize(
-    ("color_mode", "supported_color_modes", "warning_expected"),
+    ("color_mode", "supported_color_modes", "error_expected"),
     [
         (light.ColorMode.ONOFF, None, True),
         (light.ColorMode.ONOFF, {light.ColorMode.ONOFF}, False),
@@ -2365,7 +2365,7 @@ async def test_report_no_color_modes(
     caplog: pytest.LogCaptureFixture,
     color_mode: str,
     supported_color_modes: set[str],
-    warning_expected: bool,
+    error_expected: bool,
 ) -> None:
     """Test a light setting no color mode."""
 
@@ -2378,9 +2378,13 @@ async def test_report_no_color_modes(
     entity = MockLightEntityEntity()
     platform = MockEntityPlatform(hass, domain="test", platform_name="test")
     await platform.async_add_entities([entity])
-    entity._async_calculate_state()
-    expected_warning = "does not set supported color modes"
-    assert (expected_warning in caplog.text) is warning_expected
+    raised_error = ""
+    try:
+        entity._async_calculate_state()
+    except vol.Error as err:
+        raised_error = str(err)
+    expected_error = "Invalid supported_color_modes"
+    assert (expected_error in raised_error) is error_expected
 
 
 @pytest.mark.parametrize(
@@ -2438,7 +2442,7 @@ async def test_report_invalid_color_mode(
 
 
 @pytest.mark.parametrize(
-    ("color_mode", "supported_color_modes", "platform_name", "warning_expected"),
+    ("color_mode", "supported_color_modes", "platform_name", "error_expected"),
     [
         (
             light.ColorMode.ONOFF,
@@ -2464,12 +2468,6 @@ async def test_report_invalid_color_mode(
             "test",
             False,
         ),
-        (
-            light.ColorMode.ONOFF,
-            {light.ColorMode.ONOFF, light.ColorMode.BRIGHTNESS},
-            "philips_js",  # We don't log issues for philips_js
-            False,
-        ),
     ],
 )
 def test_report_invalid_color_modes(
@@ -2478,7 +2476,7 @@ def test_report_invalid_color_modes(
     color_mode: str,
     supported_color_modes: set[str],
     platform_name: str,
-    warning_expected: bool,
+    error_expected: bool,
 ) -> None:
     """Test a light setting an invalid color mode."""
 
@@ -2490,9 +2488,13 @@ def test_report_invalid_color_modes(
         platform = MockEntityPlatform(hass, platform_name=platform_name)
 
     entity = MockLightEntityEntity()
-    entity._async_calculate_state()
-    expected_warning = "sets invalid supported color modes"
-    assert (expected_warning in caplog.text) is warning_expected
+    raised_error = ""
+    try:
+        entity._async_calculate_state()
+    except vol.Error as err:
+        raised_error = str(err)
+    expected_error = "Invalid supported_color_modes"
+    assert (expected_error in raised_error) is error_expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not user-facing

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reporting supported_color_mode as None or empty would previously log a warning and return ONOFF.

This is no longer supported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2945
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
