### PR TITLE
Add sleep health metrics to SleepIQ integration

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -26,6 +26,7 @@ from .coordinator import (
     SleepIQData,
     SleepIQDataUpdateCoordinator,
     SleepIQPauseUpdateCoordinator,
+    SleepIQSleepDataCoordinator,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,14 +97,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = SleepIQDataUpdateCoordinator(hass, entry, gateway)
     pause_coordinator = SleepIQPauseUpdateCoordinator(hass, entry, gateway)
+    sleep_data_coordinator = SleepIQSleepDataCoordinator(hass, entry, gateway)
 
     # Call the SleepIQ API to refresh data
     await coordinator.async_config_entry_first_refresh()
     await pause_coordinator.async_config_entry_first_refresh()
+    await sleep_data_coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = SleepIQData(
         data_coordinator=coordinator,
         pause_coordinator=pause_coordinator,
+        sleep_data_coordinator=sleep_data_coordinator,
         client=gateway,
     )
 

--- a/homeassistant/components/sleepiq/const.py
+++ b/homeassistant/components/sleepiq/const.py
@@ -19,6 +19,7 @@ SLEEP_SCORE = "sleep_score"
 SLEEP_DURATION = "sleep_duration"
 HEART_RATE = "heart_rate"
 RESPIRATORY_RATE = "respiratory_rate"
+HRV = "hrv"
 ENTITY_TYPES = {
     ACTUATOR: "Position",
     CORE_CLIMATE_TIMER: "Core Climate Timer",
@@ -33,6 +34,7 @@ ENTITY_TYPES = {
     SLEEP_DURATION: "Sleep Duration",
     HEART_RATE: "Heart Rate Average",
     RESPIRATORY_RATE: "Respiratory Rate Average",
+    HRV: "Heart Rate Variability",
 }
 
 LEFT = "left"

--- a/homeassistant/components/sleepiq/const.py
+++ b/homeassistant/components/sleepiq/const.py
@@ -15,6 +15,10 @@ PRESSURE = "pressure"
 SLEEP_NUMBER = "sleep_number"
 FOOT_WARMING_TIMER = "foot_warming_timer"
 FOOT_WARMER = "foot_warmer"
+SLEEP_SCORE = "sleep_score"
+SLEEP_DURATION = "sleep_duration"
+HEART_RATE = "heart_rate"
+RESPIRATORY_RATE = "respiratory_rate"
 ENTITY_TYPES = {
     ACTUATOR: "Position",
     CORE_CLIMATE_TIMER: "Core Climate Timer",
@@ -25,10 +29,10 @@ ENTITY_TYPES = {
     SLEEP_NUMBER: "SleepNumber",
     FOOT_WARMING_TIMER: "Foot Warming Timer",
     FOOT_WARMER: "Foot Warmer",
-    "sleep_score": "Sleep Score",
-    "sleep_duration": "Sleep Duration",
-    "heart_rate": "Heart Rate Average",
-    "respiratory_rate": "Respiratory Rate Average",
+    SLEEP_SCORE: "Sleep Score",
+    SLEEP_DURATION: "Sleep Duration",
+    HEART_RATE: "Heart Rate Average",
+    RESPIRATORY_RATE: "Respiratory Rate Average",
 }
 
 LEFT = "left"

--- a/homeassistant/components/sleepiq/const.py
+++ b/homeassistant/components/sleepiq/const.py
@@ -25,6 +25,10 @@ ENTITY_TYPES = {
     SLEEP_NUMBER: "SleepNumber",
     FOOT_WARMING_TIMER: "Foot Warming Timer",
     FOOT_WARMER: "Foot Warmer",
+    "sleep_score": "Sleep Score",
+    "sleep_duration": "Sleep Duration",
+    "heart_rate": "Heart Rate Average",
+    "respiratory_rate": "Respiratory Rate Average",
 }
 
 LEFT = "left"

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -1,8 +1,8 @@
-"""Coordinator for SleepIQ."""
+"""Coordinator for SleepIQ - Enhanced with Sleep Data."""
 
 import asyncio
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from asyncsleepiq import AsyncSleepIQ
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 UPDATE_INTERVAL = timedelta(seconds=60)
 LONGER_UPDATE_INTERVAL = timedelta(minutes=5)
+SLEEP_DATA_UPDATE_INTERVAL = timedelta(hours=1)  # Sleep data doesn't change frequently
 
 
 class SleepIQDataUpdateCoordinator(DataUpdateCoordinator[None]):
@@ -74,10 +75,90 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
         )
 
 
+class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
+    """SleepIQ sleep health data coordinator.
+
+    Fetches sleep metrics like sleep score, duration, heart rate, and respiratory rate.
+    Updates less frequently since sleep data doesn't change in real-time.
+    """
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        client: AsyncSleepIQ,
+    ) -> None:
+        """Initialize coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{config_entry.data[CONF_USERNAME]}@SleepIQSleepData",
+            update_interval=SLEEP_DATA_UPDATE_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> None:
+        """Fetch sleep health data from API.
+
+        Gets yesterday's sleep data for each sleeper and updates their attributes.
+        """
+        yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%S')
+
+        tasks = []
+        for bed in self.client.beds.values():
+            for sleeper in bed.sleepers:
+                tasks.append(self._fetch_sleeper_data(sleeper, yesterday))
+
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _fetch_sleeper_data(self, sleeper, date_str: str) -> None:
+        """Fetch and update sleep data for a single sleeper."""
+        try:
+            params = {
+                'date': date_str,
+                'interval': 'D1',
+                'sleeper': sleeper.sleeper_id,
+                'includeSlices': 'false'
+            }
+            param_str = '&'.join(f"{k}={v}" for k, v in params.items())
+            endpoint = f"sleepData?{param_str}"
+
+            data = await self.client.get(endpoint)
+
+            if data:
+                # Update sleeper attributes with sleep health metrics
+                # NOTE: totalSleepSessionTime is always 0, use inBed instead for duration
+                sleeper.sleep_duration = data.get('inBed', 0)  # seconds
+                sleeper.sleep_score = data.get('avgSleepIQ')
+                sleeper.heart_rate = data.get('avgHeartRate')
+                sleeper.respiratory_rate = data.get('avgRespirationRate')
+
+                _LOGGER.debug(
+                    "Updated sleep data for %s: score=%s, duration=%sh, hr=%s, rr=%s",
+                    sleeper.name,
+                    sleeper.sleep_score,
+                    round(sleeper.sleep_duration / 3600, 1) if sleeper.sleep_duration else None,
+                    sleeper.heart_rate,
+                    sleeper.respiratory_rate,
+                )
+        except Exception as err:
+            _LOGGER.debug(
+                "Error fetching sleep data for %s: %s",
+                sleeper.name,
+                err,
+            )
+            # Don't fail the entire update if one sleeper fails
+            # Just leave previous values
+
+
 @dataclass
 class SleepIQData:
     """Data for the sleepiq integration."""
 
     data_coordinator: SleepIQDataUpdateCoordinator
     pause_coordinator: SleepIQPauseUpdateCoordinator
+    sleep_data_coordinator: SleepIQSleepDataCoordinator
     client: AsyncSleepIQ

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -76,11 +76,7 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
 
 
 class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
-    """SleepIQ sleep health data coordinator.
-
-    Fetches sleep metrics like sleep score, duration, heart rate, and respiratory rate.
-    Updates less frequently since sleep data doesn't change in real-time.
-    """
+    """SleepIQ sleep health data coordinator."""
 
     config_entry: ConfigEntry
 
@@ -101,57 +97,52 @@ class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
         self.client = client
 
     async def _async_update_data(self) -> None:
-        """Fetch sleep health data from API.
-
-        Gets yesterday's sleep data for each sleeper and updates their attributes.
-        """
-        yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y-%m-%dT%H:%M:%S')
+        """Fetch sleep health data from API."""
+        yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
 
         tasks = []
         for bed in self.client.beds.values():
             for sleeper in bed.sleepers:
                 tasks.append(self._fetch_sleeper_data(sleeper, yesterday))
 
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.gather(*tasks)
 
     async def _fetch_sleeper_data(self, sleeper, date_str: str) -> None:
-        """Fetch and update sleep data for a single sleeper."""
+        params = {
+            "date": date_str,
+            "interval": "D1",
+            "sleeper": sleeper.sleeper_id,
+            "includeSlices": "false"
+        }
+        param_str = "&".join(f"{k}={v}" for k, v in params.items())
+        endpoint = f"sleepData?{param_str}"
+
         try:
-            params = {
-                'date': date_str,
-                'interval': 'D1',
-                'sleeper': sleeper.sleeper_id,
-                'includeSlices': 'false'
-            }
-            param_str = '&'.join(f"{k}={v}" for k, v in params.items())
-            endpoint = f"sleepData?{param_str}"
-
             data = await self.client.get(endpoint)
-
-            if data:
-                # Update sleeper attributes with sleep health metrics
-                # NOTE: totalSleepSessionTime is always 0, use inBed instead for duration
-                sleeper.sleep_duration = data.get('inBed', 0)  # seconds
-                sleeper.sleep_score = data.get('avgSleepIQ')
-                sleeper.heart_rate = data.get('avgHeartRate')
-                sleeper.respiratory_rate = data.get('avgRespirationRate')
-
-                _LOGGER.debug(
-                    "Updated sleep data for %s: score=%s, duration=%sh, hr=%s, rr=%s",
-                    sleeper.name,
-                    sleeper.sleep_score,
-                    round(sleeper.sleep_duration / 3600, 1) if sleeper.sleep_duration else None,
-                    sleeper.heart_rate,
-                    sleeper.respiratory_rate,
-                )
         except Exception as err:
             _LOGGER.debug(
                 "Error fetching sleep data for %s: %s",
                 sleeper.name,
                 err,
             )
-            # Don't fail the entire update if one sleeper fails
-            # Just leave previous values
+            return
+
+        if data:
+            # Update sleeper attributes with sleep health metrics
+            # NOTE: totalSleepSessionTime is always 0, use inBed instead for duration
+            sleeper.sleep_duration = data["inBed"]  # seconds
+            sleeper.sleep_score = data["avgSleepIQ"]
+            sleeper.heart_rate = data["avgHeartRate"]
+            sleeper.respiratory_rate = data["avgRespirationRate"]
+
+            _LOGGER.debug(
+                "Updated sleep data for %s: score=%s, duration=%sh, hr=%s, rr=%s",
+                sleeper.name,
+                sleeper.sleep_score,
+                round(sleeper.sleep_duration / 3600, 1) if sleeper.sleep_duration else None,
+                sleeper.heart_rate,
+                sleeper.respiratory_rate,
+            )
 
 
 @dataclass

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 
 from asyncsleepiq import AsyncSleepIQ
@@ -95,13 +95,11 @@ class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
         self.client = client
 
     async def _async_update_data(self) -> None:
-        """Fetch sleep health data from API."""
-        yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-
+        """Fetch sleep health data from API via asyncsleepiq library."""
         tasks = []
         for bed in self.client.beds.values():
             for sleeper in bed.sleepers:
-                tasks.append(sleeper.fetch_sleep_data(yesterday))
+                tasks.append(sleeper.fetch_sleep_data())
 
         await asyncio.gather(*tasks)
 

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -1,4 +1,4 @@
-"""Coordinator for SleepIQ - Enhanced with Sleep Data."""
+"""Coordinator for SleepIQ."""
 
 import asyncio
 from dataclasses import dataclass

--- a/homeassistant/components/sleepiq/coordinator.py
+++ b/homeassistant/components/sleepiq/coordinator.py
@@ -78,8 +78,6 @@ class SleepIQPauseUpdateCoordinator(DataUpdateCoordinator[None]):
 class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
     """SleepIQ sleep health data coordinator."""
 
-    config_entry: ConfigEntry
-
     def __init__(
         self,
         hass: HomeAssistant,
@@ -103,46 +101,9 @@ class SleepIQSleepDataCoordinator(DataUpdateCoordinator[None]):
         tasks = []
         for bed in self.client.beds.values():
             for sleeper in bed.sleepers:
-                tasks.append(self._fetch_sleeper_data(sleeper, yesterday))
+                tasks.append(sleeper.fetch_sleep_data(yesterday))
 
         await asyncio.gather(*tasks)
-
-    async def _fetch_sleeper_data(self, sleeper, date_str: str) -> None:
-        params = {
-            "date": date_str,
-            "interval": "D1",
-            "sleeper": sleeper.sleeper_id,
-            "includeSlices": "false"
-        }
-        param_str = "&".join(f"{k}={v}" for k, v in params.items())
-        endpoint = f"sleepData?{param_str}"
-
-        try:
-            data = await self.client.get(endpoint)
-        except Exception as err:
-            _LOGGER.debug(
-                "Error fetching sleep data for %s: %s",
-                sleeper.name,
-                err,
-            )
-            return
-
-        if data:
-            # Update sleeper attributes with sleep health metrics
-            # NOTE: totalSleepSessionTime is always 0, use inBed instead for duration
-            sleeper.sleep_duration = data["inBed"]  # seconds
-            sleeper.sleep_score = data["avgSleepIQ"]
-            sleeper.heart_rate = data["avgHeartRate"]
-            sleeper.respiratory_rate = data["avgRespirationRate"]
-
-            _LOGGER.debug(
-                "Updated sleep data for %s: score=%s, duration=%sh, hr=%s, rr=%s",
-                sleeper.name,
-                sleeper.sleep_score,
-                round(sleeper.sleep_duration / 3600, 1) if sleeper.sleep_duration else None,
-                sleeper.heart_rate,
-                sleeper.respiratory_rate,
-            )
 
 
 @dataclass

--- a/homeassistant/components/sleepiq/entity.py
+++ b/homeassistant/components/sleepiq/entity.py
@@ -11,9 +11,9 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ENTITY_TYPES, ICON_OCCUPIED
-from .coordinator import SleepIQDataUpdateCoordinator, SleepIQPauseUpdateCoordinator
+from .coordinator import SleepIQDataUpdateCoordinator, SleepIQPauseUpdateCoordinator, SleepIQSleepDataCoordinator
 
-type _DataCoordinatorType = SleepIQDataUpdateCoordinator | SleepIQPauseUpdateCoordinator
+type _DataCoordinatorType = SleepIQDataUpdateCoordinator | SleepIQPauseUpdateCoordinator | SleepIQSleepDataCoordinator
 
 
 def device_from_bed(bed: SleepIQBed) -> DeviceInfo:

--- a/homeassistant/components/sleepiq/icons.json
+++ b/homeassistant/components/sleepiq/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "sensor": {
+      "sleep_score": {
+        "default": "mdi:sleep"
+      },
+      "sleep_duration": {
+        "default": "mdi:sleep"
+      },
+      "heart_rate_avg": {
+        "default": "mdi:heart-pulse"
+      },
+      "respiratory_rate_avg": {
+        "default": "mdi:lungs"
+      }
+    }
+  }
+}

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -65,7 +65,7 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
         translation_key="sleep_score",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="score",
-        value_fn=lambda sleeper: sleeper.sleep_score,
+        value_fn=lambda sleeper: sleeper.sleep_data.sleep_score,
     ),
     SleepIQSensorEntityDescription(
         key=SLEEP_DURATION,
@@ -75,8 +75,8 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTime.HOURS,
         suggested_display_precision=1,
         value_fn=lambda sleeper: (
-            round(sleeper.sleep_duration / 3600, 1)
-            if sleeper.sleep_duration
+            round(sleeper.sleep_data.duration / 3600, 1)
+            if sleeper.sleep_data.duration
             else None
         ),
     ),
@@ -85,21 +85,21 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
         translation_key="heart_rate_avg",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="bpm",
-        value_fn=lambda sleeper: sleeper.heart_rate,
+        value_fn=lambda sleeper: sleeper.sleep_data.heart_rate,
     ),
     SleepIQSensorEntityDescription(
         key=RESPIRATORY_RATE,
         translation_key="respiratory_rate_avg",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="brpm",
-        value_fn=lambda sleeper: sleeper.respiratory_rate,
+        value_fn=lambda sleeper: sleeper.sleep_data.respiratory_rate,
     ),
     SleepIQSensorEntityDescription(
         key=HRV,
         translation_key="hrv",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="ms",
-        value_fn=lambda sleeper: sleeper.hrv,
+        value_fn=lambda sleeper: sleeper.sleep_data.hrv,
     ),
 )
 

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -1,4 +1,4 @@
-"""Support for SleepIQ Sensor - Enhanced with Sleep Health Metrics."""
+"""Support for SleepIQ sensors."""
 
 from __future__ import annotations
 
@@ -17,9 +17,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN, PRESSURE, SLEEP_NUMBER
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator, SleepIQSleepDataCoordinator
+from .coordinator import (
+    SleepIQData,
+    SleepIQDataUpdateCoordinator,
+    SleepIQSleepDataCoordinator,
+)
 from .entity import SleepIQSleeperEntity
 
 
@@ -30,7 +35,6 @@ class SleepIQSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[SleepIQSleeper], float | int | None]
 
 
-# Real-time bed sensors (existing)
 BED_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
     SleepIQSensorEntityDescription(
         key=PRESSURE,
@@ -46,7 +50,6 @@ BED_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
     ),
 )
 
-# Sleep health metrics sensors (NEW!)
 SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
     SleepIQSensorEntityDescription(
         key="sleep_score",
@@ -62,7 +65,11 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTime.HOURS,
         suggested_display_precision=1,
-        value_fn=lambda sleeper: round(getattr(sleeper, "sleep_duration", 0) / 3600, 1) if getattr(sleeper, "sleep_duration", 0) else None,
+        value_fn=lambda sleeper: (
+            round(getattr(sleeper, "sleep_duration", 0) / 3600, 1)
+            if getattr(sleeper, "sleep_duration", 0)
+            else None
+        ),
     ),
     SleepIQSensorEntityDescription(
         key="heart_rate",
@@ -91,17 +98,19 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
 
-    # Add real-time bed sensors
     entities.extend(
-        SleepIQSensorEntity(data.data_coordinator, bed, sleeper, description)
+        SleepIQSensorEntity(
+            data.data_coordinator, bed, sleeper, description, "mdi:bed"
+        )
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
         for description in BED_SENSORS
     )
 
-    # Add sleep health metric sensors
     entities.extend(
-        SleepIQSleepDataSensorEntity(data.sleep_data_coordinator, bed, sleeper, description)
+        SleepIQSensorEntity(
+            data.sleep_data_coordinator, bed, sleeper, description, "mdi:sleep"
+        )
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
         for description in SLEEP_HEALTH_SENSORS
@@ -110,49 +119,23 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SleepIQSensorEntity(
-    SleepIQSleeperEntity[SleepIQDataUpdateCoordinator], SensorEntity
-):
-    """Representation of a SleepIQ bed sensor (real-time)."""
+class SleepIQSensorEntity(SleepIQSleeperEntity[DataUpdateCoordinator], SensorEntity):
+    """Representation of a SleepIQ sensor."""
 
     entity_description: SleepIQSensorEntityDescription
-    _attr_icon = "mdi:bed"
 
     def __init__(
         self,
-        coordinator: SleepIQDataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator,
         bed: SleepIQBed,
         sleeper: SleepIQSleeper,
         description: SleepIQSensorEntityDescription,
+        icon: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, bed, sleeper, description.key)
         self.entity_description = description
-
-    @callback
-    def _async_update_attrs(self) -> None:
-        """Update sensor attributes."""
-        self._attr_native_value = self.entity_description.value_fn(self.sleeper)
-
-
-class SleepIQSleepDataSensorEntity(
-    SleepIQSleeperEntity[SleepIQSleepDataCoordinator], SensorEntity
-):
-    """Representation of a SleepIQ sleep health metric sensor."""
-
-    entity_description: SleepIQSensorEntityDescription
-    _attr_icon = "mdi:sleep"
-
-    def __init__(
-        self,
-        coordinator: SleepIQSleepDataCoordinator,
-        bed: SleepIQBed,
-        sleeper: SleepIQSleeper,
-        description: SleepIQSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator, bed, sleeper, description.key)
-        self.entity_description = description
+        self._attr_icon = icon
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -1,19 +1,84 @@
-"""Support for SleepIQ Sensor."""
+"""Support for SleepIQ Sensor - Enhanced with Sleep Health Metrics."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from asyncsleepiq import SleepIQBed, SleepIQSleeper
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN, PRESSURE, SLEEP_NUMBER
-from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
+from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator, SleepIQSleepDataCoordinator
 from .entity import SleepIQSleeperEntity
 
-SENSORS = [PRESSURE, SLEEP_NUMBER]
+
+@dataclass(frozen=True, kw_only=True)
+class SleepIQSensorEntityDescription(SensorEntityDescription):
+    """Describes SleepIQ sensor entity."""
+
+    value_fn: Callable[[SleepIQSleeper], float | int | None]
+
+
+# Real-time bed sensors (existing)
+BED_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
+    SleepIQSensorEntityDescription(
+        key=PRESSURE,
+        translation_key="pressure",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda sleeper: sleeper.pressure,
+    ),
+    SleepIQSensorEntityDescription(
+        key=SLEEP_NUMBER,
+        translation_key="sleep_number",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda sleeper: sleeper.sleep_number,
+    ),
+)
+
+# Sleep health metrics sensors (NEW!)
+SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
+    SleepIQSensorEntityDescription(
+        key="sleep_score",
+        translation_key="sleep_score",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="score",
+        value_fn=lambda sleeper: getattr(sleeper, "sleep_score", None),
+    ),
+    SleepIQSensorEntityDescription(
+        key="sleep_duration",
+        translation_key="sleep_duration",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        suggested_display_precision=1,
+        value_fn=lambda sleeper: round(getattr(sleeper, "sleep_duration", 0) / 3600, 1) if getattr(sleeper, "sleep_duration", 0) else None,
+    ),
+    SleepIQSensorEntityDescription(
+        key="heart_rate",
+        translation_key="heart_rate_avg",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="bpm",
+        value_fn=lambda sleeper: getattr(sleeper, "heart_rate", None),
+    ),
+    SleepIQSensorEntityDescription(
+        key="respiratory_rate",
+        translation_key="respiratory_rate_avg",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="brpm",
+        value_fn=lambda sleeper: getattr(sleeper, "respiratory_rate", None),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -23,19 +88,34 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SleepIQ bed sensors."""
     data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        SleepIQSensorEntity(data.data_coordinator, bed, sleeper, sensor_type)
+
+    entities: list[SensorEntity] = []
+
+    # Add real-time bed sensors
+    entities.extend(
+        SleepIQSensorEntity(data.data_coordinator, bed, sleeper, description)
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
-        for sensor_type in SENSORS
+        for description in BED_SENSORS
     )
+
+    # Add sleep health metric sensors
+    entities.extend(
+        SleepIQSleepDataSensorEntity(data.sleep_data_coordinator, bed, sleeper, description)
+        for bed in data.client.beds.values()
+        for sleeper in bed.sleepers
+        for description in SLEEP_HEALTH_SENSORS
+    )
+
+    async_add_entities(entities)
 
 
 class SleepIQSensorEntity(
     SleepIQSleeperEntity[SleepIQDataUpdateCoordinator], SensorEntity
 ):
-    """Representation of an SleepIQ Entity with CoordinatorEntity."""
+    """Representation of a SleepIQ bed sensor (real-time)."""
 
+    entity_description: SleepIQSensorEntityDescription
     _attr_icon = "mdi:bed"
 
     def __init__(
@@ -43,14 +123,38 @@ class SleepIQSensorEntity(
         coordinator: SleepIQDataUpdateCoordinator,
         bed: SleepIQBed,
         sleeper: SleepIQSleeper,
-        sensor_type: str,
+        description: SleepIQSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        self.sensor_type = sensor_type
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        super().__init__(coordinator, bed, sleeper, sensor_type)
+        super().__init__(coordinator, bed, sleeper, description.key)
+        self.entity_description = description
 
     @callback
     def _async_update_attrs(self) -> None:
         """Update sensor attributes."""
-        self._attr_native_value = getattr(self.sleeper, self.sensor_type)
+        self._attr_native_value = self.entity_description.value_fn(self.sleeper)
+
+
+class SleepIQSleepDataSensorEntity(
+    SleepIQSleeperEntity[SleepIQSleepDataCoordinator], SensorEntity
+):
+    """Representation of a SleepIQ sleep health metric sensor."""
+
+    entity_description: SleepIQSensorEntityDescription
+    _attr_icon = "mdi:sleep"
+
+    def __init__(
+        self,
+        coordinator: SleepIQSleepDataCoordinator,
+        bed: SleepIQBed,
+        sleeper: SleepIQSleeper,
+        description: SleepIQSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, bed, sleeper, description.key)
+        self.entity_description = description
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update sensor attributes."""
+        self._attr_native_value = self.entity_description.value_fn(self.sleeper)

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     DOMAIN,
     HEART_RATE,
+    HRV,
     PRESSURE,
     RESPIRATORY_RATE,
     SLEEP_DURATION,
@@ -92,6 +93,13 @@ SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="brpm",
         value_fn=lambda sleeper: sleeper.respiratory_rate,
+    ),
+    SleepIQSensorEntityDescription(
+        key=HRV,
+        translation_key="hrv",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="ms",
+        value_fn=lambda sleeper: sleeper.hrv,
     ),
 )
 

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -19,7 +19,15 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, PRESSURE, SLEEP_NUMBER
+from .const import (
+    DOMAIN,
+    HEART_RATE,
+    PRESSURE,
+    RESPIRATORY_RATE,
+    SLEEP_DURATION,
+    SLEEP_NUMBER,
+    SLEEP_SCORE,
+)
 from .coordinator import (
     SleepIQData,
     SleepIQDataUpdateCoordinator,
@@ -52,38 +60,38 @@ BED_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
 
 SLEEP_HEALTH_SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
     SleepIQSensorEntityDescription(
-        key="sleep_score",
+        key=SLEEP_SCORE,
         translation_key="sleep_score",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="score",
-        value_fn=lambda sleeper: getattr(sleeper, "sleep_score", None),
+        value_fn=lambda sleeper: sleeper.sleep_score,
     ),
     SleepIQSensorEntityDescription(
-        key="sleep_duration",
+        key=SLEEP_DURATION,
         translation_key="sleep_duration",
         device_class=SensorDeviceClass.DURATION,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTime.HOURS,
         suggested_display_precision=1,
         value_fn=lambda sleeper: (
-            round(getattr(sleeper, "sleep_duration", 0) / 3600, 1)
-            if getattr(sleeper, "sleep_duration", 0)
+            round(sleeper.sleep_duration / 3600, 1)
+            if sleeper.sleep_duration
             else None
         ),
     ),
     SleepIQSensorEntityDescription(
-        key="heart_rate",
+        key=HEART_RATE,
         translation_key="heart_rate_avg",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="bpm",
-        value_fn=lambda sleeper: getattr(sleeper, "heart_rate", None),
+        value_fn=lambda sleeper: sleeper.heart_rate,
     ),
     SleepIQSensorEntityDescription(
-        key="respiratory_rate",
+        key=RESPIRATORY_RATE,
         translation_key="respiratory_rate_avg",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement="brpm",
-        value_fn=lambda sleeper: getattr(sleeper, "respiratory_rate", None),
+        value_fn=lambda sleeper: sleeper.respiratory_rate,
     ),
 )
 
@@ -119,14 +127,17 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class SleepIQSensorEntity(SleepIQSleeperEntity[DataUpdateCoordinator], SensorEntity):
+class SleepIQSensorEntity(
+    SleepIQSleeperEntity[SleepIQDataUpdateCoordinator | SleepIQSleepDataCoordinator],
+    SensorEntity,
+):
     """Representation of a SleepIQ sensor."""
 
     entity_description: SleepIQSensorEntityDescription
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: SleepIQDataUpdateCoordinator | SleepIQSleepDataCoordinator,
         bed: SleepIQBed,
         sleeper: SleepIQSleeper,
         description: SleepIQSensorEntityDescription,

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -100,7 +100,7 @@ async def async_setup_entry(
 
     entities.extend(
         SleepIQSensorEntity(
-            data.data_coordinator, bed, sleeper, description, "mdi:bed"
+            data.data_coordinator, bed, sleeper, description
         )
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
@@ -109,7 +109,7 @@ async def async_setup_entry(
 
     entities.extend(
         SleepIQSensorEntity(
-            data.sleep_data_coordinator, bed, sleeper, description, "mdi:sleep"
+            data.sleep_data_coordinator, bed, sleeper, description
         )
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
@@ -130,12 +130,10 @@ class SleepIQSensorEntity(SleepIQSleeperEntity[DataUpdateCoordinator], SensorEnt
         bed: SleepIQBed,
         sleeper: SleepIQSleeper,
         description: SleepIQSensorEntityDescription,
-        icon: str,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, bed, sleeper, description.key)
         self.entity_description = description
-        self._attr_icon = icon
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -10,6 +10,7 @@ from asyncsleepiq import (
     CoreTemps,
     FootWarmingTemps,
     Side,
+    SleepData,
     SleepIQActuator,
     SleepIQBed,
     SleepIQCoreClimate,
@@ -76,11 +77,13 @@ def mock_bed() -> MagicMock:
     sleeper_l.sleep_number = 40
     sleeper_l.pressure = 1000
     sleeper_l.sleeper_id = SLEEPER_L_ID
-    sleeper_l.sleep_duration = 28800  # 8 hours in seconds
-    sleeper_l.sleep_score = 85
-    sleeper_l.heart_rate = 60
-    sleeper_l.respiratory_rate = 14
-    sleeper_l.hrv = 68
+    sleeper_l.sleep_data = SleepData(
+        duration=28800,  # 8 hours in seconds
+        sleep_score=85,
+        heart_rate=60,
+        respiratory_rate=14,
+        hrv=68,
+    )
 
     sleeper_r.side = Side.RIGHT
     sleeper_r.name = SLEEPER_R_NAME
@@ -88,11 +91,13 @@ def mock_bed() -> MagicMock:
     sleeper_r.sleep_number = 80
     sleeper_r.pressure = 1400
     sleeper_r.sleeper_id = SLEEPER_R_ID
-    sleeper_r.sleep_duration = 25200  # 7 hours in seconds
-    sleeper_r.sleep_score = 78
-    sleeper_r.heart_rate = 65
-    sleeper_r.respiratory_rate = 15
-    sleeper_r.hrv = 72
+    sleeper_r.sleep_data = SleepData(
+        duration=25200,  # 7 hours in seconds
+        sleep_score=78,
+        heart_rate=65,
+        respiratory_rate=15,
+        hrv=72,
+    )
 
     bed.foundation = create_autospec(SleepIQFoundation)
     light_1 = create_autospec(SleepIQLight)

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -80,6 +80,7 @@ def mock_bed() -> MagicMock:
     sleeper_l.sleep_score = 85
     sleeper_l.heart_rate = 60
     sleeper_l.respiratory_rate = 14
+    sleeper_l.hrv = 68
 
     sleeper_r.side = Side.RIGHT
     sleeper_r.name = SLEEPER_R_NAME
@@ -91,6 +92,7 @@ def mock_bed() -> MagicMock:
     sleeper_r.sleep_score = 78
     sleeper_r.heart_rate = 65
     sleeper_r.respiratory_rate = 15
+    sleeper_r.hrv = 72
 
     bed.foundation = create_autospec(SleepIQFoundation)
     light_1 = create_autospec(SleepIQLight)

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -76,6 +76,10 @@ def mock_bed() -> MagicMock:
     sleeper_l.sleep_number = 40
     sleeper_l.pressure = 1000
     sleeper_l.sleeper_id = SLEEPER_L_ID
+    sleeper_l.sleep_duration = 28800  # 8 hours in seconds
+    sleeper_l.sleep_score = 85
+    sleeper_l.heart_rate = 60
+    sleeper_l.respiratory_rate = 14
 
     sleeper_r.side = Side.RIGHT
     sleeper_r.name = SLEEPER_R_NAME
@@ -83,6 +87,10 @@ def mock_bed() -> MagicMock:
     sleeper_r.sleep_number = 80
     sleeper_r.pressure = 1400
     sleeper_r.sleeper_id = SLEEPER_R_ID
+    sleeper_r.sleep_duration = 25200  # 7 hours in seconds
+    sleeper_r.sleep_score = 78
+    sleeper_r.heart_rate = 65
+    sleeper_r.respiratory_rate = 15
 
     bed.foundation = create_autospec(SleepIQFoundation)
     light_1 = create_autospec(SleepIQLight)

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -250,3 +250,42 @@ async def test_respiratory_rate_sensors(
     )
     assert entry
     assert entry.unique_id == f"{SLEEPER_R_ID}_respiratory_rate"
+
+
+async def test_hrv_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ heart rate variability sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_heart_rate_variability"
+    )
+    assert state.state == "68"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Heart Rate Variability"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_heart_rate_variability"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_hrv"
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_heart_rate_variability"
+    )
+    assert state.state == "72"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Heart Rate Variability"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_heart_rate_variability"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_hrv"

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -94,3 +94,159 @@ async def test_pressure_sensors(
     )
     assert entry
     assert entry.unique_id == f"{SLEEPER_R_ID}_pressure"
+
+
+async def test_sleep_score_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ sleep score sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_sleep_score"
+    )
+    assert state.state == "85"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Sleep Score"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_sleep_score"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_sleep_score"
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleep_score"
+    )
+    assert state.state == "78"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Sleep Score"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleep_score"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_sleep_score"
+
+
+async def test_sleep_duration_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ sleep duration sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_sleep_duration"
+    )
+    assert state.state == "8.0"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Sleep Duration"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_sleep_duration"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_sleep_duration"
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleep_duration"
+    )
+    assert state.state == "7.0"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Sleep Duration"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_sleep_duration"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_sleep_duration"
+
+
+async def test_heart_rate_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ heart rate average sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_heart_rate_average"
+    )
+    assert state.state == "60"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Heart Rate Average"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_heart_rate_average"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_heart_rate"
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_heart_rate_average"
+    )
+    assert state.state == "65"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Heart Rate Average"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_heart_rate_average"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_heart_rate"
+
+
+async def test_respiratory_rate_sensors(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_asyncsleepiq
+) -> None:
+    """Test the SleepIQ respiratory rate average sensor."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_respiratory_rate_average"
+    )
+    assert state.state == "14"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_L_NAME} Respiratory Rate Average"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_L_NAME_LOWER}_respiratory_rate_average"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_L_ID}_respiratory_rate"
+
+    state = hass.states.get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_respiratory_rate_average"
+    )
+    assert state.state == "15"
+    assert state.attributes.get(ATTR_ICON) == "mdi:bed"
+    assert (
+        state.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"SleepNumber {BED_NAME} {SLEEPER_R_NAME} Respiratory Rate Average"
+    )
+
+    entry = entity_registry.async_get(
+        f"sensor.sleepnumber_{BED_NAME_LOWER}_{SLEEPER_R_NAME_LOWER}_respiratory_rate_average"
+    )
+    assert entry
+    assert entry.unique_id == f"{SLEEPER_R_ID}_respiratory_rate"


### PR DESCRIPTION
## Breaking change

N/A - This PR does not introduce breaking changes.

## Proposed change

This PR enhances the SleepIQ integration to expose sleep health metrics that are available from the Sleep Number API but currently not utilized by Home Assistant.

The asyncsleepiq library already supports the `/sleepData` endpoint. This PR adds a new coordinator and sensors to expose these metrics:

- **Sleep Score** (0-100) - SleepIQ quality rating
- **Sleep Duration** (hours) - Time in bed from yesterday's sleep session
- **Average Heart Rate** (bpm) - Heart rate during sleep
- **Average Respiratory Rate** (brpm) - Breathing rate during sleep

The new `SleepIQSleepDataCoordinator` fetches sleep data hourly (since it doesn't change in real-time) and updates sleeper attributes. The sensors use these attributes to display the metrics.

**Important API Note:** The API field `totalSleepSessionTime` is always 0, so this implementation correctly uses the `inBed` field for sleep duration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: (will create after approval)
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
