### PR TITLE
Fix handling when FRITZ!Box reboots in FRITZ!Smarthome

### DIFF
--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, UnitOfTemperature
 from homeassistant.core import Event, HomeAssistant
@@ -57,7 +59,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: FritzboxConfigEntry) -> 
 
 async def async_unload_entry(hass: HomeAssistant, entry: FritzboxConfigEntry) -> bool:
     """Unloading the AVM FRITZ!SmartHome platforms."""
-    await hass.async_add_executor_job(entry.runtime_data.fritz.logout)
+    try:
+        await hass.async_add_executor_job(entry.runtime_data.fritz.logout)
+    except (RequestConnectionError, HTTPError) as ex:
+        LOGGER.debug("logout failed with '%s', anyway continue with unload", ex)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -155,21 +155,21 @@ async def test_automatic_offset(hass: HomeAssistant, fritz: Mock) -> None:
 async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceClimateMock()
-    fritz().update_devices.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = ["", HTTPError("Boom"), ""]
     entry = await setup_config_entry(
         hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.LOADED
 
-    assert fritz().update_devices.call_count == 2
-    assert fritz().login.call_count == 2
+    assert fritz().update_devices.call_count == 1
+    assert fritz().login.call_count == 1
 
-    next_update = dt_util.utcnow() + timedelta(seconds=200)
+    next_update = dt_util.utcnow() + timedelta(seconds=35)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert fritz().update_devices.call_count == 4
-    assert fritz().login.call_count == 4
+    assert fritz().update_devices.call_count == 3
+    assert fritz().login.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -81,7 +81,7 @@ async def test_coordinator_update_when_unreachable(
         unique_id="any",
     )
     entry.add_to_hass(hass)
-    fritz().update_devices.side_effect = [ConnectionError(), ""]
+    fritz().update_devices.side_effect = [ConnectionError()]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -84,6 +84,7 @@ async def test_coordinator_update_when_unreachable(
     fritz().update_devices.side_effect = [ConnectionError()]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -40,14 +40,19 @@ async def test_coordinator_update_after_reboot(
         unique_id="any",
     )
     entry.add_to_hass(hass)
-    fritz().update_devices.side_effect = [HTTPError(), ""]
+    fritz().update_devices.side_effect = ["", HTTPError()]
 
     assert await hass.config_entries.async_setup(entry.entry_id)
-    assert fritz().update_devices.call_count == 2
+    assert fritz().update_devices.call_count == 1
     assert fritz().update_templates.call_count == 1
     assert fritz().get_devices.call_count == 1
     assert fritz().get_templates.call_count == 1
-    assert fritz().login.call_count == 2
+    assert fritz().login.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_coordinator_update_after_password_change(
@@ -60,14 +65,10 @@ async def test_coordinator_update_after_password_change(
         unique_id="any",
     )
     entry.add_to_hass(hass)
-    fritz().update_devices.side_effect = HTTPError()
-    fritz().login.side_effect = ["", LoginError("some_user")]
+    fritz().login.side_effect = [LoginError("some_user")]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
-    assert fritz().update_devices.call_count == 1
-    assert fritz().get_devices.call_count == 0
-    assert fritz().get_templates.call_count == 0
-    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_coordinator_update_when_unreachable(

--- a/tests/components/fritzbox/test_light.py
+++ b/tests/components/fritzbox/test_light.py
@@ -248,20 +248,21 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     device.get_colors.return_value = {
         "Red": [("100", "70", "10"), ("100", "50", "10"), ("100", "30", "10")]
     }
-    fritz().update_devices.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = ["", HTTPError("Boom"), ""]
     entry = await setup_config_entry(
-        hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+        hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], device=device, fritz=fritz
     )
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert fritz().update_devices.call_count == 2
-    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
 
-    next_update = dt_util.utcnow() + timedelta(seconds=200)
+    assert fritz().update_devices.call_count == 1
+    assert fritz().login.call_count == 1
+
+    next_update = dt_util.utcnow() + timedelta(seconds=35)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert fritz().update_devices.call_count == 4
-    assert fritz().login.call_count == 4
+    assert fritz().update_devices.call_count == 3
+    assert fritz().login.call_count == 2
 
 
 async def test_discover_new_device(hass: HomeAssistant, fritz: Mock) -> None:

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -80,20 +80,21 @@ async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
 async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceSensorMock()
-    fritz().update_devices.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = ["", HTTPError("Boom"), ""]
     entry = await setup_config_entry(
-        hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+        hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], device=device, fritz=fritz
     )
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert fritz().update_devices.call_count == 2
-    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
 
-    next_update = dt_util.utcnow() + timedelta(seconds=200)
+    assert fritz().update_devices.call_count == 1
+    assert fritz().login.call_count == 1
+
+    next_update = dt_util.utcnow() + timedelta(seconds=35)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert fritz().update_devices.call_count == 4
-    assert fritz().login.call_count == 4
+    assert fritz().update_devices.call_count == 3
+    assert fritz().login.call_count == 2
 
 
 async def test_discover_new_device(hass: HomeAssistant, fritz: Mock) -> None:

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -136,20 +136,21 @@ async def test_update(hass: HomeAssistant, fritz: Mock) -> None:
 async def test_update_error(hass: HomeAssistant, fritz: Mock) -> None:
     """Test update with error."""
     device = FritzDeviceSwitchMock()
-    fritz().update_devices.side_effect = HTTPError("Boom")
+    fritz().update_devices.side_effect = ["", HTTPError("Boom"), ""]
     entry = await setup_config_entry(
         hass, MOCK_CONFIG[DOMAIN][CONF_DEVICES][0], device=device, fritz=fritz
     )
-    assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert fritz().update_devices.call_count == 2
-    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
 
-    next_update = dt_util.utcnow() + timedelta(seconds=200)
+    assert fritz().update_devices.call_count == 1
+    assert fritz().login.call_count == 1
+
+    next_update = dt_util.utcnow() + timedelta(seconds=35)
     async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert fritz().update_devices.call_count == 4
-    assert fritz().login.call_count == 4
+    assert fritz().update_devices.call_count == 3
+    assert fritz().login.call_count == 2
 
 
 async def test_assume_device_unavailable(hass: HomeAssistant, fritz: Mock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This ensures that we we do a proper login cycle without trying first with a potential expired session id after a router reboot, by reloading the config entry. This is necessary to avoid running into a security feature of the router, were all sessions will be invalidated for a given source IP, in case a single request is done with an expired session - this happens when two or more integrations have an individual session to the router open (_eq using the `fritz` and the `fritzbox` integration_) and the router is rebooted.

The same change needs to be done for the [`fritz`](https://www.home-assistant.io/integrations/fritz/) (#162679) and the [`fritzbox_callmonitor`](https://www.home-assistant.io/integrations/fritzbox_callmonitor/) integration to achieve an overall solution.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #155003 #161358 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
