### PR TITLE
CI security hardening: restrict permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,8 @@ env:
   PYTHONASYNCIODEBUG: 1
   HASS_CI: 1
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -75,6 +77,9 @@ jobs:
   info:
     name: Collect information & changes data
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       # In case of issues with the partial run, use the following line instead:
       # test_full_suite: 'true'
@@ -241,6 +246,8 @@ jobs:
   prek:
     name: Run prek checks
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: [info]
     if: |
       github.event.inputs.pylint-only != 'true'
@@ -266,6 +273,8 @@ jobs:
   lint-hadolint:
     name: Check ${{ matrix.file }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: [info]
     if: |
       github.event.inputs.pylint-only != 'true'
@@ -294,6 +303,8 @@ jobs:
   base:
     name: Prepare dependencies
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs: [info]
     timeout-minutes: 60
     strategy:
@@ -426,6 +437,8 @@ jobs:
   hassfest:
     name: Check hassfest
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -481,6 +494,8 @@ jobs:
   gen-requirements-all:
     name: Check all requirements
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -516,6 +531,8 @@ jobs:
   gen-copilot-instructions:
     name: Check copilot instructions
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
     if: |
@@ -540,6 +557,8 @@ jobs:
   dependency-review:
     name: Dependency review
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -561,6 +580,8 @@ jobs:
   audit-licenses:
     name: Audit licenses
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -610,6 +631,8 @@ jobs:
   pylint:
     name: Check pylint
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -658,6 +681,8 @@ jobs:
   pylint-tests:
     name: Check pylint on tests
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -707,6 +732,8 @@ jobs:
   mypy:
     name: Check mypy
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -772,6 +799,8 @@ jobs:
   prepare-pytest-full:
     name: Split tests for full run
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     if: |
       needs.info.outputs.lint_only != 'true'
       && needs.info.outputs.test_full_suite == 'true'
@@ -838,6 +867,8 @@ jobs:
   pytest-full:
     name: Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -976,6 +1007,8 @@ jobs:
   pytest-mariadb:
     name: Run ${{ matrix.mariadb-group }} tests Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     services:
       mariadb:
         image: ${{ matrix.mariadb-group }}
@@ -1129,6 +1162,8 @@ jobs:
   pytest-postgres:
     name: Run ${{ matrix.postgresql-group }} tests Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     services:
       postgres:
         image: ${{ matrix.postgresql-group }}
@@ -1285,6 +1320,8 @@ jobs:
   coverage-full:
     name: Upload test coverage to Codecov (full suite)
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - pytest-full
@@ -1312,6 +1349,8 @@ jobs:
   pytest-partial:
     name: Run tests Python ${{ matrix.python-version }} (${{ matrix.group }})
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     needs:
       - info
       - base
@@ -1452,6 +1491,8 @@ jobs:
     name: Upload test coverage to Codecov (partial suite)
     if: needs.info.outputs.skip_coverage != 'true'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     timeout-minutes: 10
     needs:
       - info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add explicit `permissions: {}` at the workflow level and add least-privilege job-level permissions to all 20 jobs. The info job gets `contents: read` and `pull-requests: read` (needed by dorny/paths-filter to fetch PR changed files). All other jobs that were missing permissions get `contents: read` only (for checkout and cache operations). The `upload-test-results` job already had the correct `id-token: write` for Codecov OIDC uploads. Artifact upload/download and cache operations use the Actions runtime token, not the `GITHUB_TOKEN`, so no additional permissions are needed for those.

While default token permissions can be restricted at the repository level in GitHub settings, setting them explicitly in the workflow ensures forks and copies of this repository also inherit the same security posture.

Found using `zizmor`, which will be added as a CI check in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
