### PR TITLE
Add island_status sensor and grid_status binary sensor to Tessie

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -160,10 +160,16 @@ VEHICLE_DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
     ),
 )
 
-ENERGY_LIVE_DESCRIPTIONS: tuple[BinarySensorEntityDescription, ...] = (
-    BinarySensorEntityDescription(key="backup_capable"),
-    BinarySensorEntityDescription(key="grid_services_active"),
-    BinarySensorEntityDescription(key="storm_mode_active"),
+ENERGY_LIVE_DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
+    TessieBinarySensorEntityDescription(key="backup_capable"),
+    TessieBinarySensorEntityDescription(key="grid_services_active"),
+    TessieBinarySensorEntityDescription(
+        key="grid_status",
+        is_on=lambda x: x == "Active",
+        device_class=BinarySensorDeviceClass.POWER,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    TessieBinarySensorEntityDescription(key="storm_mode_active"),
 )
 
 
@@ -225,12 +231,12 @@ class TessieBinarySensorEntity(TessieEntity, BinarySensorEntity):
 class TessieEnergyLiveBinarySensorEntity(TessieEnergyEntity, BinarySensorEntity):
     """Base class for Tessie energy live binary sensors."""
 
-    entity_description: BinarySensorEntityDescription
+    entity_description: TessieBinarySensorEntityDescription
 
     def __init__(
         self,
         data: TessieEnergyData,
-        description: BinarySensorEntityDescription,
+        description: TessieBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
         self.entity_description = description
@@ -239,7 +245,7 @@ class TessieEnergyLiveBinarySensorEntity(TessieEnergyEntity, BinarySensorEntity)
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the binary sensor."""
-        self._attr_is_on = self._value
+        self._attr_is_on = self.entity_description.is_on(self._value)
 
 
 class TessieEnergyInfoBinarySensorEntity(TessieEnergyEntity, BinarySensorEntity):

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -25,6 +25,12 @@
       "grid_services_power": {
         "default": "mdi:transmission-tower"
       },
+      "grid_status": {
+        "state": {
+          "off": "mdi:transmission-tower-off",
+          "on": "mdi:transmission-tower"
+        }
+      },
       "storm_mode_active": {
         "default": "mdi:weather-sunny",
         "state": {

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -344,6 +344,17 @@ ENERGY_LIVE_DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
     ),
+    TessieSensorEntityDescription(
+        key="island_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "on_grid",
+            "off_grid",
+            "off_grid_intentional",
+            "off_grid_unintentional",
+            "island_status_unknown",
+        ],
+    ),
 )
 
 WALL_CONNECTOR_DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -81,6 +81,9 @@
       "grid_services_active": {
         "name": "Grid services active"
       },
+      "grid_status": {
+        "name": "Grid status"
+      },
       "state": {
         "name": "Status"
       },
@@ -428,6 +431,16 @@
       },
       "grid_services_power": {
         "name": "Grid services power"
+      },
+      "island_status": {
+        "name": "Island status",
+        "state": {
+          "island_status_unknown": "Unknown",
+          "off_grid": "Off-grid",
+          "off_grid_intentional": "Off-grid intentional",
+          "off_grid_unintentional": "Off-grid unintentional",
+          "on_grid": "On-grid"
+        }
       },
       "load_power": {
         "name": "Load power"

--- a/tests/components/tessie/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tessie/snapshots/test_binary_sensor.ambr
@@ -146,6 +146,56 @@
     'state': 'off',
   })
 # ---
+# name: test_binary_sensors[binary_sensor.energy_site_grid_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.energy_site_grid_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Grid status',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Grid status',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'grid_status',
+    'unique_id': '123456-grid_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.energy_site_grid_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Energy Site Grid status',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.energy_site_grid_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_binary_sensors[binary_sensor.energy_site_storm_watch_active-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tessie/snapshots/test_sensor.ambr
+++ b/tests/components/tessie/snapshots/test_sensor.ambr
@@ -299,6 +299,71 @@
     'state': '0.0',
   })
 # ---
+# name: test_sensors[sensor.energy_site_island_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'on_grid',
+        'off_grid',
+        'off_grid_intentional',
+        'off_grid_unintentional',
+        'island_status_unknown',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.energy_site_island_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Island status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Island status',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'island_status',
+    'unique_id': '123456-island_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.energy_site_island_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Energy Site Island status',
+      'options': list([
+        'on_grid',
+        'off_grid',
+        'off_grid_intentional',
+        'off_grid_unintentional',
+        'island_status_unknown',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.energy_site_island_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on_grid',
+  })
+# ---
 # name: test_sensors[sensor.energy_site_load_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({


### PR DESCRIPTION
## Proposed change

Adds two new energy site sensors to the Tessie integration:
- **island_status**: An enum sensor tracking grid connection state (on-grid, off-grid, off-grid intentional, off-grid unintentional, unknown)
- **grid_status**: A binary sensor indicating if the grid is active

These entities provide visibility into energy site grid connectivity and islanding mode, useful for monitoring backup power scenarios.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- Link to documentation pull request: (if applicable)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.