### PR TITLE
Handle Z-Wave values (re-)added at runtime

### DIFF
--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -43,6 +43,8 @@ DOMAIN = "zwave_js"
 
 
 EVENT_DEVICE_ADDED_TO_REGISTRY = f"{DOMAIN}_device_added_to_registry"
+EVENT_VALUE_ADDED = "value added"
+EVENT_VALUE_REMOVED = "value removed"
 EVENT_VALUE_UPDATED = "value updated"
 
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -27,6 +27,7 @@ from .discovery_data_template import BaseDiscoverySchemaDataTemplate
 from .helpers import get_device_id, get_unique_id, get_valueless_base_unique_id
 from .models import PlatformZwaveDiscoveryInfo, ZwaveDiscoveryInfo
 
+EVENT_VALUE_ADDED = "value added"
 EVENT_VALUE_REMOVED = "value removed"
 
 
@@ -62,6 +63,7 @@ class ZWaveBaseEntity(Entity):
         self.config_entry = config_entry
         self.driver = driver
         self.info = info
+        self._primary_value_removed = False
         # entities requiring additional values, can add extra ids to this list
         self.watched_value_ids = {self.info.primary_value.value_id}
 
@@ -135,6 +137,7 @@ class ZWaveBaseEntity(Entity):
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_UPDATED, self._value_changed)
         )
+        self.async_on_remove(self.info.node.on(EVENT_VALUE_ADDED, self._value_added))
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_REMOVED, self._value_removed)
         )
@@ -226,7 +229,11 @@ class ZWaveBaseEntity(Entity):
     @property
     def available(self) -> bool:
         """Return entity availability."""
-        return self.driver.client.connected and bool(self.info.node.ready)
+        return (
+            self.driver.client.connected
+            and bool(self.info.node.ready)
+            and not self._primary_value_removed
+        )
 
     @callback
     def _value_changed(self, event_data: dict) -> None:
@@ -269,7 +276,30 @@ class ZWaveBaseEntity(Entity):
             value_id,
         )
 
-        self.hass.async_create_task(self.async_remove())
+        self._primary_value_removed = True
+        self.async_write_ha_state()
+
+    @callback
+    def _value_added(self, event_data: dict) -> None:
+        """Call when a value associated with our node is added.
+
+        Should not be overridden by subclasses.
+        """
+        value = event_data["value"]
+
+        if value.value_id != self.info.primary_value.value_id:
+            return
+
+        LOGGER.debug(
+            "[%s] Primary value %s was added",
+            self.entity_id,
+            value.value_id,
+        )
+
+        self.info.primary_value = value
+        self._primary_value_removed = False
+        self.on_value_update()
+        self.async_write_ha_state()
 
     @callback
     def get_zwave_value(

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -22,13 +22,16 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.typing import UNDEFINED
 
-from .const import DOMAIN, EVENT_VALUE_UPDATED, LOGGER
+from .const import (
+    DOMAIN,
+    EVENT_VALUE_ADDED,
+    EVENT_VALUE_REMOVED,
+    EVENT_VALUE_UPDATED,
+    LOGGER,
+)
 from .discovery_data_template import BaseDiscoverySchemaDataTemplate
 from .helpers import get_device_id, get_unique_id, get_valueless_base_unique_id
 from .models import PlatformZwaveDiscoveryInfo, ZwaveDiscoveryInfo
-
-EVENT_VALUE_ADDED = "value added"
-EVENT_VALUE_REMOVED = "value removed"
 
 
 @dataclass(kw_only=True)

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -795,10 +795,10 @@ class ZWaveNumericSensor(ZwaveSensor):
         self._attr_native_unit_of_measurement = data.unit_of_measurement
 
     @property
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return state of the sensor."""
         if self.info.primary_value.value is None:
-            return 0
+            return None
         return float(self.info.primary_value.value)
 
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1917,11 +1917,12 @@ async def test_disabled_node_status_entity_on_node_replaced(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_remove_entity_on_value_removed(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     zp3111: Node,
     client: MagicMock,
     integration: MockConfigEntry,
 ) -> None:
-    """Test that when entity primary values are removed the entity is removed."""
+    """Test that when entity primary values are removed the entity becomes unavailable."""
     idle_cover_status_button_entity = (
         "button.4_in_1_sensor_idle_home_security_cover_status"
     )
@@ -2038,6 +2039,153 @@ async def test_remove_entity_on_value_removed(
         }
         == new_unavailable_entities
     )
+
+    # Entities should still be in the entity registry (not fully removed)
+    assert entity_registry.async_get(battery_level_entity) is not None
+    assert entity_registry.async_get(binary_cover_entity) is not None
+    assert entity_registry.async_get(idle_cover_status_button_entity) is not None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_value_removed_and_readded(
+    hass: HomeAssistant,
+    zp3111: Node,
+    client: MagicMock,
+    integration: MockConfigEntry,
+) -> None:
+    """Test entity recovers when primary value is removed and re-added."""
+    battery_level_entity = "sensor.4_in_1_sensor_battery_level"
+
+    state = hass.states.get(battery_level_entity)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    # Remove the battery level value
+    event = Event(
+        type="value removed",
+        data={
+            "source": "node",
+            "event": "value removed",
+            "nodeId": zp3111.node_id,
+            "args": {
+                "commandClassName": "Battery",
+                "commandClass": 128,
+                "endpoint": 0,
+                "property": "level",
+                "prevValue": 100,
+                "propertyName": "level",
+            },
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(battery_level_entity)
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+    # Re-add the battery level value with a new reading
+    event = Event(
+        type="value added",
+        data={
+            "source": "node",
+            "event": "value added",
+            "nodeId": zp3111.node_id,
+            "args": {
+                "commandClassName": "Battery",
+                "commandClass": 128,
+                "endpoint": 0,
+                "property": "level",
+                "propertyName": "level",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Battery level",
+                    "min": 0,
+                    "max": 100,
+                    "unit": "%",
+                },
+                "value": 80,
+            },
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(battery_level_entity)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "80.0"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_value_never_populated_then_added(
+    hass: HomeAssistant,
+    zp3111_state: NodeDataType,
+    client: MagicMock,
+    integration: MockConfigEntry,
+) -> None:
+    """Test entity updates when value metadata exists but value is None, then added."""
+    # Modify the battery level value to have value=None (metadata exists but no data)
+    node_state = deepcopy(zp3111_state)
+    for value in node_state["values"]:
+        if value["commandClass"] == 128 and value["property"] == "level":
+            value["value"] = None
+            break
+
+    event = Event(
+        "node added",
+        {
+            "source": "controller",
+            "event": "node added",
+            "node": node_state,
+            "result": {},
+        },
+    )
+    client.driver.controller.receive_event(event)
+    await hass.async_block_till_done()
+
+    # The entity should exist but have unknown state (value is None)
+    battery_level_entity = "sensor.4_in_1_sensor_battery_level"
+    state = hass.states.get(battery_level_entity)
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    node = client.driver.controller.nodes[node_state["nodeId"]]
+
+    # Now send "value added" event with actual value
+    event = Event(
+        type="value added",
+        data={
+            "source": "node",
+            "event": "value added",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Battery",
+                "commandClass": 128,
+                "endpoint": 0,
+                "property": "level",
+                "propertyName": "level",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Battery level",
+                    "min": 0,
+                    "max": 100,
+                    "unit": "%",
+                },
+                "value": 75,
+            },
+        },
+    )
+    client.driver.receive_event(event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(battery_level_entity)
+    assert state
+    assert state.state == "75.0"
 
 
 async def test_identify_event(

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -26,7 +26,7 @@ from homeassistant.components.persistent_notification import async_dismiss
 from homeassistant.components.zwave_js import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id, get_device_id_ext
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
@@ -2047,6 +2047,7 @@ async def test_remove_entity_on_value_removed(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_value_removed_and_readded(
     hass: HomeAssistant,
     zp3111: Node,
@@ -2058,7 +2059,7 @@ async def test_value_removed_and_readded(
 
     state = hass.states.get(battery_level_entity)
     assert state
-    assert state.state != STATE_UNAVAILABLE
+    assert state.state == "0.0"
 
     # Remove the battery level value
     event = Event(
@@ -2120,6 +2121,7 @@ async def test_value_removed_and_readded(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
 async def test_value_never_populated_then_added(
     hass: HomeAssistant,
     zp3111_state: NodeDataType,
@@ -2150,7 +2152,7 @@ async def test_value_never_populated_then_added(
     battery_level_entity = "sensor.4_in_1_sensor_battery_level"
     state = hass.states.get(battery_level_entity)
     assert state
-    assert state.state != STATE_UNAVAILABLE
+    assert state.state == STATE_UNKNOWN
 
     node = client.driver.controller.nodes[node_state["nodeId"]]
 

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -125,9 +125,7 @@ async def test_battery_sensors(
     entity_id = "sensor.keypad_v2_maximum_capacity"
     state = hass.states.get(entity_id)
     assert state
-    assert (
-        state.state == "0"
-    )  # This should be None/unknown but will be fixed in a future PR.
+    assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
     assert ATTR_DEVICE_CLASS not in state.attributes
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
@@ -143,9 +141,7 @@ async def test_battery_sensors(
     entity_id = "sensor.keypad_v2_temperature"
     state = hass.states.get(entity_id)
     assert state
-    assert (
-        state.state == "0"
-    )  # This should be None/unknown but will be fixed in a future PR.
+    assert state.state == STATE_UNKNOWN
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
@@ -225,7 +221,7 @@ async def test_numeric_sensor(
     await hass.async_block_till_done()
     state = hass.states.get("sensor.hsm200_illuminance")
     assert state
-    assert state.state == "0"
+    assert state.state == STATE_UNKNOWN
 
 
 async def test_invalid_multilevel_sensor_scale(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a Z-Wave value loses its value at runtime (e.g. when a battery is disconnected), the corresponding entity goes unavailable in HA - as expected. When the value is re-added later (battery re-connected), the entity stays unavailable and there is a warning from Recorder about re-used entity IDs.

This PR fixes this shortcoming:

When Z-Wave values become undefined (e.g., battery disconnected), mark entities as unavailable instead of removing them. When the value returns, restore the entity automatically.                     
                                                                                                                                                                                                         
Previously, a "value removed" event would permanently remove the entity via `async_remove()`, causing it to not reappear until a node re-interview, and triggering recorder migration warnings from entity ID changes. Now:

  - Value removed: Entity is marked unavailable (`_primary_value_removed` flag) instead of being deleted
  - Value re-added: A new `"value added"` listener on each entity detects when the primary value returns and restores availability
  - Value initially `None`: Entities created with `value=None` (metadata exists but no data yet) now pick up their value when a `"value added"` event fires

[Screencast from 2026-02-13 13-20-22.webm](https://github.com/user-attachments/assets/8674b21b-16fa-4ab7-9894-de59931c017e)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
