### PR TITLE
Add zeroconf support to Homevolt

### DIFF
--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -176,8 +176,7 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             self._need_password = True
         elif errors:
             return self.async_abort(reason=errors["base"])
-
-        if not self._need_password:
+        else:
             await self.async_set_unique_id(client.unique_id)
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: self._host},
@@ -190,17 +189,44 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Confirm zeroconf discovery."""
         assert self._host is not None
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             if self._need_password:
-                return await self.async_step_credentials()
+                password = user_input[CONF_PASSWORD]
+                websession = async_get_clientsession(self.hass)
+                client = Homevolt(self._host, password, websession=websession)
+                errors = await self.check_status(client)
 
-            return self.async_create_entry(
-                title="Homevolt",
-                data={
-                    CONF_HOST: self._host,
-                    CONF_PASSWORD: None,
-                },
+                if not errors:
+                    device_id = client.unique_id
+                    await self.async_set_unique_id(device_id)
+                    self._abort_if_unique_id_configured(
+                        updates={CONF_HOST: self._host},
+                    )
+
+                    return self.async_create_entry(
+                        title="Homevolt",
+                        data={
+                            CONF_HOST: self._host,
+                            CONF_PASSWORD: password,
+                        },
+                    )
+            else:
+                return self.async_create_entry(
+                    title="Homevolt",
+                    data={
+                        CONF_HOST: self._host,
+                        CONF_PASSWORD: None,
+                    },
+                )
+
+        if self._need_password:
+            return self.async_show_form(
+                step_id="zeroconf_confirm",
+                data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
+                errors=errors,
+                description_placeholders={"host": self._host},
             )
 
         self._set_confirm_only()

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homevolt import Homevolt, HomevoltAuthenticationError, HomevoltConnectionError
 import voluptuous as vol
 
+from homeassistant.components import onboarding
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 
@@ -154,5 +156,58 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="credentials",
             data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
             errors=errors,
+            description_placeholders={"host": self._host},
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+
+        host = discovery_info.host
+        cast(dict[str, Any], self.context)[CONF_HOST] = host
+        if self._async_in_progress(
+            include_uninitialized=True, match_context={CONF_HOST: host}
+        ):
+            return self.async_abort(reason="already_in_progress")
+
+        self._async_abort_entries_match({CONF_HOST: host})
+
+        self._host = host
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm zeroconf discovery."""
+        assert self._host is not None
+
+        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
+            websession = async_get_clientsession(self.hass)
+            client = Homevolt(self._host, None, websession=websession)
+            errors = await self.check_status(client)
+            if errors.get("base") == "invalid_auth":
+                return await self.async_step_credentials()
+
+            if errors:
+                return self.async_abort(reason=errors["base"])
+
+            await self.async_set_unique_id(client.unique_id)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: self._host},
+                reload_on_update=True,
+            )
+
+            return self.async_create_entry(
+                title="Homevolt",
+                data={
+                    CONF_HOST: self._host,
+                    CONF_PASSWORD: None,
+                },
+            )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
             description_placeholders={"host": self._host},
         )

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -189,46 +189,37 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self._host is not None
         errors: dict[str, str] = {}
 
-        if user_input is not None:
+        if user_input is None:
             if self._need_password:
-                password = user_input[CONF_PASSWORD]
-                websession = async_get_clientsession(self.hass)
-                client = Homevolt(self._host, password, websession=websession)
-                errors = await self.check_status(client)
-
-                if not errors:
-                    device_id = client.unique_id
-                    await self.async_set_unique_id(device_id)
-                    self._abort_if_unique_id_configured(
-                        updates={CONF_HOST: self._host},
-                    )
-
-                    return self.async_create_entry(
-                        title="Homevolt",
-                        data={
-                            CONF_HOST: self._host,
-                            CONF_PASSWORD: password,
-                        },
-                    )
-            else:
-                return self.async_create_entry(
-                    title="Homevolt",
-                    data={
-                        CONF_HOST: self._host,
-                        CONF_PASSWORD: None,
-                    },
+                return self.async_show_form(
+                    step_id="zeroconf_confirm",
+                    data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
+                    errors=errors,
+                    description_placeholders={"host": self._host},
                 )
-
-        if self._need_password:
+            self._set_confirm_only()
             return self.async_show_form(
                 step_id="zeroconf_confirm",
-                data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
-                errors=errors,
                 description_placeholders={"host": self._host},
             )
 
-        self._set_confirm_only()
-        return self.async_show_form(
-            step_id="zeroconf_confirm",
-            description_placeholders={"host": self._host},
+        password: str | None = None
+        if self._need_password:
+            password = user_input[CONF_PASSWORD]
+            websession = async_get_clientsession(self.hass)
+            client = Homevolt(self._host, password, websession=websession)
+            errors = await self.check_status(client)
+            if errors:
+                return self.async_show_form(
+                    step_id="zeroconf_confirm",
+                    data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
+                    errors=errors,
+                    description_placeholders={"host": self._host},
+                )
+            await self.async_set_unique_id(client.unique_id)
+            self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})
+
+        return self.async_create_entry(
+            title="Homevolt",
+            data={CONF_HOST: self._host, CONF_PASSWORD: password},
         )

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -142,7 +142,9 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             if not errors:
                 device_id = client.unique_id
                 await self.async_set_unique_id(device_id)
-                self._abort_if_unique_id_configured()
+                self._abort_if_unique_id_configured(
+                    updates={CONF_HOST: self._host},
+                )
 
                 return self.async_create_entry(
                     title="Homevolt",
@@ -177,6 +179,9 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if not self._need_password:
             await self.async_set_unique_id(client.unique_id)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: self._host},
+            )
 
         return await self.async_step_zeroconf_confirm()
 
@@ -189,10 +194,6 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if self._need_password:
                 return await self.async_step_credentials()
-
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: self._host},
-            )
 
             return self.async_create_entry(
                 title="Homevolt",

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import logging
-from typing import Any, cast
+from typing import Any
 
 from homevolt import Homevolt, HomevoltAuthenticationError, HomevoltConnectionError
 import voluptuous as vol
 
-from homeassistant.components import onboarding
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -41,6 +40,7 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._host: str | None = None
+        self._need_password: bool = False
 
     async def check_status(self, client: Homevolt) -> dict[str, str]:
         """Check connection status and return errors if any."""
@@ -164,16 +164,20 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
 
-        host = discovery_info.host
-        cast(dict[str, Any], self.context)[CONF_HOST] = host
-        if self._async_in_progress(
-            include_uninitialized=True, match_context={CONF_HOST: host}
-        ):
-            return self.async_abort(reason="already_in_progress")
+        self._host = discovery_info.host
+        self._async_abort_entries_match({CONF_HOST: self._host})
 
-        self._async_abort_entries_match({CONF_HOST: host})
+        websession = async_get_clientsession(self.hass)
+        client = Homevolt(self._host, None, websession=websession)
+        errors = await self.check_status(client)
+        if errors.get("base") == "invalid_auth":
+            self._need_password = True
+        elif errors:
+            return self.async_abort(reason=errors["base"])
 
-        self._host = host
+        if not self._need_password:
+            await self.async_set_unique_id(client.unique_id)
+
         return await self.async_step_zeroconf_confirm()
 
     async def async_step_zeroconf_confirm(
@@ -182,20 +186,12 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
         """Confirm zeroconf discovery."""
         assert self._host is not None
 
-        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
-            websession = async_get_clientsession(self.hass)
-            client = Homevolt(self._host, None, websession=websession)
-            errors = await self.check_status(client)
-            if errors.get("base") == "invalid_auth":
+        if user_input is not None:
+            if self._need_password:
                 return await self.async_step_credentials()
 
-            if errors:
-                return self.async_abort(reason=errors["base"])
-
-            await self.async_set_unique_id(client.unique_id)
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: self._host},
-                reload_on_update=True,
             )
 
             return self.async_create_entry(

--- a/homeassistant/components/homevolt/config_flow.py
+++ b/homeassistant/components/homevolt/config_flow.py
@@ -142,9 +142,7 @@ class HomevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             if not errors:
                 device_id = client.unique_id
                 await self.async_set_unique_id(device_id)
-                self._abort_if_unique_id_configured(
-                    updates={CONF_HOST: self._host},
-                )
+                self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(
                     title="Homevolt",

--- a/homeassistant/components/homevolt/manifest.json
+++ b/homeassistant/components/homevolt/manifest.json
@@ -7,5 +7,11 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["homevolt==0.4.4"]
+  "requirements": ["homevolt==0.4.4"],
+  "zeroconf": [
+    {
+      "name": "homevolt*",
+      "type": "_http._tcp.local."
+    }
+  ]
 }

--- a/homeassistant/components/homevolt/quality_scale.yaml
+++ b/homeassistant/components/homevolt/quality_scale.yaml
@@ -44,8 +44,8 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info: todo
-  discovery: todo
+  discovery-update-info: done
+  discovery: done
   docs-data-update: todo
   docs-examples: todo
   docs-known-limitations: todo

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -5,6 +5,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unknown": "[%key:common::config_flow::abort::unknown%]",
       "wrong_account": "The device you authenticated with is different from the one configured. Re-authenticate with the same Homevolt battery."
     },
     "error": {

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -42,6 +42,12 @@
         "description": "Connect Home Assistant to your Homevolt battery over the local network."
       },
       "zeroconf_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "[%key:component::homevolt::config::step::credentials::data_description::password%]"
+        },
         "description": "Do you want to set up the Homevolt battery at {host}?"
       }
     }

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -38,6 +38,9 @@
           "host": "The IP address or hostname of your Homevolt battery on your local network."
         },
         "description": "Connect Home Assistant to your Homevolt battery over the local network."
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to set up the Homevolt battery at {host}?"
       }
     }
   },

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -2,6 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "wrong_account": "The device you authenticated with is different from the one configured. Re-authenticate with the same Homevolt battery."
     },

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -5,7 +5,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "unknown": "[%key:common::config_flow::abort::unknown%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "wrong_account": "The device you authenticated with is different from the one configured. Re-authenticate with the same Homevolt battery."
     },
     "error": {

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -594,6 +594,10 @@ ZEROCONF = {
             "name": "vrroom-*",
         },
         {
+            "domain": "homevolt",
+            "name": "homevolt*",
+        },
+        {
             "domain": "lektrico",
             "name": "lektrico*",
         },

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -102,60 +102,6 @@ async def test_flow_auth_error_then_password_success(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_credentials_step_invalid_password(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
-) -> None:
-    """Test invalid password in credentials step shows error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    user_input = {
-        CONF_HOST: "192.168.1.100",
-    }
-
-    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-
-    # Provide wrong password - should show error
-    password_input = {
-        CONF_PASSWORD: "wrong-password",
-    }
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], password_input
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-    mock_homevolt_client.update_info.side_effect = None
-
-    password_input = {
-        CONF_PASSWORD: "correct-password",
-    }
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], password_input
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Homevolt"
-    assert result["data"] == {
-        CONF_HOST: "192.168.1.100",
-        CONF_PASSWORD: "correct-password",
-    }
-    assert result["result"].unique_id == "40580137858664"
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 @pytest.mark.parametrize(
     ("exception", "expected_error"),
     [
@@ -235,6 +181,60 @@ async def test_duplicate_entry(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_credentials_step_invalid_password(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
+) -> None:
+    """Test invalid password in credentials step shows error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    user_input = {
+        CONF_HOST: "192.168.1.100",
+    }
+
+    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+    # Provide wrong password - should show error
+    password_input = {
+        CONF_PASSWORD: "wrong-password",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], password_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_homevolt_client.update_info.side_effect = None
+
+    password_input = {
+        CONF_PASSWORD: "correct-password",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], password_input
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Homevolt"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.100",
+        CONF_PASSWORD: "correct-password",
+    }
+    assert result["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_reauth_success(

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -334,12 +334,12 @@ async def test_zeroconf_confirm_flow_success(
     assert result["step_id"] == "zeroconf_confirm"
     assert result["description_placeholders"] == {"host": "192.168.1.123"}
 
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Homevolt"
-    assert result2["data"] == {CONF_HOST: "192.168.1.123", CONF_PASSWORD: None}
-    assert result2["result"].unique_id == "40580137858664"
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Homevolt"
+    assert result["data"] == {CONF_HOST: "192.168.1.123", CONF_PASSWORD: None}
+    assert result["result"].unique_id == "40580137858664"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -361,10 +361,10 @@ async def test_zeroconf_duplicate_aborts(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "zeroconf_confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
@@ -391,14 +391,14 @@ async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "zeroconf_confirm"
 
-    result2 = await hass.config_entries.flow.async_configure(
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {},
     )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "credentials"
-    assert result2["description_placeholders"] == {"host": "192.168.1.123"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert result["description_placeholders"] == {"host": "192.168.1.123"}
 
 
 async def test_zeroconf_connection_error_aborts(
@@ -417,3 +417,21 @@ async def test_zeroconf_connection_error_aborts(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_zeroconf_unknown_error_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test zeroconf flow aborts on unknown error during discovery."""
+    mock_homevolt_client.update_info.side_effect = Exception("Unexpected error")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unknown"

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,13 +10,129 @@ from homevolt import HomevoltAuthenticationError, HomevoltConnectionError
 import pytest
 
 from homeassistant.components.homevolt.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
+
+DISCOVERY_INFO = ZeroconfServiceInfo(
+    ip_address=IPv4Address("192.168.1.123"),
+    ip_addresses=[IPv4Address("192.168.1.123")],
+    port=80,
+    hostname="homevolt.local.",
+    type="_http._tcp.local.",
+    name="homevolt._http._tcp.local.",
+    properties={},
+)
+
+
+async def test_zeroconf_already_in_progress_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test zeroconf flow aborts when already in progress for the same host."""
+
+    discovery_info = dataclasses.replace(
+        DISCOVERY_INFO,
+        ip_address=IPv4Address("192.168.1.125"),
+        ip_addresses=[IPv4Address("192.168.1.125")],
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_in_progress"
+
+
+async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test zeroconf confirm goes to credentials step when auth is required."""
+
+    monkeypatch.setattr(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        lambda hass: True,
+    )
+
+    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
+
+    discovery_info = dataclasses.replace(
+        DISCOVERY_INFO,
+        ip_address=IPv4Address("192.168.1.126"),
+        ip_addresses=[IPv4Address("192.168.1.126")],
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "credentials"
+    assert result2["description_placeholders"] == {"host": "192.168.1.126"}
+
+
+async def test_zeroconf_confirm_onboarded_errors_abort(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test zeroconf confirm aborts on non-auth errors when onboarded."""
+
+    monkeypatch.setattr(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        lambda hass: True,
+    )
+
+    mock_homevolt_client.update_info.side_effect = HomevoltConnectionError
+
+    discovery_info = DISCOVERY_INFO
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "cannot_connect"
 
 
 async def test_full_flow_success(
@@ -50,19 +167,11 @@ async def test_zeroconf_confirm_flow_success(
 ) -> None:
     """Test zeroconf flow shows confirm step before creating entry."""
 
-    discovery_info = ZeroconfServiceInfo(
-        ip_address=IPv4Address("192.168.1.123"),
-        ip_addresses=[IPv4Address("192.168.1.123")],
-        port=80,
-        hostname="homevolt.local.",
-        type="_http._tcp.local.",
-        name="homevolt._http._tcp.local.",
-        properties={},
-    )
+    discovery_info = DISCOVERY_INFO
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": "zeroconf"},
+        context={"source": SOURCE_ZEROCONF},
         data=discovery_info,
     )
 
@@ -88,19 +197,11 @@ async def test_zeroconf_duplicate_aborts(
     """Test zeroconf flow aborts when unique id is already configured."""
     mock_config_entry.add_to_hass(hass)
 
-    discovery_info = ZeroconfServiceInfo(
-        ip_address=IPv4Address("192.168.1.124"),
-        ip_addresses=[IPv4Address("192.168.1.124")],
-        port=80,
-        hostname="homevolt.local.",
-        type="_http._tcp.local.",
-        name="homevolt._http._tcp.local.",
-        properties={},
-    )
+    discovery_info = DISCOVERY_INFO
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        context={"source": "zeroconf"},
+        context={"source": SOURCE_ZEROCONF},
         data=discovery_info,
     )
 

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, MagicMock
 
 from homevolt import HomevoltAuthenticationError, HomevoltConnectionError
@@ -12,6 +13,7 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
 
@@ -41,6 +43,74 @@ async def test_full_flow_success(
     assert result["data"] == {CONF_HOST: "192.168.1.100", CONF_PASSWORD: None}
     assert result["result"].unique_id == "40580137858664"
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_confirm_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
+) -> None:
+    """Test zeroconf flow shows confirm step before creating entry."""
+
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=IPv4Address("192.168.1.123"),
+        ip_addresses=[IPv4Address("192.168.1.123")],
+        port=80,
+        hostname="homevolt.local.",
+        type="_http._tcp.local.",
+        name="homevolt._http._tcp.local.",
+        properties={},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {"host": "192.168.1.123"}
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Homevolt"
+    assert result2["data"] == {CONF_HOST: "192.168.1.123", CONF_PASSWORD: None}
+    assert result2["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_duplicate_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf flow aborts when unique id is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    discovery_info = ZeroconfServiceInfo(
+        ip_address=IPv4Address("192.168.1.124"),
+        ip_addresses=[IPv4Address("192.168.1.124")],
+        port=80,
+        hostname="homevolt.local.",
+        type="_http._tcp.local.",
+        name="homevolt._http._tcp.local.",
+        properties={},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "zeroconf"},
+        data=discovery_info,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
 
 
 async def test_flow_auth_error_then_password_success(

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -358,13 +358,9 @@ async def test_zeroconf_duplicate_aborts(
         data=DISCOVERY_INFO,
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
 
 
 async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -363,13 +363,55 @@ async def test_zeroconf_duplicate_aborts(
     assert mock_config_entry.data[CONF_HOST] == "192.168.1.123"
 
 
-async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
+async def test_zeroconf_confirm_with_password_success(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_homevolt_client: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test zeroconf confirm goes to credentials step when auth is required."""
+    """Test zeroconf confirm collects password and creates entry when auth is required."""
+
+    monkeypatch.setattr(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        lambda hass: True,
+    )
+
+    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {"host": "192.168.1.123"}
+
+    mock_homevolt_client.update_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "test-password"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Homevolt"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.123",
+        CONF_PASSWORD: "test-password",
+    }
+    assert result["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_confirm_with_password_invalid_then_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test zeroconf confirm shows error on invalid password, then succeeds."""
 
     monkeypatch.setattr(
         "homeassistant.components.onboarding.async_is_onboarded",
@@ -389,12 +431,28 @@ async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {},
+        {CONF_PASSWORD: "wrong-password"},
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-    assert result["description_placeholders"] == {"host": "192.168.1.123"}
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_homevolt_client.update_info.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "correct-password"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Homevolt"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.123",
+        CONF_PASSWORD: "correct-password",
+    }
+    assert result["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_zeroconf_connection_error_aborts(

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, MagicMock
 
@@ -36,16 +35,10 @@ async def test_zeroconf_already_in_progress_aborts(
 ) -> None:
     """Test zeroconf flow aborts when already in progress for the same host."""
 
-    discovery_info = dataclasses.replace(
-        DISCOVERY_INFO,
-        ip_address=IPv4Address("192.168.1.125"),
-        ip_addresses=[IPv4Address("192.168.1.125")],
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -53,7 +46,7 @@ async def test_zeroconf_already_in_progress_aborts(
     result2 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result2["type"] is FlowResultType.ABORT
@@ -75,16 +68,10 @@ async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
 
     mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
 
-    discovery_info = dataclasses.replace(
-        DISCOVERY_INFO,
-        ip_address=IPv4Address("192.168.1.126"),
-        ip_addresses=[IPv4Address("192.168.1.126")],
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -97,7 +84,7 @@ async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["step_id"] == "credentials"
-    assert result2["description_placeholders"] == {"host": "192.168.1.126"}
+    assert result2["description_placeholders"] == {"host": "192.168.1.123"}
 
 
 async def test_zeroconf_confirm_onboarded_errors_abort(
@@ -115,12 +102,10 @@ async def test_zeroconf_confirm_onboarded_errors_abort(
 
     mock_homevolt_client.update_info.side_effect = HomevoltConnectionError
 
-    discovery_info = DISCOVERY_INFO
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -167,12 +152,10 @@ async def test_zeroconf_confirm_flow_success(
 ) -> None:
     """Test zeroconf flow shows confirm step before creating entry."""
 
-    discovery_info = DISCOVERY_INFO
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -197,12 +180,10 @@ async def test_zeroconf_duplicate_aborts(
     """Test zeroconf flow aborts when unique id is already configured."""
     mock_config_entry.add_to_hass(hass)
 
-    discovery_info = DISCOVERY_INFO
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},
-        data=discovery_info,
+        data=DISCOVERY_INFO,
     )
 
     assert result["type"] is FlowResultType.FORM

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -455,13 +455,23 @@ async def test_zeroconf_confirm_with_password_invalid_then_success(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_connection_error_aborts(
+@pytest.mark.parametrize(
+    ("exception", "expected_reason"),
+    [
+        (HomevoltConnectionError, "cannot_connect"),
+        (Exception("Unexpected error"), "unknown"),
+    ],
+    ids=["connection_error", "unknown_error"],
+)
+async def test_zeroconf_error_aborts(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_homevolt_client: MagicMock,
+    exception: Exception,
+    expected_reason: str,
 ) -> None:
-    """Test zeroconf flow aborts on connection error during discovery."""
-    mock_homevolt_client.update_info.side_effect = HomevoltConnectionError
+    """Test zeroconf flow aborts on error during discovery."""
+    mock_homevolt_client.update_info.side_effect = exception
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -470,22 +480,4 @@ async def test_zeroconf_connection_error_aborts(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-
-async def test_zeroconf_unknown_error_aborts(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_homevolt_client: MagicMock,
-) -> None:
-    """Test zeroconf flow aborts on unknown error during discovery."""
-    mock_homevolt_client.update_info.side_effect = Exception("Unexpected error")
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "unknown"
+    assert result["reason"] == expected_reason

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -371,11 +371,6 @@ async def test_zeroconf_confirm_with_password_success(
 ) -> None:
     """Test zeroconf confirm collects password and creates entry when auth is required."""
 
-    monkeypatch.setattr(
-        "homeassistant.components.onboarding.async_is_onboarded",
-        lambda hass: True,
-    )
-
     mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
 
     result = await hass.config_entries.flow.async_init(
@@ -412,11 +407,6 @@ async def test_zeroconf_confirm_with_password_invalid_then_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test zeroconf confirm shows error on invalid password, then succeeds."""
-
-    monkeypatch.setattr(
-        "homeassistant.components.onboarding.async_is_onboarded",
-        lambda hass: True,
-    )
 
     mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
 

--- a/tests/components/homevolt/test_config_flow.py
+++ b/tests/components/homevolt/test_config_flow.py
@@ -28,98 +28,6 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
 )
 
 
-async def test_zeroconf_already_in_progress_aborts(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_homevolt_client: MagicMock,
-) -> None:
-    """Test zeroconf flow aborts when already in progress for the same host."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-
-    result2 = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_in_progress"
-
-
-async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_homevolt_client: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test zeroconf confirm goes to credentials step when auth is required."""
-
-    monkeypatch.setattr(
-        "homeassistant.components.onboarding.async_is_onboarded",
-        lambda hass: True,
-    )
-
-    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {},
-    )
-
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["step_id"] == "credentials"
-    assert result2["description_placeholders"] == {"host": "192.168.1.123"}
-
-
-async def test_zeroconf_confirm_onboarded_errors_abort(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_homevolt_client: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test zeroconf confirm aborts on non-auth errors when onboarded."""
-
-    monkeypatch.setattr(
-        "homeassistant.components.onboarding.async_is_onboarded",
-        lambda hass: True,
-    )
-
-    mock_homevolt_client.update_info.side_effect = HomevoltConnectionError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {},
-    )
-
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "cannot_connect"
-
-
 async def test_full_flow_success(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
 ) -> None:
@@ -145,54 +53,6 @@ async def test_full_flow_success(
     assert result["data"] == {CONF_HOST: "192.168.1.100", CONF_PASSWORD: None}
     assert result["result"].unique_id == "40580137858664"
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_zeroconf_confirm_flow_success(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
-) -> None:
-    """Test zeroconf flow shows confirm step before creating entry."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-    assert result["description_placeholders"] == {"host": "192.168.1.123"}
-
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Homevolt"
-    assert result2["data"] == {CONF_HOST: "192.168.1.123", CONF_PASSWORD: None}
-    assert result2["result"].unique_id == "40580137858664"
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_zeroconf_duplicate_aborts(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_homevolt_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test zeroconf flow aborts when unique id is already configured."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
 
 
 async def test_flow_auth_error_then_password_success(
@@ -237,6 +97,60 @@ async def test_flow_auth_error_then_password_success(
     assert result["data"] == {
         CONF_HOST: "192.168.1.100",
         CONF_PASSWORD: "test-password",
+    }
+    assert result["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_credentials_step_invalid_password(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
+) -> None:
+    """Test invalid password in credentials step shows error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    user_input = {
+        CONF_HOST: "192.168.1.100",
+    }
+
+    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+    # Provide wrong password - should show error
+    password_input = {
+        CONF_PASSWORD: "wrong-password",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], password_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_homevolt_client.update_info.side_effect = None
+
+    password_input = {
+        CONF_PASSWORD: "correct-password",
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], password_input
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Homevolt"
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.100",
+        CONF_PASSWORD: "correct-password",
     }
     assert result["result"].unique_id == "40580137858664"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -323,60 +237,6 @@ async def test_duplicate_entry(
     assert result["reason"] == "already_configured"
 
 
-async def test_credentials_step_invalid_password(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
-) -> None:
-    """Test invalid password in credentials step shows error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    user_input = {
-        CONF_HOST: "192.168.1.100",
-    }
-
-    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-
-    # Provide wrong password - should show error
-    password_input = {
-        CONF_PASSWORD: "wrong-password",
-    }
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], password_input
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-    assert result["errors"] == {"base": "invalid_auth"}
-
-    mock_homevolt_client.update_info.side_effect = None
-
-    password_input = {
-        CONF_PASSWORD: "correct-password",
-    }
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], password_input
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Homevolt"
-    assert result["data"] == {
-        CONF_HOST: "192.168.1.100",
-        CONF_PASSWORD: "correct-password",
-    }
-    assert result["result"].unique_id == "40580137858664"
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
 async def test_reauth_success(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
@@ -457,3 +317,103 @@ async def test_reauth_flow_errors(
         CONF_HOST: "127.0.0.1",
         CONF_PASSWORD: "correct-password",
     }
+
+
+async def test_zeroconf_confirm_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_homevolt_client: MagicMock
+) -> None:
+    """Test zeroconf flow shows confirm step before creating entry."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["description_placeholders"] == {"host": "192.168.1.123"}
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Homevolt"
+    assert result2["data"] == {CONF_HOST: "192.168.1.123", CONF_PASSWORD: None}
+    assert result2["result"].unique_id == "40580137858664"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_duplicate_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf flow aborts when unique id is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+async def test_zeroconf_confirm_onboarded_invalid_auth_shows_credentials(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test zeroconf confirm goes to credentials step when auth is required."""
+
+    monkeypatch.setattr(
+        "homeassistant.components.onboarding.async_is_onboarded",
+        lambda hass: True,
+    )
+
+    mock_homevolt_client.update_info.side_effect = HomevoltAuthenticationError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "credentials"
+    assert result2["description_placeholders"] == {"host": "192.168.1.123"}
+
+
+async def test_zeroconf_connection_error_aborts(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test zeroconf flow aborts on connection error during discovery."""
+    mock_homevolt_client.update_info.side_effect = HomevoltConnectionError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Homevolt support zeroconf


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
