### PR TITLE
Bump typedmonarchmoney to 0.7.0

### DIFF
--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["typedmonarchmoney==0.5.0"]
+  "requirements": ["typedmonarchmoney==0.6.0"]
 }

--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["typedmonarchmoney==0.6.0"]
+  "requirements": ["typedmonarchmoney==0.6.1"]
 }

--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["typedmonarchmoney==0.6.1"]
+  "requirements": ["typedmonarchmoney==0.6.2"]
 }

--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["typedmonarchmoney==0.4.4"]
+  "requirements": ["typedmonarchmoney==0.5.0"]
 }

--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["typedmonarchmoney==0.6.2"]
+  "requirements": ["typedmonarchmoney==0.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3094,7 +3094,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.4.4
+typedmonarchmoney==0.5.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3094,7 +3094,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.2
+typedmonarchmoney==0.7.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3094,7 +3094,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.5.0
+typedmonarchmoney==0.6.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3094,7 +3094,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.1
+typedmonarchmoney==0.6.2
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3094,7 +3094,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.0
+typedmonarchmoney==0.6.1
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2591,7 +2591,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.4.4
+typedmonarchmoney==0.5.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2591,7 +2591,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.2
+typedmonarchmoney==0.7.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2591,7 +2591,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.5.0
+typedmonarchmoney==0.6.0
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2591,7 +2591,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.0
+typedmonarchmoney==0.6.1
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2591,7 +2591,7 @@ twilio==6.32.0
 twitchAPI==4.2.1
 
 # homeassistant.components.monarch_money
-typedmonarchmoney==0.6.1
+typedmonarchmoney==0.6.2
 
 # homeassistant.components.ukraine_alarm
 uasiren==0.0.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This integration uses a library that wraps a backing lib for monarch. The backing lib is no longer maintained so we are moving to a new library that is maintained: `monarchmoneycommunity` 

We implemented this PR in the backing lib: https://github.com/jeeftor/monarchmoney-typed/pull/110 to integrate these changes.

A summary of backing lib changes are here:

https://github.com/jeeftor/monarchmoney-typed/compare/v0.4.4...v0.7.0
- update of GitHub actions
- migration to UV from poetyr/python
- Update of dep to `monarchmoneycommunity` 

## Version 0.7 update

Talked with maintainer of backing lib and they rolled back to GQL 3.5

## Version 0.6 update

- After a discussion with  @joostlek - I've pinned to a specific version of `monarchmoneycommunity` 

<img width="279" height="105" alt="image" src="https://github.com/user-attachments/assets/8d9e00c4-6519-4bd3-8036-65d92f9e0acf" />

This should enhance security.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/jeeftor/monarchmoney-typed/issues/107
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
