### PR TITLE
Add storage sensor support for Proxmox VE integration

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
 from proxmoxer import AuthenticationError, ProxmoxAPI
 import requests.exceptions
@@ -31,6 +31,7 @@ from .common import (
     ProxmoxClient,
     ResourceException,
     call_api_container_vm,
+    get_node_storages,
     parse_api_container_vm,
 )
 from .const import (
@@ -43,15 +44,26 @@ from .const import (
     DEFAULT_REALM,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    NODE_STORAGE_KEY,
     TYPE_CONTAINER,
     TYPE_VM,
     UPDATE_INTERVAL,
 )
 
-PLATFORMS = [Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+
+type ProxmoxCoordinator = DataUpdateCoordinator[
+    dict[str, Any] | list[dict[str, Any]] | None
+]
 
 type ProxmoxConfigEntry = ConfigEntry[
-    dict[str, dict[str, dict[int, DataUpdateCoordinator[dict[str, Any] | None]]]]
+    dict[
+        str,
+        dict[
+            str,
+            dict[int | str, ProxmoxCoordinator],
+        ],
+    ]
 ]
 
 CONFIG_SCHEMA = vol.Schema(
@@ -179,7 +191,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
     proxmox_client = await hass.async_add_executor_job(build_client)
 
     coordinators: dict[
-        str, dict[str, dict[int, DataUpdateCoordinator[dict[str, Any] | None]]]
+        str,
+        dict[
+            str,
+            dict[
+                int | str,
+                DataUpdateCoordinator[dict[str, Any] | list[dict[str, Any]] | None],
+            ],
+        ],
     ] = {}
     entry.runtime_data = coordinators
 
@@ -206,7 +225,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
             )
             await coordinator.async_config_entry_first_refresh()
 
-            node_coordinators[vm["vmid"]] = coordinator
+            node_coordinators[vm["vmid"]] = cast(ProxmoxCoordinator, coordinator)
 
         for container in containers:
             coordinator = _create_coordinator_container_vm(
@@ -220,7 +239,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
             )
             await coordinator.async_config_entry_first_refresh()
 
-            node_coordinators[container["vmid"]] = coordinator
+            node_coordinators[container["vmid"]] = cast(ProxmoxCoordinator, coordinator)
+
+        storage_coordinator = _create_storage_coordinator(
+            hass, entry, proxmox, host_name, node_name
+        )
+        await storage_coordinator.async_config_entry_first_refresh()
+        node_coordinators[NODE_STORAGE_KEY] = cast(
+            ProxmoxCoordinator, storage_coordinator
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -271,6 +298,34 @@ def _create_coordinator_container_vm(
         LOGGER,
         config_entry=entry,
         name=f"proxmox_coordinator_{host_name}_{node_name}_{vm_id}",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=UPDATE_INTERVAL),
+    )
+
+
+def _create_storage_coordinator(
+    hass: HomeAssistant,
+    entry: ProxmoxConfigEntry,
+    proxmox: ProxmoxAPI,
+    host_name: str,
+    node_name: str,
+) -> DataUpdateCoordinator[list[dict[str, Any]] | None]:
+    """Create and return a DataUpdateCoordinator for node storage list."""
+
+    async def async_update_data() -> list[dict[str, Any]] | None:
+        """Fetch storage list for the node."""
+
+        def poll_storages() -> list[dict[str, Any]]:
+            """Call the api."""
+            return get_node_storages(proxmox, node_name)
+
+        return await hass.async_add_executor_job(poll_storages)
+
+    return DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        config_entry=entry,
+        name=f"proxmox_storage_{host_name}_{node_name}",
         update_method=async_update_data,
         update_interval=timedelta(seconds=UPDATE_INTERVAL),
     )

--- a/homeassistant/components/proxmoxve/common.py
+++ b/homeassistant/components/proxmoxve/common.py
@@ -86,3 +86,47 @@ def call_api_container_vm(
         return None
 
     return status
+
+
+def get_node_storages(
+    proxmox: ProxmoxAPI,
+    node_name: str,
+) -> list[dict[str, Any]]:
+    """Get storage list with total, used and avail space for a node.
+
+    Returns a list of dicts with keys: storage, type, total, used, avail (bytes).
+    On API errors, skips failing storages and returns the rest; on total failure
+    returns an empty list.
+    """
+    result: list[dict[str, Any]] = []
+    try:
+        storages = proxmox.nodes(node_name).storage.get()
+    except ResourceException, requests.exceptions.ConnectionError:
+        return result
+    if not storages:
+        return result
+    for storage_info in storages:
+        storage_id = storage_info.get("storage")
+        if not storage_id:
+            continue
+        try:
+            status = proxmox.nodes(node_name).storage(storage_id).status.get()
+        except ResourceException, requests.exceptions.ConnectionError:
+            continue
+        total = status.get("total") or 0
+        used = status.get("used") or 0
+        avail = status.get("avail")
+        if avail is None and total is not None and used is not None:
+            avail = max(0, total - used)
+        elif avail is None:
+            avail = 0
+        result.append(
+            {
+                "storage": storage_id,
+                "type": storage_info.get("type", ""),
+                "total": total,
+                "used": used,
+                "avail": avail,
+            }
+        )
+    return result

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -6,7 +6,7 @@ CONF_NODE = "node"
 CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
-
+NODE_STORAGE_KEY = "_storage"
 
 DEFAULT_PORT = 8006
 DEFAULT_REALM = "pam"

--- a/homeassistant/components/proxmoxve/sensor.py
+++ b/homeassistant/components/proxmoxve/sensor.py
@@ -1,0 +1,137 @@
+"""Sensor to read Proxmox VE storage disk space."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.const import CONF_HOST, PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from . import ProxmoxConfigEntry
+from .const import CONF_NODE, CONF_NODES, NODE_STORAGE_KEY
+
+BYTES_TO_GIB = 1 / (1024**3)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ProxmoxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up storage sensors."""
+    sensors: list[ProxmoxStorageSensor] = []
+    host_name = entry.data[CONF_HOST]
+    coordinators = entry.runtime_data[host_name]
+
+    for node_config in entry.data[CONF_NODES]:
+        node_name = node_config[CONF_NODE]
+        coord = coordinators[node_name].get(NODE_STORAGE_KEY)
+        if coord is None or coord.data is None:
+            continue
+        storage_coordinator = cast(
+            DataUpdateCoordinator[list[dict[str, Any]] | None], coord
+        )
+        storage_data = storage_coordinator.data
+        assert storage_data is not None
+        sensors.extend(
+            ProxmoxStorageSensor(
+                coordinator=storage_coordinator,
+                host_name=host_name,
+                node_name=node_name,
+                storage_id=storage_info["storage"],
+                storage_type=storage_info.get("type", ""),
+            )
+            for storage_info in storage_data
+        )
+
+    async_add_entities(sensors)
+
+
+class ProxmoxStorageSensor(
+    CoordinatorEntity[DataUpdateCoordinator[list[dict[str, Any]] | None]],
+    SensorEntity,
+):
+    """Sensor for one Proxmox node storage (state = % free, attributes = sizes)."""
+
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[list[dict[str, Any]] | None],
+        host_name: str,
+        node_name: str,
+        storage_id: str,
+        storage_type: str,
+    ) -> None:
+        """Create the storage sensor."""
+        super().__init__(coordinator)
+        self._host_name = host_name
+        self._node_name = node_name
+        self._storage_id = storage_id
+        self._storage_type = storage_type
+        self._attr_name = f"{node_name}_{storage_id} Disk Free"
+        self._attr_unique_id = f"proxmox_{host_name}_{node_name}_{storage_id}_disk_used"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return free space as percentage."""
+        if self.coordinator.data is None:
+            return None
+        for item in self.coordinator.data:
+            if item.get("storage") == self._storage_id:
+                total = item.get("total") or 0
+                avail = item.get("avail")
+                if total and total > 0 and avail is not None:
+                    return round(100.0 * avail / total, 1)
+                return None
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, float | None]:
+        """Return total_gib, free_gib, percent_used and used_gib."""
+        if self.coordinator.data is None:
+            return {
+                "total_gib": None,
+                "free_gib": None,
+                "percent_used": None,
+                "used_gib": None,
+            }
+        for item in self.coordinator.data:
+            if item.get("storage") == self._storage_id:
+                total = item.get("total") or 0
+                used = item.get("used") or 0
+                avail = item.get("avail") or 0
+                total_gib = round(total * BYTES_TO_GIB, 2) if total else None
+                free_gib = round(avail * BYTES_TO_GIB, 2) if avail is not None else None
+                used_gib = round(used * BYTES_TO_GIB, 2) if used is not None else None
+                percent_used = (
+                    round(100.0 * used / total, 1) if total and total > 0 else None
+                )
+                return {
+                    "total_gib": total_gib,
+                    "free_gib": free_gib,
+                    "percent_used": percent_used,
+                    "used_gib": used_gib,
+                }
+        return {
+            "total_gib": None,
+            "free_gib": None,
+            "percent_used": None,
+            "used_gib": None,
+        }
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self.native_value is not None
+        )

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -49,6 +49,16 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "disk_free": {
+        "name": "Disk free"
+      },
+      "disk_used": {
+        "name": "Disk used"
+      }
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_connect_timeout": {
       "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your configuration, a connection timeout occurred. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -118,6 +118,34 @@ def mock_proxmox_client():
         node_mock.qemu.side_effect = _qemu_resource
         node_mock.lxc.side_effect = _lxc_resource
 
+        # Storage API: nodes(node).storage.get() and nodes(node).storage(id).status.get()
+        storage_list = [
+            {"storage": "local", "type": "dir"},
+            {"storage": "local-lvm", "type": "lvm"},
+        ]
+        storage_status_by_id = {
+            "local": {
+                "total": 500000000000,
+                "used": 100000000000,
+                "avail": 400000000000,
+            },
+            "local-lvm": {
+                "total": 300000000000,
+                "used": 60000000000,
+                "avail": 240000000000,
+            },
+        }
+
+        def _storage_resource(storage_id: str) -> MagicMock:
+            resource = MagicMock()
+            resource.status.get.return_value = storage_status_by_id.get(
+                storage_id, {"total": 0, "used": 0, "avail": 0}
+            )
+            return resource
+
+        node_mock.storage.get.return_value = storage_list
+        node_mock.storage.side_effect = _storage_resource
+
         nodes_mock = MagicMock()
         nodes_mock.get.return_value = load_json_array_fixture(
             "nodes/nodes.json", DOMAIN

--- a/tests/components/proxmoxve/snapshots/test_sensor.ambr
+++ b/tests/components/proxmoxve/snapshots/test_sensor.ambr
@@ -1,0 +1,229 @@
+# serializer version: 1
+# name: test_all_storage_sensors[sensor.pve1_local_disk_free-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pve1_local_disk_free',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'pve1_local Disk Free',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'pve1_local Disk Free',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'proxmox_127.0.0.1_pve1_local_disk_used',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve1_local_disk_free-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'free_gib': 372.53,
+      'friendly_name': 'pve1_local Disk Free',
+      'percent_used': 20.0,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'total_gib': 465.66,
+      'unit_of_measurement': '%',
+      'used_gib': 93.13,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pve1_local_disk_free',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80.0',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve1_local_lvm_disk_free-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pve1_local_lvm_disk_free',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'pve1_local-lvm Disk Free',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'pve1_local-lvm Disk Free',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'proxmox_127.0.0.1_pve1_local-lvm_disk_used',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve1_local_lvm_disk_free-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'free_gib': 223.52,
+      'friendly_name': 'pve1_local-lvm Disk Free',
+      'percent_used': 20.0,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'total_gib': 279.4,
+      'unit_of_measurement': '%',
+      'used_gib': 55.88,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pve1_local_lvm_disk_free',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80.0',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve2_local_disk_free-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pve2_local_disk_free',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'pve2_local Disk Free',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'pve2_local Disk Free',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'proxmox_127.0.0.1_pve2_local_disk_used',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve2_local_disk_free-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'free_gib': 372.53,
+      'friendly_name': 'pve2_local Disk Free',
+      'percent_used': 20.0,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'total_gib': 465.66,
+      'unit_of_measurement': '%',
+      'used_gib': 93.13,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pve2_local_disk_free',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80.0',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve2_local_lvm_disk_free-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pve2_local_lvm_disk_free',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'pve2_local-lvm Disk Free',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'pve2_local-lvm Disk Free',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'proxmox_127.0.0.1_pve2_local-lvm_disk_used',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_storage_sensors[sensor.pve2_local_lvm_disk_free-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'free_gib': 223.52,
+      'friendly_name': 'pve2_local-lvm Disk Free',
+      'percent_used': 20.0,
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'total_gib': 279.4,
+      'unit_of_measurement': '%',
+      'used_gib': 55.88,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pve2_local_lvm_disk_free',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80.0',
+  })
+# ---

--- a/tests/components/proxmoxve/test_common.py
+++ b/tests/components/proxmoxve/test_common.py
@@ -1,0 +1,120 @@
+"""Tests for Proxmox VE common module."""
+
+from unittest.mock import MagicMock
+
+from proxmoxer.core import ResourceException
+import requests.exceptions
+
+from homeassistant.components.proxmoxve.common import (
+    call_api_container_vm,
+    get_node_storages,
+    parse_api_container_vm,
+)
+from homeassistant.components.proxmoxve.const import TYPE_CONTAINER, TYPE_VM
+
+
+def test_parse_api_container_vm() -> None:
+    """Test parsing VM/container API response."""
+    status = {"status": "running", "name": "test-vm"}
+    result = parse_api_container_vm(status)
+    assert result == {"status": "running", "name": "test-vm"}
+
+
+def test_call_api_container_vm_qemu(
+    mock_proxmox_client: MagicMock,
+) -> None:
+    """Test call_api_container_vm for QEMU VM."""
+    result = call_api_container_vm(mock_proxmox_client, "pve1", 100, TYPE_VM)
+    assert result is not None
+    assert result["status"] == "running"
+    assert result["name"] == "vm-web"
+
+
+def test_call_api_container_vm_lxc(
+    mock_proxmox_client: MagicMock,
+) -> None:
+    """Test call_api_container_vm for LXC container."""
+    result = call_api_container_vm(mock_proxmox_client, "pve1", 200, TYPE_CONTAINER)
+    assert result is not None
+    assert result["status"] == "running"
+    assert result["name"] == "ct-nginx"
+
+
+def test_call_api_container_vm_returns_none_on_resource_exception() -> None:
+    """Test call_api_container_vm returns None on ResourceException."""
+    node_mock = MagicMock()
+    node_mock.qemu.return_value.status.current.get.side_effect = ResourceException(
+        "404", "status", "content"
+    )
+    proxmox = MagicMock()
+    proxmox.nodes.return_value = node_mock
+    result = call_api_container_vm(proxmox, "pve1", 100, TYPE_VM)
+    assert result is None
+
+
+def test_get_node_storages(
+    mock_proxmox_client: MagicMock,
+) -> None:
+    """Test get_node_storages returns list of storage info."""
+    result = get_node_storages(mock_proxmox_client, "pve1")
+    assert len(result) == 2
+    storages = {s["storage"]: s for s in result}
+    assert "local" in storages
+    assert "local-lvm" in storages
+    assert storages["local"]["type"] == "dir"
+    assert storages["local"]["total"] == 500000000000
+    assert storages["local"]["used"] == 100000000000
+    assert storages["local"]["avail"] == 400000000000
+
+
+def test_get_node_storages_returns_empty_on_connection_error(
+    mock_proxmox_client: MagicMock,
+) -> None:
+    """Test get_node_storages returns empty list when storage.get() fails."""
+    mock_proxmox_client.nodes.return_value.storage.get.side_effect = (
+        requests.exceptions.ConnectionError()
+    )
+    result = get_node_storages(mock_proxmox_client, "pve1")
+    assert result == []
+
+
+def test_get_node_storages_returns_empty_on_resource_exception(
+    mock_proxmox_client: MagicMock,
+) -> None:
+    """Test get_node_storages returns empty list when storage.get() raises ResourceException."""
+    mock_proxmox_client.nodes.return_value.storage.get.side_effect = ResourceException(
+        "500", "status", "content"
+    )
+    result = get_node_storages(mock_proxmox_client, "pve1")
+    assert result == []
+
+
+def test_get_node_storages_skips_storage_when_status_fails() -> None:
+    """Test get_node_storages skips a storage when its status.get() fails."""
+    node_mock = MagicMock()
+    node_mock.storage.get.return_value = [
+        {"storage": "local", "type": "dir"},
+        {"storage": "broken", "type": "dir"},
+    ]
+
+    def storage_side_effect(storage_id: str) -> MagicMock:
+        resource = MagicMock()
+        if storage_id == "broken":
+            resource.status.get.side_effect = ResourceException(
+                "500", "status", "content"
+            )
+        else:
+            resource.status.get.return_value = {
+                "total": 100,
+                "used": 50,
+                "avail": 50,
+            }
+        return resource
+
+    node_mock.storage.side_effect = storage_side_effect
+    proxmox = MagicMock()
+    proxmox.nodes.return_value = node_mock
+
+    result = get_node_storages(proxmox, "pve1")
+    assert len(result) == 1
+    assert result[0]["storage"] == "local"

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -18,8 +18,35 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+import homeassistant.helpers.entity_registry as er
 import homeassistant.helpers.issue_registry as ir
 from homeassistant.setup import async_setup_component
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry_creates_binary_sensor_and_storage_sensor_entities(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that setup creates binary sensors for VMs/containers and sensors for storage."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    binary_sensor_entities = [e for e in entries if e.domain == "binary_sensor"]
+    sensor_entities = [e for e in entries if e.domain == "sensor"]
+
+    # Two nodes × (2 VMs + 2 containers) = 8 binary sensors
+    assert len(binary_sensor_entities) == 8
+    # Two nodes × 2 storages (local, local-lvm) = 4 storage sensors
+    assert len(sensor_entities) == 4
 
 
 async def test_config_import(

--- a/tests/components/proxmoxve/test_sensor.py
+++ b/tests/components/proxmoxve/test_sensor.py
@@ -1,0 +1,145 @@
+"""Test the Proxmox VE sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.proxmoxve.sensor import ProxmoxStorageSensor
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_storage_sensors(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all storage disk sensors."""
+    with patch(
+        "homeassistant.components.proxmoxve.PLATFORMS",
+        [Platform.SENSOR],
+    ):
+        await setup_integration(hass, mock_config_entry)
+        await snapshot_platform(
+            hass, entity_registry, snapshot, mock_config_entry.entry_id
+        )
+
+
+async def test_storage_sensor_native_value_and_attributes(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ProxmoxStorageSensor native_value and extra_state_attributes."""
+    storage_data = [
+        {
+            "storage": "local",
+            "type": "dir",
+            "total": 500000000000,
+            "used": 100000000000,
+            "avail": 400000000000,
+        },
+    ]
+    coordinator = DataUpdateCoordinator(
+        hass,
+        MagicMock(),
+        name="test",
+        update_method=lambda: None,
+        config_entry=mock_config_entry,
+    )
+    coordinator.data = storage_data
+    coordinator.last_update_success = True
+
+    sensor = ProxmoxStorageSensor(
+        coordinator=coordinator,
+        host_name="127.0.0.1",
+        node_name="pve1",
+        storage_id="local",
+        storage_type="dir",
+    )
+
+    # State = % free (avail/total*100); 400e9/500e9 = 80%
+    assert sensor.native_value == 80.0
+    attrs = sensor.extra_state_attributes
+    assert attrs["total_gib"] == 465.66
+    assert attrs["free_gib"] == 372.53
+    assert attrs["percent_used"] == 20.0
+    assert attrs["used_gib"] == 93.13
+    assert sensor.available is True
+
+
+async def test_storage_sensor_unavailable_when_no_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ProxmoxStorageSensor is unavailable when coordinator has no data."""
+    coordinator = DataUpdateCoordinator(
+        hass,
+        MagicMock(),
+        name="test",
+        update_method=lambda: None,
+        config_entry=mock_config_entry,
+    )
+    coordinator.data = None
+    coordinator.last_update_success = True
+
+    sensor = ProxmoxStorageSensor(
+        coordinator=coordinator,
+        host_name="127.0.0.1",
+        node_name="pve1",
+        storage_id="local",
+        storage_type="dir",
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {
+        "total_gib": None,
+        "free_gib": None,
+        "percent_used": None,
+        "used_gib": None,
+    }
+    assert sensor.available is False
+
+
+async def test_storage_sensor_missing_storage_in_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ProxmoxStorageSensor when storage id is not in coordinator data."""
+    coordinator = DataUpdateCoordinator(
+        hass,
+        MagicMock(),
+        name="test",
+        update_method=lambda: None,
+        config_entry=mock_config_entry,
+    )
+    coordinator.data = [
+        {"storage": "other", "type": "dir", "total": 100, "used": 50, "avail": 50},
+    ]
+    coordinator.last_update_success = True
+
+    sensor = ProxmoxStorageSensor(
+        coordinator=coordinator,
+        host_name="127.0.0.1",
+        node_name="pve1",
+        storage_id="local",
+        storage_type="dir",
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {
+        "total_gib": None,
+        "free_gib": None,
+        "percent_used": None,
+        "used_gib": None,
+    }
+    assert sensor.available is False


### PR DESCRIPTION
- Introduced a new sensor platform to monitor disk space for Proxmox VE storage.
- Implemented get_node_storages function to retrieve storage details including total, used, and available space.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
