### PR TITLE
Set default file transfer timeouts for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -97,6 +97,7 @@ from .const import (
     CONF_API_ENDPOINT,
     CONF_CHAT_ID,
     CONF_PROXY_URL,
+    DEFAULT_TIMEOUT_SECONDS,
     DOMAIN,
     EVENT_TELEGRAM_ATTACHMENT,
     EVENT_TELEGRAM_CALLBACK,
@@ -1089,12 +1090,26 @@ def initialize_bot(hass: HomeAssistant, p_config: MappingProxyType[str, Any]) ->
 
     api_key: str = p_config[CONF_API_KEY]
 
+    # set up timeouts to handle large file downloads and uploads
+    # server-side file size limit is 2GB
+    read_timeout = DEFAULT_TIMEOUT_SECONDS
+    media_write_timeout = DEFAULT_TIMEOUT_SECONDS
+
     proxy_url: str | None = p_config.get(CONF_PROXY_URL)
     if proxy_url is not None:
         proxy = httpx.Proxy(proxy_url)
-        request = HTTPXRequest(connection_pool_size=8, proxy=proxy)
+        request = HTTPXRequest(
+            connection_pool_size=8,
+            proxy=proxy,
+            read_timeout=read_timeout,
+            media_write_timeout=media_write_timeout,
+        )
     else:
-        request = HTTPXRequest(connection_pool_size=8)
+        request = HTTPXRequest(
+            connection_pool_size=8,
+            read_timeout=read_timeout,
+            media_write_timeout=media_write_timeout,
+        )
 
     base_url: str = p_config[CONF_API_ENDPOINT]
 
@@ -1133,7 +1148,9 @@ async def load_data(
             params["verify"] = verify_ssl
 
         retry_num = 0
-        async with httpx.AsyncClient(timeout=15, headers=headers, **params) as client:
+        async with httpx.AsyncClient(
+            timeout=DEFAULT_TIMEOUT_SECONDS, headers=headers, **params
+        ) as client:
             while retry_num < num_retries:
                 try:
                     req = await client.get(url)
@@ -1157,6 +1174,7 @@ async def load_data(
                     if data.read():
                         data.seek(0)
                         data.name = url
+                        _LOGGER.debug("file downloaded: %s", url)
                         return data
                     _LOGGER.warning("Empty data (retry #%s) in %s)", retry_num + 1, url)
                 retry_num += 1

--- a/homeassistant/components/telegram_bot/const.py
+++ b/homeassistant/components/telegram_bot/const.py
@@ -24,6 +24,8 @@ BOT_NAME = "telegram_bot"
 ERROR_FIELD = "error_field"
 ERROR_MESSAGE = "error_message"
 
+
+DEFAULT_TIMEOUT_SECONDS = 1800  # 30 minutes
 DEFAULT_API_ENDPOINT = "https://api.telegram.org"
 DEFAULT_TRUSTED_NETWORKS = [ip_network("149.154.160.0/20"), ip_network("91.108.4.0/22")]
 

--- a/tests/components/telegram_bot/test_broadcast.py
+++ b/tests/components/telegram_bot/test_broadcast.py
@@ -1,12 +1,18 @@
 """Test Telegram broadcast."""
 
+from httpx import Request as HTTPXRequest
+
+from homeassistant.components.telegram_bot.bot import TelegramBotConfigEntry
+from homeassistant.components.telegram_bot.const import DEFAULT_TIMEOUT_SECONDS
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
 async def test_setup(
-    hass: HomeAssistant, mock_broadcast_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_broadcast_config_entry: MockConfigEntry,
+    mock_external_calls: None,
 ) -> None:
     """Test setting up Telegram broadcast."""
     mock_broadcast_config_entry.add_to_hass(hass)
@@ -14,3 +20,10 @@ async def test_setup(
     await hass.async_block_till_done()
 
     assert hass.services.has_service("telegram_bot", "send_message") is True
+
+    config_entry: TelegramBotConfigEntry = hass.config_entries.async_get_known_entry(
+        mock_broadcast_config_entry.entry_id
+    )
+    request: HTTPXRequest = config_entry.runtime_data.bot.request
+    assert request.read_timeout == DEFAULT_TIMEOUT_SECONDS
+    assert request._media_write_timeout == DEFAULT_TIMEOUT_SECONDS


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
### Background
2026.2 introduced custom API endpoints to allow users to use their self-hosted Telegram bot API server (file size limit **2GB**) instead of using the default official server (file size limit **50MB**).
These file size limits are used in send file actions such as `telegram_bot.send_video` and `telegram_bot.send_document`.

Currently, the integration has a **default timeout of 20 seconds** for file uploads which is sufficient for small files.
This PR updates the timeout to allow for larger file sizes supported by the self-hosted Telegram bot API server.

### Changes
- updated `read_timeout` to support large file downloads for the `download_file` action.
- updated download timeout from **15 seconds** to the new value. (the `send_*` actions will download remote files before sending them to the recipients)
- updated `media_write_timeout` to support large file uploads for all the `send_*` actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160776
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
