### PR TITLE
Use suggested_display_precision for HmIP absolute humidity sensor

### DIFF
--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -622,6 +622,7 @@ class HomematicipAbsoluteHumiditySensor(HomematicipGenericEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.ABSOLUTE_HUMIDITY
     _attr_native_unit_of_measurement = CONCENTRATION_GRAMS_PER_CUBIC_METER
+    _attr_suggested_display_precision = 1
     _attr_suggested_unit_of_measurement = CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -636,7 +637,7 @@ class HomematicipAbsoluteHumiditySensor(HomematicipGenericEntity, SensorEntity):
         if value is None or value == "":
             return None
 
-        return round(value, 3)
+        return value
 
 
 class HomematicipIlluminanceSensor(HomematicipGenericEntity, SensorEntity):

--- a/tests/components/homematicip_cloud/test_sensor.py
+++ b/tests/components/homematicip_cloud/test_sensor.py
@@ -778,7 +778,7 @@ async def test_hmip_absolute_humidity_sensor(
         hass, mock_hap, entity_id, entity_name, device_model
     )
 
-    assert ha_state.state == "6099.0"
+    assert ha_state.state == "6098.93825139002"
 
 
 async def test_hmip_absolute_humidity_sensor_invalid_value(


### PR DESCRIPTION
## Breaking change

N/A - state values change slightly due to removing rounding, but this delivers more accurate data.

## Proposed change

Follow-up to #162455. Instead of rounding the absolute humidity `native_value` to 3 decimal places, pass through the raw value from the API and use `suggested_display_precision` to control the UI display.

The HomematicIP API returns full-precision floats (e.g. `6.098938251390021` g/m³). Previously, `round(value, 3)` truncated this to `6.099`, losing sub-mg/m³ precision. Now the raw value is preserved, and `suggested_display_precision = 1` provides a clean UI display in mg/m³.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR is related to issue: #162455

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr