### PR TITLE
Fix `home-assistant-intents` breaking nightly builds

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -165,6 +165,8 @@ jobs:
             sed -i "s|home-assistant-intents==.*|home-assistant-intents==${BASH_REMATCH[1]}|" \
               homeassistant/package_constraints.txt
 
+            sed -i "s|home-assistant-intents==.*||" requirements.txt
+
             sed -i "s|home-assistant-intents==.*||" requirements_all.txt
           fi
 

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -165,9 +165,7 @@ jobs:
             sed -i "s|home-assistant-intents==.*|home-assistant-intents==${BASH_REMATCH[1]}|" \
               homeassistant/package_constraints.txt
 
-            sed -i "s|home-assistant-intents==.*||" requirements.txt
-
-            sed -i "s|home-assistant-intents==.*||" requirements_all.txt
+            sed -i "s|home-assistant-intents==.*||" requirements_all.txt requirements.txt
           fi
 
       - name: Download translations


### PR DESCRIPTION
Note: This PR is untested.

## Proposed change

This PR clears the `home-assistant-intents` package from `requirements.txt`, as this conflicts with `package_constraints.txt` and we later try to install the latest nightly wheel in the `Dockerfile` anyway.

### Issue

Nightlies have failed for a week now: https://github.com/home-assistant/core/actions/workflows/builder.yml
They fail with this reason when trying to install `requirements.txt` from the [Dockerfile here](https://github.com/home-assistant/core/blob/b11a75d438d7e83f4da593e270123f3c0ff617d7/Dockerfile#L37-L43).
```yaml
× No solution found when resolving dependencies:
╰─▶ Because you require home-assistant-intents==2026.1.28 and
    home-assistant-intents==2026.2.3, we can conclude that your requirements
    are unsatisfiable.
```

### Background

`requirements.txt` references `package_constraints.txt` as a constraints file. During the nightly version adjustment in the builder workflow, `package_constraints.txt` is updated to the nightly intents version but `requirements.txt` was not, causing a conflict when trying to install `requirements.txt`.

Now, the fix clears the `home-assistant-intents` entry from `requirements.txt`, as already done for `requirements_all.txt`. This should work, as the package is installed via the nightly `.whl` file in the [Dockerfile here](https://github.com/home-assistant/core/blob/b11a75d438d7e83f4da593e270123f3c0ff617d7/Dockerfile#L45-L52).


### Alternative

Alternatively, we could also consider dropping the idea of nightlies always including the latest `home-assistant-intents`.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
