### PR TITLE
Bump pysmarlaapi to 1.0.1 and compatibility changes

### DIFF
--- a/homeassistant/components/smarla/__init__.py
+++ b/homeassistant/components/smarla/__init__.py
@@ -1,6 +1,10 @@
 """The Swing2Sleep Smarla integration."""
 
 from pysmarlaapi import Connection, Federwiege
+from pysmarlaapi.connection.exceptions import (
+    AuthenticationException,
+    ConnectionException,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
@@ -17,8 +21,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: FederwiegeConfigEntry) -
     connection = Connection(HOST, token_b64=entry.data[CONF_ACCESS_TOKEN])
 
     # Check if token still has access
-    if not await connection.refresh_token():
-        raise ConfigEntryError("Invalid authentication")
+    try:
+        await connection.refresh_token()
+    except (ConnectionException, AuthenticationException) as e:
+        raise ConfigEntryError("Invalid authentication") from e
 
     federwiege = Federwiege(hass.loop, connection)
     federwiege.register()

--- a/homeassistant/components/smarla/config_flow.py
+++ b/homeassistant/components/smarla/config_flow.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from pysmarlaapi import Connection
+from pysmarlaapi.connection.exceptions import (
+    AuthenticationException,
+    ConnectionException,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -30,7 +34,9 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "malformed_token"
             return errors, None
 
-        if not await conn.refresh_token():
+        try:
+            await conn.refresh_token()
+        except ConnectionException, AuthenticationException:
             errors["base"] = "invalid_auth"
             return errors, None
 

--- a/homeassistant/components/smarla/manifest.json
+++ b/homeassistant/components/smarla/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pysmarlaapi", "pysignalr"],
   "quality_scale": "bronze",
-  "requirements": ["pysmarlaapi==0.13.0"]
+  "requirements": ["pysmarlaapi==1.0.1"]
 }

--- a/homeassistant/components/smarla/number.py
+++ b/homeassistant/components/smarla/number.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from pysmarlaapi.federwiege.classes import Property
+from pysmarlaapi.federwiege.services.classes import Property
 
 from homeassistant.components.number import (
     NumberEntity,

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from pysmarlaapi.federwiege.classes import Property
+from pysmarlaapi.federwiege.services.classes import Property
 
 from homeassistant.components.sensor import (
     SensorEntity,

--- a/homeassistant/components/smarla/switch.py
+++ b/homeassistant/components/smarla/switch.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from pysmarlaapi.federwiege.classes import Property
+from pysmarlaapi.federwiege.services.classes import Property
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2437,7 +2437,7 @@ pysma==1.1.0
 pysmappee==0.2.29
 
 # homeassistant.components.smarla
-pysmarlaapi==0.13.0
+pysmarlaapi==1.0.1
 
 # homeassistant.components.smartthings
 pysmartthings==3.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2063,7 +2063,7 @@ pysma==1.1.0
 pysmappee==0.2.29
 
 # homeassistant.components.smarla
-pysmarlaapi==0.13.0
+pysmarlaapi==1.0.1
 
 # homeassistant.components.smartthings
 pysmartthings==3.5.1

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
-from pysmarlaapi.classes import AuthToken
-from pysmarlaapi.federwiege.classes import Property, Service
+from pysmarlaapi import AuthToken
+from pysmarlaapi.federwiege.services.classes import Property, Service
 import pytest
 
 from homeassistant.components.smarla.const import DOMAIN
@@ -49,7 +49,6 @@ def mock_connection() -> Generator[MagicMock]:
     ):
         connection = mock_connection.return_value
         connection.token = AuthToken.from_json(MOCK_ACCESS_TOKEN_JSON)
-        connection.refresh_token.return_value = True
         yield connection
 
 

--- a/tests/components/smarla/test_init.py
+++ b/tests/components/smarla/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from pysmarlaapi.connection.exceptions import AuthenticationException
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
@@ -17,7 +18,7 @@ async def test_init_invalid_auth(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_connection: MagicMock
 ) -> None:
     """Test init invalid authentication behavior."""
-    mock_connection.refresh_token.return_value = False
+    mock_connection.refresh_token.side_effect = AuthenticationException
 
     assert not await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump pysmarlaapi to 1.0.1
- Added functionality to differentiate between connection and authentication failures
- Added functionality to track/get notified when controller connection changes (availability)
- Some refactoring
- Diff: https://github.com/Explicatis-GmbH/pysmarlaapi/compare/0.13.0...1.0.1

I needed to make some minor adjustments to the connection error handling and import paths, so that the integration is compatible with the new version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
