### PR TITLE
Allow setting dns servers in http configuration

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -92,6 +92,7 @@ CONF_LOGIN_ATTEMPTS_THRESHOLD: Final = "login_attempts_threshold"
 CONF_IP_BAN_ENABLED: Final = "ip_ban_enabled"
 CONF_SSL_PROFILE: Final = "ssl_profile"
 CONF_NAMESERVERS: Final = "nameservers"
+CONF_CARES_INIT_FLAGS: Final = "cares_init_flags"
 
 SSL_MODERN: Final = "modern"
 SSL_INTERMEDIATE: Final = "intermediate"
@@ -142,6 +143,7 @@ HTTP_SCHEMA: Final = vol.All(
             ),
             vol.Optional(CONF_USE_X_FRAME_OPTIONS, default=True): cv.boolean,
             vol.Optional(CONF_NAMESERVERS): vol.All(cv.ensure_list, [ip_address]),
+            vol.Optional(CONF_CARES_INIT_FLAGS): cv.positive_int,
         }
     ),
 )
@@ -181,6 +183,7 @@ class ConfData(TypedDict, total=False):
     ip_ban_enabled: bool
     ssl_profile: str
     nameservers: list[IPv4Address | IPv6Address]
+    cares_init_flags: int
 
 
 @bind_hass

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -7,7 +7,14 @@ from collections.abc import Collection
 from dataclasses import dataclass
 import datetime
 from functools import partial
-from ipaddress import IPv4Network, IPv6Network, ip_network
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
 import logging
 import os
 import socket
@@ -84,6 +91,7 @@ CONF_TRUSTED_PROXIES: Final = "trusted_proxies"
 CONF_LOGIN_ATTEMPTS_THRESHOLD: Final = "login_attempts_threshold"
 CONF_IP_BAN_ENABLED: Final = "ip_ban_enabled"
 CONF_SSL_PROFILE: Final = "ssl_profile"
+CONF_NAMESERVERS: Final = "nameservers"
 
 SSL_MODERN: Final = "modern"
 SSL_INTERMEDIATE: Final = "intermediate"
@@ -133,6 +141,7 @@ HTTP_SCHEMA: Final = vol.All(
                 [SSL_INTERMEDIATE, SSL_MODERN]
             ),
             vol.Optional(CONF_USE_X_FRAME_OPTIONS, default=True): cv.boolean,
+            vol.Optional(CONF_NAMESERVERS): vol.All(cv.ensure_list, [ip_address]),
         }
     ),
 )
@@ -171,6 +180,7 @@ class ConfData(TypedDict, total=False):
     login_attempts_threshold: int
     ip_ban_enabled: bool
     ssl_profile: str
+    nameservers: list[IPv4Address | IPv6Address]
 
 
 @bind_hass
@@ -207,6 +217,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     if conf is None:
         conf = cast(ConfData, HTTP_SCHEMA({}))
+
+    hass.data[DOMAIN] = conf
 
     if CONF_SERVER_HOST in conf and is_hassio(hass):
         issue_id = "server_host_deprecated_hassio"

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -19,6 +19,7 @@ from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
+from homeassistant.components.http import CONF_NAMESERVERS, DOMAIN as HTTP_DOMAIN
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
@@ -403,4 +404,13 @@ def _async_get_or_create_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
 
 @callback
 def _async_make_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
-    return HassAsyncDNSResolver(async_zeroconf=zeroconf.async_get_async_zeroconf(hass))
+    kwargs = {}
+
+    http_conf = hass.data.get(HTTP_DOMAIN, {})
+    if (nameservers := http_conf.get(CONF_NAMESERVERS)) is not None:
+        kwargs["nameservers"] = list(map(str, nameservers))
+
+    return HassAsyncDNSResolver(
+        async_zeroconf=zeroconf.async_get_async_zeroconf(hass),
+        **kwargs,  # type: ignore [arg-type]
+    )

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -19,7 +19,11 @@ from aiohttp_asyncmdnsresolver.api import AsyncDualMDNSResolver
 
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.components.http import CONF_NAMESERVERS, DOMAIN as HTTP_DOMAIN
+from homeassistant.components.http import (
+    CONF_CARES_INIT_FLAGS,
+    CONF_NAMESERVERS,
+    DOMAIN as HTTP_DOMAIN,
+)
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.loader import bind_hass
@@ -404,13 +408,14 @@ def _async_get_or_create_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
 
 @callback
 def _async_make_resolver(hass: HomeAssistant) -> HassAsyncDNSResolver:
-    kwargs = {}
-
     http_conf = hass.data.get(HTTP_DOMAIN, {})
+    kwargs: dict[str, Any] = {
+        "async_zeroconf": zeroconf.async_get_async_zeroconf(hass),
+    }
     if (nameservers := http_conf.get(CONF_NAMESERVERS)) is not None:
-        kwargs["nameservers"] = list(map(str, nameservers))
+        kwargs["nameservers"] = [str(nameserver) for nameserver in nameservers]
 
-    return HassAsyncDNSResolver(
-        async_zeroconf=zeroconf.async_get_async_zeroconf(hass),
-        **kwargs,  # type: ignore [arg-type]
-    )
+    if (cares_init_flags := http_conf.get(CONF_CARES_INIT_FLAGS)) is not None:
+        kwargs["flags"] = cares_init_flags
+
+    return HassAsyncDNSResolver(**kwargs)

--- a/tests/helpers/test_aiohttp_client_custom_dns.py
+++ b/tests/helpers/test_aiohttp_client_custom_dns.py
@@ -1,0 +1,30 @@
+"""Test the aiohttp client helper with custom DNS."""
+
+import aiohttp
+import pytest
+
+from homeassistant.components.http import CONF_NAMESERVERS, DOMAIN as HTTP_DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client as client
+from homeassistant.setup import async_setup_component
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "disable_mock_zeroconf_resolver")
+async def test_resolver_uses_configured_nameservers(hass: HomeAssistant) -> None:
+    """Test that the resolver uses the configured nameservers."""
+    assert await async_setup_component(
+        hass,
+        HTTP_DOMAIN,
+        {HTTP_DOMAIN: {CONF_NAMESERVERS: ["1.1.1.1", "1.0.0.1"]}},
+    )
+
+    session = client.async_get_clientsession(hass)
+    assert isinstance(session._connector, aiohttp.TCPConnector)
+    resolver = session._connector._resolver
+    assert isinstance(resolver, client.HassAsyncDNSResolver)
+
+    # AsyncDualMDNSResolver passes nameservers to the underlying aiohttp Resolver
+    # We can check if the nameservers are correctly set in the resolver
+    # resolver._resolver is the aiodns.DNSResolver instance
+    assert "1.1.1.1" in resolver._resolver.nameservers
+    assert "1.0.0.1" in resolver._resolver.nameservers

--- a/tests/helpers/test_aiohttp_client_custom_dns.py
+++ b/tests/helpers/test_aiohttp_client_custom_dns.py
@@ -1,9 +1,15 @@
 """Test the aiohttp client helper with custom DNS."""
 
+from unittest.mock import patch
+
 import aiohttp
 import pytest
 
-from homeassistant.components.http import CONF_NAMESERVERS, DOMAIN as HTTP_DOMAIN
+from homeassistant.components.http import (
+    CONF_CARES_INIT_FLAGS,
+    CONF_NAMESERVERS,
+    DOMAIN as HTTP_DOMAIN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client as client
 from homeassistant.setup import async_setup_component
@@ -28,3 +34,22 @@ async def test_resolver_uses_configured_nameservers(hass: HomeAssistant) -> None
     # resolver._resolver is the aiodns.DNSResolver instance
     assert "1.1.1.1" in resolver._resolver.nameservers
     assert "1.0.0.1" in resolver._resolver.nameservers
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "disable_mock_zeroconf_resolver")
+async def test_resolver_uses_configured_cares_init_flags(hass: HomeAssistant) -> None:
+    """Test that the resolver uses the configured cares_init_flags."""
+    with patch(
+        "homeassistant.helpers.aiohttp_client.HassAsyncDNSResolver",
+        side_effect=client.HassAsyncDNSResolver,
+    ) as mock_resolver:
+        assert await async_setup_component(
+            hass,
+            HTTP_DOMAIN,
+            {HTTP_DOMAIN: {CONF_CARES_INIT_FLAGS: 0}},
+        )
+
+        client.async_get_clientsession(hass)
+
+    assert mock_resolver.called
+    assert mock_resolver.call_args.kwargs["flags"] == 0


### PR DESCRIPTION
## Proposed change
Allows users to override the default (system controlled) name servers with manually configured ones in yaml.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:  #145708
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
