### PR TITLE
Add Matter TVOC level entity

### DIFF
--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -70,6 +70,16 @@ CONTAMINATION_STATE_MAP = {
     clusters.SmokeCoAlarm.Enums.ContaminationStateEnum.kCritical: "critical",
 }
 
+CONCENTRATION_LEVEL_MAP = {
+    # enum with known Concentration Level values which we can translate
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kUnknown: None,
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kLow: "low",
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kMedium: "medium",
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kHigh: "high",
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kCritical: "critical",
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Enums.LevelValueEnum.kUnknownEnumValue: None,
+}
+
 EVE_CLUSTER_WEATHER_MAP = {
     # enum with known Weather state values which we can translate
     1: "sunny",
@@ -626,6 +636,21 @@ DISCOVERY_SCHEMAS = [
         required_attributes=(
             clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Attributes.MeasuredValue,
         ),
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
+            key="TotalVolatileOrganicCompoundsSensorLevel",
+            device_class=SensorDeviceClass.ENUM,
+            translation_key="tvoc_level",
+            options=[x for x in CONCENTRATION_LEVEL_MAP.values() if x is not None],
+            device_to_ha=CONCENTRATION_LEVEL_MAP.get,
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Attributes.LevelValue,
+        ),
+        featuremap_contains=clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Bitmaps.Feature.kLevelIndication,
     ),
     MatterDiscoverySchema(
         platform=Platform.SENSOR,

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -564,6 +564,15 @@
       "tank_volume": {
         "name": "Tank volume"
       },
+      "tvoc_level": {
+        "name": "TVOC level",
+        "state": {
+          "critical": "Critical",
+          "high": "[%key:common::state::high%]",
+          "low": "[%key:common::state::low%]",
+          "medium": "Medium"
+        }
+      },
       "valve_position": {
         "name": "Valve position"
       },

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -570,7 +570,7 @@
           "critical": "Critical",
           "high": "[%key:common::state::high%]",
           "low": "[%key:common::state::low%]",
-          "medium": "Medium"
+          "medium": "[%key:common::state::medium%]"
         }
       },
       "valve_position": {

--- a/tests/components/matter/snapshots/test_sensor.ambr
+++ b/tests/components/matter/snapshots/test_sensor.ambr
@@ -7901,6 +7901,69 @@
     'state': '20.0',
   })
 # ---
+# name: test_sensors[mock_air_purifier][sensor.mock_air_purifier_tvoc_level-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'low',
+        'medium',
+        'high',
+        'critical',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_air_purifier_tvoc_level',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'TVOC level',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'TVOC level',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tvoc_level',
+    'unique_id': '00000000000004D2-000000000000008F-MatterNodeDevice-2-TotalVolatileOrganicCompoundsSensorLevel-1070-10',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[mock_air_purifier][sensor.mock_air_purifier_tvoc_level-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Mock Air Purifier TVOC level',
+      'options': list([
+        'low',
+        'medium',
+        'high',
+        'critical',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_air_purifier_tvoc_level',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'low',
+  })
+# ---
 # name: test_sensors[mock_air_purifier][sensor.mock_air_purifier_volatile_organic_compounds_parts-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -347,6 +347,53 @@ async def test_air_quality_sensor(
     assert state.state == "50.0"
 
 
+@pytest.mark.parametrize("node_fixture", ["mock_air_purifier"])
+async def test_tvoc_level_sensor(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test TVOC level sensor (LevelIndication feature)."""
+    # TVOC Level - initial state is low (attribute 10 = 1 in fixture)
+    state = hass.states.get("sensor.mock_air_purifier_tvoc_level")
+    assert state
+    assert state.state == "low"
+    assert state.attributes["device_class"] == "enum"
+    assert state.attributes["options"] == ["low", "medium", "high", "critical"]
+
+    # Test changing to medium level (2)
+    set_node_attribute(matter_node, 2, 1070, 10, 2)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("sensor.mock_air_purifier_tvoc_level")
+    assert state
+    assert state.state == "medium"
+
+    # Test changing to high level (3)
+    set_node_attribute(matter_node, 2, 1070, 10, 3)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("sensor.mock_air_purifier_tvoc_level")
+    assert state
+    assert state.state == "high"
+
+    # Test changing to critical level (4)
+    set_node_attribute(matter_node, 2, 1070, 10, 4)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("sensor.mock_air_purifier_tvoc_level")
+    assert state
+    assert state.state == "critical"
+
+    # Test changing to unknown level (0)
+    set_node_attribute(matter_node, 2, 1070, 10, 0)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("sensor.mock_air_purifier_tvoc_level")
+    assert state
+    assert state.state == "unknown"
+
+
 @pytest.mark.parametrize("node_fixture", ["silabs_dishwasher"])
 async def test_operational_state_sensor(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support in the Matter integration for exposing TVOC “level” (via the Total Volatile Organic Compounds cluster `LevelIndication` feature) as an enum sensor entity, including translations and test coverage.

- Add a new Matter sensor discovery schema for TVOC level using `SensorDeviceClass.ENUM`.
- Add translations for the new `tvoc_level` sensor states.
- Add a dedicated test and snapshot coverage for the new entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161895
- This PR is related to issue: #161895
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
