### PR TITLE
Add HDFury CEC and 5v switches

### DIFF
--- a/homeassistant/components/hdfury/icons.json
+++ b/homeassistant/components/hdfury/icons.json
@@ -64,6 +64,9 @@
       "autosw": {
         "default": "mdi:import"
       },
+      "cec": {
+        "default": "mdi:remote-tv"
+      },
       "cec0en": {
         "default": "mdi:remote-tv"
       },
@@ -102,6 +105,12 @@
       },
       "relay": {
         "default": "mdi:electric-switch"
+      },
+      "tx0plus5": {
+        "default": "mdi:lightning-bolt"
+      },
+      "tx1plus5": {
+        "default": "mdi:lightning-bolt"
       }
     }
   }

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -121,6 +121,9 @@
       "autosw": {
         "name": "Auto switch inputs"
       },
+      "cec": {
+        "name": "CEC"
+      },
       "cec0en": {
         "name": "CEC RX0"
       },
@@ -159,6 +162,12 @@
       },
       "relay": {
         "name": "Relay"
+      },
+      "tx0plus5": {
+        "name": "TX0 force +5v"
+      },
+      "tx1plus5": {
+        "name": "TX1 force +5v"
       }
     }
   },

--- a/homeassistant/components/hdfury/switch.py
+++ b/homeassistant/components/hdfury/switch.py
@@ -34,6 +34,12 @@ SWITCHES: tuple[HDFurySwitchEntityDescription, ...] = (
         set_value_fn=lambda client, value: client.set_auto_switch_inputs(value),
     ),
     HDFurySwitchEntityDescription(
+        key="cec",
+        translation_key="cec",
+        entity_category=EntityCategory.CONFIG,
+        set_value_fn=lambda client, value: client.set_cec(value),
+    ),
+    HDFurySwitchEntityDescription(
         key="cec0en",
         translation_key="cec0en",
         entity_category=EntityCategory.CONFIG,
@@ -110,6 +116,20 @@ SWITCHES: tuple[HDFurySwitchEntityDescription, ...] = (
         translation_key="relay",
         entity_category=EntityCategory.CONFIG,
         set_value_fn=lambda client, value: client.set_relay(value),
+    ),
+    HDFurySwitchEntityDescription(
+        key="tx0plus5",
+        translation_key="tx0plus5",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+        set_value_fn=lambda client, value: client.set_tx0_force_5v(value),
+    ),
+    HDFurySwitchEntityDescription(
+        key="tx1plus5",
+        translation_key="tx1plus5",
+        entity_registry_enabled_default=False,
+        entity_category=EntityCategory.CONFIG,
+        set_value_fn=lambda client, value: client.set_tx1_force_5v(value),
     ),
 )
 

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -86,12 +86,15 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
         )
         coord_client.get_config = AsyncMock(
             return_value={
+                "cec": "1",
                 "cec0en": "1",
                 "cec1en": "1",
                 "cec2en": "1",
                 "cec3en": "1",
                 "autosw": "1",
                 "iractive": "1",
+                "tx0plus5": "1",
+                "tx1plus5": "1",
                 "htpcmode0": "0",
                 "htpcmode1": "0",
                 "htpcmode2": "0",

--- a/tests/components/hdfury/snapshots/test_diagnostics.ambr
+++ b/tests/components/hdfury/snapshots/test_diagnostics.ambr
@@ -10,6 +10,7 @@
     }),
     'config': dict({
       'autosw': '1',
+      'cec': '1',
       'cec0en': '1',
       'cec1en': '1',
       'cec2en': '1',
@@ -24,6 +25,8 @@
       'mutetx1': '1',
       'oled': '1',
       'relay': '0',
+      'tx0plus5': '1',
+      'tx1plus5': '1',
     }),
     'info': dict({
       'AUD0': 'bitstream 48kHz',

--- a/tests/components/hdfury/snapshots/test_switch.ambr
+++ b/tests/components/hdfury/snapshots/test_switch.ambr
@@ -48,6 +48,55 @@
     'state': 'on',
   })
 # ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_cec-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.hdfury_vrroom_02_cec',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'CEC',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'CEC',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'cec',
+    'unique_id': '000123456789_cec',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_cec-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HDFury VRROOM-02 CEC',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.hdfury_vrroom_02_cec',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switch_entities[switch.hdfury_vrroom_02_cec_rx0-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -683,5 +732,103 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_tx0_force_5v-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.hdfury_vrroom_02_tx0_force_5v',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'TX0 force +5v',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'TX0 force +5v',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tx0plus5',
+    'unique_id': '000123456789_tx0plus5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_tx0_force_5v-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HDFury VRROOM-02 TX0 force +5v',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.hdfury_vrroom_02_tx0_force_5v',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_tx1_force_5v-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.hdfury_vrroom_02_tx1_force_5v',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'TX1 force +5v',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'TX1 force +5v',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tx1plus5',
+    'unique_id': '000123456789_tx1plus5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.hdfury_vrroom_02_tx1_force_5v-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'HDFury VRROOM-02 TX1 force +5v',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.hdfury_vrroom_02_tx1_force_5v',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---

--- a/tests/components/hdfury/test_switch.py
+++ b/tests/components/hdfury/test_switch.py
@@ -41,6 +41,8 @@ async def test_switch_entities(
 @pytest.mark.parametrize(
     ("entity_id", "method", "service"),
     [
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_cec", "set_cec", SERVICE_TURN_OFF),
         (
             "switch.hdfury_vrroom_02_auto_switch_inputs",
             "set_auto_switch_inputs",
@@ -53,8 +55,13 @@ async def test_switch_entities(
         ),
         ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_ON),
         ("switch.hdfury_vrroom_02_oled_display", "set_oled", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_tx0_force_5v", "set_tx0_force_5v", SERVICE_TURN_OFF),
+        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_ON),
+        ("switch.hdfury_vrroom_02_tx1_force_5v", "set_tx1_force_5v", SERVICE_TURN_OFF),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_turn_on_off(
     hass: HomeAssistant,
     mock_hdfury_client: AsyncMock,

--- a/tests/components/hdfury/test_switch.py
+++ b/tests/components/hdfury/test_switch.py
@@ -25,6 +25,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_switch_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds CEC and +5v switch entities to the HDFury integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43537
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
