### PR TITLE
Deprecate async_listen in labs

### DIFF
--- a/homeassistant/components/labs/helpers.py
+++ b/homeassistant/components/labs/helpers.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.const import EVENT_LABS_UPDATED
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers.frame import ReportBehavior, report_usage
+from homeassistant.helpers.frame import report_usage
 
 from .const import LABS_DATA
 from .models import EventLabsUpdatedData
@@ -94,7 +94,6 @@ def async_listen(
     report_usage(
         "calls `async_listen` which is deprecated, "
         "use `async_subscribe_preview_feature` instead",
-        core_behavior=ReportBehavior.LOG,
         breaks_in_ha_version="2027.3.0",
     )
 

--- a/homeassistant/components/labs/helpers.py
+++ b/homeassistant/components/labs/helpers.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from homeassistant.const import EVENT_LABS_UPDATED
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.frame import ReportBehavior, report_usage
 
 from .const import LABS_DATA
 from .models import EventLabsUpdatedData
@@ -79,6 +80,8 @@ def async_listen(
 ) -> Callable[[], None]:
     """Listen for changes to a specific preview feature.
 
+    Deprecated: use async_subscribe_preview_feature instead.
+
     Args:
         hass: HomeAssistant instance
         domain: Integration domain
@@ -88,6 +91,12 @@ def async_listen(
     Returns:
         Callable to unsubscribe from the listener
     """
+    report_usage(
+        "calls `async_listen` which is deprecated, "
+        "use `async_subscribe_preview_feature` instead",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2027.3.0",
+    )
 
     async def _listener(_event_data: EventLabsUpdatedData) -> None:
         listener()

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Coroutine
-from functools import partial
 import logging
 from typing import Any
 
@@ -13,7 +12,10 @@ from homeassistant.components.automation import (
     DOMAIN as AUTOMATION_DOMAIN,
     NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
 )
-from homeassistant.components.labs import async_listen as async_labs_listen
+from homeassistant.components.labs import (
+    EventLabsUpdatedData,
+    async_subscribe_preview_feature,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_DEVICE_ID,
@@ -22,7 +24,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     SERVICE_RELOAD,
 )
-from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.core import Event, HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryError, HomeAssistantError
 from homeassistant.helpers import discovery, issue_registry as ir
 from homeassistant.helpers.device import (
@@ -99,18 +101,19 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async_register_admin_service(hass, DOMAIN, SERVICE_RELOAD, _reload_config)
 
-    @callback
-    def new_triggers_conditions_listener() -> None:
+    async def _handle_new_triggers_conditions(
+        _event_data: EventLabsUpdatedData,
+    ) -> None:
         """Handle new_triggers_conditions flag change."""
         hass.async_create_task(
             _reload_config(ServiceCall(hass, DOMAIN, SERVICE_RELOAD))
         )
 
-    async_labs_listen(
+    async_subscribe_preview_feature(
         hass,
         AUTOMATION_DOMAIN,
         NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
-        new_triggers_conditions_listener,
+        _handle_new_triggers_conditions,
     )
 
     return True
@@ -139,12 +142,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry, (entry.options["template_type"],)
     )
 
+    async def _handle_entry_reload(_event_data: EventLabsUpdatedData) -> None:
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+
     entry.async_on_unload(
-        async_labs_listen(
+        async_subscribe_preview_feature(
             hass,
             AUTOMATION_DOMAIN,
             NEW_TRIGGERS_CONDITIONS_FEATURE_FLAG,
-            partial(hass.config_entries.async_schedule_reload, entry.entry_id),
+            _handle_entry_reload,
         )
     )
 

--- a/tests/components/labs/test_init.py
+++ b/tests/components/labs/test_init.py
@@ -360,7 +360,9 @@ async def test_preview_feature_to_dict_is_built_in(
     assert result["is_built_in"] is expected_default
 
 
-async def test_async_listen_helper(hass: HomeAssistant) -> None:
+async def test_async_listen_helper(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test the async_listen helper function for preview feature events."""
     # Load kitchen_sink integration
     hass.config.components.add("kitchen_sink")
@@ -382,6 +384,8 @@ async def test_async_listen_helper(hass: HomeAssistant) -> None:
         preview_feature="special_repair",
         listener=test_listener,
     )
+
+    assert ("calls `async_listen` which is deprecated") in caplog.text
 
     # Fire event for the subscribed feature
     hass.bus.async_fire(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `async_listen` in labs.

`async_subscribe_preview_feature` should be used instead, as it has following advantages:
- Allows async listeners.
- Passes through preview feature data as a function argument.
- Has a name, that is more in line with other labs helpers.

Last usage of `async_listen` in core is removed.
Only two custom components were found to use it, so the impact is very minor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2963
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
