### PR TITLE
Improve MCP SSE fallback error handling

### DIFF
--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -4,7 +4,8 @@ import re
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
-from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
+from mcp import McpError
+from mcp.types import CallToolResult, ErrorData, ListToolsResult, TextContent, Tool
 import pytest
 import voluptuous as vol
 
@@ -136,30 +137,44 @@ async def test_mcp_server_sse_transport_failure(
         "Connection error", [httpx.ConnectError("Connection failed")]
     )
 
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
-
+@pytest.mark.parametrize(
+    ("side_effect"),
+    [
+        (
+            ExceptionGroup(
+                "Method not allowed",
+                [
+                    httpx.HTTPStatusError(
+                        "Method not allowed",
+                        request=None,  # type: ignore[arg-type]
+                        response=httpx.Response(405),
+                    )
+                ],
+            ),
+        ),
+        (
+            ExceptionGroup(
+                "Some exception group",
+                [McpError(ErrorData(code=500, message="Session terminated"))],
+            )
+        ),
+    ],
+)
 async def test_mcp_client_fallback_to_sse_success(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_http_streamable_client: AsyncMock,
     mock_sse_client: AsyncMock,
     mock_mcp_client: Mock,
+    side_effect: Exception,
 ) -> None:
     """Test mcp_client falls back to SSE on method not allowed error.
 
     This exercises the backwards compatibility part of the MCP Transport
     specification.
     """
-    http_405 = httpx.HTTPStatusError(
-        "Method not allowed",
-        request=None,  # type: ignore[arg-type]
-        response=httpx.Response(405),
-    )
-    mock_http_streamable_client.side_effect = ExceptionGroup(
-        "Method not allowed", [http_405]
-    )
+    mock_http_streamable_client.side_effect = side_effect
 
     # Setup mocks for SSE fallback
     mock_sse_client.return_value.__aenter__.return_value = ("read", "write")

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -169,7 +169,7 @@ async def test_mcp_client_fallback_to_sse_success(
     mock_mcp_client: Mock,
     side_effect: Exception,
 ) -> None:
-    """Test mcp_client falls back to SSE on method not allowed error.
+    """Test mcp_client falls back to SSE on some errors.
 
     This exercises the backwards compatibility part of the MCP Transport
     specification.

--- a/tests/components/mcp/test_init.py
+++ b/tests/components/mcp/test_init.py
@@ -147,7 +147,7 @@ async def test_mcp_server_sse_transport_failure(
                 [
                     httpx.HTTPStatusError(
                         "Method not allowed",
-                        request=None,  # type: ignore[arg-type]
+                        request=None,
                         response=httpx.Response(405),
                     )
                 ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update MCP client fallback handling. This currently attempts HTTP streamable (the newer more popular protocol in industry) and will fallback to SSE (the older protocol, likely used by existing users). This includes more errors that can trigger fallback, based on errors seen by users talking to an MCP proxy that may not respond with 405 like the newer spec suggests. 

An alternative is we can fallback on nearly any error, but it doesn't seem necessary yet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162601
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
