### PR TITLE
Raise error when light reports invalid supported color modes

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -988,32 +988,6 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             f"of {effect_color_modes}"
         )
 
-    def __validate_supported_color_modes(
-        self,
-        supported_color_modes: set[ColorMode],
-    ) -> None:
-        """Validate the supported color modes."""
-        if self.__color_mode_reported:
-            return
-
-        try:
-            valid_supported_color_modes(supported_color_modes)
-        except vol.Error:
-            # Warning added in 2024.3, reject in 2025.3
-            if not self.__color_mode_reported and self.__should_report_light_issue():
-                self.__color_mode_reported = True
-                report_issue = self._suggest_report_issue()
-                _LOGGER.warning(
-                    (
-                        "%s (%s) sets invalid supported color modes %s, this will stop "
-                        "working in Home Assistant Core 2025.3, please %s"
-                    ),
-                    self.entity_id,
-                    type(self),
-                    supported_color_modes,
-                    report_issue,
-                )
-
     @final
     @property
     def state_attributes(self) -> dict[str, Any] | None:
@@ -1069,7 +1043,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def _light_internal_supported_color_modes(self) -> set[ColorMode]:
         """Calculate supported color modes with backwards compatibility."""
         if (_supported_color_modes := self.supported_color_modes) is not None:
-            self.__validate_supported_color_modes(_supported_color_modes)
+            valid_supported_color_modes(_supported_color_modes)
             return _supported_color_modes
 
         # Backwards compatibility for supported_color_modes added in 2021.4

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -988,6 +988,19 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             f"of {effect_color_modes}"
         )
 
+    def __validate_supported_color_modes(
+        self,
+        supported_color_modes: set[ColorMode],
+    ) -> None:
+        """Validate the supported color modes."""
+        try:
+            valid_supported_color_modes(supported_color_modes)
+        except vol.Error as err:
+            raise HomeAssistantError(
+                f"{self.entity_id} ({type(self)}) sets invalid supported color modes "
+                f"{supported_color_modes}"
+            ) from err
+
     @final
     @property
     def state_attributes(self) -> dict[str, Any] | None:
@@ -1043,7 +1056,7 @@ class LightEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     def _light_internal_supported_color_modes(self) -> set[ColorMode]:
         """Calculate supported color modes with backwards compatibility."""
         if (_supported_color_modes := self.supported_color_modes) is not None:
-            valid_supported_color_modes(_supported_color_modes)
+            self.__validate_supported_color_modes(_supported_color_modes)
             return _supported_color_modes
 
         # Backwards compatibility for supported_color_modes added in 2021.4

--- a/homeassistant/components/openrgb/light.py
+++ b/homeassistant/components/openrgb/light.py
@@ -194,8 +194,8 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
             # If Off by color, retain previous color mode to avoid changing the UI
             color_mode = self._attr_color_mode
 
-        if color_mode is None:
-            # If color mode is still None, default to RGB
+        if color_mode is None or color_mode == ColorMode.UNKNOWN:
+            # If color mode is still unknown, default to RGB
             color_mode = ColorMode.RGB
 
         if self._attr_brightness is not None and self._attr_brightness != brightness:

--- a/homeassistant/components/openrgb/light.py
+++ b/homeassistant/components/openrgb/light.py
@@ -194,8 +194,8 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
             # If Off by color, retain previous color mode to avoid changing the UI
             color_mode = self._attr_color_mode
 
-        if color_mode is None or color_mode == ColorMode.UNKNOWN:
-            # If color mode is still unknown, default to RGB
+        if color_mode is None:
+            # If color mode is still None, default to RGB
             color_mode = ColorMode.RGB
 
         if self._attr_brightness is not None and self._attr_brightness != brightness:

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -2438,7 +2438,7 @@ async def test_report_invalid_color_mode(
 
 
 @pytest.mark.parametrize(
-    ("color_mode", "supported_color_modes", "platform_name", "warning_expected"),
+    ("color_mode", "supported_color_modes", "platform_name", "error_expected"),
     [
         (
             light.ColorMode.ONOFF,
@@ -2464,12 +2464,6 @@ async def test_report_invalid_color_mode(
             "test",
             False,
         ),
-        (
-            light.ColorMode.ONOFF,
-            {light.ColorMode.ONOFF, light.ColorMode.BRIGHTNESS},
-            "philips_js",  # We don't log issues for philips_js
-            False,
-        ),
     ],
 )
 def test_report_invalid_color_modes(
@@ -2478,7 +2472,7 @@ def test_report_invalid_color_modes(
     color_mode: str,
     supported_color_modes: set[str],
     platform_name: str,
-    warning_expected: bool,
+    error_expected: bool,
 ) -> None:
     """Test a light setting an invalid color mode."""
 
@@ -2490,9 +2484,13 @@ def test_report_invalid_color_modes(
         platform = MockEntityPlatform(hass, platform_name=platform_name)
 
     entity = MockLightEntityEntity()
-    entity._async_calculate_state()
-    expected_warning = "sets invalid supported color modes"
-    assert (expected_warning in caplog.text) is warning_expected
+    raised_error = ""
+    try:
+        entity._async_calculate_state()
+    except vol.Error as err:
+        raised_error = str(err)
+    expected_error = "Invalid supported_color_modes"
+    assert (expected_error in raised_error) is error_expected
 
 
 @pytest.mark.parametrize(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -2487,9 +2487,9 @@ def test_report_invalid_color_modes(
     raised_error = ""
     try:
         entity._async_calculate_state()
-    except vol.Error as err:
+    except HomeAssistantError as err:
         raised_error = str(err)
-    expected_error = "Invalid supported_color_modes"
+    expected_error = "sets invalid supported color modes"
     assert (expected_error in raised_error) is error_expected
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Not user-facing

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reporting invalid supported_color_mode is no longer supported.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2945
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
