### PR TITLE
Bump python-bsblan to version 4.2.0

### DIFF
--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==4.1.0"],
+  "requirements": ["python-bsblan==4.2.0"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2503,7 +2503,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==4.1.0
+python-bsblan==4.2.0
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2123,7 +2123,7 @@ python-MotionMount==2.3.0
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==4.1.0
+python-bsblan==4.2.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/bsblan/snapshots/test_diagnostics.ambr
+++ b/tests/components/bsblan/snapshots/test_diagnostics.ambr
@@ -11,6 +11,8 @@
       'dhw': dict({
         'dhw_actual_value_top_temperature': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW temperature actual value',
@@ -22,6 +24,8 @@
         }),
         'nominal_setpoint': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW nominal setpoint',
@@ -33,6 +37,8 @@
         }),
         'operating_mode': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'On',
           'error': 0,
           'name': 'DHW operating mode',
@@ -44,6 +50,8 @@
         }),
         'release': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Released',
           'error': 0,
           'name': 'DHW release programme',
@@ -55,6 +63,8 @@
         }),
         'state_dhw_pump': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Off',
           'error': 0,
           'name': 'State DHW circulation pump',
@@ -68,6 +78,8 @@
       'sensor': dict({
         'current_temperature': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'Room temp 1 actual value',
@@ -79,6 +91,8 @@
         }),
         'outside_temperature': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'Outside temp sensor local',
@@ -92,6 +106,8 @@
       'state': dict({
         'current_temperature': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'Room temp 1 actual value',
@@ -103,6 +119,8 @@
         }),
         'hvac_action': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Raumtemp’begrenzung',
           'error': 0,
           'name': 'Status heating circuit 1',
@@ -114,6 +132,8 @@
         }),
         'hvac_mode': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Komfort',
           'error': 0,
           'name': 'Operating mode',
@@ -126,6 +146,8 @@
         'hvac_mode_changeover': None,
         'room1_temp_setpoint_boost': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Boost',
           'error': 0,
           'name': 'Room 1 Temp Setpoint Boost',
@@ -137,6 +159,8 @@
         }),
         'room1_thermostat_mode': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Kein Bedarf',
           'error': 0,
           'name': 'Raumthermostat 1',
@@ -148,6 +172,8 @@
         }),
         'target_temperature': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'Room temperature Comfort setpoint',
@@ -162,6 +188,8 @@
     'info': dict({
       'controller_family': dict({
         'data_type': 0,
+        'data_type_family': '',
+        'data_type_name': '',
         'desc': '',
         'error': 0,
         'name': 'Device family',
@@ -173,6 +201,8 @@
       }),
       'controller_variant': dict({
         'data_type': 0,
+        'data_type_family': '',
+        'data_type_name': '',
         'desc': '',
         'error': 0,
         'name': 'Device variant',
@@ -184,6 +214,8 @@
       }),
       'device_identification': dict({
         'data_type': 7,
+        'data_type_family': '',
+        'data_type_name': '',
         'desc': '',
         'error': 0,
         'name': 'Gerte-Identifikation',
@@ -198,6 +230,8 @@
       'dhw_config': dict({
         'dhw_charging_priority': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'High',
           'error': 0,
           'name': 'DHW charging priority',
@@ -210,6 +244,8 @@
         'dhw_circulation_pump_cycling': None,
         'dhw_circulation_pump_release': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Released',
           'error': 0,
           'name': 'DHW circulation pump release',
@@ -221,6 +257,8 @@
         }),
         'dhw_circulation_setpoint': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW circulation pump setpoint',
@@ -232,6 +270,8 @@
         }),
         'eco_mode_selection': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Comfort',
           'error': 0,
           'name': 'DHW eco mode selection',
@@ -245,6 +285,8 @@
         'legionella_circulation_temp_diff': None,
         'legionella_function': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Off',
           'error': 0,
           'name': 'Legionella function fixed weekday',
@@ -261,6 +303,8 @@
         'legionella_function_time': None,
         'nominal_setpoint_max': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW nominal setpoint maximum',
@@ -272,6 +316,8 @@
         }),
         'operating_mode_changeover': dict({
           'data_type': 1,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': 'Manual',
           'error': 0,
           'name': 'DHW operating mode changeover',
@@ -283,6 +329,8 @@
         }),
         'reduced_setpoint': dict({
           'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW reduced setpoint',
@@ -296,6 +344,8 @@
       'dhw_schedule': dict({
         'dhw_time_program_friday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Friday',
@@ -307,6 +357,8 @@
         }),
         'dhw_time_program_monday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Monday',
@@ -318,6 +370,8 @@
         }),
         'dhw_time_program_saturday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Saturday',
@@ -329,6 +383,8 @@
         }),
         'dhw_time_program_standard_values': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program standard values',
@@ -340,6 +396,8 @@
         }),
         'dhw_time_program_sunday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Sunday',
@@ -351,6 +409,8 @@
         }),
         'dhw_time_program_thursday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Thursday',
@@ -362,6 +422,8 @@
         }),
         'dhw_time_program_tuesday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Tuesday',
@@ -373,6 +435,8 @@
         }),
         'dhw_time_program_wednesday': dict({
           'data_type': 7,
+          'data_type_family': '',
+          'data_type_name': '',
           'desc': '',
           'error': 0,
           'name': 'DHW time program Wednesday',
@@ -387,6 +451,8 @@
     'static': dict({
       'max_temp': dict({
         'data_type': 0,
+        'data_type_family': '',
+        'data_type_name': '',
         'desc': '',
         'error': 0,
         'name': 'Summer/winter changeover temp heat circuit 1',
@@ -398,6 +464,8 @@
       }),
       'min_temp': dict({
         'data_type': 0,
+        'data_type_family': '',
+        'data_type_name': '',
         'desc': '',
         'error': 0,
         'name': 'Room temp frost protection setpoint',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request updates the `python-bsblan` dependency from version 4.1.0 to 4.2.0 across the Home Assistant BSBLan integration. This ensures the integration uses the latest features and fixes from the upstream library.

https://github.com/liudger/python-bsblan/releases/tag/v4.2.0

Dependency updates:

* Updated the `python-bsblan` requirement to version 4.2.0 in the BSBLan integration manifest (`homeassistant/components/bsblan/manifest.json`).
* Updated the `python-bsblan` version to 4.2.0 in both `requirements_all.txt` and `requirements_test_all.txt` to ensure consistency for production and testing environments. [[1]](diffhunk://#diff-ae66cd41e5a8644fe0cdd7b9a2f0fee97b5deabe5f3793da15b73fa6353d2128L2506-R2506) [[2]](diffhunk://#diff-f946654c97927cbf41d54a07e10b9f92e95e9a43c0a7e2455d30acc696f08019L2126-R2126)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
