### PR TITLE
feat:   Add options flow for IntelliFire read/control mode configuration

### DIFF
--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 
 from intellifire4py import UnifiedFireplace
 from intellifire4py.cloud_interface import IntelliFireCloudInterface
+from intellifire4py.const import IntelliFireApiMode
 from intellifire4py.model import IntelliFireCommonFireplaceData
 
 from homeassistant.const import (
@@ -55,8 +56,8 @@ def _construct_common_data(
         serial=entry.data[CONF_SERIAL],
         api_key=entry.data[CONF_API_KEY],
         ip_address=entry.data[CONF_IP_ADDRESS],
-        read_mode=entry.options[CONF_READ_MODE],
-        control_mode=entry.options[CONF_CONTROL_MODE],
+        read_mode=IntelliFireApiMode(entry.options[CONF_READ_MODE]),
+        control_mode=IntelliFireApiMode(entry.options[CONF_CONTROL_MODE]),
     )
 
 
@@ -139,7 +140,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntellifireConfigEntry) 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     return True
+
+
+async def async_update_options(
+    hass: HomeAssistant, entry: IntellifireConfigEntry
+) -> None:
+    """Handle options update."""
+    coordinator: IntellifireDataUpdateCoordinator = entry.runtime_data
+
+    new_read_mode = IntelliFireApiMode(entry.options[CONF_READ_MODE])
+    new_control_mode = IntelliFireApiMode(entry.options[CONF_CONTROL_MODE])
+
+    current_read_mode = coordinator.get_read_mode()
+    current_control_mode = coordinator.get_control_mode()
+
+    # Only update modes that actually changed
+    if new_read_mode != current_read_mode:
+        LOGGER.debug("Updating read mode: %s -> %s", current_read_mode, new_read_mode)
+        await coordinator.set_read_mode(new_read_mode)
+
+    if new_control_mode != current_control_mode:
+        LOGGER.debug(
+            "Updating control mode: %s -> %s", current_control_mode, new_control_mode
+        )
+        await coordinator.set_control_mode(new_control_mode)
+
+    # Refresh data with new mode settings
+    await coordinator.async_request_refresh()
 
 
 async def _async_wait_for_initialization(

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -13,7 +13,13 @@ from intellifire4py.local_api import IntelliFireAPILocal
 from intellifire4py.model import IntelliFireCommonFireplaceData
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_HOST,
@@ -21,9 +27,12 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_USERNAME,
 )
+from homeassistant.core import callback
+from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import (
+    API_MODE_CLOUD,
     API_MODE_LOCAL,
     CONF_AUTH_COOKIE,
     CONF_CONTROL_MODE,
@@ -260,3 +269,81 @@ class IntelliFireConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="not_intellifire_device")
 
         return await self.async_step_cloud_api()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Create the options flow."""
+        return IntelliFireOptionsFlowHandler()
+
+
+class IntelliFireOptionsFlowHandler(OptionsFlow):
+    """Options flow for IntelliFire component."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Validate connectivity for requested modes
+            coordinator = self.config_entry.runtime_data
+            fireplace = coordinator.fireplace
+
+            if (
+                user_input[CONF_READ_MODE] == API_MODE_LOCAL
+                and not fireplace.local_connectivity
+            ):
+                errors[CONF_READ_MODE] = "local_disabled"
+            if (
+                user_input[CONF_READ_MODE] == API_MODE_CLOUD
+                and not fireplace.cloud_connectivity
+            ):
+                errors[CONF_READ_MODE] = "cloud_disabled"
+            if (
+                user_input[CONF_CONTROL_MODE] == API_MODE_LOCAL
+                and not fireplace.local_connectivity
+            ):
+                errors[CONF_CONTROL_MODE] = "local_disabled"
+            if (
+                user_input[CONF_CONTROL_MODE] == API_MODE_CLOUD
+                and not fireplace.cloud_connectivity
+            ):
+                errors[CONF_CONTROL_MODE] = "cloud_disabled"
+
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
+
+        existing_read = self.config_entry.options.get(CONF_READ_MODE, API_MODE_LOCAL)
+        existing_control = self.config_entry.options.get(
+            CONF_CONTROL_MODE, API_MODE_LOCAL
+        )
+
+        cloud_local_options = selector.SelectSelectorConfig(
+            options=[
+                selector.SelectOptionDict(value=API_MODE_LOCAL, label="Local"),
+                selector.SelectOptionDict(value=API_MODE_CLOUD, label="Cloud"),
+            ]
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_READ_MODE,
+                        default=user_input.get(CONF_READ_MODE, existing_read)
+                        if user_input
+                        else existing_read,
+                    ): selector.SelectSelector(cloud_local_options),
+                    vol.Required(
+                        CONF_CONTROL_MODE,
+                        default=user_input.get(CONF_CONTROL_MODE, existing_control)
+                        if user_input
+                        else existing_control,
+                    ): selector.SelectSelector(cloud_local_options),
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/intellifire/config_flow.py
+++ b/homeassistant/components/intellifire/config_flow.py
@@ -291,6 +291,9 @@ class IntelliFireOptionsFlowHandler(OptionsFlow):
             coordinator = self.config_entry.runtime_data
             fireplace = coordinator.fireplace
 
+            # Refresh connectivity status before validating
+            await fireplace.async_validate_connectivity()
+
             if (
                 user_input[CONF_READ_MODE] == API_MODE_LOCAL
                 and not fireplace.local_connectivity

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from intellifire4py import UnifiedFireplace
+from intellifire4py.const import IntelliFireApiMode
 from intellifire4py.control import IntelliFireController
 from intellifire4py.model import IntelliFirePollData
 from intellifire4py.read import IntelliFireDataProvider
@@ -50,6 +51,22 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntelliFirePollData
     def control_api(self) -> IntelliFireController:
         """Return the control API."""
         return self.fireplace.control_api
+
+    def get_read_mode(self) -> IntelliFireApiMode:
+        """Return the current read mode."""
+        return self.fireplace.read_mode
+
+    async def set_read_mode(self, mode: IntelliFireApiMode) -> None:
+        """Set the read mode between cloud/local."""
+        await self.fireplace.set_read_mode(mode)
+
+    def get_control_mode(self) -> IntelliFireApiMode:
+        """Return the current control mode."""
+        return self.fireplace.control_mode
+
+    async def set_control_mode(self, mode: IntelliFireApiMode) -> None:
+        """Set the control mode between cloud/local."""
+        await self.fireplace.set_control_mode(mode)
 
     async def _async_update_data(self) -> IntelliFirePollData:
         return self.fireplace.data

--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -67,6 +67,18 @@ def _uptime_to_timestamp(
 
 INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
     IntellifireSensorEntityDescription(
+        key="read_mode",
+        translation_key="read_mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.get_read_mode().value,
+    ),
+    IntellifireSensorEntityDescription(
+        key="control_mode",
+        translation_key="control_mode",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda coordinator: coordinator.get_control_mode().value,
+    ),
+    IntellifireSensorEntityDescription(
         key="flame_height",
         translation_key="flame_height",
         state_class=SensorStateClass.MEASUREMENT,

--- a/homeassistant/components/intellifire/strings.json
+++ b/homeassistant/components/intellifire/strings.json
@@ -100,6 +100,9 @@
       "connection_quality": {
         "name": "Connection quality"
       },
+      "control_mode": {
+        "name": "Control mode"
+      },
       "downtime": {
         "name": "Downtime"
       },
@@ -114,6 +117,9 @@
       },
       "ipv4_address": {
         "name": "IP address"
+      },
+      "read_mode": {
+        "name": "Read mode"
       },
       "target_temp": {
         "name": "Target temperature"
@@ -131,6 +137,24 @@
       },
       "pilot_light": {
         "name": "Pilot light"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "cloud_disabled": "Cloud connectivity is not available",
+      "local_disabled": "Local connectivity is not available"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "cloud_control": "Control mode",
+          "cloud_read": "Read mode"
+        },
+        "data_description": {
+          "cloud_control": "Select endpoint to use for controlling device",
+          "cloud_read": "Select endpoint to use for reading data"
+        }
       }
     }
   }

--- a/tests/components/intellifire/snapshots/test_sensor.ambr
+++ b/tests/components/intellifire/snapshots/test_sensor.ambr
@@ -49,6 +49,56 @@
     'state': '988451',
   })
 # ---
+# name: test_all_sensor_entities[sensor.intellifire_control_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.intellifire_control_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Control mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Control mode',
+    'platform': 'intellifire',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'control_mode',
+    'unique_id': 'control_mode_mock_serial',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_sensor_entities[sensor.intellifire_control_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by unpublished Intellifire API',
+      'friendly_name': 'IntelliFire Control mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.intellifire_control_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'local',
+  })
+# ---
 # name: test_all_sensor_entities[sensor.intellifire_downtime-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -304,6 +354,56 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '192.168.2.108',
+  })
+# ---
+# name: test_all_sensor_entities[sensor.intellifire_read_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.intellifire_read_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Read mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Read mode',
+    'platform': 'intellifire',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'read_mode',
+    'unique_id': 'read_mode_mock_serial',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_sensor_entities[sensor.intellifire_read_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by unpublished Intellifire API',
+      'friendly_name': 'IntelliFire Read mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.intellifire_read_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'local',
   })
 # ---
 # name: test_all_sensor_entities[sensor.intellifire_target_temperature-entry]

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock
 from intellifire4py.exceptions import LoginError
 
 from homeassistant import config_entries
-from homeassistant.components.intellifire.const import CONF_SERIAL, DOMAIN
+from homeassistant.components.intellifire.const import (
+    API_MODE_CLOUD,
+    API_MODE_LOCAL,
+    CONF_CONTROL_MODE,
+    CONF_READ_MODE,
+    CONF_SERIAL,
+    DOMAIN,
+)
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -227,3 +234,101 @@ async def test_reauth_flow(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test options flow for changing read/control modes."""
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Enable both connectivity for this test
+    mock_fp.local_connectivity = True
+    mock_fp.cloud_connectivity = True
+
+    # Start options flow
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_current.entry_id
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Submit new options - both should succeed with connectivity enabled
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_READ_MODE: API_MODE_CLOUD,
+        CONF_CONTROL_MODE: API_MODE_LOCAL,
+    }
+
+
+async def test_options_flow_local_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test options flow shows error when local connectivity unavailable."""
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Disable local connectivity
+    mock_fp.local_connectivity = False
+    mock_fp.cloud_connectivity = True
+
+    # Start options flow
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_current.entry_id
+    )
+
+    # Try to select local mode - should fail
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_LOCAL, CONF_CONTROL_MODE: API_MODE_CLOUD},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_READ_MODE: "local_disabled"}
+
+
+async def test_options_flow_cloud_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test options flow shows error when cloud connectivity unavailable."""
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Disable cloud connectivity (this is the default in mock, but be explicit)
+    mock_fp.local_connectivity = True
+    mock_fp.cloud_connectivity = False
+
+    # Start options flow
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_current.entry_id
+    )
+
+    # Try to select cloud mode - should fail
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_READ_MODE: "cloud_disabled"}

--- a/tests/components/intellifire/test_config_flow.py
+++ b/tests/components/intellifire/test_config_flow.py
@@ -272,12 +272,12 @@ async def test_options_flow(
     }
 
 
-async def test_options_flow_local_unavailable(
+async def test_options_flow_local_read_unavailable(
     hass: HomeAssistant,
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when local connectivity unavailable."""
+    """Test options flow shows error when local connectivity unavailable for read mode."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
@@ -293,7 +293,7 @@ async def test_options_flow_local_unavailable(
         mock_config_entry_current.entry_id
     )
 
-    # Try to select local mode - should fail
+    # Try to select local read mode - should fail
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {CONF_READ_MODE: API_MODE_LOCAL, CONF_CONTROL_MODE: API_MODE_CLOUD},
@@ -301,21 +301,54 @@ async def test_options_flow_local_unavailable(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_READ_MODE: "local_disabled"}
+    # Verify connectivity was checked
+    mock_fp.async_validate_connectivity.assert_called_once()
 
 
-async def test_options_flow_cloud_unavailable(
+async def test_options_flow_local_control_unavailable(
     hass: HomeAssistant,
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test options flow shows error when cloud connectivity unavailable."""
+    """Test options flow shows error when local connectivity unavailable for control mode."""
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
     mock_config_entry_current.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
     await hass.async_block_till_done()
 
-    # Disable cloud connectivity (this is the default in mock, but be explicit)
+    # Disable local connectivity
+    mock_fp.local_connectivity = False
+    mock_fp.cloud_connectivity = True
+
+    # Start options flow
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_current.entry_id
+    )
+
+    # Try to select local control mode - should fail
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_CONTROL_MODE: "local_disabled"}
+
+
+async def test_options_flow_cloud_read_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test options flow shows error when cloud connectivity unavailable for read mode."""
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Disable cloud connectivity
     mock_fp.local_connectivity = True
     mock_fp.cloud_connectivity = False
 
@@ -324,7 +357,7 @@ async def test_options_flow_cloud_unavailable(
         mock_config_entry_current.entry_id
     )
 
-    # Try to select cloud mode - should fail
+    # Try to select cloud read mode - should fail
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {CONF_READ_MODE: API_MODE_CLOUD, CONF_CONTROL_MODE: API_MODE_LOCAL},
@@ -332,3 +365,36 @@ async def test_options_flow_cloud_unavailable(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_READ_MODE: "cloud_disabled"}
+    # Verify connectivity was checked
+    mock_fp.async_validate_connectivity.assert_called_once()
+
+
+async def test_options_flow_cloud_control_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test options flow shows error when cloud connectivity unavailable for control mode."""
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Disable cloud connectivity
+    mock_fp.local_connectivity = True
+    mock_fp.cloud_connectivity = False
+
+    # Start options flow
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_current.entry_id
+    )
+
+    # Try to select cloud control mode - should fail
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_READ_MODE: API_MODE_LOCAL, CONF_CONTROL_MODE: API_MODE_CLOUD},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_CONTROL_MODE: "cloud_disabled"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

  Allow users to configure whether the integration uses **local** or **cloud**  endpoints for reading data and controlling the fireplace through an  options flow in the UI. 

The backing library has supported both local and cloud control for some time - aside from HACS this functionality has not been present in the core integration. This is the first step towards giving users the ability to select whether they want a purely local control or a cloud based control. 

### Why Local vs Cloud

Due to the fireplace IOT hardware some users (like me) find that the hardware prioritizes cloud communication and can sometimes time out on local control - however for other users they find local preferable (of course). As Home assistant is all about choice this gives users better choice for how to work with their setup.


### Connectivity

At startup the fireplace will determine the connectivity status of the fireplace. There are some issues where local connectivity doesn't work well (like in my current test setup) and in that case (see below).
```
2026-02-09 12:21:59.183 DEBUG (MainThread) [intellifire4py.local_api] poll() http://192.168.1.xxx/poll with timeout: 10.0
2026-02-09 12:21:59.184 DEBUG (MainThread) [intellifire4py.cloud_api] poll() https://iftapi.net/a/xxxxxxxx//apppoll
```

The options flow allows the user to select both Local or Cloud for READ and CONTROL end points.


<img width="469" height="503" alt="image" src="https://github.com/user-attachments/assets/d81a4069-494c-4bc2-83c3-8a24109d6ee7" />

Upon selecting endpoints if connectivity fails (it will be retested)

<img width="404" height="536" alt="image" src="https://github.com/user-attachments/assets/d9c78e14-5527-4cc2-89ea-ada128526506" />


We get an error


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
