### PR TITLE
add OnOffLight without brightness control to velux integration

### DIFF
--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -60,7 +60,7 @@ class VeluxOnOffLight(VeluxEntity, LightEntity):
         await self.node.turn_off(wait_for_completion=True)
 
 
-class VeluxLight(VeluxOnOffLight, LightEntity):
+class VeluxLight(VeluxOnOffLight):
     """Representation of a Velux light with brightness control."""
 
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -23,7 +23,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up light(s) for Velux platform."""
     pyvlx = config_entry.runtime_data
-    entities: list = []
+    entities: list[VeluxOnOffLight] = []
     for node in pyvlx.nodes:
         if isinstance(node, Light):
             entities.append(VeluxDimmableLight(node, config_entry.entry_id))

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pyvlx import Intensity, Light, OnOffLight
+from pyvlx import DimmableDevice, Intensity, Light, OnOffLight
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
@@ -42,7 +42,7 @@ class VeluxOnOffLight(VeluxEntity, LightEntity):
     _attr_color_mode = ColorMode.ONOFF
     _attr_name = None
 
-    node: OnOffLight
+    node: DimmableDevice
 
     @property
     def is_on(self) -> bool:
@@ -66,8 +66,6 @@ class VeluxLight(VeluxOnOffLight, LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_name = None
-
-    node: Light
 
     @property
     def brightness(self) -> int:

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -23,16 +23,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up light(s) for Velux platform."""
     pyvlx = config_entry.runtime_data
-    async_add_entities(
-        VeluxDimmableLight(node, config_entry.entry_id)
-        for node in pyvlx.nodes
-        if isinstance(node, Light)
-    )
-    async_add_entities(
-        VeluxOnOffLight(node, config_entry.entry_id)
-        for node in pyvlx.nodes
-        if isinstance(node, OnOffLight)
-    )
+    entities: list = []
+    for node in pyvlx.nodes:
+        if isinstance(node, Light):
+            entities.append(VeluxDimmableLight(node, config_entry.entry_id))
+        elif isinstance(node, OnOffLight):
+            entities.append(VeluxOnOffLight(node, config_entry.entry_id))
+    async_add_entities(entities)
 
 
 class VeluxOnOffLight(VeluxEntity, LightEntity):

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     """Set up light(s) for Velux platform."""
     pyvlx = config_entry.runtime_data
     async_add_entities(
-        VeluxLight(node, config_entry.entry_id)
+        VeluxDimmableLight(node, config_entry.entry_id)
         for node in pyvlx.nodes
         if isinstance(node, Light)
     )
@@ -60,7 +60,7 @@ class VeluxOnOffLight(VeluxEntity, LightEntity):
         await self.node.turn_off(wait_for_completion=True)
 
 
-class VeluxLight(VeluxOnOffLight):
+class VeluxDimmableLight(VeluxOnOffLight):
     """Representation of a Velux light with brightness control."""
 
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}

--- a/homeassistant/components/velux/light.py
+++ b/homeassistant/components/velux/light.py
@@ -26,12 +26,42 @@ async def async_setup_entry(
     async_add_entities(
         VeluxLight(node, config_entry.entry_id)
         for node in pyvlx.nodes
-        if isinstance(node, (Light, OnOffLight))
+        if isinstance(node, Light)
+    )
+    async_add_entities(
+        VeluxOnOffLight(node, config_entry.entry_id)
+        for node in pyvlx.nodes
+        if isinstance(node, OnOffLight)
     )
 
 
-class VeluxLight(VeluxEntity, LightEntity):
-    """Representation of a Velux light."""
+class VeluxOnOffLight(VeluxEntity, LightEntity):
+    """Representation of a Velux light without brightness control."""
+
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_name = None
+
+    node: OnOffLight
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        return not self.node.intensity.off and self.node.intensity.known
+
+    @wrap_pyvlx_call_exceptions
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Instruct the light to turn on."""
+        await self.node.turn_on(wait_for_completion=True)
+
+    @wrap_pyvlx_call_exceptions
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Instruct the light to turn off."""
+        await self.node.turn_off(wait_for_completion=True)
+
+
+class VeluxLight(VeluxOnOffLight, LightEntity):
+    """Representation of a Velux light with brightness control."""
 
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_color_mode = ColorMode.BRIGHTNESS
@@ -40,14 +70,9 @@ class VeluxLight(VeluxEntity, LightEntity):
     node: Light
 
     @property
-    def brightness(self):
+    def brightness(self) -> int:
         """Return the current brightness."""
         return int(self.node.intensity.intensity_percent * 255 / 100)
-
-    @property
-    def is_on(self):
-        """Return true if light is on."""
-        return not self.node.intensity.off and self.node.intensity.known
 
     @wrap_pyvlx_call_exceptions
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -60,8 +85,3 @@ class VeluxLight(VeluxEntity, LightEntity):
             )
         else:
             await self.node.turn_on(wait_for_completion=True)
-
-    @wrap_pyvlx_call_exceptions
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Instruct the light to turn off."""
-        await self.node.turn_off(wait_for_completion=True)

--- a/tests/components/velux/snapshots/test_light.ambr
+++ b/tests/components/velux/snapshots/test_light.ambr
@@ -65,7 +65,7 @@
     'area_id': None,
     'capabilities': dict({
       'supported_color_modes': list([
-        <ColorMode.BRIGHTNESS: 'brightness'>,
+        <ColorMode.ONOFF: 'onoff'>,
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -101,11 +101,10 @@
 # name: test_light_setup[mock_onoff_light][light.test_on_off_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'brightness': None,
       'color_mode': None,
       'friendly_name': 'Test On Off Light',
       'supported_color_modes': list([
-        <ColorMode.BRIGHTNESS: 'brightness'>,
+        <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),

--- a/tests/components/velux/test_light.py
+++ b/tests/components/velux/test_light.py
@@ -1,6 +1,6 @@
 """Test Velux light entities."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -202,7 +202,7 @@ async def test_light_turn_on_with_brightness_uses_set_intensity(
     "mock_pyvlx", ["mock_light", "mock_onoff_light"], indirect=True
 )
 async def test_light_turn_on_without_brightness_calls_turn_on(
-    hass: HomeAssistant, mock_pyvlx: AsyncMock
+    hass: HomeAssistant, mock_pyvlx: MagicMock
 ) -> None:
     """Turning on without brightness uses node.turn_on."""
 
@@ -224,7 +224,7 @@ async def test_light_turn_on_without_brightness_calls_turn_on(
     "mock_pyvlx", ["mock_light", "mock_onoff_light"], indirect=True
 )
 async def test_light_turn_off_calls_turn_off(
-    hass: HomeAssistant, mock_pyvlx: AsyncMock
+    hass: HomeAssistant, mock_pyvlx: MagicMock
 ) -> None:
     """Turning off calls device.turn_off with wait_for_completion."""
 

--- a/tests/components/velux/test_light.py
+++ b/tests/components/velux/test_light.py
@@ -10,7 +10,7 @@ from homeassistant.components.light import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import Platform
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -107,14 +107,14 @@ async def test_entity_availability(
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state != "unavailable"
+    assert state.state != STATE_UNAVAILABLE
 
     # Simulate disconnection
     mock_light.pyvlx.get_connected.return_value = False
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == STATE_UNAVAILABLE
     assert caplog.text.count(f"Entity {entity_id} is unavailable") == 1
 
     # Simulate disconnection, check we don't log again
@@ -122,7 +122,7 @@ async def test_entity_availability(
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == STATE_UNAVAILABLE
     assert caplog.text.count(f"Entity {entity_id} is unavailable") == 1
 
     # Simulate reconnection
@@ -130,7 +130,7 @@ async def test_entity_availability(
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state != "unavailable"
+    assert state.state != STATE_UNAVAILABLE
     assert caplog.text.count(f"Entity {entity_id} is back online") == 1
 
     # Simulate reconnection, check we don't log again
@@ -138,7 +138,7 @@ async def test_entity_availability(
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state != "unavailable"
+    assert state.state != STATE_UNAVAILABLE
     assert caplog.text.count(f"Entity {entity_id} is back online") == 1
 
 
@@ -160,15 +160,15 @@ async def test_light_brightness_and_is_on(
     state = hass.states.get(entity_id)
     assert state is not None
     # brightness = int(20 * 255 / 100) = int(51)
-    assert state.attributes.get("brightness") == 51
-    assert state.state == "on"
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 51
+    assert state.state == STATE_ON
 
     # Mark as off
     mock_light.intensity.off = True
     await update_callback_entity(hass, mock_light)
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "off"
+    assert state.state == STATE_OFF
 
 
 async def test_light_turn_on_with_brightness_uses_set_intensity(
@@ -198,12 +198,16 @@ async def test_light_turn_on_with_brightness_uses_set_intensity(
     assert kwargs.get("wait_for_completion") is True
 
 
+@pytest.mark.parametrize(
+    "mock_pyvlx", ["mock_light", "mock_onoff_light"], indirect=True
+)
 async def test_light_turn_on_without_brightness_calls_turn_on(
-    hass: HomeAssistant, mock_light: AsyncMock
+    hass: HomeAssistant, mock_pyvlx: AsyncMock
 ) -> None:
-    """Turning on without brightness uses device.turn_on."""
+    """Turning on without brightness uses node.turn_on."""
 
-    entity_id = f"light.{mock_light.name.lower().replace(' ', '_')}"
+    node = mock_pyvlx.nodes[0]
+    entity_id = f"light.{node.name.lower().replace(' ', '_')}"
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -212,16 +216,19 @@ async def test_light_turn_on_without_brightness_calls_turn_on(
         blocking=True,
     )
 
-    mock_light.turn_on.assert_awaited_once_with(wait_for_completion=True)
-    assert mock_light.set_intensity.await_count == 0
+    node.turn_on.assert_awaited_once_with(wait_for_completion=True)
 
 
+@pytest.mark.parametrize(
+    "mock_pyvlx", ["mock_light", "mock_onoff_light"], indirect=True
+)
 async def test_light_turn_off_calls_turn_off(
-    hass: HomeAssistant, mock_light: AsyncMock
+    hass: HomeAssistant, mock_pyvlx: AsyncMock
 ) -> None:
     """Turning off calls device.turn_off with wait_for_completion."""
 
-    entity_id = f"light.{mock_light.name.lower().replace(' ', '_')}"
+    node = mock_pyvlx.nodes[0]
+    entity_id = f"light.{node.name.lower().replace(' ', '_')}"
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -230,4 +237,4 @@ async def test_light_turn_off_calls_turn_off(
         blocking=True,
     )
 
-    mock_light.turn_off.assert_awaited_once_with(wait_for_completion=True)
+    node.turn_off.assert_awaited_once_with(wait_for_completion=True)

--- a/tests/components/velux/test_light.py
+++ b/tests/components/velux/test_light.py
@@ -217,6 +217,7 @@ async def test_light_turn_on_without_brightness_calls_turn_on(
     )
 
     node.turn_on.assert_awaited_once_with(wait_for_completion=True)
+    assert node.set_intensity.await_count == 0
 
 
 @pytest.mark.parametrize(
@@ -238,3 +239,4 @@ async def test_light_turn_off_calls_turn_off(
     )
 
     node.turn_off.assert_awaited_once_with(wait_for_completion=True)
+    assert node.set_intensity.await_count == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Velux integration also supports light entities and up until now it didn't differentiate between lights with and without brightness control, enabling brightness control for all, even though only a subset support it (possibly creating unpredictable results). This PR adds separate on-off-only lights for the ones that do not support brightness control. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
