### PR TITLE
Fix Peblar coordinator to silently re-login on auth errors

### DIFF
--- a/homeassistant/components/peblar/__init__.py
+++ b/homeassistant/components/peblar/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PeblarConfigEntry) -> bo
         ) from err
 
     # Setup the data coordinators
-    meter_coordinator = PeblarDataUpdateCoordinator(hass, entry, api)
+    meter_coordinator = PeblarDataUpdateCoordinator(hass, entry, peblar, api)
     user_configuration_coordinator = PeblarUserConfigurationDataUpdateCoordinator(
         hass, entry, peblar
     )

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -22,6 +22,8 @@ from peblar import (
     PeblarVersions,
 )
 
+import asyncio
+
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -86,24 +88,18 @@ def _coordinator_exception_handler[
             entry = getattr(self, "config_entry", None)
             peblar_obj = getattr(self, "peblar", None)
 
-            if entry and peblar_obj and not getattr(self, "_reauth_lock", False):
-                try:
-                    self._reauth_lock = True
-                    await peblar_obj.login(password=entry.data[CONF_PASSWORD])
+            if not entry or not peblar_obj:
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="authentication_error",
+                ) from error
 
-                    after = getattr(self, "_async_after_reauth", None)
-                    if callable(after):
-                        await after()
+            async with self._reauth_lock:
+                await peblar_obj.login(password=entry.data[CONF_PASSWORD])
+                await self._async_after_reauth()
 
-                    # 1 retry after successful login
-                    return await func(self, *args, **kwargs)
-                finally:
-                    self._reauth_lock = False
-
-            raise ConfigEntryAuthFailed(
-                translation_domain=DOMAIN,
-                translation_key="authentication_error",
-            ) from error
+                # 1 retry after successful login
+                return await func(self, *args, **kwargs)
         except PeblarConnectionError as error:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -158,7 +154,7 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
         """Initialize the coordinator."""
         self.peblar = peblar
         self.api = api
-        self._reauth_lock = False
+        self._reauth_lock = asyncio.Lock()
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -23,7 +23,7 @@ from peblar import (
 )
 
 from homeassistant.const import CONF_PASSWORD
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -95,7 +95,7 @@ def _coordinator_exception_handler[
                     if callable(after):
                         await after()
 
-                    # 1 retry after succesfull login
+                    # 1 retry after successful login
                     return await func(self, *args, **kwargs)
                 finally:
                     self._reauth_lock = False
@@ -168,7 +168,7 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
         )
 
     async def _async_after_reauth(self) -> None:
-        # After relogin: rebuild API object
+        """Rebuild the API object after reauthentication."""
         self.api = await self.peblar.rest_api(enable=True, access_mode=AccessMode.READ_WRITE)
 
     @_coordinator_exception_handler

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -85,10 +85,7 @@ def _coordinator_exception_handler[
         try:
             return await func(self, *args, **kwargs)
         except PeblarAuthenticationError as error:
-            entry = getattr(self, "config_entry", None)
-            peblar_obj = getattr(self, "peblar", None)
-
-            if not entry or not peblar_obj:
+            if not self.config_entry or not self.peblar:
                 raise ConfigEntryAuthFailed(
                     translation_domain=DOMAIN,
                     translation_key="authentication_error",

--- a/homeassistant/components/peblar/coordinator.py
+++ b/homeassistant/components/peblar/coordinator.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Any, Concatenate
 
 from peblar import (
+    AccessMode,
     Peblar,
     PeblarApi,
     PeblarAuthenticationError,
@@ -21,6 +22,7 @@ from peblar import (
     PeblarVersions,
 )
 
+from homeassistant.const import CONF_PASSWORD
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -81,13 +83,23 @@ def _coordinator_exception_handler[
         try:
             return await func(self, *args, **kwargs)
         except PeblarAuthenticationError as error:
-            if self.config_entry and self.config_entry.state is ConfigEntryState.LOADED:
-                # This is not the first refresh, so let's reload
-                # the config entry to ensure we trigger a re-authentication
-                # flow (or recover in case of API token changes).
-                self.hass.config_entries.async_schedule_reload(
-                    self.config_entry.entry_id
-                )
+            entry = getattr(self, "config_entry", None)
+            peblar_obj = getattr(self, "peblar", None)
+
+            if entry and peblar_obj and not getattr(self, "_reauth_lock", False):
+                try:
+                    self._reauth_lock = True
+                    await peblar_obj.login(password=entry.data[CONF_PASSWORD])
+
+                    after = getattr(self, "_async_after_reauth", None)
+                    if callable(after):
+                        await after()
+
+                    # 1 retry after succesfull login
+                    return await func(self, *args, **kwargs)
+                finally:
+                    self._reauth_lock = False
+
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="authentication_error",
@@ -141,10 +153,12 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
     config_entry: PeblarConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, entry: PeblarConfigEntry, api: PeblarApi
+        self, hass: HomeAssistant, entry: PeblarConfigEntry, peblar: Peblar, api: PeblarApi
     ) -> None:
         """Initialize the coordinator."""
+        self.peblar = peblar
         self.api = api
+        self._reauth_lock = False
         super().__init__(
             hass,
             LOGGER,
@@ -152,6 +166,10 @@ class PeblarDataUpdateCoordinator(DataUpdateCoordinator[PeblarData]):
             name=f"Peblar {entry.title} meter",
             update_interval=timedelta(seconds=10),
         )
+
+    async def _async_after_reauth(self) -> None:
+        # After relogin: rebuild API object
+        self.api = await self.peblar.rest_api(enable=True, access_mode=AccessMode.READ_WRITE)
 
     @_coordinator_exception_handler
     async def _async_update_data(self) -> PeblarData:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix recurring reauthentication prompts in the Peblar integration by performing a silent re-login when the Peblar client raises `PeblarAuthenticationError`, instead of scheduling a config entry reload (which triggers the user-facing reauth flow).

Changes:
- **`__init__.py`**: Pass the Peblar client instance into the coordinator (`PeblarDataUpdateCoordinator(..., peblar, api)`), so the coordinator can re-authenticate without reloading the entry.
- **`coordinator.py`**: Replace the old behavior:
  - **Old:** On `PeblarAuthenticationError`, schedule `async_schedule_reload()` if the config entry is loaded (causes reauth prompts every few days).
  - **New:** On `PeblarAuthenticationError`:
    - Use a simple `_reauth_lock` guard to prevent concurrent reauth attempts.
    - Call `await peblar.login(password=entry.data[CONF_PASSWORD])` to reauthenticate silently.
    - Run `_async_after_reauth()` to rebuild the REST API object after relogin.
    - Retry the original request **once** after a successful login.
- **Added:** `_async_after_reauth()` which rebuilds the API object:
  - `self.api = await self.peblar.rest_api(enable=True, access_mode=AccessMode.READ_WRITE)`

User-facing result:
- Users should no longer see periodic reauthentication requests; the integration should recover automatically when the session expires by re-logging in and retrying once.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #138535
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
