### PR TITLE
Fix bug in edit_message_media action for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -643,23 +643,41 @@ class TelegramNotificationService:
 
         media: InputMedia
         if media_type == InputMediaType.ANIMATION:
-            media = InputMediaAnimation(file_content, caption=kwargs.get(ATTR_CAPTION))
+            media = InputMediaAnimation(
+                file_content,
+                caption=kwargs.get(ATTR_CAPTION),
+                parse_mode=params[ATTR_PARSER],
+            )
         elif media_type == InputMediaType.AUDIO:
-            media = InputMediaAudio(file_content, caption=kwargs.get(ATTR_CAPTION))
+            media = InputMediaAudio(
+                file_content,
+                caption=kwargs.get(ATTR_CAPTION),
+                parse_mode=params[ATTR_PARSER],
+            )
         elif media_type == InputMediaType.DOCUMENT:
-            media = InputMediaDocument(file_content, caption=kwargs.get(ATTR_CAPTION))
+            media = InputMediaDocument(
+                file_content,
+                caption=kwargs.get(ATTR_CAPTION),
+                parse_mode=params[ATTR_PARSER],
+            )
         elif media_type == InputMediaType.PHOTO:
-            media = InputMediaPhoto(file_content, caption=kwargs.get(ATTR_CAPTION))
+            media = InputMediaPhoto(
+                file_content,
+                caption=kwargs.get(ATTR_CAPTION),
+                parse_mode=params[ATTR_PARSER],
+            )
         else:
-            media = InputMediaVideo(file_content, caption=kwargs.get(ATTR_CAPTION))
+            media = InputMediaVideo(
+                file_content,
+                caption=kwargs.get(ATTR_CAPTION),
+                parse_mode=params[ATTR_PARSER],
+            )
 
         return await self._send_msg(
             self.bot.edit_message_media,
             "Error editing message media",
             params[ATTR_MESSAGE_TAG],
             media=media,
-            caption=kwargs.get(ATTR_CAPTION),
-            parse_mode=params[ATTR_PARSER],
             chat_id=chat_id,
             message_id=message_id,
             inline_message_id=inline_message_id,

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -1206,7 +1206,7 @@ async def test_edit_message_media(
     mock.assert_called_once()
     assert mock.call_args[1]["media"].__class__.__name__ == expected_media_class
     assert mock.call_args[1]["media"].caption == "mock caption"
-    assert mock.call_args[1]["parse_mode"] == PARSER_MD
+    assert mock.call_args[1]["media"].parse_mode == PARSER_MD
     assert mock.call_args[1]["chat_id"] == 123456
     assert mock.call_args[1]["message_id"] == 12345
     assert mock.call_args[1]["reply_markup"] == InlineKeyboardMarkup(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `caption` and `parse_mode` arguments for the `edit_message_media` action is in the wrong position.
They are supposed to be specified within the `media` argument and not part of the keyword args.
This PR fixes them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162639
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
