### PR TITLE
Bump pyvlx to 0.2.29 

### DIFF
--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyvlx import Intensity, Light
+from pyvlx import Intensity, Light, OnOffLight
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -26,7 +26,7 @@ async def async_setup_entry(
     async_add_entities(
         VeluxLight(node, config_entry.entry_id)
         for node in pyvlx.nodes
-        if isinstance(node, Light)
+        if isinstance(node, (Light, OnOffLight))
     )
 
 
@@ -42,7 +42,7 @@ class VeluxLight(VeluxEntity, LightEntity):
     @property
     def brightness(self):
         """Return the current brightness."""
-        return int((100 - self.node.intensity.intensity_percent) * 255 / 100)
+        return int(self.node.intensity.intensity_percent * 255 / 100)
 
     @property
     def is_on(self):
@@ -53,7 +53,7 @@ class VeluxLight(VeluxEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
         if ATTR_BRIGHTNESS in kwargs:
-            intensity_percent = int(100 - kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+            intensity_percent = int(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
             await self.node.set_intensity(
                 Intensity(intensity_percent=intensity_percent),
                 wait_for_completion=True,

--- a/homeassistant/components/velux/manifest.json
+++ b/homeassistant/components/velux/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pyvlx"],
-  "requirements": ["pyvlx==0.2.28"]
+  "requirements": ["pyvlx==0.2.29"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2676,7 +2676,7 @@ pyvesync==3.4.1
 pyvizio==0.1.61
 
 # homeassistant.components.velux
-pyvlx==0.2.28
+pyvlx==0.2.29
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2254,7 +2254,7 @@ pyvesync==3.4.1
 pyvizio==0.1.61
 
 # homeassistant.components.velux
-pyvlx==0.2.28
+pyvlx==0.2.29
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5

--- a/tests/components/velux/snapshots/test_light.ambr
+++ b/tests/components/velux/snapshots/test_light.ambr
@@ -1,0 +1,119 @@
+# serializer version: 1
+# name: test_light_setup[mock_light][light.test_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.test_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'velux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '0815',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_setup[mock_light][light.test_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Test Light',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.test_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_light_setup[mock_onoff_light][light.test_on_off_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.test_on_off_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'velux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '0816',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light_setup[mock_onoff_light][light.test_on_off_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Test On Off Light',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.test_on_off_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/velux/test_light.py
+++ b/tests/components/velux/test_light.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import update_callback_entity
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, SnapshotAssertion, snapshot_platform
 
 # Apply setup_integration fixture to all tests in this module
 pytestmark = pytest.mark.usefixtures("setup_integration")
@@ -28,20 +28,33 @@ def platform() -> Platform:
     return Platform.LIGHT
 
 
+@pytest.mark.parametrize(
+    "mock_pyvlx", ["mock_light", "mock_onoff_light"], indirect=True
+)
 async def test_light_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the entity and validate registry metadata for light entities."""
+    await snapshot_platform(
+        hass,
+        entity_registry,
+        snapshot,
+        mock_config_entry.entry_id,
+    )
+
+
+async def test_light_device_association(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
     mock_light: AsyncMock,
 ) -> None:
-    """Test light entity setup and device association."""
+    """Test light device association."""
 
     test_entity_id = f"light.{mock_light.name.lower().replace(' ', '_')}"
-
-    # Check that the entity exists and its name matches the node name (the light is the main feature).
-    state = hass.states.get(test_entity_id)
-    assert state is not None
-    assert state.attributes.get("friendly_name") == mock_light.name
 
     # Get entity + device entry
     entity_entry = entity_registry.async_get(test_entity_id)
@@ -137,7 +150,7 @@ async def test_light_brightness_and_is_on(
     entity_id = f"light.{mock_light.name.lower().replace(' ', '_')}"
 
     # Set initial intensity values
-    mock_light.intensity.intensity_percent = 20  # 20% "intensity" -> 80% brightness
+    mock_light.intensity.intensity_percent = 20  # 20% "intensity" -> 20% brightness
     mock_light.intensity.off = False
     mock_light.intensity.known = True
 
@@ -146,8 +159,8 @@ async def test_light_brightness_and_is_on(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    # brightness = int((100 - 20) * 255 / 100) = int(204)
-    assert state.attributes.get("brightness") == 204
+    # brightness = int(20 * 255 / 100) = int(51)
+    assert state.attributes.get("brightness") == 51
     assert state.state == "on"
 
     # Mark as off
@@ -180,8 +193,8 @@ async def test_light_turn_on_with_brightness_uses_set_intensity(
     # Inspect the intensity argument (first positional)
     args, kwargs = mock_light.set_intensity.await_args
     intensity_obj = args[0]
-    # brightness 51 -> 20% normalized -> intensity_percent = 80
-    assert intensity_obj.intensity_percent == 80
+    # brightness 51 -> 20% normalized -> intensity_percent = 20
+    assert intensity_obj.intensity_percent == 20
     assert kwargs.get("wait_for_completion") is True
 
 

--- a/tests/components/velux/test_light.py
+++ b/tests/components/velux/test_light.py
@@ -174,7 +174,7 @@ async def test_light_brightness_and_is_on(
 async def test_light_turn_on_with_brightness_uses_set_intensity(
     hass: HomeAssistant, mock_light: AsyncMock
 ) -> None:
-    """Turning on with brightness calls set_intensity with inverted percent."""
+    """Turning on with brightness calls set_intensity with percent."""
 
     entity_id = f"light.{mock_light.name.lower().replace(' ', '_')}"
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps the velux integration library to 0.2.29.
Release notes: https://github.com/Julius2342/pyvlx/releases/tag/0.2.29
Full changes: https://github.com/Julius2342/pyvlx/compare/0.2.28...0.2.29

This version bump also includes a few necessary code changes because the library includes two incompatible changes:
* it introduces a separate class for lights (`OnOffLight`) that do not have brightness control (this used to be included in `Light`, so this will now allow to fix this bug (lights announcing brightness control even though they don't have it) in HA in a follow-up PR
* `Intensity` class for brightness control now works as expected (0% = off, 100% = full brightness) instead of inverted
 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
