### PR TITLE
Improve Mealie todo items by using structured fields

### DIFF
--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -29,18 +29,42 @@ TODO_STATUS_MAP_INV = {v: k for k, v in TODO_STATUS_MAP.items()}
 
 
 def _convert_api_item(item: ShoppingItem) -> TodoItem:
-    """Convert Mealie shopping list items into a TodoItem."""
+    """Convert Mealie shopping list items into structured TodoItems."""
+
+    # Prefer structured food name as summary
+    summary = item.food.name if item.food else item.display
+
+    description_parts: list[str] = []
+
+    # Quantity and unit
+    if item.quantity:
+        description_parts.append(str(item.quantity))
+
+    if item.unit:
+        description_parts.append(item.unit.name)
+
+    # Notes and extras
+    if item.note:
+        description_parts.append(item.note)
+
+    if item.extras:
+        description_parts.extend(
+            extra.text for extra in item.extras if extra.text
+        )
+
+    description = " ".join(description_parts) or None
 
     return TodoItem(
-        summary=item.display,
+        summary=summary,
         uid=item.item_id,
         status=TODO_STATUS_MAP.get(
             item.checked,
             TodoItemStatus.NEEDS_ACTION,
         ),
         due=None,
-        description=None,
+        description=description,
     )
+
 
 
 async def async_setup_entry(

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -194,8 +194,11 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             unit_id=list_item.unit_id,
         )
 
+        # Only sync summary (semantic item name) back to Mealie.
+        # Description is intentionally ignored, as Mealie does not provide a
+        # structured target field for it and re-parsing would be ambiguous.
         stripped_item_summary = item.summary.strip() if item.summary else item.summary
-
+        
         if list_item.display.strip() != stripped_item_summary:
             update_shopping_item.note = stripped_item_summary
             update_shopping_item.position = position


### PR DESCRIPTION
## Summary

Improve the Mealie Todo integration by preserving structured shopping list
data (food, quantity, unit, notes) instead of collapsing everything into a
single display string.

This change only affects how items are represented in Home Assistant and
keeps full backward compatibility.

---

## Motivation

Mealie already stores shopping list items in a structured form, but the current
integration discards this information by mapping everything to `item.display`.

This makes automations brittle and downstream integrations (e.g. Bring)
hard to use reliably.

---

## Proposed solution

- Use `food.name` as the Todo item summary when available
- Move quantity, unit, notes and extras into the Todo item description
- Keep `item.display` as a fallback for backward compatibility
- On updates originating from Home Assistant, only sync the summary back
  to Mealie. The description is intentionally not written back, as Mealie
  does not provide a structured target field for it.

---

## Breaking change

- [ ] Yes
- [x] No

---

## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Code quality
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation

---

## Additional notes

This PR intentionally avoids parsing free-text back into structured Mealie
fields, as this would reintroduce ambiguity. The goal is to preserve existing
structured data where possible, while remaining compatible with Home
Assistant’s Todo data model.
