### PR TITLE
Change lunatone config entry title to only include the URL

### DIFF
--- a/homeassistant/components/lunatone/config_flow.py
+++ b/homeassistant/components/lunatone/config_flow.py
@@ -22,11 +22,6 @@ DATA_SCHEMA: Final[vol.Schema] = vol.Schema(
 )
 
 
-def compose_title(name: str | None, serial_number: int) -> str:
-    """Compose a title string from a given name and serial number."""
-    return f"{name or 'DALI Gateway'} {serial_number}"
-
-
 class LunatoneConfigFlow(ConfigFlow, domain=DOMAIN):
     """Lunatone config flow."""
 
@@ -54,22 +49,17 @@ class LunatoneConfigFlow(ConfigFlow, domain=DOMAIN):
             except aiohttp.ClientConnectionError:
                 errors["base"] = "cannot_connect"
             else:
-                if info_api.data is None or info_api.serial_number is None:
+                if info_api.serial_number is None:
                     errors["base"] = "missing_device_info"
                 else:
                     await self.async_set_unique_id(str(info_api.serial_number))
                     if self.source == SOURCE_RECONFIGURE:
                         self._abort_if_unique_id_mismatch()
                         return self.async_update_reload_and_abort(
-                            self._get_reconfigure_entry(),
-                            data_updates=data,
-                            title=compose_title(info_api.name, info_api.serial_number),
+                            self._get_reconfigure_entry(), data_updates=data, title=url
                         )
                     self._abort_if_unique_id_configured()
-                    return self.async_create_entry(
-                        title=compose_title(info_api.name, info_api.serial_number),
-                        data={CONF_URL: url},
-                    )
+                    return self.async_create_entry(title=url, data={CONF_URL: url})
         return self.async_show_form(
             step_id="user",
             data_schema=DATA_SCHEMA,

--- a/tests/components/lunatone/conftest.py
+++ b/tests/components/lunatone/conftest.py
@@ -96,7 +96,7 @@ def mock_lunatone_dali_broadcast() -> Generator[AsyncMock]:
 def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        title=f"Lunatone {SERIAL_NUMBER}",
+        title=BASE_URL,
         domain=DOMAIN,
         data={CONF_URL: BASE_URL},
         unique_id=str(SERIAL_NUMBER),

--- a/tests/components/lunatone/test_config_flow.py
+++ b/tests/components/lunatone/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from . import BASE_URL, SERIAL_NUMBER
+from . import BASE_URL
 
 from tests.common import MockConfigEntry
 
@@ -32,7 +32,7 @@ async def test_full_flow(
         {CONF_URL: BASE_URL},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Test {SERIAL_NUMBER}"
+    assert result["title"] == BASE_URL
     assert result["data"] == {CONF_URL: BASE_URL}
 
 
@@ -41,7 +41,7 @@ async def test_full_flow_fail_because_of_missing_device_infos(
     mock_lunatone_info: AsyncMock,
 ) -> None:
     """Test full flow."""
-    mock_lunatone_info.data = None
+    mock_lunatone_info.serial_number = None
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -117,7 +117,7 @@ async def test_user_step_fail_with_error(
         {CONF_URL: BASE_URL},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"Test {SERIAL_NUMBER}"
+    assert result["title"] == BASE_URL
     assert result["data"] == {CONF_URL: BASE_URL}
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change config entry title to only include the URL.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
