### PR TITLE
Add light support for HmIP-MP3P (Combination Signalling Device)

### DIFF
--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -11,10 +11,14 @@ from homematicip.base.enums import (
     OpticalSignalBehaviour,
     RGBColorState,
 )
-from homematicip.base.functionalChannels import NotificationLightChannel
+from homematicip.base.functionalChannels import (
+    NotificationLightChannel,
+    NotificationMp3SoundChannel,
+)
 from homematicip.device import (
     BrandDimmer,
     BrandSwitchNotificationLight,
+    CombinationSignallingDevice,
     Device,
     Dimmer,
     DinRailDimmer3,
@@ -108,6 +112,8 @@ async def async_setup_entry(
                 entities.append(
                     HomematicipOpticalSignalLight(hap, device, ch.index, led_number)
                 )
+        elif isinstance(device, CombinationSignallingDevice):
+            entities.append(HomematicipCombinationSignallingLight(hap, device))
 
     async_add_entities(entities)
 
@@ -586,3 +592,70 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
             rgb=simple_rgb_color,
             dimLevel=0.0,
         )
+
+
+class HomematicipCombinationSignallingLight(HomematicipGenericEntity, LightEntity):
+    """Representation of the HomematicIP combination signalling device light (HmIP-MP3P)."""
+
+    _attr_color_mode = ColorMode.HS
+    _attr_supported_color_modes = {ColorMode.HS}
+
+    _color_switcher: dict[str, tuple[float, float]] = {
+        "WHITE": (0.0, 0.0),
+        "RED": (0.0, 100.0),
+        "YELLOW": (60.0, 100.0),
+        "GREEN": (120.0, 100.0),
+        "TURQUOISE": (180.0, 100.0),
+        "BLUE": (240.0, 100.0),
+        "PURPLE": (300.0, 100.0),
+    }
+
+    def __init__(
+        self, hap: HomematicipHAP, device: CombinationSignallingDevice
+    ) -> None:
+        """Initialize the combination signalling light entity."""
+        super().__init__(hap, device, channel=1, is_multi_channel=False)
+
+    @property
+    def _func_channel(self) -> NotificationMp3SoundChannel:
+        return self._device.functionalChannels[self._channel]
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        return self._func_channel.on
+
+    @property
+    def brightness(self) -> int:
+        """Return the brightness of this light between 0..255."""
+        return int((self._func_channel.dimLevel or 0.0) * 255)
+
+    @property
+    def hs_color(self) -> tuple[float, float]:
+        """Return the hue and saturation color value [float, float]."""
+        simple_rgb_color = self._func_channel.simpleRGBColorState
+        return self._color_switcher.get(simple_rgb_color, (0.0, 0.0))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        hs_color = kwargs.get(ATTR_HS_COLOR, self.hs_color)
+        simple_rgb_color = _convert_color(hs_color)
+
+        brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)
+
+        # Default to full brightness when no kwargs given
+        if not kwargs:
+            brightness = 255
+
+        # Minimum brightness is 10, otherwise the LED is disabled
+        brightness = max(10, brightness)
+        dim_level = brightness / 255.0
+
+        await self._func_channel.set_rgb_dim_level_async(
+            rgb_color_state=simple_rgb_color.name,
+            dim_level=dim_level,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._func_channel.turn_off_async()

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -601,13 +601,13 @@ class HomematicipCombinationSignallingLight(HomematicipGenericEntity, LightEntit
     _attr_supported_color_modes = {ColorMode.HS}
 
     _color_switcher: dict[str, tuple[float, float]] = {
-        "WHITE": (0.0, 0.0),
-        "RED": (0.0, 100.0),
-        "YELLOW": (60.0, 100.0),
-        "GREEN": (120.0, 100.0),
-        "TURQUOISE": (180.0, 100.0),
-        "BLUE": (240.0, 100.0),
-        "PURPLE": (300.0, 100.0),
+        RGBColorState.WHITE: (0.0, 0.0),
+        RGBColorState.RED: (0.0, 100.0),
+        RGBColorState.YELLOW: (60.0, 100.0),
+        RGBColorState.GREEN: (120.0, 100.0),
+        RGBColorState.TURQUOISE: (180.0, 100.0),
+        RGBColorState.BLUE: (240.0, 100.0),
+        RGBColorState.PURPLE: (300.0, 100.0),
     }
 
     def __init__(

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -22,7 +22,7 @@ async def test_hmip_load_all_supported_devices(
         test_devices=None, test_groups=None
     )
 
-    assert len(mock_hap.hmip_device_by_entity_id) == 350
+    assert len(mock_hap.hmip_device_by_entity_id) == 351
 
 
 async def test_hmip_remove_device(

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -907,6 +907,6 @@ async def test_hmip_combination_signalling_light(
     assert len(functional_channel.mock_calls) == service_call_counter + 2
 
     # Test state update when turned off
-    await async_manipulate_test_data(hass, hmip_device, "dimLevel", 0.0, channel=1)
+    await async_manipulate_test_data(hass, hmip_device, "on", False, channel=1)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_OFF

--- a/tests/components/homematicip_cloud/test_light.py
+++ b/tests/components/homematicip_cloud/test_light.py
@@ -854,3 +854,59 @@ async def test_hmip_wired_push_button_led_2(
     assert hmip_device.mock_calls[-1][0] == "set_optical_signal_async"
     assert hmip_device.mock_calls[-1][2]["channelIndex"] == 8
     assert len(hmip_device.mock_calls) == service_call_counter + 1
+
+
+async def test_hmip_combination_signalling_light(
+    hass: HomeAssistant, default_mock_hap_factory: HomeFactory
+) -> None:
+    """Test HomematicipCombinationSignallingLight (HmIP-MP3P)."""
+    entity_id = "light.kombisignalmelder"
+    entity_name = "Kombisignalmelder"
+    device_model = "HmIP-MP3P"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Kombisignalmelder"]
+    )
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+
+    # Fixture has dimLevel=0.5, simpleRGBColorState=RED, on=true
+    assert ha_state.state == STATE_ON
+    assert ha_state.attributes[ATTR_COLOR_MODE] == ColorMode.HS
+    assert ha_state.attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.HS]
+    assert ha_state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+    assert ha_state.attributes[ATTR_BRIGHTNESS] == 127  # 0.5 * 255
+    assert ha_state.attributes[ATTR_HS_COLOR] == (0.0, 100.0)  # RED
+
+    functional_channel = hmip_device.functionalChannels[1]
+    service_call_counter = len(functional_channel.mock_calls)
+
+    # Test turn_on with color and brightness
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity_id, ATTR_HS_COLOR: [240.0, 100.0], ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+    assert functional_channel.mock_calls[-1][0] == "set_rgb_dim_level_async"
+    assert functional_channel.mock_calls[-1][2] == {
+        "rgb_color_state": "BLUE",
+        "dim_level": 1.0,
+    }
+    assert len(functional_channel.mock_calls) == service_call_counter + 1
+
+    # Test turn_off
+    await hass.services.async_call(
+        "light",
+        "turn_off",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+    assert functional_channel.mock_calls[-1][0] == "turn_off_async"
+    assert len(functional_channel.mock_calls) == service_call_counter + 2
+
+    # Test state update when turned off
+    await async_manipulate_test_data(hass, hmip_device, "dimLevel", 0.0, channel=1)
+    ha_state = hass.states.get(entity_id)
+    assert ha_state.state == STATE_OFF


### PR DESCRIPTION
## Proposed change

Add light entity for HmIP-MP3P (Combination Signalling Device). Supports on/off, brightness, and color control with the device's 7-color palette (white, red, yellow, green, turquoise, blue, purple) mapped to HS color mode.

The device's color name is already fully represented by `hs_color`, so no extra state attributes are added.

Split from #161634 (siren), which is now a separate PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #161634
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr