### PR TITLE
Add @lackas as code owner for homematicip_cloud

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -715,8 +715,8 @@ build.json @home-assistant/supervisor
 /tests/components/homekit_controller/ @Jc2k @bdraco
 /homeassistant/components/homematic/ @pvizeli
 /tests/components/homematic/ @pvizeli
-/homeassistant/components/homematicip_cloud/ @hahn-th
-/tests/components/homematicip_cloud/ @hahn-th
+/homeassistant/components/homematicip_cloud/ @hahn-th @lackas
+/tests/components/homematicip_cloud/ @hahn-th @lackas
 /homeassistant/components/homewizard/ @DCSBL
 /tests/components/homewizard/ @DCSBL
 /homeassistant/components/honeywell/ @rdfurman @mkmer

--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "homematicip_cloud",
   "name": "HomematicIP Cloud",
-  "codeowners": ["@hahn-th"],
+  "codeowners": ["@hahn-th", "@lackas"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
   "integration_type": "hub",


### PR DESCRIPTION
## Proposed change

Add @lackas as co-maintainer of the HomematicIP Cloud integration alongside @hahn-th.

I've been actively contributing to both the upstream library ([homematicip-rest-api](https://github.com/hahn-th/homematicip-rest-api)) and the HA integration, with 12 library PRs merged and multiple HA Core PRs open for new device support and bug fixes.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure