### PR TITLE
Add configurable panel properties to frontend

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -337,14 +337,16 @@ class Panel:
             "config_panel_domain": self.config_panel_domain,
         }
         if config_override:
-            if "icon" in config_override:
-                response["icon"] = config_override["icon"]
-            if "title" in config_override:
-                response["title"] = config_override["title"]
-            if "show_in_sidebar" in config_override:
-                response["default_visible"] = config_override["show_in_sidebar"]
             if "require_admin" in config_override:
                 response["require_admin"] = config_override["require_admin"]
+            if config_override.get("show_in_sidebar") is False:
+                response["title"] = None
+                response["icon"] = None
+            else:
+                if "icon" in config_override:
+                    response["icon"] = config_override["icon"]
+                if "title" in config_override:
+                    response["title"] = config_override["title"]
         return response
 
 
@@ -1030,7 +1032,6 @@ def websocket_subscribe_extra_js(
         vol.Optional("icon"): vol.Any(cv.icon, None),
         vol.Optional("require_admin"): vol.Any(cv.boolean, None),
         vol.Optional("show_in_sidebar"): vol.Any(cv.boolean, None),
-        vol.Optional("reset"): True,
     }
 )
 @websocket_api.require_admin
@@ -1046,23 +1047,19 @@ async def websocket_update_panel(
         return
 
     panels_config = hass.data[DATA_PANELS_CONFIG]
+    panel_config = dict(panels_config.get(url_path, {}))
 
-    if msg.get("reset"):
-        panels_config.pop(url_path, None)
+    for key in ("title", "icon", "require_admin", "show_in_sidebar"):
+        if key in msg:
+            if msg[key] is None:
+                panel_config.pop(key, None)
+            else:
+                panel_config[key] = msg[key]
+
+    if panel_config:
+        panels_config[url_path] = panel_config
     else:
-        panel_config = dict(panels_config.get(url_path, {}))
-
-        for key in ("title", "icon", "require_admin", "show_in_sidebar"):
-            if key in msg:
-                if msg[key] is None:
-                    panel_config.pop(key, None)
-                else:
-                    panel_config[key] = msg[key]
-
-        if panel_config:
-            panels_config[url_path] = panel_config
-        else:
-            panels_config.pop(url_path, None)
+        panels_config.pop(url_path, None)
 
     hass.data[DATA_PANELS_STORE].async_delay_save(
         lambda: hass.data[DATA_PANELS_CONFIG], PANELS_SAVE_DELAY

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -590,6 +590,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
 
     async_register_built_in_panel(hass, "profile")
+    async_register_built_in_panel(hass, "notfound")
 
     @callback
     def async_change_listener(
@@ -923,7 +924,7 @@ def websocket_get_panels(
             if config_override
             else panel.require_admin
         )
-        if not user_is_admin and require_admin and panel_key != "home":
+        if not user_is_admin and require_admin:
             continue
         panels[panel_key] = panel.to_response(config_override)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -18,7 +18,7 @@ from yarl import URL
 
 from homeassistant.components import onboarding, websocket_api
 from homeassistant.components.http import KEY_HASS, HomeAssistantView, StaticPathConfig
-from homeassistant.components.websocket_api import ActiveConnection
+from homeassistant.components.websocket_api import ERR_NOT_FOUND, ActiveConnection
 from homeassistant.config import async_hass_config_yaml
 from homeassistant.const import (
     CONF_MODE,
@@ -1049,7 +1049,7 @@ async def websocket_update_panel(
     url_path: str = msg["url_path"]
 
     if url_path not in hass.data.get(DATA_PANELS, {}):
-        connection.send_error(msg["id"], "not_found", "Panel not found")
+        connection.send_error(msg["id"], ERR_NOT_FOUND, "Panel not found")
         return
 
     panels_config = hass.data[DATA_PANELS_CONFIG]
@@ -1057,10 +1057,10 @@ async def websocket_update_panel(
 
     for key in ("title", "icon", "require_admin", "show_in_sidebar"):
         if key in msg:
-            if msg[key] is None:
+            if (value := msg[key]) is None:
                 panel_config.pop(key, None)
             else:
-                panel_config[key] = msg[key]
+                panel_config[key] = value
 
     if panel_config:
         panels_config[url_path] = panel_config

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -81,7 +81,7 @@ DATA_THEMES: HassKey[dict[str, Any]] = HassKey("frontend_themes")
 
 PANELS_STORAGE_KEY = f"{DOMAIN}_panels"
 PANELS_STORAGE_VERSION = 1
-PANELS_SAVE_DELAY = 1
+PANELS_SAVE_DELAY = 10
 DATA_PANELS_STORE: HassKey[Store[dict[str, dict[str, Any]]]] = HassKey(
     "frontend_panels_store"
 )

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -923,7 +923,7 @@ def websocket_get_panels(
             if config_override
             else panel.require_admin
         )
-        if not user_is_admin and require_admin:
+        if not user_is_admin and require_admin and panel_key != "home":
             continue
         panels[panel_key] = panel.to_response(config_override)
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -443,7 +443,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     panels_store = hass.data[DATA_PANELS_STORE] = Store[dict[str, dict[str, Any]]](
         hass, PANELS_STORAGE_VERSION, PANELS_STORAGE_KEY
     )
-    hass.data[DATA_PANELS_CONFIG] = await panels_store.async_load() or {}
+    loaded: Any = await panels_store.async_load()
+    if not isinstance(loaded, dict):
+        if loaded is not None:
+            _LOGGER.warning("Ignoring invalid panel storage data")
+        loaded = {}
+    hass.data[DATA_PANELS_CONFIG] = loaded
 
     websocket_api.async_register_command(hass, websocket_get_icons)
     websocket_api.async_register_command(hass, websocket_get_panels)

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -78,6 +78,16 @@ THEMES_STORAGE_VERSION = 1
 THEMES_SAVE_DELAY = 60
 DATA_THEMES_STORE: HassKey[Store] = HassKey("frontend_themes_store")
 DATA_THEMES: HassKey[dict[str, Any]] = HassKey("frontend_themes")
+
+PANELS_STORAGE_KEY = f"{DOMAIN}_panels"
+PANELS_STORAGE_VERSION = 1
+PANELS_SAVE_DELAY = 1
+DATA_PANELS_STORE: HassKey[Store[dict[str, dict[str, Any]]]] = HassKey(
+    "frontend_panels_store"
+)
+DATA_PANELS_CONFIG: HassKey[dict[str, dict[str, Any]]] = HassKey(
+    "frontend_panels_config"
+)
 DATA_DEFAULT_THEME = "frontend_default_theme"
 DATA_DEFAULT_DARK_THEME = "frontend_default_dark_theme"
 DEFAULT_THEME = "default"
@@ -312,9 +322,11 @@ class Panel:
         self.sidebar_default_visible = sidebar_default_visible
 
     @callback
-    def to_response(self) -> PanelResponse:
+    def to_response(
+        self, config_override: dict[str, Any] | None = None
+    ) -> PanelResponse:
         """Panel as dictionary."""
-        return {
+        response: PanelResponse = {
             "component_name": self.component_name,
             "icon": self.sidebar_icon,
             "title": self.sidebar_title,
@@ -324,6 +336,16 @@ class Panel:
             "require_admin": self.require_admin,
             "config_panel_domain": self.config_panel_domain,
         }
+        if config_override:
+            if "icon" in config_override:
+                response["icon"] = config_override["icon"]
+            if "title" in config_override:
+                response["title"] = config_override["title"]
+            if "show_in_sidebar" in config_override:
+                response["default_visible"] = config_override["show_in_sidebar"]
+            if "require_admin" in config_override:
+                response["require_admin"] = config_override["require_admin"]
+        return response
 
 
 @bind_hass
@@ -415,12 +437,19 @@ def _frontend_root(dev_repo_path: str | None) -> pathlib.Path:
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the serving of the frontend."""
     await async_setup_frontend_storage(hass)
+
+    panels_store = hass.data[DATA_PANELS_STORE] = Store[dict[str, dict[str, Any]]](
+        hass, PANELS_STORAGE_VERSION, PANELS_STORAGE_KEY
+    )
+    hass.data[DATA_PANELS_CONFIG] = await panels_store.async_load() or {}
+
     websocket_api.async_register_command(hass, websocket_get_icons)
     websocket_api.async_register_command(hass, websocket_get_panels)
     websocket_api.async_register_command(hass, websocket_get_themes)
     websocket_api.async_register_command(hass, websocket_get_translations)
     websocket_api.async_register_command(hass, websocket_get_version)
     websocket_api.async_register_command(hass, websocket_subscribe_extra_js)
+    websocket_api.async_register_command(hass, websocket_update_panel)
     hass.http.register_view(ManifestJSONView())
 
     conf = config.get(DOMAIN, {})
@@ -883,11 +912,18 @@ def websocket_get_panels(
 ) -> None:
     """Handle get panels command."""
     user_is_admin = connection.user.is_admin
-    panels = {
-        panel_key: panel.to_response()
-        for panel_key, panel in connection.hass.data[DATA_PANELS].items()
-        if user_is_admin or not panel.require_admin
-    }
+    panels_config = hass.data[DATA_PANELS_CONFIG]
+    panels: dict[str, PanelResponse] = {}
+    for panel_key, panel in connection.hass.data[DATA_PANELS].items():
+        config_override = panels_config.get(panel_key)
+        require_admin = (
+            config_override.get("require_admin", panel.require_admin)
+            if config_override
+            else panel.require_admin
+        )
+        if not user_is_admin and require_admin:
+            continue
+        panels[panel_key] = panel.to_response(config_override)
 
     connection.send_message(websocket_api.result_message(msg["id"], panels))
 
@@ -984,6 +1020,55 @@ def websocket_subscribe_extra_js(
 
     connection.subscriptions[msg["id"]] = cancel_subscription
     connection.send_message(websocket_api.result_message(msg["id"]))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "frontend/update_panel",
+        vol.Required("url_path"): str,
+        vol.Optional("title"): vol.Any(cv.string, None),
+        vol.Optional("icon"): vol.Any(cv.icon, None),
+        vol.Optional("require_admin"): vol.Any(cv.boolean, None),
+        vol.Optional("show_in_sidebar"): vol.Any(cv.boolean, None),
+        vol.Optional("reset"): True,
+    }
+)
+@websocket_api.require_admin
+@websocket_api.async_response
+async def websocket_update_panel(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
+) -> None:
+    """Handle update panel command."""
+    url_path: str = msg["url_path"]
+
+    if url_path not in hass.data.get(DATA_PANELS, {}):
+        connection.send_error(msg["id"], "not_found", "Panel not found")
+        return
+
+    panels_config = hass.data[DATA_PANELS_CONFIG]
+
+    if msg.get("reset"):
+        panels_config.pop(url_path, None)
+    else:
+        panel_config = dict(panels_config.get(url_path, {}))
+
+        for key in ("title", "icon", "require_admin", "show_in_sidebar"):
+            if key in msg:
+                if msg[key] is None:
+                    panel_config.pop(key, None)
+                else:
+                    panel_config[key] = msg[key]
+
+        if panel_config:
+            panels_config[url_path] = panel_config
+        else:
+            panels_config.pop(url_path, None)
+
+    hass.data[DATA_PANELS_STORE].async_delay_save(
+        lambda: hass.data[DATA_PANELS_CONFIG], PANELS_SAVE_DELAY
+    )
+    hass.bus.async_fire(EVENT_PANELS_UPDATED)
+    connection.send_result(msg["id"])
 
 
 class PanelResponse(TypedDict):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1221,7 +1221,6 @@ async def test_update_panel(
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["require_admin"] is False
-    assert msg["result"]["light"]["default_visible"] is False
 
     # Update the light panel
     events = async_capture_events(hass, EVENT_PANELS_UPDATED)
@@ -1233,7 +1232,6 @@ async def test_update_panel(
             "title": "My Lights",
             "icon": "mdi:lightbulb",
             "require_admin": True,
-            "show_in_sidebar": True,
         }
     )
     msg = await ws_client.receive_json()
@@ -1246,7 +1244,6 @@ async def test_update_panel(
     assert msg["result"]["light"]["icon"] == "mdi:lightbulb"
     assert msg["result"]["light"]["title"] == "My Lights"
     assert msg["result"]["light"]["require_admin"] is True
-    assert msg["result"]["light"]["default_visible"] is True
 
 
 async def test_update_panel_partial(
@@ -1323,7 +1320,6 @@ async def test_update_panel_persists(
             "light": {
                 "title": "Saved Lights",
                 "icon": "mdi:lamp",
-                "show_in_sidebar": True,
                 "require_admin": True,
             },
         },
@@ -1337,7 +1333,6 @@ async def test_update_panel_persists(
     assert msg["result"]["light"]["title"] == "Saved Lights"
     assert msg["result"]["light"]["icon"] == "mdi:lamp"
     assert msg["result"]["light"]["require_admin"] is True
-    assert msg["result"]["light"]["default_visible"] is True
 
     # Verify other panels still have defaults
     assert msg["result"]["climate"]["title"] == "climate"
@@ -1381,51 +1376,48 @@ async def test_update_panel_reset_param(
     assert msg["result"]["security"]["icon"] == "mdi:security"
 
 
-async def test_update_panel_reset_all(
+async def test_update_panel_hide_sidebar(
     hass: HomeAssistant, ws_client: MockHAClientWebSocket
 ) -> None:
-    """Test that reset=True restores all properties to original values."""
-    # Set multiple custom properties
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/update_panel",
-            "url_path": "light",
-            "title": "My Lights",
-            "icon": "mdi:lightbulb",
-            "require_admin": True,
-            "show_in_sidebar": True,
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert msg["success"]
-
-    # Verify overrides applied
-    await ws_client.send_json({"id": 2, "type": "get_panels"})
-    msg = await ws_client.receive_json()
-    assert msg["result"]["light"]["title"] == "My Lights"
-    assert msg["result"]["light"]["icon"] == "mdi:lightbulb"
-    assert msg["result"]["light"]["require_admin"] is True
-    assert msg["result"]["light"]["default_visible"] is True
-
-    # Reset all
-    events = async_capture_events(hass, EVENT_PANELS_UPDATED)
-    await ws_client.send_json(
-        {
-            "id": 3,
-            "type": "frontend/update_panel",
-            "url_path": "light",
-            "reset": True,
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert msg["success"]
-    assert len(events) == 1
-
-    # Verify all properties restored to originals
-    await ws_client.send_json({"id": 4, "type": "get_panels"})
+    """Test that show_in_sidebar=false clears title and icon like lovelace."""
+    # Verify initial state has title and icon
+    await ws_client.send_json({"id": 1, "type": "get_panels"})
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
-    assert msg["result"]["light"]["require_admin"] is False
-    assert msg["result"]["light"]["default_visible"] is False
+
+    # Hide from sidebar
+    await ws_client.send_json(
+        {
+            "id": 2,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "show_in_sidebar": False,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Title and icon should be None
+    await ws_client.send_json({"id": 3, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["title"] is None
+    assert msg["result"]["light"]["icon"] is None
+
+    # Show in sidebar again by resetting show_in_sidebar
+    await ws_client.send_json(
+        {
+            "id": 4,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "show_in_sidebar": None,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Title and icon should be restored
+    await ws_client.send_json({"id": 5, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["title"] == "light"
+    assert msg["result"]["light"]["icon"] == "mdi:lamps"

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1421,3 +1421,39 @@ async def test_update_panel_hide_sidebar(
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
+
+
+async def test_home_panel_always_visible(
+    hass: HomeAssistant,
+    ws_client: MockHAClientWebSocket,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that the home panel is always returned even with require_admin."""
+    # Set home panel to require_admin
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "home",
+            "require_admin": True,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Make user non-admin
+    hass_admin_user.groups = []
+
+    # Home panel should still be present for non-admin
+    await ws_client.send_json({"id": 2, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert "home" in msg["result"]
+
+    # Other admin panels should be filtered out
+    async_register_built_in_panel(
+        hass, "admin_only", "Admin", "mdi:lock", require_admin=True
+    )
+    await ws_client.send_json({"id": 3, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert "admin_only" not in msg["result"]
+    assert "home" in msg["result"]

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1421,39 +1421,3 @@ async def test_update_panel_hide_sidebar(
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
-
-
-async def test_home_panel_always_visible(
-    hass: HomeAssistant,
-    ws_client: MockHAClientWebSocket,
-    hass_admin_user: MockUser,
-) -> None:
-    """Test that the home panel is always returned even with require_admin."""
-    # Set home panel to require_admin
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "frontend/update_panel",
-            "url_path": "home",
-            "require_admin": True,
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert msg["success"]
-
-    # Make user non-admin
-    hass_admin_user.groups = []
-
-    # Home panel should still be present for non-admin
-    await ws_client.send_json({"id": 2, "type": "get_panels"})
-    msg = await ws_client.receive_json()
-    assert "home" in msg["result"]
-
-    # Other admin panels should be filtered out
-    async_register_built_in_panel(
-        hass, "admin_only", "Admin", "mdi:lock", require_admin=True
-    )
-    await ws_client.send_json({"id": 3, "type": "get_panels"})
-    msg = await ws_client.receive_json()
-    assert "admin_only" not in msg["result"]
-    assert "home" in msg["result"]

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1421,3 +1421,28 @@ async def test_update_panel_hide_sidebar(
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
+
+
+async def test_panels_config_invalid_storage(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that corrupted panel storage is ignored with a warning."""
+    hass_storage["frontend_panels"] = {
+        "key": "frontend_panels",
+        "version": 1,
+        "data": "not_a_dict",
+    }
+
+    assert await async_setup_component(hass, "frontend", {})
+    assert "Ignoring invalid panel storage data" in caplog.text
+
+    client = await hass_ws_client(hass)
+
+    # Panels should still load with defaults
+    await client.send_json({"id": 1, "type": "get_panels"})
+    msg = await client.receive_json()
+    assert msg["result"]["light"]["title"] == "light"
+    assert msg["result"]["light"]["icon"] == "mdi:lamps"

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1209,3 +1209,223 @@ async def test_setup_with_development_pr_unexpected_error(
         await hass.async_block_till_done()
 
         assert "Unexpected error downloading PR #12345" in caplog.text
+
+
+async def test_update_panel(
+    hass: HomeAssistant, ws_client: MockHAClientWebSocket
+) -> None:
+    """Test frontend/update_panel command."""
+    # Verify initial state
+    await ws_client.send_json({"id": 1, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["icon"] == "mdi:lamps"
+    assert msg["result"]["light"]["title"] == "light"
+    assert msg["result"]["light"]["require_admin"] is False
+    assert msg["result"]["light"]["default_visible"] is False
+
+    # Update the light panel
+    events = async_capture_events(hass, EVENT_PANELS_UPDATED)
+    await ws_client.send_json(
+        {
+            "id": 2,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "title": "My Lights",
+            "icon": "mdi:lightbulb",
+            "require_admin": True,
+            "show_in_sidebar": True,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(events) == 1
+
+    # Verify the panel was updated
+    await ws_client.send_json({"id": 3, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["icon"] == "mdi:lightbulb"
+    assert msg["result"]["light"]["title"] == "My Lights"
+    assert msg["result"]["light"]["require_admin"] is True
+    assert msg["result"]["light"]["default_visible"] is True
+
+
+async def test_update_panel_partial(
+    hass: HomeAssistant, ws_client: MockHAClientWebSocket
+) -> None:
+    """Test that partial updates only change specified properties."""
+    # Update only title
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "climate",
+            "title": "HVAC",
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Verify only title changed, others kept defaults
+    await ws_client.send_json({"id": 2, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["climate"]["title"] == "HVAC"
+    assert msg["result"]["climate"]["icon"] == "mdi:home-thermometer"
+    assert msg["result"]["climate"]["require_admin"] is False
+    assert msg["result"]["climate"]["default_visible"] is False
+
+
+async def test_update_panel_not_found(ws_client: MockHAClientWebSocket) -> None:
+    """Test that non-existent panels are rejected."""
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "nonexistent",
+            "title": "Does Not Exist",
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+
+
+async def test_update_panel_requires_admin(
+    hass: HomeAssistant,
+    ws_client: MockHAClientWebSocket,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that non-admin users cannot update panels."""
+    hass_admin_user.groups = []
+
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "title": "My Lights",
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+
+@pytest.mark.usefixtures("ignore_frontend_deps")
+async def test_update_panel_persists(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test that panel config is loaded from storage on startup."""
+    hass_storage["frontend_panels"] = {
+        "key": "frontend_panels",
+        "version": 1,
+        "data": {
+            "light": {
+                "title": "Saved Lights",
+                "icon": "mdi:lamp",
+                "show_in_sidebar": True,
+                "require_admin": True,
+            },
+        },
+    }
+
+    assert await async_setup_component(hass, "frontend", {})
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "get_panels"})
+    msg = await client.receive_json()
+    assert msg["result"]["light"]["title"] == "Saved Lights"
+    assert msg["result"]["light"]["icon"] == "mdi:lamp"
+    assert msg["result"]["light"]["require_admin"] is True
+    assert msg["result"]["light"]["default_visible"] is True
+
+    # Verify other panels still have defaults
+    assert msg["result"]["climate"]["title"] == "climate"
+    assert msg["result"]["climate"]["icon"] == "mdi:home-thermometer"
+
+
+async def test_update_panel_reset_param(
+    hass: HomeAssistant, ws_client: MockHAClientWebSocket
+) -> None:
+    """Test that setting a param to None resets it to the original value."""
+    # First set a custom icon
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "security",
+            "icon": "mdi:shield",
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    await ws_client.send_json({"id": 2, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["security"]["icon"] == "mdi:shield"
+
+    # Reset icon by setting to None — should restore original
+    await ws_client.send_json(
+        {
+            "id": 3,
+            "type": "frontend/update_panel",
+            "url_path": "security",
+            "icon": None,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    await ws_client.send_json({"id": 4, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["security"]["icon"] == "mdi:security"
+
+
+async def test_update_panel_reset_all(
+    hass: HomeAssistant, ws_client: MockHAClientWebSocket
+) -> None:
+    """Test that reset=True restores all properties to original values."""
+    # Set multiple custom properties
+    await ws_client.send_json(
+        {
+            "id": 1,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "title": "My Lights",
+            "icon": "mdi:lightbulb",
+            "require_admin": True,
+            "show_in_sidebar": True,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    # Verify overrides applied
+    await ws_client.send_json({"id": 2, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["title"] == "My Lights"
+    assert msg["result"]["light"]["icon"] == "mdi:lightbulb"
+    assert msg["result"]["light"]["require_admin"] is True
+    assert msg["result"]["light"]["default_visible"] is True
+
+    # Reset all
+    events = async_capture_events(hass, EVENT_PANELS_UPDATED)
+    await ws_client.send_json(
+        {
+            "id": 3,
+            "type": "frontend/update_panel",
+            "url_path": "light",
+            "reset": True,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert len(events) == 1
+
+    # Verify all properties restored to originals
+    await ws_client.send_json({"id": 4, "type": "get_panels"})
+    msg = await ws_client.receive_json()
+    assert msg["result"]["light"]["title"] == "light"
+    assert msg["result"]["light"]["icon"] == "mdi:lamps"
+    assert msg["result"]["light"]["require_admin"] is False
+    assert msg["result"]["light"]["default_visible"] is False


### PR DESCRIPTION
## Proposed change

Add the ability for admins to configure panel properties (title, icon, require_admin, show_in_sidebar) for any registered panel via a new `frontend/update_panel` websocket command.

Currently, lovelace dashboards support configuring these properties, but built-in panels (light, security, climate, home) and other panels have their properties hardcoded. This change introduces a dedicated `frontend_panels` storage that persists panel configuration overrides.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/29572

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
