### PR TITLE
Fix missing translations for HTML5 Push Notifications

### DIFF
--- a/homeassistant/components/html5/strings.json
+++ b/homeassistant/components/html5/strings.json
@@ -40,6 +40,36 @@
         }
       },
       "name": "Dismiss"
+    },
+    "html5": {
+      "description": "Sends a notification message using the HTML5 service.",
+      "fields": {
+        "message": {
+          "description": "The message to be sent.",
+          "name": "Message"
+        },
+        "target": {
+          "description": "An array of targets.",
+          "name": "Target"
+        },
+        "title": {
+          "description": "The title of the message (optional).",
+          "name": "Title"
+        },
+        "data": {
+          "description": "Extended information of notification.",
+          "name": "Data"
+        },
+        "actions": {
+          "description": "Array of actions.",
+          "name": "Actions"
+        },
+        "tag": {
+          "description": "Tag for identify notification.",
+          "name": "Tag"
+        }
+      },
+      "name": "Send a notification"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes issue #129359 - Adds missing translatable strings for the HTML5 Push Notifications service.

## Changes

Added the following translations to `homeassistant/components/html5/strings.json`:

### Service: notify.html5
- **Name**: "Send a notification"
- **Description**: "Sends a notification message using the HTML5 service."

### Fields:
| Field | Name | Description |
|-------|------|-------------|
| message | Message | The message to be sent. |
| title | Title | The title of the message (optional). |
| target | Target | An array of targets. |
| data | Data | Extended information of notification. |
| actions | Actions | Array of actions. |
| tag | Tag | Tag for identify notification. |

## Why this fix is needed

The HTML5 Push Notifications integration was missing translatable strings in the services section, which prevented proper localization of the "Send a notification with html5" service and its parameters.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/home-assistant/core/blob/master/CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have documented my changes where appropriate.
- [x] My changes do not require documentation updates (only translation changes).

## Related Issues

Fixes #129359