### PR TITLE
Revert "Cleanup unnecessary brackets for except statements (q-z)"

### DIFF
--- a/homeassistant/components/qbittorrent/config_flow.py
+++ b/homeassistant/components/qbittorrent/config_flow.py
@@ -45,7 +45,7 @@ class QbittorrentConfigFlow(ConfigFlow, domain=DOMAIN):
                     user_input[CONF_PASSWORD],
                     user_input[CONF_VERIFY_SSL],
                 )
-            except LoginFailed, Forbidden403Error:
+            except (LoginFailed, Forbidden403Error):
                 errors = {"base": "invalid_auth"}
             except APIConnectionError:
                 errors = {"base": "cannot_connect"}

--- a/homeassistant/components/rachio/webhooks.py
+++ b/homeassistant/components/rachio/webhooks.py
@@ -98,7 +98,7 @@ def async_register_webhook(hass: HomeAssistant, entry: RachioConfigEntry) -> Non
                 data.get(KEY_EXTERNAL_ID, "").split(":")[1]
                 == person.rachio.webhook_auth
             )
-        except AssertionError, IndexError:
+        except (AssertionError, IndexError):
             return web.Response(status=web.HTTPForbidden.status_code)
 
         update_type = data[KEY_TYPE]

--- a/homeassistant/components/radarr/config_flow.py
+++ b/homeassistant/components/radarr/config_flow.py
@@ -59,7 +59,7 @@ class RadarrConfigFlow(ConfigFlow, domain=DOMAIN):
                     user_input[CONF_API_KEY] = result[1]
             except exceptions.ArrAuthenticationException:
                 errors = {"base": "invalid_auth"}
-            except ClientConnectorError, exceptions.ArrConnectionException:
+            except (ClientConnectorError, exceptions.ArrConnectionException):
                 errors = {"base": "cannot_connect"}
             except exceptions.ArrWrongAppException:
                 errors = {"base": "wrong_app"}

--- a/homeassistant/components/rainforest_eagle/data.py
+++ b/homeassistant/components/rainforest_eagle/data.py
@@ -44,7 +44,7 @@ async def async_get_type(hass, cloud_id, install_code, host):
             meters = await hub.get_device_list()
     except aioeagle.BadAuth as err:
         raise InvalidAuth from err
-    except KeyError, aiohttp.ClientError:
+    except (KeyError, aiohttp.ClientError):
         # This can happen if it's an eagle-100
         meters = None
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -653,7 +653,7 @@ def _add_columns(
             connection.execute(
                 text(f"ALTER TABLE {table_name} {', '.join(columns_def)}")
             )
-        except InternalError, OperationalError, ProgrammingError:
+        except (InternalError, OperationalError, ProgrammingError):
             # Some engines support adding all columns at once,
             # this error is when they don't
             _LOGGER.info("Unable to use quick column add. Adding 1 by 1")
@@ -716,7 +716,7 @@ def _modify_columns(
             connection.execute(
                 text(f"ALTER TABLE {table_name} {', '.join(columns_def)}")
             )
-        except InternalError, OperationalError:
+        except (InternalError, OperationalError):
             _LOGGER.info("Unable to use quick column modify. Modifying 1 by 1")
         else:
             return
@@ -726,7 +726,7 @@ def _modify_columns(
             try:
                 connection = session.connection()
                 connection.execute(text(f"ALTER TABLE {table_name} {column_def}"))
-            except InternalError, OperationalError:
+            except (InternalError, OperationalError):
                 _LOGGER.exception(
                     "Could not modify column %s in table %s", column_def, table_name
                 )
@@ -791,7 +791,7 @@ def _update_states_table_with_foreign_key_options(
                         add_constraint = AddConstraint(fkc)
                         fkc._create_rule = create_rule  # noqa: SLF001
                         connection.execute(add_constraint)
-            except InternalError, OperationalError:
+            except (InternalError, OperationalError):
                 _LOGGER.exception(
                     "Could not update foreign options in %s table", TABLE_STATES
                 )
@@ -827,7 +827,7 @@ def _drop_foreign_key_constraints(
             try:
                 connection = session.connection()
                 connection.execute(DropConstraint(drop))
-            except InternalError, OperationalError:
+            except (InternalError, OperationalError):
                 _LOGGER.exception(
                     "Could not drop foreign constraints in %s table on %s",
                     TABLE_STATES,
@@ -907,7 +907,7 @@ def _add_constraint(
         try:
             connection = session.connection()
             connection.execute(add_constraint)
-        except InternalError, OperationalError:
+        except (InternalError, OperationalError):
             _LOGGER.exception("Could not update foreign options in %s table", table)
             raise
 

--- a/homeassistant/components/rejseplanen/sensor.py
+++ b/homeassistant/components/rejseplanen/sensor.py
@@ -196,7 +196,7 @@ class PublicTransportData:
         except rjpl.rjplAPIError as error:
             _LOGGER.debug("API returned error: %s", error)
             return
-        except rjpl.rjplConnectionError, rjpl.rjplHTTPError:
+        except (rjpl.rjplConnectionError, rjpl.rjplHTTPError):
             _LOGGER.debug("Error occurred while connecting to the API")
             return
 

--- a/homeassistant/components/remote_rpi_gpio/__init__.py
+++ b/homeassistant/components/remote_rpi_gpio/__init__.py
@@ -21,7 +21,7 @@ def setup_output(address, port, invert_logic):
         return LED(
             port, active_high=not invert_logic, pin_factory=PiGPIOFactory(address)
         )
-    except ValueError, IndexError, KeyError:
+    except (ValueError, IndexError, KeyError):
         return None
 
 
@@ -40,7 +40,7 @@ def setup_input(address, port, pull_mode, bouncetime):
             bounce_time=bouncetime,
             pin_factory=PiGPIOFactory(address),
         )
-    except ValueError, IndexError, KeyError, OSError:
+    except (ValueError, IndexError, KeyError, OSError):
         return None
 
 

--- a/homeassistant/components/remote_rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/remote_rpi_gpio/binary_sensor.py
@@ -59,7 +59,7 @@ def setup_platform(
     for port_num, port_name in ports.items():
         try:
             remote_sensor = setup_input(address, port_num, pull_mode, bouncetime)
-        except ValueError, IndexError, KeyError, OSError:
+        except (ValueError, IndexError, KeyError, OSError):
             return
         new_sensor = RemoteRPiGPIOBinarySensor(port_name, remote_sensor, invert_logic)
         devices.append(new_sensor)

--- a/homeassistant/components/remote_rpi_gpio/switch.py
+++ b/homeassistant/components/remote_rpi_gpio/switch.py
@@ -47,7 +47,7 @@ def setup_platform(
     for port, name in ports.items():
         try:
             led = setup_output(address, port, invert_logic)
-        except ValueError, IndexError, KeyError, OSError:
+        except (ValueError, IndexError, KeyError, OSError):
             return
         new_switch = RemoteRPiGPIOSwitch(name, led)
         devices.append(new_switch)

--- a/homeassistant/components/renault/config_flow.py
+++ b/homeassistant/components/renault/config_flow.py
@@ -60,7 +60,7 @@ class RenaultFlowHandler(ConfigFlow, domain=DOMAIN):
                 login_success = await self.renault_hub.attempt_login(
                     user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
                 )
-            except aiohttp.ClientConnectionError, GigyaException:
+            except (aiohttp.ClientConnectionError, GigyaException):
                 errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/reolink/select.py
+++ b/homeassistant/components/reolink/select.py
@@ -479,7 +479,7 @@ class ReolinkSelectEntity(ReolinkChannelCoordinatorEntity, SelectEntity):
 
         try:
             option = self.entity_description.value(self._host.api, self._channel)
-        except ValueError, KeyError:
+        except (ValueError, KeyError):
             if self._log_error:
                 _LOGGER.exception("Reolink '%s' has an unknown value", self.name)
                 self._log_error = False

--- a/homeassistant/components/rest/switch.py
+++ b/homeassistant/components/rest/switch.py
@@ -115,7 +115,7 @@ async def async_setup_platform(
             _LOGGER.error("Got non-ok response from resource: %s", req.status_code)
         else:
             async_add_entities([switch])
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         _LOGGER.error(
             "Missing resource or schema in configuration. "
             "Add http:// or https:// to your URL"
@@ -172,7 +172,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
                 _LOGGER.error(
                     "Can't turn on %s. Is resource/endpoint offline?", self._resource
                 )
-        except TimeoutError, httpx.RequestError:
+        except (TimeoutError, httpx.RequestError):
             _LOGGER.error("Error while switching on %s", self._resource)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -187,7 +187,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
                 _LOGGER.error(
                     "Can't turn off %s. Is resource/endpoint offline?", self._resource
                 )
-        except TimeoutError, httpx.RequestError:
+        except (TimeoutError, httpx.RequestError):
             _LOGGER.error("Error while switching off %s", self._resource)
 
     async def set_device_state(self, body: Any) -> httpx.Response:
@@ -212,7 +212,7 @@ class RestSwitch(ManualTriggerEntity, SwitchEntity):
         req = None
         try:
             req = await self.get_response(self.hass)
-        except TimeoutError, httpx.TimeoutException:
+        except (TimeoutError, httpx.TimeoutException):
             _LOGGER.exception("Timed out while fetching data")
         except httpx.RequestError:
             _LOGGER.exception("Error while fetching data")

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -647,7 +647,7 @@ def _test_transport(host: str | None, port: int | None, device: str | None) -> b
 
     try:
         conn.connect()
-    except rfxtrxmod.RFXtrxTransportError, TimeoutError:
+    except (rfxtrxmod.RFXtrxTransportError, TimeoutError):
         return False
 
     return True

--- a/homeassistant/components/rmvtransport/sensor.py
+++ b/homeassistant/components/rmvtransport/sensor.py
@@ -246,7 +246,7 @@ class RMVDepartureData:
                 max_journeys=50,
             )
 
-        except RMVtransportApiConnectionError, RMVtransportDataError:
+        except (RMVtransportApiConnectionError, RMVtransportDataError):
             self.departures = []
             _LOGGER.warning("Could not retrieve data from rmv.de")
             return

--- a/homeassistant/components/rova/config_flow.py
+++ b/homeassistant/components/rova/config_flow.py
@@ -36,7 +36,7 @@ class RovaConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 if not await self.hass.async_add_executor_job(api.is_rova_area):
                     errors = {"base": "invalid_rova_area"}
-            except ConnectTimeout, HTTPError:
+            except (ConnectTimeout, HTTPError):
                 errors = {"base": "cannot_connect"}
 
             if not errors:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -287,7 +287,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
 
         try:
             return self._get_remote() is not None
-        except UnhandledResponse, AccessDenied:
+        except (UnhandledResponse, AccessDenied):
             # We got a response so it's working.
             return True
 
@@ -346,7 +346,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
                 self.auth_failed = True
                 self._notify_reauth_callback()
                 raise
-            except ConnectionClosed, OSError:
+            except (ConnectionClosed, OSError):
                 pass
         return self._remote
 
@@ -370,7 +370,7 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
                     if remote := self._get_remote():
                         remote.control(key)
                     break
-                except ConnectionClosed, BrokenPipeError:
+                except (ConnectionClosed, BrokenPipeError):
                     # BrokenPipe can occur when the commands is sent to fast
                     self._remote = None
         except (UnhandledResponse, AccessDenied) as err:

--- a/homeassistant/components/script/config.py
+++ b/homeassistant/components/script/config.py
@@ -280,7 +280,7 @@ async def _try_async_validate_config_item(
     """Validate config item."""
     try:
         return await _async_validate_config_item(hass, object_id, config, False, True)
-    except vol.Invalid, HomeAssistantError:
+    except (vol.Invalid, HomeAssistantError):
         return None
 
 

--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -54,7 +54,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SensiboConfigEntry) ->
 
         try:
             new_unique_id = await async_validate_api(hass, api_key)
-        except AuthenticationError, ConnectionError, NoDevicesError, NoUsernameError:
+        except (AuthenticationError, ConnectionError, NoDevicesError, NoUsernameError):
             return False
 
         LOGGER.debug("Migrate Sensibo config entry unique id to %s", new_unique_id)

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -228,7 +228,7 @@ def _entity_history_to_float_and_state(
                 float_state
             ):
                 append((float_state, state))
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             pass
     return float_states
 

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -292,7 +292,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
             # Ping to verify connection is still alive
             try:
                 await self._ble_rpc_device.update_status()
-            except DeviceConnectionError, RpcCallError:
+            except (DeviceConnectionError, RpcCallError):
                 # Connection dropped, need to reconnect
                 LOGGER.debug("BLE connection lost, reconnecting")
                 await self._async_disconnect_ble()
@@ -307,7 +307,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         try:
             await device.initialize()
-        except DeviceConnectionError, RpcCallError:
+        except (DeviceConnectionError, RpcCallError):
             await device.shutdown()
             raise
         self._ble_rpc_device = device
@@ -1203,14 +1203,14 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 info = await self._async_get_info(host, port)
-            except DeviceConnectionError, InvalidAuthError:
+            except (DeviceConnectionError, InvalidAuthError):
                 return self.async_abort(reason="reauth_unsuccessful")
 
             if get_device_entry_gen(reauth_entry) != 1:
                 user_input[CONF_USERNAME] = "admin"
             try:
                 await validate_input(self.hass, host, port, info, user_input)
-            except DeviceConnectionError, InvalidAuthError:
+            except (DeviceConnectionError, InvalidAuthError):
                 return self.async_abort(reason="reauth_unsuccessful")
             except MacAddressMismatchError:
                 return self.async_abort(reason="mac_address_mismatch")

--- a/homeassistant/components/shelly/repairs.py
+++ b/homeassistant/components/shelly/repairs.py
@@ -295,7 +295,7 @@ class FirmwareUpdateFlow(ShellyRpcRepairsFlow):
             return self.async_abort(reason="update_not_available")
         try:
             await self._device.trigger_ota_update()
-        except DeviceConnectionError, RpcCallError:
+        except (DeviceConnectionError, RpcCallError):
             return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(title="", data={})
@@ -318,7 +318,7 @@ class DisableOutboundWebSocketFlow(ShellyRpcRepairsFlow):
             )
             if result["restart_required"]:
                 await self._device.trigger_reboot()
-        except DeviceConnectionError, RpcCallError:
+        except (DeviceConnectionError, RpcCallError):
             return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(title="", data={})
@@ -354,7 +354,7 @@ class DisableOpenWiFiApFlow(RepairsFlow):
             result = await self._device.wifi_setconfig(ap_enable=False)
             if result.get("restart_required"):
                 await self._device.trigger_reboot()
-        except DeviceConnectionError, RpcCallError:
+        except (DeviceConnectionError, RpcCallError):
             return self.async_abort(reason="cannot_connect")
 
         return self.async_create_entry(title="", data={})

--- a/homeassistant/components/slide_local/config_flow.py
+++ b/homeassistant/components/slide_local/config_flow.py
@@ -63,9 +63,9 @@ class SlideConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             result = await slide.slide_info(user_input[CONF_HOST])
-        except ClientConnectionError, ClientTimeoutError:
+        except (ClientConnectionError, ClientTimeoutError):
             return {"base": "cannot_connect"}
-        except AuthenticationFailed, DigestAuthCalcError:
+        except (AuthenticationFailed, DigestAuthCalcError):
             return {"base": "invalid_auth"}
         except Exception:
             _LOGGER.exception("Exception occurred during connection test")
@@ -85,9 +85,9 @@ class SlideConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             result = await slide.slide_info(user_input[CONF_HOST])
-        except ClientConnectionError, ClientTimeoutError:
+        except (ClientConnectionError, ClientTimeoutError):
             return {"base": "cannot_connect"}
-        except AuthenticationFailed, DigestAuthCalcError:
+        except (AuthenticationFailed, DigestAuthCalcError):
             return {"base": "invalid_auth"}
         except Exception:
             _LOGGER.exception("Exception occurred during connection test")

--- a/homeassistant/components/smartthings/application_credentials.py
+++ b/homeassistant/components/smartthings/application_credentials.py
@@ -50,7 +50,7 @@ class SmartThingsOAuth2Implementation(AuthImplementation):
         if resp.status >= 400:
             try:
                 error_response = await resp.json()
-            except ClientError, JSONDecodeError:
+            except (ClientError, JSONDecodeError):
                 error_response = {}
             error_code = error_response.get("error", "unknown")
             error_description = error_response.get("error_description", "unknown error")

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -170,7 +170,7 @@ class MailNotificationService(BaseNotificationService):
         server = None
         try:
             server = self.connect()
-        except socket.gaierror, ConnectionRefusedError:
+        except (socket.gaierror, ConnectionRefusedError):
             _LOGGER.exception(
                 (
                     "SMTP server not found or refused connection (%s:%s). Please check"

--- a/homeassistant/components/solaredge/config_flow.py
+++ b/homeassistant/components/solaredge/config_flow.py
@@ -61,7 +61,7 @@ class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
             if response["details"]["status"].lower() != "active":
                 self._errors[CONF_SITE_ID] = "site_not_active"
                 return False
-        except TimeoutError, ClientError, socket.gaierror:
+        except (TimeoutError, ClientError, socket.gaierror):
             self._errors[CONF_SITE_ID] = "cannot_connect"
             return False
         except KeyError:
@@ -87,7 +87,7 @@ class SolarEdgeConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 self._errors["base"] = "cannot_connect"
             return False
-        except TimeoutError, ClientError:
+        except (TimeoutError, ClientError):
             self._errors["base"] = "cannot_connect"
             return False
         return True

--- a/homeassistant/components/solaredge_local/sensor.py
+++ b/homeassistant/components/solaredge_local/sensor.py
@@ -223,7 +223,7 @@ def setup_platform(
     except AttributeError:
         _LOGGER.error("Missing details data in solaredge status")
         return
-    except ConnectTimeout, HTTPError:
+    except (ConnectTimeout, HTTPError):
         _LOGGER.error("Could not retrieve details from SolarEdge API")
         return
 

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -54,7 +54,7 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             serial_number = await validate_api(user_input)
-        except ConnectionError, DiscoveryError:
+        except (ConnectionError, DiscoveryError):
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -291,7 +291,7 @@ class SonosSpeaker:
         else:
             try:
                 value = int(state)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 _LOGGER.error(
                     "Invalid value for %s %s",
                     speaker_attribute,

--- a/homeassistant/components/spotify/browse_media.py
+++ b/homeassistant/components/spotify/browse_media.py
@@ -427,7 +427,7 @@ async def build_item_response(  # noqa: C901
             browse_media.children.append(
                 item_payload(item, can_play_artist=can_play_artist)
             )
-        except MissingMediaInformation, UnknownMediaType:
+        except (MissingMediaInformation, UnknownMediaType):
             continue
 
     return browse_media

--- a/homeassistant/components/sql/config_flow.py
+++ b/homeassistant/components/sql/config_flow.py
@@ -227,11 +227,11 @@ class SQLConfigFlow(ConfigFlow, domain=DOMAIN):
             except NoSuchColumnError:
                 errors["column"] = "column_invalid"
                 description_placeholders = {"column": column}
-            except MultipleResultsFound, MultipleQueryError:
+            except (MultipleResultsFound, MultipleQueryError):
                 errors["query"] = "multiple_queries"
             except SQLAlchemyError:
                 errors["db_url"] = "db_url_invalid"
-            except NotSelectQueryError, UnknownQueryTypeError:
+            except (NotSelectQueryError, UnknownQueryTypeError):
                 errors["query"] = "query_no_read_only"
             except (TemplateError, EmptyQueryError, InvalidSqlQuery) as err:
                 _LOGGER.debug("Invalid query: %s", err)
@@ -285,11 +285,11 @@ class SQLOptionsFlowHandler(OptionsFlowWithReload):
             except NoSuchColumnError:
                 errors["column"] = "column_invalid"
                 description_placeholders = {"column": column}
-            except MultipleResultsFound, MultipleQueryError:
+            except (MultipleResultsFound, MultipleQueryError):
                 errors["query"] = "multiple_queries"
             except SQLAlchemyError:
                 errors["db_url"] = "db_url_invalid"
-            except NotSelectQueryError, UnknownQueryTypeError:
+            except (NotSelectQueryError, UnknownQueryTypeError):
                 errors["query"] = "query_no_read_only"
             except (TemplateError, EmptyQueryError, InvalidSqlQuery) as err:
                 _LOGGER.debug("Invalid query: %s", err)

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -573,7 +573,7 @@ def stream_worker(
     keyframe_converter.create_codec_context(codec_context=video_stream.codec_context)
     try:
         audio_stream = container.streams.audio[0]
-    except KeyError, IndexError:
+    except (KeyError, IndexError):
         audio_stream = None
     if audio_stream and audio_stream.name not in AUDIO_CODECS:
         audio_stream = None

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -104,7 +104,7 @@ class Pet(SurePetcareBinarySensor):
         state = surepy_entity.location
         try:
             self._attr_is_on = bool(Location(state.where) == Location.INSIDE)
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             self._attr_is_on = False
         if state:
             self._attr_extra_state_attributes = {

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -72,7 +72,7 @@ class SureBattery(SurePetcareEntity, SensorEntity):
             self._attr_native_value = min(
                 int(voltage_diff / SURE_BATT_VOLTAGE_DIFF * 100), 100
             )
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             self._attr_native_value = None
 
         if state:

--- a/homeassistant/components/tedee/config_flow.py
+++ b/homeassistant/components/tedee/config_flow.py
@@ -53,7 +53,7 @@ class TedeeConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             try:
                 local_bridge = await tedee_client.get_local_bridge()
-            except TedeeAuthException, TedeeLocalAuthException:
+            except (TedeeAuthException, TedeeLocalAuthException):
                 errors[CONF_LOCAL_ACCESS_TOKEN] = "invalid_api_key"
             except TedeeClientException:
                 errors[CONF_HOST] = "invalid_host"

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -35,7 +35,7 @@ def error_callback(bot: Bot, error: Exception, update: object | None = None) -> 
     """Log the error."""
     try:
         raise error
-    except TimedOut, NetworkError, RetryAfter:
+    except (TimedOut, NetworkError, RetryAfter):
         # Long polling timeout or connection problem. Nothing serious.
         pass
     except TelegramError:

--- a/homeassistant/components/thermoworks_smoke/sensor.py
+++ b/homeassistant/components/thermoworks_smoke/sensor.py
@@ -164,5 +164,5 @@ class ThermoworksSmokeSensor(SensorEntity):
                     self._attr_native_unit_of_measurement
                 )
 
-        except RequestException, ValueError, KeyError:
+        except (RequestException, ValueError, KeyError):
             _LOGGER.warning("Could not update status for %s", self.name)

--- a/homeassistant/components/threshold/binary_sensor.py
+++ b/homeassistant/components/threshold/binary_sensor.py
@@ -221,7 +221,7 @@ class ThresholdSensor(BinarySensorEntity):
                     if new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]
                     else float(new_state.state)
                 )
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 self.sensor_value = None
                 _LOGGER.warning("State is not numerical")
 

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -803,7 +803,7 @@ class TibberSensorElPrice(TibberSensor):
         _LOGGER.debug("Fetching data")
         try:
             await self._tibber_home.update_info_and_price_info()
-        except TimeoutError, aiohttp.ClientError:
+        except (TimeoutError, aiohttp.ClientError):
             return
         data = self._tibber_home.info["viewer"]["home"]
         self._attr_extra_state_attributes["app_nickname"] = data["appNickname"]

--- a/homeassistant/components/tilt_pi/config_flow.py
+++ b/homeassistant/components/tilt_pi/config_flow.py
@@ -26,7 +26,7 @@ class TiltPiConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         try:
             await client.get_hydrometers()
-        except TiltPiError, TimeoutError, aiohttp.ClientError:
+        except (TiltPiError, TimeoutError, aiohttp.ClientError):
             return "cannot_connect"
         return None
 

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -145,7 +145,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bo
     if conn_params_dict := entry.data.get(CONF_CONNECTION_PARAMETERS):
         try:
             conn_params = Device.ConnectionParameters.from_dict(conn_params_dict)
-        except KasaException, TypeError, ValueError, LookupError:
+        except (KasaException, TypeError, ValueError, LookupError):
             _LOGGER.warning(
                 "Invalid connection parameters dict for %s: %s", host, conn_params_dict
             )

--- a/homeassistant/components/transmission/config_flow.py
+++ b/homeassistant/components/transmission/config_flow.py
@@ -81,7 +81,7 @@ class TransmissionFlowHandler(ConfigFlow, domain=DOMAIN):
             except AuthenticationError:
                 errors[CONF_USERNAME] = "invalid_auth"
                 errors[CONF_PASSWORD] = "invalid_auth"
-            except CannotConnect, UnknownError:
+            except (CannotConnect, UnknownError):
                 errors["base"] = "cannot_connect"
 
             if not errors:
@@ -115,7 +115,7 @@ class TransmissionFlowHandler(ConfigFlow, domain=DOMAIN):
 
             except AuthenticationError:
                 errors[CONF_PASSWORD] = "invalid_auth"
-            except CannotConnect, UnknownError:
+            except (CannotConnect, UnknownError):
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_update_reload_and_abort(reauth_entry, data=user_input)

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -418,7 +418,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     try:
         await tts.async_init_cache()
-    except HomeAssistantError, KeyError:
+    except (HomeAssistantError, KeyError):
         _LOGGER.exception("Error on cache init")
         return False
 

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -43,7 +43,7 @@ class TwinklyConfigFlow(ConfigFlow, domain=DOMAIN):
                 device_info = await Twinkly(
                     host, async_get_clientsession(self.hass)
                 ).get_details()
-            except TimeoutError, ClientError:
+            except (TimeoutError, ClientError):
                 errors[CONF_HOST] = "cannot_connect"
             else:
                 await self.async_set_unique_id(

--- a/homeassistant/components/unifi/hub/websocket.py
+++ b/homeassistant/components/unifi/hub/websocket.py
@@ -78,7 +78,7 @@ class UnifiWebsocket:
             """Start websocket."""
             try:
                 await self.api.start_websocket()
-            except aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError:
+            except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError):
                 LOGGER.error("Websocket setup failed")
             except aiounifi.WebsocketError:
                 LOGGER.error("Websocket disconnected")

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -339,7 +339,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         """Volume level of entity specified in attributes or active child."""
         try:
             return float(self._override_or_child_attr(ATTR_MEDIA_VOLUME_LEVEL))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             return None
 
     @property

--- a/homeassistant/components/upcloud/entity.py
+++ b/homeassistant/components/upcloud/entity.py
@@ -52,7 +52,7 @@ class UpCloudServerEntity(CoordinatorEntity[UpCloudDataUpdateCoordinator]):
         """Return the name of the component."""
         try:
             return DEFAULT_COMPONENT_NAME.format(self._server.title)
-        except AttributeError, KeyError, TypeError:
+        except (AttributeError, KeyError, TypeError):
             return DEFAULT_COMPONENT_NAME.format(self.uuid)
 
     @property

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -64,7 +64,7 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self.hass.async_add_executor_job(login, self.hass, user_input)
-            except PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError:
+            except (PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError):
                 errors["base"] = "invalid_auth"
             else:
                 return self.async_create_entry(title=VICARE_NAME, data=user_input)
@@ -99,7 +99,7 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 await self.hass.async_add_executor_job(login, self.hass, data)
-            except PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError:
+            except (PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError):
                 errors["base"] = "invalid_auth"
             else:
                 return self.async_update_reload_and_abort(reauth_entry, data=data)

--- a/homeassistant/components/voicerss/tts.py
+++ b/homeassistant/components/voicerss/tts.py
@@ -220,7 +220,7 @@ class VoiceRSSProvider(Provider):
                     _LOGGER.error("Error receive %s from VoiceRSS", str(data, "utf-8"))
                     return (None, None)
 
-        except TimeoutError, aiohttp.ClientError:
+        except (TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Timeout for VoiceRSS API")
             return (None, None)
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -577,7 +577,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_TEMPERATURE] = round_temperature(
                     value_temp, precision
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_TEMPERATURE] = temperature
 
         if (apparent_temperature := self.native_apparent_temperature) is not None:
@@ -591,7 +591,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_APPARENT_TEMPERATURE] = round_temperature(
                     value_apparent_temp, precision
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_APPARENT_TEMPERATURE] = apparent_temperature
 
         if (dew_point := self.native_dew_point) is not None:
@@ -605,7 +605,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_DEW_POINT] = round_temperature(
                     value_dew_point, precision
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_DEW_POINT] = dew_point
 
         data[ATTR_WEATHER_TEMPERATURE_UNIT] = self._temperature_unit
@@ -631,7 +631,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                     pressure_f, from_unit, to_unit
                 )
                 data[ATTR_WEATHER_PRESSURE] = round(value_pressure, ROUNDING_PRECISION)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_PRESSURE] = pressure
 
         data[ATTR_WEATHER_PRESSURE_UNIT] = self._pressure_unit
@@ -650,7 +650,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_WIND_GUST_SPEED] = round(
                     value_wind_gust_speed, ROUNDING_PRECISION
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_WIND_GUST_SPEED] = wind_gust_speed
 
         if (wind_speed := self.native_wind_speed) is not None:
@@ -664,7 +664,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_WIND_SPEED] = round(
                     value_wind_speed, ROUNDING_PRECISION
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_WIND_SPEED] = wind_speed
 
         data[ATTR_WEATHER_WIND_SPEED_UNIT] = self._wind_speed_unit
@@ -680,7 +680,7 @@ class WeatherEntity(Entity, PostInit, cached_properties=CACHED_PROPERTIES_WITH_A
                 data[ATTR_WEATHER_VISIBILITY] = round(
                     value_visibility, ROUNDING_PRECISION
                 )
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 data[ATTR_WEATHER_VISIBILITY] = visibility
 
         data[ATTR_WEATHER_VISIBILITY_UNIT] = self._visibility_unit

--- a/homeassistant/components/weatherflow/config_flow.py
+++ b/homeassistant/components/weatherflow/config_flow.py
@@ -63,7 +63,7 @@ class WeatherFlowConfigFlow(ConfigFlow, domain=DOMAIN):
             found = await _async_can_discover_devices()
         except AddressInUseError:
             errors["base"] = ERROR_MSG_ADDRESS_IN_USE
-        except ListenerError, EndpointError, CancelledError:
+        except (ListenerError, EndpointError, CancelledError):
             errors["base"] = ERROR_MSG_CANNOT_CONNECT
 
         if not found and not errors:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -370,7 +370,7 @@ def handle_get_states(
 
     try:
         serialized_states = [state.as_dict_json for state in states]
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         pass
     else:
         _send_handle_get_states_response(connection, msg["id"], serialized_states)
@@ -381,7 +381,7 @@ def handle_get_states(
     for state in states:
         try:
             serialized_states.append(state.as_dict_json)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             connection.logger.error(
                 "Unable to serialize to JSON. Bad data found at %s",
                 format_unserializable_data(
@@ -478,7 +478,7 @@ def handle_subscribe_entities(
         else:
             # Fast path when not filtering
             serialized_states = [state.as_compressed_state_json for state in states]
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         pass
     else:
         _send_handle_entities_init_response(
@@ -494,7 +494,7 @@ def handle_subscribe_entities(
             continue
         try:
             serialized_states.append(state.as_compressed_state_json)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             connection.logger.error(
                 "Unable to serialize to JSON. Bad data found at %s",
                 format_unserializable_data(

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -255,7 +255,7 @@ def _message_to_json_bytes_or_none(message: dict[str, Any]) -> bytes | None:
     """Serialize a websocket message to json or return None."""
     try:
         return json_bytes(message)
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         _LOGGER.error(
             "Unable to serialize to JSON. Bad data found at %s",
             format_unserializable_data(

--- a/homeassistant/components/whirlpool/config_flow.py
+++ b/homeassistant/components/whirlpool/config_flow.py
@@ -57,7 +57,7 @@ async def authenticate(
         await auth.do_auth()
     except WhirlpoolAccountLocked:
         return "account_locked"
-    except TimeoutError, ClientError:
+    except (TimeoutError, ClientError):
         return "cannot_connect"
     except Exception:
         _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/worxlandroid/sensor.py
+++ b/homeassistant/components/worxlandroid/sensor.py
@@ -101,7 +101,7 @@ class WorxLandroidSensor(SensorEntity):
             async with asyncio.timeout(self.timeout):
                 auth = aiohttp.helpers.BasicAuth("admin", self.pin)
                 mower_response = await session.get(self.url, auth=auth)
-        except TimeoutError, aiohttp.ClientError:
+        except (TimeoutError, aiohttp.ClientError):
             if self.allow_unreachable is False:
                 _LOGGER.error("Error connecting to mower at %s", self.url)
 

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -126,7 +126,7 @@ async def load_wyoming_info(
 
                 if wyoming_info is not None:
                     break  # for
-        except TimeoutError, OSError, WyomingError:
+        except (TimeoutError, OSError, WyomingError):
             # Sleep and try again
             await asyncio.sleep(retry_wait)
 

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -126,7 +126,7 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                         text = transcript.text
                         break
 
-        except OSError, WyomingError:
+        except (OSError, WyomingError):
             _LOGGER.exception("Error processing audio stream")
             return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
 

--- a/homeassistant/components/wyoming/tts.py
+++ b/homeassistant/components/wyoming/tts.py
@@ -133,7 +133,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
 
                     data = wav_io.getvalue()
 
-        except OSError, WyomingError:
+        except (OSError, WyomingError):
             return (None, None)
 
         return ("wav", data)
@@ -195,7 +195,7 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
 
             # End stream
             await client.write_event(SynthesizeStop().event())
-        except OSError, WyomingError:
+        except (OSError, WyomingError):
             # Disconnected
             _LOGGER.warning("Unexpected disconnection from TTS client")
 
@@ -229,6 +229,6 @@ class WyomingTtsProvider(tts.TextToSpeechEntity):
                 elif SynthesizeStopped.is_type(event.type):
                     # All TTS audio has been received
                     break
-        except OSError, WyomingError:
+        except (OSError, WyomingError):
             # Disconnected
             _LOGGER.warning("Unexpected disconnection from TTS client")

--- a/homeassistant/components/wyoming/wake_word.py
+++ b/homeassistant/components/wyoming/wake_word.py
@@ -190,7 +190,7 @@ class WyomingWakeWordProvider(wake_word.WakeWordDetectionEntity):
                     for task in pending:
                         task.cancel()
 
-        except OSError, WyomingError:
+        except (OSError, WyomingError):
             _LOGGER.exception("Error processing audio stream")
 
         return None

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -212,7 +212,7 @@ class XboxSource(MediaSource):
                         to_https(images[int(identifier.media_id)].url),
                         MIME_TYPE_MAP[ATTR_SCREENSHOTS],
                     )
-                except ValueError, IndexError:
+                except (ValueError, IndexError):
                     pass
 
         raise Unresolvable(

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -54,7 +54,7 @@ async def async_validate_lock_or_error(
         return {CONF_SLOT: "invalid_key_index"}
     try:
         await PushLock(local_name, device.address, device, key, slot).validate()
-    except DisconnectedError, AuthError, ValueError:
+    except (DisconnectedError, AuthError, ValueError):
         return {CONF_KEY: "invalid_auth"}
     except BleakError:
         return {"base": "cannot_connect"}

--- a/homeassistant/components/yamaha_musiccast/config_flow.py
+++ b/homeassistant/components/yamaha_musiccast/config_flow.py
@@ -52,7 +52,7 @@ class MusicCastFlowHandler(ConfigFlow, domain=DOMAIN):
             info = await MusicCastDevice.get_device_info(
                 host, async_create_clientsession(self.hass, cookie_jar=DummyCookieJar())
             )
-        except MusicCastConnectionException, ClientConnectorError:
+        except (MusicCastConnectionException, ClientConnectorError):
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/yandextts/tts.py
+++ b/homeassistant/components/yandextts/tts.py
@@ -150,7 +150,7 @@ class YandexSpeechKitProvider(Provider):
                     return (None, None)
                 data = await request.read()
 
-        except TimeoutError, aiohttp.ClientError:
+        except (TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Timeout for yandex speech kit API")
             return (None, None)
 

--- a/homeassistant/components/youless/config_flow.py
+++ b/homeassistant/components/youless/config_flow.py
@@ -33,7 +33,7 @@ class YoulessConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 api = YoulessAPI(user_input[CONF_HOST])
                 await self.hass.async_add_executor_job(api.initialize)
-            except HTTPError, URLError:
+            except (HTTPError, URLError):
                 _LOGGER.exception("Cannot connect to host")
                 errors["base"] = "cannot_connect"
             else:

--- a/homeassistant/components/zabbix/__init__.py
+++ b/homeassistant/components/zabbix/__init__.py
@@ -164,7 +164,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
             attribute_id = f"{entity_id}/{key}"
             try:
                 float_value = float(value)
-            except ValueError, TypeError:
+            except (ValueError, TypeError):
                 float_value = None
             if float_value is None or not math.isfinite(float_value):
                 # Don't store string attributes for now

--- a/homeassistant/components/zamg/weather.py
+++ b/homeassistant/components/zamg/weather.py
@@ -68,7 +68,7 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
                 value := self.coordinator.data[self.station_id]["TL"]["data"]
             ) is not None:
                 return float(value)
-        except KeyError, ValueError, TypeError:
+        except (KeyError, ValueError, TypeError):
             return None
         return None
 
@@ -77,7 +77,7 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
         """Return the pressure."""
         try:
             return float(self.coordinator.data[self.station_id]["P"]["data"])
-        except KeyError, ValueError, TypeError:
+        except (KeyError, ValueError, TypeError):
             return None
 
     @property
@@ -85,7 +85,7 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
         """Return the humidity."""
         try:
             return float(self.coordinator.data[self.station_id]["RFAM"]["data"])
-        except KeyError, ValueError, TypeError:
+        except (KeyError, ValueError, TypeError):
             return None
 
     @property
@@ -100,7 +100,7 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
                 value := self.coordinator.data[self.station_id]["FFX"]["data"]
             ) is not None:
                 return float(value)
-        except KeyError, ValueError, TypeError:
+        except (KeyError, ValueError, TypeError):
             return None
         return None
 
@@ -116,6 +116,6 @@ class ZamgWeather(CoordinatorEntity, WeatherEntity):
                 value := self.coordinator.data[self.station_id]["DDX"]["data"]
             ) is not None:
                 return float(value)
-        except KeyError, ValueError, TypeError:
+        except (KeyError, ValueError, TypeError):
             return None
         return None

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -161,7 +161,7 @@ async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice]:
 
         try:
             addon_info = await multipan_manager.async_get_addon_info()
-        except AddonError, KeyError:
+        except (AddonError, KeyError):
             addon_info = None
 
         if addon_info is not None and addon_info.state != AddonState.NOT_INSTALLED:

--- a/homeassistant/components/zha/device_action.py
+++ b/homeassistant/components/zha/device_action.py
@@ -150,7 +150,7 @@ async def async_get_actions(
     """List device actions."""
     try:
         zha_device = async_get_zha_device_proxy(hass, device_id).device
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         return []
     cluster_handlers = [
         ch.name
@@ -187,7 +187,7 @@ async def _execute_service_based_action(
     service_name = SERVICE_NAMES[action_type]
     try:
         zha_device = async_get_zha_device_proxy(hass, config[CONF_DEVICE_ID]).device
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         return
 
     service_data = {ATTR_IEEE: str(zha_device.ieee)}
@@ -207,7 +207,7 @@ async def _execute_cluster_handler_command_based_action(
     cluster_handler_name = CLUSTER_HANDLER_MAPPINGS[action_type]
     try:
         zha_device = async_get_zha_device_proxy(hass, config[CONF_DEVICE_ID]).device
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         return
 
     action_cluster_handler = None

--- a/homeassistant/components/zha/logbook.py
+++ b/homeassistant/components/zha/logbook.py
@@ -44,7 +44,7 @@ def async_describe_events(
             zha_device = async_get_zha_device_proxy(
                 hass, event.data[ATTR_DEVICE_ID]
             ).device
-        except KeyError, AttributeError:
+        except (KeyError, AttributeError):
             pass
 
         if (

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -232,7 +232,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
         """Optionally return the temperature value of a setpoint."""
         try:
             temp = self._setpoint_value_or_raise(setpoint_type)
-        except IndexError, ValueError:
+        except (IndexError, ValueError):
             return None
         return get_value_of_zwave_value(temp)
 
@@ -425,7 +425,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 min_temp = temp.metadata.min
                 base_unit = self.temperature_unit
         # In case of any error, we fallback to the default
-        except IndexError, ValueError, TypeError:
+        except (IndexError, ValueError, TypeError):
             pass
 
         return TemperatureConverter.convert(min_temp, base_unit, self.temperature_unit)
@@ -441,7 +441,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 max_temp = temp.metadata.max
                 base_unit = self.temperature_unit
         # In case of any error, we fallback to the default
-        except IndexError, ValueError, TypeError:
+        except (IndexError, ValueError, TypeError):
             pass
 
         return TemperatureConverter.convert(max_temp, base_unit, self.temperature_unit)

--- a/homeassistant/components/zwave_js/repairs.py
+++ b/homeassistant/components/zwave_js/repairs.py
@@ -66,12 +66,12 @@ class MigrateUniqueIDFlow(RepairsFlow):
 
         try:
             new_unique_id_hex = format_home_id_for_display(int(data["new_unique_id"]))
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             new_unique_id_hex = data["new_unique_id"]
 
         try:
             old_unique_id_hex = format_home_id_for_display(int(data["old_unique_id"]))
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             old_unique_id_hex = data["old_unique_id"]
 
         self.description_placeholders: dict[str, str] = {


### PR DESCRIPTION
## Summary

Reverts #162408.

PR #162408 removed parentheses from `except` clauses catching **multiple** exception types across 71 files. However, in Python 3 this syntax is invalid:

```python
# SyntaxError in Python 3
except KeyError, AttributeError:

# Correct
except (KeyError, AttributeError):
```

In Python 2, `except A, B:` meant `except A as B:` (binding the exception to variable `B`). Python 3 removed this syntax entirely and requires parentheses for multiple exception types.

This causes affected integrations to fail to load with:

```
SyntaxError: multiple exception types must be parenthesized
```

All 110+ changes across 71 files in the original PR are affected, since every change involved a multi-exception `except` clause.

## Test plan

- [x] Verified ZHA integration loads and completes config flow after the fix (Docker HA 2026.2.1)
- [x] Confirmed `python3 -c "compile(...)"` passes for all affected files