### PR TITLE
Centralize ViCare error handling in base entity class

### DIFF
--- a/homeassistant/components/vicare/binary_sensor.py
+++ b/homeassistant/components/vicare/binary_sensor.py
@@ -12,14 +12,7 @@ from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-import requests
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -233,18 +226,5 @@ class ViCareBinarySensor(ViCareEntity, BinarySensorEntity):
 
     def update(self) -> None:
         """Update state of sensor."""
-        try:
-            with suppress(PyViCareNotSupportedFeatureError):
-                self._attr_is_on = self.entity_description.value_getter(self._api)
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
+        with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
+            self._attr_is_on = self.entity_description.value_getter(self._api)

--- a/homeassistant/components/vicare/button.py
+++ b/homeassistant/components/vicare/button.py
@@ -8,14 +8,7 @@ import logging
 
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-import requests
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -104,18 +97,5 @@ class ViCareButton(ViCareEntity, ButtonEntity):
 
     def press(self) -> None:
         """Handle the button press."""
-        try:
-            with suppress(PyViCareNotSupportedFeatureError):
-                self.entity_description.value_setter(self._api)
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
+        with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
+            self.entity_description.value_setter(self._api)

--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -11,13 +11,8 @@ from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import HeatingCircuit as PyViCareHeatingCircuit
 from PyViCare.PyViCareUtils import (
     PyViCareCommandError,
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
     PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
 )
-import requests
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -160,7 +155,7 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
 
     def update(self) -> None:
         """Let HA know there has been an update from the ViCare API."""
-        try:
+        with self.vicare_api_handler():
             _room_temperature = None
             with suppress(PyViCareNotSupportedFeatureError):
                 self._attributes["room_temperature"] = _room_temperature = (
@@ -215,19 +210,6 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
                     self._current_action = (
                         self._current_action or compressor.getActive()
                     )
-
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -1,21 +1,52 @@
 """Entities for the ViCare integration."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
+import logging
+
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
+from PyViCare.PyViCareUtils import (
+    PyViCareDeviceCommunicationError,
+    PyViCareInternalServerError,
+    PyViCareInvalidDataError,
+    PyViCareRateLimitError,
+)
+from requests.exceptions import ConnectionError as RequestConnectionError
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, VIESSMANN_DEVELOPER_PORTAL
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class ViCareEntity(Entity):
     """Base class for ViCare entities."""
 
     _attr_has_entity_name = True
+
+    @contextmanager
+    def vicare_api_handler(self) -> Generator[None]:
+        """Handle common ViCare API errors."""
+        try:
+            yield
+        except RequestConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareRateLimitError as err:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", err)
+        except PyViCareInvalidDataError as err:
+            _LOGGER.error("Invalid data from Vicare server: %s", err)
+        except PyViCareDeviceCommunicationError as err:
+            _LOGGER.warning("Device communication error: %s", err)
+        except PyViCareInternalServerError as err:
+            _LOGGER.warning("Vicare server error: %s", err)
 
     def __init__(
         self,

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -40,13 +40,13 @@ class ViCareEntity(Entity):
         except ValueError:
             _LOGGER.error("Unable to decode data from ViCare server")
         except PyViCareRateLimitError as err:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", err)
+            _LOGGER.error("ViCare API rate limit exceeded: %s", err)
         except PyViCareInvalidDataError as err:
-            _LOGGER.error("Invalid data from Vicare server: %s", err)
+            _LOGGER.error("Invalid data from ViCare server: %s", err)
         except PyViCareDeviceCommunicationError as err:
             _LOGGER.warning("Device communication error: %s", err)
         except PyViCareInternalServerError as err:
-            _LOGGER.warning("Vicare server error: %s", err)
+            _LOGGER.warning("ViCare server error: %s", err)
 
     def __init__(
         self,

--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -9,14 +9,7 @@ from typing import Any
 
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-from requests.exceptions import ConnectionError as RequestConnectionError
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant
@@ -173,7 +166,7 @@ class ViCareFan(ViCareEntity, FanEntity):
     def update(self) -> None:
         """Update state of fan."""
         level: str | None = None
-        try:
+        with self.vicare_api_handler():
             with suppress(PyViCareNotSupportedFeatureError):
                 self._attr_preset_mode = VentilationMode.from_vicare_mode(
                     self._api.getActiveVentilationMode()
@@ -187,18 +180,6 @@ class ViCareFan(ViCareEntity, FanEntity):
                 )
             else:
                 self._attr_percentage = 0
-        except RequestConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/vicare/number.py
+++ b/homeassistant/components/vicare/number.py
@@ -13,14 +13,7 @@ from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-from requests.exceptions import ConnectionError as RequestConnectionError
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -437,38 +430,25 @@ class ViCareNumber(ViCareEntity, NumberEntity):
 
     def update(self) -> None:
         """Update state of number."""
-        try:
-            with suppress(PyViCareNotSupportedFeatureError):
-                self._attr_native_value = self.entity_description.value_getter(
-                    self._api
-                )
+        with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
+            self._attr_native_value = self.entity_description.value_getter(
+                self._api
+            )
 
-                if min_value := _get_value(
-                    self.entity_description.min_value_getter, self._api
-                ):
-                    self._attr_native_min_value = min_value
+            if min_value := _get_value(
+                self.entity_description.min_value_getter, self._api
+            ):
+                self._attr_native_min_value = min_value
 
-                if max_value := _get_value(
-                    self.entity_description.max_value_getter, self._api
-                ):
-                    self._attr_native_max_value = max_value
+            if max_value := _get_value(
+                self.entity_description.max_value_getter, self._api
+            ):
+                self._attr_native_max_value = max_value
 
-                if stepping_value := _get_value(
-                    self.entity_description.stepping_getter, self._api
-                ):
-                    self._attr_native_step = stepping_value
-        except RequestConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
+            if stepping_value := _get_value(
+                self.entity_description.stepping_getter, self._api
+            ):
+                self._attr_native_step = stepping_value
 
 
 def _get_value(

--- a/homeassistant/components/vicare/number.py
+++ b/homeassistant/components/vicare/number.py
@@ -431,9 +431,7 @@ class ViCareNumber(ViCareEntity, NumberEntity):
     def update(self) -> None:
         """Update state of number."""
         with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
-            self._attr_native_value = self.entity_description.value_getter(
-                self._api
-            )
+            self._attr_native_value = self.entity_description.value_getter(self._api)
 
             if min_value := _get_value(
                 self.entity_description.min_value_getter, self._api

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -12,14 +12,7 @@ from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-import requests
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -1556,26 +1549,13 @@ class ViCareSensor(ViCareEntity, SensorEntity):
     def update(self) -> None:
         """Update state of sensor."""
         vicare_unit = None
-        try:
-            with suppress(PyViCareNotSupportedFeatureError):
-                self._attr_native_value = self.entity_description.value_getter(
-                    self._api
-                )
+        with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
+            self._attr_native_value = self.entity_description.value_getter(
+                self._api
+            )
 
-                if self.entity_description.unit_getter:
-                    vicare_unit = self.entity_description.unit_getter(self._api)
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
+            if self.entity_description.unit_getter:
+                vicare_unit = self.entity_description.unit_getter(self._api)
 
         if vicare_unit is not None:
             if (

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -1550,9 +1550,7 @@ class ViCareSensor(ViCareEntity, SensorEntity):
         """Update state of sensor."""
         vicare_unit = None
         with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
-            self._attr_native_value = self.entity_description.value_getter(
-                self._api
-            )
+            self._attr_native_value = self.entity_description.value_getter(self._api)
 
             if self.entity_description.unit_getter:
                 vicare_unit = self.entity_description.unit_getter(self._api)

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -9,14 +9,7 @@ from typing import Any
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import HeatingCircuit as PyViCareHeatingCircuit
-from PyViCare.PyViCareUtils import (
-    PyViCareDeviceCommunicationError,
-    PyViCareInternalServerError,
-    PyViCareInvalidDataError,
-    PyViCareNotSupportedFeatureError,
-    PyViCareRateLimitError,
-)
-import requests
+from PyViCare.PyViCareUtils import PyViCareNotSupportedFeatureError
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
@@ -120,7 +113,7 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
 
     def update(self) -> None:
         """Let HA know there has been an update from the ViCare API."""
-        try:
+        with self.vicare_api_handler():
             with suppress(PyViCareNotSupportedFeatureError):
                 self._attr_current_temperature = (
                     self._api.getDomesticHotWaterStorageTemperature()
@@ -136,19 +129,6 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
 
             with suppress(PyViCareNotSupportedFeatureError):
                 self._dhw_active = self._api.getDomesticHotWaterActive()
-
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from ViCare server")
-        except PyViCareRateLimitError as limit_exception:
-            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
-        except ValueError:
-            _LOGGER.error("Unable to decode data from ViCare server")
-        except PyViCareInvalidDataError as invalid_data_exception:
-            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
-        except PyViCareDeviceCommunicationError as comm_exception:
-            _LOGGER.warning("Device communication error: %s", comm_exception)
-        except PyViCareInternalServerError as server_exception:
-            _LOGGER.warning("Vicare server error: %s", server_exception)
 
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperatures."""


### PR DESCRIPTION
## Proposed change

Refactor duplicated error handling from 8 ViCare entity platforms into a shared `vicare_api_handler()` context manager on the `ViCareEntity` base class.

**Before:** Each platform (sensor, binary_sensor, climate, water_heater, number, fan, button) had its own copy of the same try/except block catching `ConnectionError`, `PyViCareRateLimitError`, `ValueError`, `PyViCareInvalidDataError`, `PyViCareDeviceCommunicationError`, and `PyViCareInternalServerError`.

**After:** A single `vicare_api_handler()` context manager in `entity.py` handles all these exceptions. Each platform's `update()` method uses `with self.vicare_api_handler():` instead of duplicated try/except blocks.

This removes ~106 lines of duplicated code with no behavior change.

**Note:** This PR is stacked on #162618 (which adds the two new error types). The first commit is shared with that PR.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr