### PR TITLE
Z-Wave lock service action modernization

### DIFF
--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -7,8 +7,6 @@ from typing import Any
 import voluptuous as vol
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.lock import (
-    ATTR_CODE_SLOT,
-    ATTR_USERCODE,
     LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP,
     LOCK_CMD_CLASS_TO_PROPERTY_MAP,
     DoorLockCCConfigurationSetOptions,
@@ -40,9 +38,7 @@ from .const import (
     ATTR_TWIST_ASSIST,
     DOMAIN,
     LOGGER,
-    SERVICE_CLEAR_LOCK_USERCODE,
     SERVICE_SET_LOCK_CONFIGURATION,
-    SERVICE_SET_LOCK_USERCODE,
 )
 from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
@@ -88,23 +84,6 @@ async def async_setup_entry(
     )
 
     platform = entity_platform.async_get_current_platform()
-
-    platform.async_register_entity_service(
-        SERVICE_SET_LOCK_USERCODE,
-        {
-            vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
-            vol.Required(ATTR_USERCODE): cv.string,
-        },
-        "async_set_lock_usercode",
-    )
-
-    platform.async_register_entity_service(
-        SERVICE_CLEAR_LOCK_USERCODE,
-        {
-            vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
-        },
-        "async_clear_lock_usercode",
-    )
 
     platform.async_register_entity_service(
         SERVICE_SET_LOCK_CONFIGURATION,
@@ -170,8 +149,13 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
             await set_usercode(self.info.node, code_slot, usercode)
         except BaseZwaveJSServerError as err:
             raise HomeAssistantError(
-                f"Unable to set lock usercode on lock {self.entity_id} code_slot "
-                f"{code_slot}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="set_lock_usercode_failed",
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                    "code_slot": str(code_slot),
+                    "error": str(err),
+                },
             ) from err
         LOGGER.debug("User code at slot %s on lock %s set", code_slot, self.entity_id)
 
@@ -222,8 +206,13 @@ class ZWaveLock(ZWaveBaseEntity, LockEntity):
             await clear_usercode(self.info.node, code_slot)
         except BaseZwaveJSServerError as err:
             raise HomeAssistantError(
-                f"Unable to clear lock usercode on lock {self.entity_id} code_slot "
-                f"{code_slot}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="clear_lock_usercode_failed",
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                    "code_slot": str(code_slot),
+                    "error": str(err),
+                },
             ) from err
         LOGGER.debug(
             "User code at slot %s on lock %s cleared", code_slot, self.entity_id

--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import voluptuous as vol
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.lock import (
     LOCK_CMD_CLASS_TO_LOCKED_STATE_MAP,
@@ -25,21 +24,10 @@ from zwave_js_server.util.lock import (
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockEntity, LockState
 from homeassistant.core import HomeAssistant, ServiceResponse, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    ATTR_AUTO_RELOCK_TIME,
-    ATTR_BLOCK_TO_BLOCK,
-    ATTR_HOLD_AND_RELEASE_TIME,
-    ATTR_LOCK_TIMEOUT,
-    ATTR_OPERATION_TYPE,
-    ATTR_TWIST_ASSIST,
-    DOMAIN,
-    LOGGER,
-    SERVICE_SET_LOCK_CONFIGURATION,
-)
+from .const import DOMAIN, LOGGER
 from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
 from .models import ZwaveJSConfigEntry
@@ -56,7 +44,6 @@ STATE_TO_ZWAVE_MAP: dict[int, dict[str, int | bool]] = {
         LockState.LOCKED: True,
     },
 }
-UNIT16_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=65535))
 
 
 async def async_setup_entry(
@@ -81,26 +68,6 @@ async def async_setup_entry(
         async_dispatcher_connect(
             hass, f"{DOMAIN}_{config_entry.entry_id}_add_{LOCK_DOMAIN}", async_add_lock
         )
-    )
-
-    platform = entity_platform.async_get_current_platform()
-
-    platform.async_register_entity_service(
-        SERVICE_SET_LOCK_CONFIGURATION,
-        {
-            vol.Required(ATTR_OPERATION_TYPE): vol.All(
-                cv.string,
-                vol.Upper,
-                vol.In(["TIMED", "CONSTANT"]),
-                lambda x: OperationType[x],
-            ),
-            vol.Optional(ATTR_LOCK_TIMEOUT): UNIT16_SCHEMA,
-            vol.Optional(ATTR_AUTO_RELOCK_TIME): UNIT16_SCHEMA,
-            vol.Optional(ATTR_HOLD_AND_RELEASE_TIME): UNIT16_SCHEMA,
-            vol.Optional(ATTR_TWIST_ASSIST): vol.Coerce(bool),
-            vol.Optional(ATTR_BLOCK_TO_BLOCK): vol.Coerce(bool),
-        },
-        "async_set_lock_configuration",
     )
 
 

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -11,7 +11,11 @@ from typing import Any
 import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import SET_VALUE_SUCCESS, CommandClass, CommandStatus
-from zwave_js_server.const.command_class.lock import ATTR_CODE_SLOT, ATTR_USERCODE
+from zwave_js_server.const.command_class.lock import (
+    ATTR_CODE_SLOT,
+    ATTR_USERCODE,
+    OperationType,
+)
 from zwave_js_server.const.command_class.notification import NotificationType
 from zwave_js_server.exceptions import FailedZWaveCommand, SetValueFailed
 from zwave_js_server.model.endpoint import Endpoint
@@ -53,6 +57,8 @@ from .helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 type _NodeOrEndpointType = ZwaveNode | Endpoint
+
+UNIT16_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=65535))
 
 TARGET_VALIDATORS = {
     vol.Optional(ATTR_AREA_ID): vol.All(cv.ensure_list, [cv.string]),
@@ -515,6 +521,27 @@ class ZWaveServices:
                 vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
             },
             func="async_clear_lock_usercode",
+        )
+
+        async_register_platform_entity_service(
+            self._hass,
+            const.DOMAIN,
+            const.SERVICE_SET_LOCK_CONFIGURATION,
+            entity_domain=LOCK_DOMAIN,
+            schema={
+                vol.Required(const.ATTR_OPERATION_TYPE): vol.All(
+                    cv.string,
+                    vol.Upper,
+                    vol.In(["TIMED", "CONSTANT"]),
+                    lambda x: OperationType[x],
+                ),
+                vol.Optional(const.ATTR_LOCK_TIMEOUT): UNIT16_SCHEMA,
+                vol.Optional(const.ATTR_AUTO_RELOCK_TIME): UNIT16_SCHEMA,
+                vol.Optional(const.ATTR_HOLD_AND_RELEASE_TIME): UNIT16_SCHEMA,
+                vol.Optional(const.ATTR_TWIST_ASSIST): vol.Coerce(bool),
+                vol.Optional(const.ATTR_BLOCK_TO_BLOCK): vol.Coerce(bool),
+            },
+            func="async_set_lock_configuration",
         )
 
     async def async_set_config_parameter(self, service: ServiceCall) -> None:

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -11,7 +11,7 @@ from typing import Any
 import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import SET_VALUE_SUCCESS, CommandClass, CommandStatus
-from zwave_js_server.const.command_class.lock import ATTR_CODE_SLOT
+from zwave_js_server.const.command_class.lock import ATTR_CODE_SLOT, ATTR_USERCODE
 from zwave_js_server.const.command_class.notification import NotificationType
 from zwave_js_server.exceptions import FailedZWaveCommand, SetValueFailed
 from zwave_js_server.model.endpoint import Endpoint
@@ -492,6 +492,29 @@ class ZWaveServices:
             },
             func="async_get_lock_usercode",
             supports_response=SupportsResponse.ONLY,
+        )
+
+        async_register_platform_entity_service(
+            self._hass,
+            const.DOMAIN,
+            const.SERVICE_SET_LOCK_USERCODE,
+            entity_domain=LOCK_DOMAIN,
+            schema={
+                vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+                vol.Required(ATTR_USERCODE): cv.string,
+            },
+            func="async_set_lock_usercode",
+        )
+
+        async_register_platform_entity_service(
+            self._hass,
+            const.DOMAIN,
+            const.SERVICE_CLEAR_LOCK_USERCODE,
+            entity_domain=LOCK_DOMAIN,
+            schema={
+                vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
+            },
+            func="async_clear_lock_usercode",
         )
 
     async def async_set_config_parameter(self, service: ServiceCall) -> None:

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -382,7 +382,7 @@
       "fields": {
         "code_slot": {
           "description": "Code slot to clear code from.",
-          "name": "Code slot"
+          "name": "[%key:component::zwave_js::device_automation::extra_fields::code_slot%]"
         }
       },
       "name": "Clear lock user code"
@@ -392,7 +392,7 @@
       "fields": {
         "code_slot": {
           "description": "Code slot to get code from. If not specified, all code slots are returned.",
-          "name": "Code slot"
+          "name": "[%key:component::zwave_js::device_automation::extra_fields::code_slot%]"
         }
       },
       "name": "Get lock user code"
@@ -638,7 +638,7 @@
       "fields": {
         "code_slot": {
           "description": "Code slot to set the code.",
-          "name": "[%key:component::zwave_js::services::clear_lock_usercode::fields::code_slot::name%]"
+          "name": "[%key:component::zwave_js::device_automation::extra_fields::code_slot%]"
         },
         "usercode": {
           "description": "Lock code to set.",

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -292,8 +292,14 @@
     }
   },
   "exceptions": {
+    "clear_lock_usercode_failed": {
+      "message": "Unable to clear lock usercode on lock {entity_id} code_slot {code_slot}: {error}"
+    },
     "get_lock_usercode_not_found": {
       "message": "Code slot {code_slot} not found on lock {entity_id}"
+    },
+    "set_lock_usercode_failed": {
+      "message": "Unable to set lock usercode on lock {entity_id} code_slot {code_slot}: {error}"
     }
   },
   "issues": {

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -23,14 +23,12 @@ from homeassistant.components.zwave_js.const import (
     ATTR_LOCK_TIMEOUT,
     ATTR_OPERATION_TYPE,
     DOMAIN,
-    SERVICE_GET_LOCK_USERCODE,
-)
-from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
-from homeassistant.components.zwave_js.lock import (
     SERVICE_CLEAR_LOCK_USERCODE,
+    SERVICE_GET_LOCK_USERCODE,
     SERVICE_SET_LOCK_CONFIGURATION,
     SERVICE_SET_LOCK_USERCODE,
 )
+from homeassistant.components.zwave_js.helpers import ZwaveValueMatcher
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -417,6 +417,54 @@ async def test_get_lock_usercode(
         }
 
 
+async def test_set_lock_usercode_error(
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+) -> None:
+    """Test set lock usercode service error handling."""
+    client.async_send_command.side_effect = FailedZWaveCommand("test", 1, "test")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_LOCK_USERCODE,
+            {
+                ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY,
+                ATTR_CODE_SLOT: 1,
+                ATTR_USERCODE: "1234",
+            },
+            blocking=True,
+        )
+
+    assert str(exc_info.value) == (
+        "Unable to set lock usercode on lock "
+        f"{SCHLAGE_BE469_LOCK_ENTITY} code_slot 1: zwave_error: Z-Wave error 1 - test"
+    )
+
+
+async def test_clear_lock_usercode_error(
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+) -> None:
+    """Test clear lock usercode service error handling."""
+    client.async_send_command.side_effect = FailedZWaveCommand("test", 1, "test")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_LOCK_USERCODE,
+            {ATTR_ENTITY_ID: SCHLAGE_BE469_LOCK_ENTITY, ATTR_CODE_SLOT: 1},
+            blocking=True,
+        )
+
+    assert str(exc_info.value) == (
+        "Unable to clear lock usercode on lock "
+        f"{SCHLAGE_BE469_LOCK_ENTITY} code_slot 1: zwave_error: Z-Wave error 1 - test"
+    )
+
+
 async def test_get_lock_usercode_error(
     hass: HomeAssistant,
     client,


### PR DESCRIPTION
## Proposed change

* Modernizes registration of lock user code entity services (based on a feedback on #162057)
* Extracts error message from f-strings to the strings.json file
* Adds test verifying that everything still works the same


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
