### PR TITLE
Fix flaky lunatone test

### DIFF
--- a/tests/components/lunatone/__init__.py
+++ b/tests/components/lunatone/__init__.py
@@ -23,39 +23,7 @@ PRODUCT_NAME: Final = "Test Product"
 SERIAL_NUMBER: Final = 12345
 VERSION: Final = "v1.14.1/1.4.3"
 
-DEVICE_DATA_LIST: Final[list[DeviceData]] = [
-    DeviceData(
-        id=1,
-        name="Device 1",
-        available=True,
-        status=DeviceStatus(),
-        features=FeaturesStatus(
-            switchable=Status[bool](status=False),
-            dimmable=Status[float](status=0.0),
-            colorKelvin=Status[int](status=1000),
-            colorRGB=Status[ColorRGBData](status=ColorRGBData(r=0, g=0, b=0)),
-            colorWAF=Status[ColorWAFData](status=ColorWAFData(w=0, a=0, f=0)),
-        ),
-        address=0,
-        line=0,
-    ),
-    DeviceData(
-        id=2,
-        name="Device 2",
-        available=True,
-        status=DeviceStatus(),
-        features=FeaturesStatus(
-            switchable=Status[bool](status=False),
-            dimmable=Status[float](status=0.0),
-            colorKelvin=Status[int](status=1000),
-            colorRGB=Status[ColorRGBData](status=ColorRGBData(r=0, g=0, b=0)),
-            colorWAF=Status[ColorWAFData](status=ColorWAFData(w=0, a=0, f=0)),
-        ),
-        address=1,
-        line=0,
-    ),
-]
-DEVICES_DATA: Final[DevicesData] = DevicesData(devices=DEVICE_DATA_LIST)
+
 DEVICE_INFO_DATA: Final[DeviceInfoData] = DeviceInfoData(
     serial=SERIAL_NUMBER,
     gtin=192837465,
@@ -94,6 +62,47 @@ INFO_DATA: Final[InfoData] = InfoData(
         ),
     },
 )
+
+
+def build_devices_data() -> DevicesData:
+    """Build DevicesData."""
+    return DevicesData(devices=build_device_data_list())
+
+
+def build_device_data_list() -> list[DeviceData]:
+    """Build a list of DeviceData."""
+    return [
+        DeviceData(
+            id=1,
+            name="Device 1",
+            available=True,
+            status=DeviceStatus(),
+            features=FeaturesStatus(
+                switchable=Status[bool](status=False),
+                dimmable=Status[float](status=0.0),
+                colorKelvin=Status[int](status=1000),
+                colorRGB=Status[ColorRGBData](status=ColorRGBData(r=0, g=0, b=0)),
+                colorWAF=Status[ColorWAFData](status=ColorWAFData(w=0, a=0, f=0)),
+            ),
+            address=0,
+            line=0,
+        ),
+        DeviceData(
+            id=2,
+            name="Device 2",
+            available=True,
+            status=DeviceStatus(),
+            features=FeaturesStatus(
+                switchable=Status[bool](status=False),
+                dimmable=Status[float](status=0.0),
+                colorKelvin=Status[int](status=1000),
+                colorRGB=Status[ColorRGBData](status=ColorRGBData(r=0, g=0, b=0)),
+                colorWAF=Status[ColorWAFData](status=ColorWAFData(w=0, a=0, f=0)),
+            ),
+            address=1,
+            line=0,
+        ),
+    ]
 
 
 async def setup_integration(

--- a/tests/components/lunatone/conftest.py
+++ b/tests/components/lunatone/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.components.lunatone.const import DOMAIN
 from homeassistant.const import CONF_URL
 
-from . import BASE_URL, DEVICES_DATA, INFO_DATA, PRODUCT_NAME, SERIAL_NUMBER
+from . import BASE_URL, INFO_DATA, PRODUCT_NAME, SERIAL_NUMBER, build_devices_data
 
 from tests.common import MockConfigEntry
 
@@ -50,7 +50,7 @@ def mock_lunatone_devices() -> Generator[AsyncMock]:
         "homeassistant.components.lunatone.Devices", autospec=True
     ) as mock_devices:
         devices = mock_devices.return_value
-        devices.data = DEVICES_DATA
+        devices.data = build_devices_data()
         type(devices).devices = PropertyMock(
             side_effect=lambda d=devices: build_devices_mock(d)
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #162406

Spotted in https://github.com/home-assistant/core/actions/runs/21866887809/job/63112765173?pr=162715

The light tests are modifying the device constants, and the failure could be replicated with:
`pytest tests/components/lunatone/test_light.py tests/components/lunatone/test_diagnostics.py`

This ensure that new DeviceData is generated for every test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
