### PR TITLE
Add category support for OurGroceries integration

### DIFF
--- a/homeassistant/components/ourgroceries/coordinator.py
+++ b/homeassistant/components/ourgroceries/coordinator.py
@@ -10,7 +10,7 @@ from ourgroceries import OurGroceries
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
 
@@ -50,7 +50,12 @@ class OurGroceriesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
 
     async def async_refresh_categories(self) -> None:
         """Refresh category data from OurGroceries."""
-        category_data = await self.og.get_category_items()
+        try:
+            category_data = await self.og.get_category_items()
+        except Exception as err:
+            raise UpdateFailed(
+                f"Error fetching OurGroceries category data: {err}"
+            ) from err
         category_items = category_data.get("list", {}).get("items", [])
         self.categories = {cat["id"]: cat["name"] for cat in category_items}
         self.category_sort_order = {

--- a/homeassistant/components/ourgroceries/coordinator.py
+++ b/homeassistant/components/ourgroceries/coordinator.py
@@ -30,6 +30,8 @@ class OurGroceriesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
         """Initialize global OurGroceries data updater."""
         self.og = og
         self.lists: list[dict] = []
+        self.categories: dict[str, str] = {}
+        self.category_sort_order: dict[str, str] = {}
         self._cache: dict[str, dict] = {}
         interval = timedelta(seconds=SCAN_INTERVAL)
         super().__init__(
@@ -46,9 +48,19 @@ class OurGroceriesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict]]):
             return
         self._cache[list_id] = await self.og.get_list_items(list_id=list_id)
 
+    async def async_refresh_categories(self) -> None:
+        """Refresh category data from OurGroceries."""
+        category_data = await self.og.get_category_items()
+        category_items = category_data.get("list", {}).get("items", [])
+        self.categories = {cat["id"]: cat["name"] for cat in category_items}
+        self.category_sort_order = {
+            cat["id"]: cat.get("sortOrder", "") for cat in category_items
+        }
+
     async def _async_update_data(self) -> dict[str, dict]:
         """Fetch data from OurGroceries."""
         self.lists = (await self.og.get_my_lists())["shoppingLists"]
+        await self.async_refresh_categories()
         await asyncio.gather(
             *[self._update_list(sl["id"], sl["versionId"]) for sl in self.lists]
         )

--- a/homeassistant/components/ourgroceries/todo.py
+++ b/homeassistant/components/ourgroceries/todo.py
@@ -47,6 +47,7 @@ class OurGroceriesTodoListEntity(
         TodoListEntityFeature.CREATE_TODO_ITEM
         | TodoListEntityFeature.UPDATE_TODO_ITEM
         | TodoListEntityFeature.DELETE_TODO_ITEM
+        | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
 
     def __init__(
@@ -67,13 +68,23 @@ class OurGroceriesTodoListEntity(
         if self.coordinator.data is None:
             self._attr_todo_items = None
         else:
+            items = self.coordinator.data[self._list_id]["list"]["items"]
+            cat_order = self.coordinator.category_sort_order
+            sorted_items = sorted(
+                items,
+                key=lambda item: cat_order.get(item.get("categoryId", ""), "\uffff"),
+            )
             self._attr_todo_items = [
                 TodoItem(
                     summary=item["name"],
                     uid=item["id"],
+                    description=self.coordinator.categories.get(
+                        item.get("categoryId", ""), ""
+                    )
+                    or None,
                     status=_completion_status(item),
                 )
-                for item in self.coordinator.data[self._list_id]["list"]["items"]
+                for item in sorted_items
             ]
         super()._handle_coordinator_update()
 
@@ -86,18 +97,52 @@ class OurGroceriesTodoListEntity(
         )
         await self.coordinator.async_refresh()
 
+    async def _resolve_category_id(self, category_name: str) -> str:
+        """Resolve a category name to its ID, creating it if needed."""
+        # Look up existing category by name
+        for cat_id, name in self.coordinator.categories.items():
+            if name.lower() == category_name.lower():
+                return cat_id
+        # Category doesn't exist, create it
+        await self.coordinator.og.create_category(category_name)
+        # Refresh categories to get the new ID
+        await self.coordinator.async_refresh_categories()
+        for cat_id, name in self.coordinator.categories.items():
+            if name.lower() == category_name.lower():
+                return cat_id
+        return "uncategorized"
+
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
+        api_items = self.coordinator.data[self._list_id]["list"]["items"]
+        current_item = next(
+            (api_item for api_item in api_items if api_item["id"] == item.uid),
+            None,
+        )
+        if current_item is None:
+            return
+
+        category = current_item.get("categoryId", "uncategorized")
+
+        if item.description is not None:
+            if item.description:
+                category = await self._resolve_category_id(item.description)
+            else:
+                category = "uncategorized"
+
         if item.summary:
-            api_items = self.coordinator.data[self._list_id]["list"]["items"]
-            category = next(
-                api_item.get("categoryId")
-                for api_item in api_items
-                if api_item["id"] == item.uid
-            )
             await self.coordinator.og.change_item_on_list(
                 self._list_id, item.uid, category, item.summary
             )
+        elif item.description is not None:
+            # Description changed but summary didn't — still need to update
+            await self.coordinator.og.change_item_on_list(
+                self._list_id,
+                item.uid,
+                category,
+                current_item["name"],
+            )
+
         if item.status is not None:
             cross_off = item.status == TodoItemStatus.COMPLETED
             await self.coordinator.og.toggle_item_crossed_off(

--- a/homeassistant/components/ourgroceries/todo.py
+++ b/homeassistant/components/ourgroceries/todo.py
@@ -1,6 +1,7 @@
 """A todo platform for OurGroceries."""
 
 import asyncio
+import logging
 from typing import Any
 
 from homeassistant.components.todo import (
@@ -16,6 +17,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OurGroceriesDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -104,9 +107,13 @@ class OurGroceriesTodoListEntity(
             if name.lower() == category_name.lower():
                 return cat_id
         # Category doesn't exist, create it
-        await self.coordinator.og.create_category(category_name)
-        # Refresh categories to get the new ID
-        await self.coordinator.async_refresh_categories()
+        try:
+            await self.coordinator.og.create_category(category_name)
+            # Refresh categories to get the new ID
+            await self.coordinator.async_refresh_categories()
+        except Exception:
+            _LOGGER.exception("Failed to create category '%s'", category_name)
+            return "uncategorized"
         for cat_id, name in self.coordinator.categories.items():
             if name.lower() == category_name.lower():
                 return cat_id
@@ -114,6 +121,8 @@ class OurGroceriesTodoListEntity(
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
+        if self.coordinator.data is None:
+            return
         api_items = self.coordinator.data[self._list_id]["list"]["items"]
         current_item = next(
             (api_item for api_item in api_items if api_item["id"] == item.uid),

--- a/tests/components/ourgroceries/conftest.py
+++ b/tests/components/ourgroceries/conftest.py
@@ -50,6 +50,22 @@ def mock_ourgroceries(items: list[dict]) -> AsyncMock:
         "shoppingLists": [{"id": "test_list", "name": "Test List", "versionId": "1"}]
     }
     og.get_list_items.return_value = items_to_shopping_list(items)
+    og.get_category_items.return_value = {
+        "list": {
+            "items": [
+                {
+                    "id": "test_category",
+                    "name": "Test Category",
+                    "sortOrder": "B",
+                },
+                {
+                    "id": "other_category",
+                    "name": "Other Category",
+                    "sortOrder": "A",
+                },
+            ]
+        }
+    }
     return og
 
 

--- a/tests/components/ourgroceries/test_todo.py
+++ b/tests/components/ourgroceries/test_todo.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components.ourgroceries.coordinator import SCAN_INTERVAL
 from homeassistant.components.todo import (
+    ATTR_DESCRIPTION,
     ATTR_ITEM,
     ATTR_RENAME,
     ATTR_STATUS,
@@ -162,7 +163,7 @@ async def test_update_todo_item_status(
             [{"id": "12345", "name": "Soda", "categoryId": "test_category"}],
             "test_category",
         ),
-        ([{"id": "12345", "name": "Uncategorized"}], None),
+        ([{"id": "12345", "name": "Uncategorized"}], "uncategorized"),
     ],
 )
 async def test_update_todo_item_summary(
@@ -285,3 +286,171 @@ async def test_coordinator_error(
 
     state = hass.states.get("todo.test_list")
     assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("items", "expected_descriptions"),
+    [
+        (
+            [{"id": "12345", "name": "Soda", "categoryId": "test_category"}],
+            ["Test Category"],
+        ),
+        (
+            [{"id": "12345", "name": "Soda"}],
+            [None],
+        ),
+        (
+            [
+                {"id": "1", "name": "A", "categoryId": "test_category"},
+                {"id": "2", "name": "B", "categoryId": "other_category"},
+            ],
+            ["Other Category", "Test Category"],
+        ),
+    ],
+)
+async def test_todo_item_category_description(
+    hass: HomeAssistant,
+    setup_integration: None,
+    expected_descriptions: list[str | None],
+) -> None:
+    """Test that category names are shown as item descriptions."""
+    result = await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.GET_ITEMS,
+        {},
+        target={ATTR_ENTITY_ID: "todo.test_list"},
+        blocking=True,
+        return_response=True,
+    )
+    items = result["todo.test_list"]["items"]
+    assert [item.get("description") for item in items] == expected_descriptions
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [
+            {"id": "1", "name": "A", "categoryId": "test_category"},
+            {"id": "2", "name": "B", "categoryId": "other_category"},
+            {"id": "3", "name": "C"},
+        ],
+    ],
+)
+async def test_todo_items_sorted_by_category(
+    hass: HomeAssistant,
+    setup_integration: None,
+) -> None:
+    """Test that items are sorted by category sort order."""
+    result = await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.GET_ITEMS,
+        {},
+        target={ATTR_ENTITY_ID: "todo.test_list"},
+        blocking=True,
+        return_response=True,
+    )
+    items = result["todo.test_list"]["items"]
+    summaries = [item["summary"] for item in items]
+    # "B" has "other_category" (sort "A"), "A" has "test_category" (sort "B"),
+    # "C" has no category (sorts last)
+    assert summaries == ["B", "A", "C"]
+
+
+@pytest.mark.parametrize(
+    "items",
+    [[{"id": "12345", "name": "Soda", "categoryId": "test_category"}]],
+)
+async def test_update_todo_item_description_existing_category(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ourgroceries: AsyncMock,
+) -> None:
+    """Test updating an item's description to an existing category."""
+    ourgroceries.change_item_on_list = AsyncMock()
+    _mock_version_id(ourgroceries, 2)
+    ourgroceries.get_list_items.return_value = items_to_shopping_list(
+        [{"id": "12345", "name": "Soda", "categoryId": "other_category"}],
+        version_id="2",
+    )
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "12345", ATTR_DESCRIPTION: "Other Category"},
+        target={ATTR_ENTITY_ID: "todo.test_list"},
+        blocking=True,
+    )
+    assert ourgroceries.change_item_on_list.called
+    args = ourgroceries.change_item_on_list.call_args
+    assert args.args == ("test_list", "12345", "other_category", "Soda")
+    ourgroceries.create_category.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "items",
+    [[{"id": "12345", "name": "Soda", "categoryId": "test_category"}]],
+)
+async def test_update_todo_item_description_new_category(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ourgroceries: AsyncMock,
+) -> None:
+    """Test updating an item's description creates a new category."""
+    ourgroceries.change_item_on_list = AsyncMock()
+    ourgroceries.create_category = AsyncMock()
+    # After create_category, the refresh returns the new category
+    ourgroceries.get_category_items.return_value = {
+        "list": {
+            "items": [
+                {"id": "test_category", "name": "Test Category", "sortOrder": "B"},
+                {"id": "other_category", "name": "Other Category", "sortOrder": "A"},
+                {"id": "new_cat_id", "name": "New Category", "sortOrder": "C"},
+            ]
+        }
+    }
+    _mock_version_id(ourgroceries, 2)
+    ourgroceries.get_list_items.return_value = items_to_shopping_list(
+        [{"id": "12345", "name": "Soda", "categoryId": "new_cat_id"}],
+        version_id="2",
+    )
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "12345", ATTR_DESCRIPTION: "New Category"},
+        target={ATTR_ENTITY_ID: "todo.test_list"},
+        blocking=True,
+    )
+    ourgroceries.create_category.assert_called_once_with("New Category")
+    assert ourgroceries.change_item_on_list.called
+    args = ourgroceries.change_item_on_list.call_args
+    assert args.args == ("test_list", "12345", "new_cat_id", "Soda")
+
+
+@pytest.mark.parametrize(
+    "items",
+    [[{"id": "12345", "name": "Soda", "categoryId": "test_category"}]],
+)
+async def test_update_todo_item_clear_description(
+    hass: HomeAssistant,
+    setup_integration: None,
+    ourgroceries: AsyncMock,
+) -> None:
+    """Test clearing an item's description sets uncategorized."""
+    ourgroceries.change_item_on_list = AsyncMock()
+    _mock_version_id(ourgroceries, 2)
+    ourgroceries.get_list_items.return_value = items_to_shopping_list(
+        [{"id": "12345", "name": "Soda"}],
+        version_id="2",
+    )
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "12345", ATTR_DESCRIPTION: ""},
+        target={ATTR_ENTITY_ID: "todo.test_list"},
+        blocking=True,
+    )
+    assert ourgroceries.change_item_on_list.called
+    args = ourgroceries.change_item_on_list.call_args
+    assert args.args == ("test_list", "12345", "uncategorized", "Soda")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for categories to OurGroceries integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Adds support for categories in OurGroceries lists
- Description field of todo items will show the item's category, if it has one
- When adding an item, e.g. "milk", and it was already assigned to a category in OurGroceries (e.g. "dairy"), description will be automatically updated with the category (e.g. todo item summary will be "milk", and todo item description will be "dairy")
- If categories are sorted in OurGroceries, that sorting order will be used in ToDo lists as well
- Updating description in Home Assistant will change the category for the item, and if the description doesn't match any existing category in OurGroceries, a new category will be created.

Example list in OurGroceries app:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/56541fa6-7a23-46ca-8d03-4f8035cc36f5" />


And how it looks in Home Assistant:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8680ce18-bc91-4e39-9656-ec82d3ac0cf6" />



## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
