### PR TITLE
Make template lock code error consistent between state based and trigger based template entities

### DIFF
--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -104,7 +104,7 @@ class AbstractTemplateEntity(Entity):
         validator: Callable[[Any], Any] | None = None,
         on_update: Callable[[Any], None] | None = None,
         render_complex: bool = False,
-        **kwargs,
+        none_on_template_error: bool = True,
     ) -> None:
         """Set up a template that manages any property or attribute of the entity.
 
@@ -124,6 +124,9 @@ class AbstractTemplateEntity(Entity):
             This signals trigger based template entities to render the template
             as a complex result. State based template entities always render
             complex results.
+        none_on_template_error (default=True)
+            If set to false, template errors will be supplied in the result to
+            on_update.
         """
 
     def add_template(

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -305,7 +305,9 @@ class TemplateEntity(AbstractTemplateEntity):
             else:
                 setattr(self, attribute, state)
 
-        self.add_template(option, attribute, on_update=_update_state)
+        self.add_template(
+            option, attribute, on_update=_update_state, none_on_template_error=False
+        )
 
     def setup_template(
         self,
@@ -314,7 +316,7 @@ class TemplateEntity(AbstractTemplateEntity):
         validator: Callable[[Any], Any] | None = None,
         on_update: Callable[[Any], None] | None = None,
         render_complex: bool = False,
-        **kwargs,
+        none_on_template_error: bool = True,
     ):
         """Set up a template that manages any property or attribute of the entity.
 
@@ -334,8 +336,10 @@ class TemplateEntity(AbstractTemplateEntity):
             This signals trigger based template entities to render the template
             as a complex result. State based template entities always render
             complex results.
+        none_on_template_error (default=True)
+            If set to false, template errors will be supplied in the result to
+            on_update.
         """
-        none_on_template_error = kwargs.get("none_on_template_error", True)
         self.add_template(
             option, attribute, validator, on_update, none_on_template_error
         )

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -757,16 +757,16 @@ async def test_lock_actions_fail_with_invalid_code(
     ],
 )
 @pytest.mark.parametrize(
-    ("style", "attribute", "expected"),
+    ("style", "attribute"),
     [
-        (ConfigurationStyle.LEGACY, "code_format_template", 0),
-        (ConfigurationStyle.MODERN, "code_format", 0),
-        (ConfigurationStyle.TRIGGER, "code_format", 2),
+        (ConfigurationStyle.LEGACY, "code_format_template"),
+        (ConfigurationStyle.MODERN, "code_format"),
+        (ConfigurationStyle.TRIGGER, "code_format"),
     ],
 )
 @pytest.mark.usefixtures("setup_state_lock_with_attribute")
 async def test_lock_actions_dont_execute_with_code_template_rendering_error(
-    hass: HomeAssistant, calls: list[ServiceCall], expected: int
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test lock code format rendering fails block lock/unlock actions."""
 
@@ -786,10 +786,7 @@ async def test_lock_actions_dont_execute_with_code_template_rendering_error(
     )
     await hass.async_block_till_done()
 
-    # Trigger expects calls here because trigger based entities don't
-    # allow template exception resolutions into code_format property so
-    # the actions will fire using the previous code_format.
-    assert len(calls) == expected
+    assert len(calls) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During the template lock refactoring, it was found that trigger based locks and state based locks behaved differently when evaluating templated code errors.

This PR addresses that functionality and cleans up the **kwargs on setup_template.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
