### PR TITLE
Allow to configure the FRITZ!Smarthome integration with an URL

### DIFF
--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -96,13 +96,11 @@ async def async_migrate_entry(
                 host = f"http://{config_entry.data[CONF_HOST]}"
             else:
                 host = f"{url.scheme}://{url.host}"
-            port = url.port or 80
-            verify_ssl = DEFAULT_VERIFY_SSL
             new_data = {
                 **config_entry.data,
                 CONF_HOST: host,
-                CONF_PORT: port,
-                CONF_VERIFY_SSL: verify_ssl,
+                CONF_PORT: url.port or 80,
+                CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
             }
 
         hass.config_entries.async_update_entry(

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
 from yarl import URL
 
@@ -91,15 +93,23 @@ async def async_migrate_entry(
         new_data = {**config_entry.data}
         if config_entry.minor_version < 2:
             LOGGER.debug("Migrate config entry data to URL based configuration")
-            url = URL(config_entry.data[CONF_HOST])
-            if not url.scheme:
-                host = f"http://{config_entry.data[CONF_HOST]}"
+            if "://" not in config_entry.data[CONF_HOST]:
+                host = URL().build(
+                    scheme="http",
+                    host=config_entry.data[CONF_HOST],
+                )
+                port = 80
             else:
-                host = f"{url.scheme}://{url.host}"
+                host = config_entry.data[CONF_HOST]
+                url = URL(config_entry.data[CONF_HOST])
+                if TYPE_CHECKING:
+                    assert isinstance(url.port, int)
+                port = url.port
+
             new_data = {
                 **config_entry.data,
-                CONF_HOST: host,
-                CONF_PORT: url.port or 80,
+                CONF_HOST: str(host),
+                CONF_PORT: port,
                 CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
             }
 

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
+from yarl import URL
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, UnitOfTemperature
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_VERIFY_SSL,
+    EVENT_HOMEASSISTANT_STOP,
+    UnitOfTemperature,
+)
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 
-from .const import DOMAIN, LOGGER, PLATFORMS
+from .const import DEFAULT_VERIFY_SSL, DOMAIN, LOGGER, PLATFORMS
 from .coordinator import FritzboxConfigEntry, FritzboxDataUpdateCoordinator
 
 
@@ -65,6 +72,49 @@ async def async_unload_entry(hass: HomeAssistant, entry: FritzboxConfigEntry) ->
         LOGGER.debug("logout failed with '%s', anyway continue with unload", ex)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: FritzboxConfigEntry
+) -> bool:
+    """Migrate old config entry to a new format."""
+    LOGGER.debug(
+        "Migrating configuration from version %s.%s",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+
+    if config_entry.version == 1:
+        new_data = {**config_entry.data}
+        if config_entry.minor_version < 2:
+            LOGGER.debug("Migrate config entry data to URL based configuration")
+            url = URL(config_entry.data[CONF_HOST])
+            if not url.scheme:
+                host = f"http://{config_entry.data[CONF_HOST]}"
+            else:
+                host = f"{url.scheme}://{url.host}"
+            port = url.port or 80
+            verify_ssl = DEFAULT_VERIFY_SSL
+            new_data = {
+                **config_entry.data,
+                CONF_HOST: host,
+                CONF_PORT: port,
+                CONF_VERIFY_SSL: verify_ssl,
+            }
+
+        hass.config_entries.async_update_entry(
+            config_entry, data=new_data, version=1, minor_version=2
+        )
+
+    LOGGER.debug(
+        "Migration to configuration version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+    return True
 
 
 async def async_remove_config_entry_device(

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
 from yarl import URL
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
-    CONF_PORT,
     CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STOP,
     UnitOfTemperature,
@@ -98,18 +95,12 @@ async def async_migrate_entry(
                     scheme="http",
                     host=config_entry.data[CONF_HOST],
                 )
-                port = 80
             else:
                 host = config_entry.data[CONF_HOST]
-                url = URL(config_entry.data[CONF_HOST])
-                if TYPE_CHECKING:
-                    assert isinstance(url.port, int)
-                port = url.port
 
             new_data = {
                 **config_entry.data,
                 CONF_HOST: str(host),
-                CONF_PORT: port,
                 CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,
             }
 

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -4,35 +4,55 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 import ipaddress
-from typing import Any, Self
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any, Self
 
 from pyfritzhome import Fritzhome, LoginError
 from requests.exceptions import HTTPError
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_PRESENTATION_URL,
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
 
-from .const import DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
+from .const import DEFAULT_URL, DEFAULT_USERNAME, DEFAULT_VERIFY_SSL, DOMAIN
 
 DATA_SCHEMA_USER = vol.Schema(
     {
-        vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+        vol.Required(CONF_URL, default=DEFAULT_URL): TextSelector(
+            config=TextSelectorConfig(type=TextSelectorType.URL)
+        ),
         vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_PASSWORD): TextSelector(
+            config=TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
+        vol.Required(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
     }
 )
 
 DATA_SCHEMA_CONFIRM = vol.Schema(
     {
         vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_PASSWORD): TextSelector(
+            config=TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
     }
 )
 
@@ -46,14 +66,17 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a AVM FRITZ!SmartHome config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     _name: str
 
     def __init__(self) -> None:
         """Initialize flow."""
         self._host: str | None = None
+        self._port: int | None = None
         self._password: str | None = None
         self._username: str | None = None
+        self._verify_ssl: bool = DEFAULT_VERIFY_SSL
 
     def _get_entry(self, name: str) -> ConfigFlowResult:
         return self.async_create_entry(
@@ -62,6 +85,8 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_HOST: self._host,
                 CONF_PASSWORD: self._password,
                 CONF_USERNAME: self._username,
+                CONF_PORT: self._port,
+                CONF_VERIFY_SSL: self._verify_ssl,
             },
         )
 
@@ -72,7 +97,11 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     def _try_connect(self) -> str:
         """Try to connect and check auth."""
         fritzbox = Fritzhome(
-            host=self._host, user=self._username, password=self._password
+            host=self._host,
+            user=self._username,
+            password=self._password,
+            port=self._port,
+            ssl_verify=self._verify_ssl,
         )
         try:
             fritzbox.login()
@@ -93,12 +122,15 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
-
-            self._host = user_input[CONF_HOST]
-            self._name = str(user_input[CONF_HOST])
+            url = URL(user_input[CONF_URL])
+            self._host = f"{url.scheme}://{url.host}"
+            self._port = url.port
+            self._verify_ssl = user_input[CONF_VERIFY_SSL]
             self._password = user_input[CONF_PASSWORD]
             self._username = user_input[CONF_USERNAME]
+            self._name = str(self._host)
+
+            self._async_abort_entries_match({CONF_HOST: self._host})
 
             result = await self.async_try_connect()
 
@@ -116,32 +148,35 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
         """Handle a flow initialized by discovery."""
-        host = urlparse(discovery_info.ssdp_location).hostname
-        assert isinstance(host, str)
+        self._host = discovery_info.upnp[ATTR_UPNP_PRESENTATION_URL]
+        represenation_url = URL(self._host)
+        self._port = represenation_url.port or 80
+
+        if TYPE_CHECKING:
+            assert isinstance(represenation_url.host, str)
 
         if (
-            ipaddress.ip_address(host).version == 6
-            and ipaddress.ip_address(host).is_link_local
+            ipaddress.ip_address(represenation_url.host).version == 6
+            and ipaddress.ip_address(represenation_url.host).is_link_local
         ):
             return self.async_abort(reason="ignore_ip6_link_local")
 
         if uuid := discovery_info.upnp.get(ATTR_UPNP_UDN):
             uuid = uuid.removeprefix("uuid:")
             await self.async_set_unique_id(uuid)
-            self._abort_if_unique_id_configured({CONF_HOST: host})
+            self._abort_if_unique_id_configured({CONF_HOST: self._host})
 
-        self._host = host
         if self.hass.config_entries.flow.async_has_matching_flow(self):
             return self.async_abort(reason="already_in_progress")
 
         # update old and user-configured config entries
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] == host:
+            if entry.data[CONF_HOST] == self._host:
                 if uuid and not entry.unique_id:
                     self.hass.config_entries.async_update_entry(entry, unique_id=uuid)
                 return self.async_abort(reason="already_configured")
 
-        self._name = str(discovery_info.upnp.get(ATTR_UPNP_FRIENDLY_NAME) or host)
+        self._name = str(discovery_info.upnp.get(ATTR_UPNP_FRIENDLY_NAME) or self._host)
 
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_confirm()
@@ -179,6 +214,8 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Trigger a reauthentication flow."""
         self._host = entry_data[CONF_HOST]
+        self._port = entry_data[CONF_PORT]
+        self._verify_ssl = entry_data[CONF_VERIFY_SSL]
         self._name = str(entry_data[CONF_HOST])
         self._username = entry_data[CONF_USERNAME]
 
@@ -199,8 +236,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
             if result == RESULT_SUCCESS:
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
-                    data={
-                        CONF_HOST: self._host,
+                    data_updates={
                         CONF_PASSWORD: self._password,
                         CONF_USERNAME: self._username,
                     },
@@ -226,31 +262,41 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a reconfiguration flow initialized by the user."""
         errors = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        self._host = reconfigure_entry.data[CONF_HOST]
+        self._port = reconfigure_entry.data[CONF_PORT]
+        self._verify_ssl = reconfigure_entry.data[CONF_VERIFY_SSL]
+        self._username = reconfigure_entry.data[CONF_USERNAME]
+        self._password = reconfigure_entry.data[CONF_PASSWORD]
 
         if user_input is not None:
-            self._host = user_input[CONF_HOST]
-
-            reconfigure_entry = self._get_reconfigure_entry()
-            self._username = reconfigure_entry.data[CONF_USERNAME]
-            self._password = reconfigure_entry.data[CONF_PASSWORD]
+            url = URL(user_input[CONF_URL])
+            self._host = f"{url.scheme}://{url.host}"
+            self._port = url.port
+            self._verify_ssl = user_input[CONF_VERIFY_SSL]
 
             result = await self.async_try_connect()
 
             if result == RESULT_SUCCESS:
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
-                    data_updates={CONF_HOST: self._host},
+                    data_updates={
+                        CONF_HOST: self._host,
+                        CONF_PORT: self._port,
+                        CONF_VERIFY_SSL: self._verify_ssl,
+                    },
                 )
             errors["base"] = result
 
-        host = self._get_reconfigure_entry().data[CONF_HOST]
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=host): str,
+                    vol.Required(CONF_URL, default=self._host): str,
+                    vol.Required(CONF_VERIFY_SSL, default=self._verify_ssl): bool,
                 }
             ),
-            description_placeholders={"name": host},
+            description_placeholders={"name": self._host},
             errors=errors,
         )

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -143,14 +143,14 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a flow initialized by discovery."""
         self._url = discovery_info.upnp[ATTR_UPNP_PRESENTATION_URL]
-        represenation_url = URL(self._url)
+        representation_url = URL(self._url)
 
         if TYPE_CHECKING:
-            assert isinstance(represenation_url.host, str)
+            assert isinstance(representation_url.host, str)
 
         if (
-            ipaddress.ip_address(represenation_url.host).version == 6
-            and ipaddress.ip_address(represenation_url.host).is_link_local
+            ipaddress.ip_address(representation_url.host).version == 6
+            and ipaddress.ip_address(representation_url.host).is_link_local
         ):
             return self.async_abort(reason="ignore_ip6_link_local")
 

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -15,7 +15,6 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -72,8 +71,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize flow."""
-        self._host: str | None = None
-        self._port: int | None = None
+        self._url: str | None = None
         self._password: str | None = None
         self._username: str | None = None
         self._verify_ssl: bool = DEFAULT_VERIFY_SSL
@@ -82,10 +80,9 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=name,
             data={
-                CONF_HOST: self._host,
+                CONF_HOST: self._url,
                 CONF_PASSWORD: self._password,
                 CONF_USERNAME: self._username,
-                CONF_PORT: self._port,
                 CONF_VERIFY_SSL: self._verify_ssl,
             },
         )
@@ -97,10 +94,9 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
     def _try_connect(self) -> str:
         """Try to connect and check auth."""
         fritzbox = Fritzhome(
-            host=self._host,
+            host=self._url,
             user=self._username,
             password=self._password,
-            port=self._port,
             ssl_verify=self._verify_ssl,
         )
         try:
@@ -122,15 +118,13 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            url = URL(user_input[CONF_URL])
-            self._host = f"{url.scheme}://{url.host}"
-            self._port = url.port
+            self._url = user_input[CONF_URL]
             self._verify_ssl = user_input[CONF_VERIFY_SSL]
             self._password = user_input[CONF_PASSWORD]
             self._username = user_input[CONF_USERNAME]
-            self._name = str(self._host)
+            self._name = str(self._url)
 
-            self._async_abort_entries_match({CONF_HOST: self._host})
+            self._async_abort_entries_match({CONF_HOST: self._url})
 
             result = await self.async_try_connect()
 
@@ -148,9 +142,8 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
         """Handle a flow initialized by discovery."""
-        self._host = discovery_info.upnp[ATTR_UPNP_PRESENTATION_URL]
-        represenation_url = URL(self._host)
-        self._port = represenation_url.port or 80
+        self._url = discovery_info.upnp[ATTR_UPNP_PRESENTATION_URL]
+        represenation_url = URL(self._url)
 
         if TYPE_CHECKING:
             assert isinstance(represenation_url.host, str)
@@ -164,26 +157,26 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         if uuid := discovery_info.upnp.get(ATTR_UPNP_UDN):
             uuid = uuid.removeprefix("uuid:")
             await self.async_set_unique_id(uuid)
-            self._abort_if_unique_id_configured({CONF_HOST: self._host})
+            self._abort_if_unique_id_configured({CONF_HOST: self._url})
 
         if self.hass.config_entries.flow.async_has_matching_flow(self):
             return self.async_abort(reason="already_in_progress")
 
         # update old and user-configured config entries
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] == self._host:
+            if entry.data[CONF_HOST] == self._url:
                 if uuid and not entry.unique_id:
                     self.hass.config_entries.async_update_entry(entry, unique_id=uuid)
                 return self.async_abort(reason="already_configured")
 
-        self._name = str(discovery_info.upnp.get(ATTR_UPNP_FRIENDLY_NAME) or self._host)
+        self._name = str(discovery_info.upnp.get(ATTR_UPNP_FRIENDLY_NAME) or self._url)
 
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_confirm()
 
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
-        return other_flow._host == self._host  # noqa: SLF001
+        return other_flow._url == self._url  # noqa: SLF001
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -213,8 +206,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Trigger a reauthentication flow."""
-        self._host = entry_data[CONF_HOST]
-        self._port = entry_data[CONF_PORT]
+        self._url = entry_data[CONF_HOST]
         self._verify_ssl = entry_data[CONF_VERIFY_SSL]
         self._name = str(entry_data[CONF_HOST])
         self._username = entry_data[CONF_USERNAME]
@@ -264,16 +256,13 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         reconfigure_entry = self._get_reconfigure_entry()
 
-        self._host = reconfigure_entry.data[CONF_HOST]
-        self._port = reconfigure_entry.data[CONF_PORT]
+        self._url = reconfigure_entry.data[CONF_HOST]
         self._verify_ssl = reconfigure_entry.data[CONF_VERIFY_SSL]
         self._username = reconfigure_entry.data[CONF_USERNAME]
         self._password = reconfigure_entry.data[CONF_PASSWORD]
 
         if user_input is not None:
-            url = URL(user_input[CONF_URL])
-            self._host = f"{url.scheme}://{url.host}"
-            self._port = url.port
+            self._url = user_input[CONF_URL]
             self._verify_ssl = user_input[CONF_VERIFY_SSL]
 
             result = await self.async_try_connect()
@@ -282,8 +271,7 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     data_updates={
-                        CONF_HOST: self._host,
-                        CONF_PORT: self._port,
+                        CONF_HOST: self._url,
                         CONF_VERIFY_SSL: self._verify_ssl,
                     },
                 )
@@ -293,10 +281,10 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_URL, default=self._host): str,
+                    vol.Required(CONF_URL, default=self._url): str,
                     vol.Required(CONF_VERIFY_SSL, default=self._verify_ssl): bool,
                 }
             ),
-            description_placeholders={"name": self._host},
+            description_placeholders={"name": self._url},
             errors=errors,
         )

--- a/homeassistant/components/fritzbox/const.py
+++ b/homeassistant/components/fritzbox/const.py
@@ -15,8 +15,9 @@ ATTR_STATE_WINDOW_OPEN: Final = "window_open"
 COLOR_MODE: Final = "1"
 COLOR_TEMP_MODE: Final = "4"
 
-DEFAULT_HOST: Final = "fritz.box"
+DEFAULT_URL: Final = "http://fritz.box"
 DEFAULT_USERNAME: Final = "admin"
+DEFAULT_VERIFY_SSL: Final = True
 
 DOMAIN: Final = "fritzbox"
 

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -10,13 +10,7 @@ from pyfritzhome.devicetypes import FritzhomeTemplate, FritzhomeTrigger
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-    CONF_VERIFY_SSL,
-)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -69,7 +63,6 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             host=self.config_entry.data[CONF_HOST],
             user=self.config_entry.data[CONF_USERNAME],
             password=self.config_entry.data[CONF_PASSWORD],
-            port=self.config_entry.data[CONF_PORT],
             ssl_verify=self.config_entry.data[CONF_VERIFY_SSL],
         )
 

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -10,7 +10,13 @@ from pyfritzhome.devicetypes import FritzhomeTemplate, FritzhomeTrigger
 from requests.exceptions import ConnectionError as RequestConnectionError, HTTPError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -63,6 +69,8 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             host=self.config_entry.data[CONF_HOST],
             user=self.config_entry.data[CONF_USERNAME],
             password=self.config_entry.data[CONF_PASSWORD],
+            port=self.config_entry.data[CONF_PORT],
+            ssl_verify=self.config_entry.data[CONF_VERIFY_SSL],
         )
 
         try:

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "data_desc_ssl_verify": "Whether to verify the SSL certificate when SSL encryption is used to connect to your FRITZ!Box.",
+    "data_desc_url": "The hostname or IP address or full URL of your FRITZ!Box."
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -31,21 +35,25 @@
       },
       "reconfigure": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "url": "[%key:common::config_flow::data::url%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your FRITZ!Box router."
+          "url": "[%key:component::fritzbox::common::data_desc_url%]",
+          "verify_ssl": "[%key:component::fritzbox::common::data_desc_ssl_verify%]"
         },
         "description": "Update your configuration information for {name}."
       },
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "username": "[%key:common::config_flow::data::username%]"
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your FRITZ!Box router."
+          "url": "[%key:component::fritzbox::common::data_desc_url%]",
+          "verify_ssl": "[%key:component::fritzbox::common::data_desc_ssl_verify%]"
         },
         "description": "Enter your FRITZ!Box information."
       }

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "data_desc_ssl_verify": "Whether to verify the SSL certificate when SSL encryption is used to connect to your FRITZ!Box.",
-    "data_desc_url": "The hostname or IP address or full URL of your FRITZ!Box."
+    "data_desc_url": "The URL of your FRITZ!Box."
   },
   "config": {
     "abort": {

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -29,9 +29,7 @@ async def setup_config_entry(
 ) -> MockConfigEntry:
     """Do setup of a MockConfigEntry."""
     entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=data,
-        unique_id=unique_id,
+        domain=DOMAIN, data=data, unique_id=unique_id, version=1, minor_version=2
     )
     entry.add_to_hass(hass)
     if device is not None and fritz is not None:

--- a/tests/components/fritzbox/const.py
+++ b/tests/components/fritzbox/const.py
@@ -1,15 +1,24 @@
 """Constants for fritzbox tests."""
 
 from homeassistant.components.fritzbox.const import DOMAIN
-from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 
 MOCK_CONFIG = {
     DOMAIN: {
         CONF_DEVICES: [
             {
-                CONF_HOST: "10.0.0.1",
+                CONF_HOST: "http://10.0.0.1",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
+                CONF_PORT: 80,
+                CONF_VERIFY_SSL: False,
             }
         ]
     }

--- a/tests/components/fritzbox/const.py
+++ b/tests/components/fritzbox/const.py
@@ -5,7 +5,6 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
@@ -17,7 +16,6 @@ MOCK_CONFIG = {
                 CONF_HOST: "http://10.0.0.1",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 80,
                 CONF_VERIFY_SSL: False,
             }
         ]

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -319,6 +319,7 @@ async def test_ssdp(
     assert result["data"][CONF_HOST] == test_data.upnp[ATTR_UPNP_PRESENTATION_URL]
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
+    assert result["data"][CONF_VERIFY_SSL] is True
     assert result["result"].unique_id == "only-a-test"
 
 

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -14,7 +14,6 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_URL,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -98,7 +97,6 @@ async def test_user(hass: HomeAssistant, fritz: Mock) -> None:
     assert result["data"][CONF_HOST] == "http://10.0.0.1"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
-    assert result["data"][CONF_PORT] == 80
     assert result["data"][CONF_VERIFY_SSL] is False
     assert not result["result"].unique_id
 
@@ -244,10 +242,9 @@ async def test_reconfigure_success(hass: HomeAssistant, fritz: Mock) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert mock_config.data[CONF_HOST] == "https://new_host"
+    assert mock_config.data[CONF_HOST] == "https://new_host:8443"
     assert mock_config.data[CONF_USERNAME] == "fake_user"
     assert mock_config.data[CONF_PASSWORD] == "fake_pass"
-    assert mock_config.data[CONF_PORT] == 8443
     assert mock_config.data[CONF_VERIFY_SSL] is True
 
 
@@ -282,10 +279,9 @@ async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert mock_config.data[CONF_HOST] == "https://new_host"
+    assert mock_config.data[CONF_HOST] == "https://new_host:8443"
     assert mock_config.data[CONF_USERNAME] == "fake_user"
     assert mock_config.data[CONF_PASSWORD] == "fake_pass"
-    assert mock_config.data[CONF_PORT] == 8443
     assert mock_config.data[CONF_VERIFY_SSL] is True
 
 
@@ -346,7 +342,6 @@ async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock) -> None:
     assert result["data"][CONF_HOST] == "http://10.0.0.1"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
-    assert result["data"][CONF_PORT] == 80
     assert result["data"][CONF_VERIFY_SSL] is True
     assert result["result"].unique_id == "only-a-test"
 

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -3,7 +3,6 @@
 import dataclasses
 from unittest import mock
 from unittest.mock import Mock, patch
-from urllib.parse import urlparse
 
 from pyfritzhome import LoginError
 import pytest
@@ -11,11 +10,20 @@ from requests.exceptions import HTTPError
 
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
-from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
+    ATTR_UPNP_PRESENTATION_URL,
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
@@ -24,33 +32,41 @@ from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 
-MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
+MOCK_USER_DATA = {
+    CONF_URL: "http://10.0.0.1",
+    CONF_PASSWORD: "fake_pass",
+    CONF_USERNAME: "fake_user",
+    CONF_VERIFY_SSL: False,
+}
 MOCK_SSDP_DATA = {
     "ip4_valid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
-        ssdp_location="https://10.0.0.1:12345/test",
+        ssdp_location="http://10.0.0.1:49000/fboxdesc.xml",
         upnp={
             ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
             ATTR_UPNP_UDN: "uuid:only-a-test",
+            ATTR_UPNP_PRESENTATION_URL: "http://10.0.0.1",
         },
     ),
     "ip6_valid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
-        ssdp_location="https://[1234::1]:12345/test",
+        ssdp_location="http://[1234::1]:49000/fboxdesc.xml",
         upnp={
             ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
             ATTR_UPNP_UDN: "uuid:only-a-test",
+            ATTR_UPNP_PRESENTATION_URL: "http://[1234::1]",
         },
     ),
     "ip6_invalid": SsdpServiceInfo(
         ssdp_usn="mock_usn",
         ssdp_st="mock_st",
-        ssdp_location="https://[fe80::1%1]:12345/test",
+        ssdp_location="http://[fe80::1%1]:49000/fboxdesc.xml",
         upnp={
             ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
             ATTR_UPNP_UDN: "uuid:only-a-test",
+            ATTR_UPNP_PRESENTATION_URL: "https://[fe80::1%1]",
         },
     ),
 }
@@ -78,10 +94,12 @@ async def test_user(hass: HomeAssistant, fritz: Mock) -> None:
         result["flow_id"], user_input=MOCK_USER_DATA
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "10.0.0.1"
-    assert result["data"][CONF_HOST] == "10.0.0.1"
+    assert result["title"] == "http://10.0.0.1"
+    assert result["data"][CONF_HOST] == "http://10.0.0.1"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
+    assert result["data"][CONF_PORT] == 80
+    assert result["data"][CONF_VERIFY_SSL] is False
     assert not result["result"].unique_id
 
 
@@ -125,7 +143,12 @@ async def test_user_already_configured(hass: HomeAssistant, fritz: Mock) -> None
 
 async def test_reauth_success(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow."""
-    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        version=1,
+        minor_version=2,
+    )
     mock_config.add_to_hass(hass)
     result = await mock_config.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -149,7 +172,12 @@ async def test_reauth_auth_failed(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow with authentication failure."""
     fritz().login.side_effect = LoginError("Boom")
 
-    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        version=1,
+        minor_version=2,
+    )
     mock_config.add_to_hass(hass)
     result = await mock_config.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -172,7 +200,12 @@ async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reauthentication flow but no connection found."""
     fritz().login.side_effect = OSError("Boom")
 
-    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        version=1,
+        minor_version=2,
+    )
     mock_config.add_to_hass(hass)
     result = await mock_config.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -192,12 +225,13 @@ async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock) -> None:
 
 async def test_reconfigure_success(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reconfigure flow."""
-    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        version=1,
+        minor_version=2,
+    )
     mock_config.add_to_hass(hass)
-
-    assert mock_config.data[CONF_HOST] == "10.0.0.1"
-    assert mock_config.data[CONF_USERNAME] == "fake_user"
-    assert mock_config.data[CONF_PASSWORD] == "fake_pass"
 
     result = await mock_config.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -205,28 +239,29 @@ async def test_reconfigure_success(hass: HomeAssistant, fritz: Mock) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_HOST: "new_host",
-        },
+        user_input={CONF_URL: "https://new_host:8443", CONF_VERIFY_SSL: True},
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert mock_config.data[CONF_HOST] == "new_host"
+    assert mock_config.data[CONF_HOST] == "https://new_host"
     assert mock_config.data[CONF_USERNAME] == "fake_user"
     assert mock_config.data[CONF_PASSWORD] == "fake_pass"
+    assert mock_config.data[CONF_PORT] == 8443
+    assert mock_config.data[CONF_VERIFY_SSL] is True
 
 
 async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
     """Test starting a reconfigure flow with failure."""
     fritz().login.side_effect = [OSError("Boom"), None]
 
-    mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    mock_config = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        version=1,
+        minor_version=2,
+    )
     mock_config.add_to_hass(hass)
-
-    assert mock_config.data[CONF_HOST] == "10.0.0.1"
-    assert mock_config.data[CONF_USERNAME] == "fake_user"
-    assert mock_config.data[CONF_PASSWORD] == "fake_pass"
 
     result = await mock_config.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -234,9 +269,7 @@ async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_HOST: "new_host",
-        },
+        user_input={CONF_URL: "https://new_host:8443", CONF_VERIFY_SSL: True},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
@@ -244,16 +277,16 @@ async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={
-            CONF_HOST: "new_host",
-        },
+        user_input={CONF_URL: "https://new_host:8443", CONF_VERIFY_SSL: True},
     )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
-    assert mock_config.data[CONF_HOST] == "new_host"
+    assert mock_config.data[CONF_HOST] == "https://new_host"
     assert mock_config.data[CONF_USERNAME] == "fake_user"
     assert mock_config.data[CONF_PASSWORD] == "fake_pass"
+    assert mock_config.data[CONF_PORT] == 8443
+    assert mock_config.data[CONF_VERIFY_SSL] is True
 
 
 @pytest.mark.parametrize(
@@ -287,7 +320,7 @@ async def test_ssdp(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == CONF_FAKE_NAME
-    assert result["data"][CONF_HOST] == urlparse(test_data.ssdp_location).hostname
+    assert result["data"][CONF_HOST] == test_data.upnp[ATTR_UPNP_PRESENTATION_URL]
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
     assert result["result"].unique_id == "only-a-test"
@@ -309,10 +342,12 @@ async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock) -> None:
         user_input={CONF_PASSWORD: "fake_pass", CONF_USERNAME: "fake_user"},
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "10.0.0.1"
-    assert result["data"][CONF_HOST] == "10.0.0.1"
+    assert result["title"] == "http://10.0.0.1"
+    assert result["data"][CONF_HOST] == "http://10.0.0.1"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"
+    assert result["data"][CONF_PORT] == 80
+    assert result["data"][CONF_VERIFY_SSL] is True
     assert result["result"].unique_id == "only-a-test"
 
 

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -337,3 +337,33 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
     entries = hass.config_entries.async_entries()
     config_entry = entries[0]
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_migrate_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    fritz: Mock,
+) -> None:
+    """Test migrate config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "10.0.0.1",
+            CONF_PASSWORD: "fake_pass",
+            CONF_USERNAME: "fake_user",
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert entry.data == {
+        CONF_HOST: "http://10.0.0.1",
+        CONF_PASSWORD: "fake_pass",
+        CONF_USERNAME: "fake_user",
+        CONF_PORT: 80,
+        CONF_VERIFY_SSL: True,
+    }

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
     CONF_PASSWORD,
-    CONF_PORT,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STOP,
@@ -44,7 +43,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     assert entries[0].data[CONF_HOST] == "http://10.0.0.1"
     assert entries[0].data[CONF_PASSWORD] == "fake_pass"
     assert entries[0].data[CONF_USERNAME] == "fake_user"
-    assert entries[0].data[CONF_PORT] == 80
     assert entries[0].data[CONF_VERIFY_SSL] is False
     assert fritz.call_count == 1
     assert fritz.call_args_list == [
@@ -52,7 +50,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
             host="http://10.0.0.1",
             password="fake_pass",
             user="fake_user",
-            port=80,
             ssl_verify=False,
         )
     ]
@@ -352,7 +349,6 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
                 CONF_HOST: "http://10.0.0.1",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 80,
                 CONF_VERIFY_SSL: True,
             },
         ),
@@ -366,7 +362,6 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
                 CONF_HOST: "https://10.0.0.1",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 443,
                 CONF_VERIFY_SSL: True,
             },
         ),
@@ -380,7 +375,6 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
                 CONF_HOST: "http://[1234::1]",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 80,
                 CONF_VERIFY_SSL: True,
             },
         ),
@@ -394,7 +388,6 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
                 CONF_HOST: "http://[1234::1]",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 80,
                 CONF_VERIFY_SSL: True,
             },
         ),
@@ -408,7 +401,6 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
                 CONF_HOST: "https://[1234::1]",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
-                CONF_PORT: 443,
                 CONF_VERIFY_SSL: True,
             },
         ),

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -17,7 +17,9 @@ from homeassistant.const import (
     CONF_DEVICES,
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_PORT,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STOP,
     STATE_UNAVAILABLE,
     UnitOfTemperature,
@@ -39,12 +41,20 @@ async def test_setup(hass: HomeAssistant, fritz: Mock) -> None:
     entries = hass.config_entries.async_entries()
     assert entries
     assert len(entries) == 1
-    assert entries[0].data[CONF_HOST] == "10.0.0.1"
+    assert entries[0].data[CONF_HOST] == "http://10.0.0.1"
     assert entries[0].data[CONF_PASSWORD] == "fake_pass"
     assert entries[0].data[CONF_USERNAME] == "fake_user"
+    assert entries[0].data[CONF_PORT] == 80
+    assert entries[0].data[CONF_VERIFY_SSL] is False
     assert fritz.call_count == 1
     assert fritz.call_args_list == [
-        call(host="10.0.0.1", password="fake_pass", user="fake_user")
+        call(
+            host="http://10.0.0.1",
+            password="fake_pass",
+            user="fake_user",
+            port=80,
+            ssl_verify=False,
+        )
     ]
 
 
@@ -86,6 +96,8 @@ async def test_update_unique_id(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id="any",
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -145,6 +157,8 @@ async def test_update_unique_id_no_change(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id="any",
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -170,6 +184,8 @@ async def test_unload_remove(hass: HomeAssistant, fritz: Mock) -> None:
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id=entity_id,
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -209,6 +225,8 @@ async def test_logout_on_stop(hass: HomeAssistant, fritz: Mock) -> None:
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id=entity_id,
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -281,6 +299,8 @@ async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant) ->
         domain=DOMAIN,
         data={CONF_HOST: "any", **MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]},
         unique_id="any",
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
     with patch(
@@ -302,6 +322,8 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
         domain=DOMAIN,
         data={CONF_HOST: "any", **MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]},
         unique_id="any",
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
     with patch(

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -339,31 +339,102 @@ async def test_raise_config_entry_error_when_login_fail(hass: HomeAssistant) -> 
     assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+@pytest.mark.parametrize(
+    ("old_data", "new_data"),
+    [
+        (
+            {
+                CONF_HOST: "10.0.0.1",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            },
+            {
+                CONF_HOST: "http://10.0.0.1",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+                CONF_PORT: 80,
+                CONF_VERIFY_SSL: True,
+            },
+        ),
+        (
+            {
+                CONF_HOST: "https://10.0.0.1",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            },
+            {
+                CONF_HOST: "https://10.0.0.1",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+                CONF_PORT: 443,
+                CONF_VERIFY_SSL: True,
+            },
+        ),
+        (
+            {
+                CONF_HOST: "1234::1",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            },
+            {
+                CONF_HOST: "http://[1234::1]",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+                CONF_PORT: 80,
+                CONF_VERIFY_SSL: True,
+            },
+        ),
+        (
+            {
+                CONF_HOST: "http://[1234::1]",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            },
+            {
+                CONF_HOST: "http://[1234::1]",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+                CONF_PORT: 80,
+                CONF_VERIFY_SSL: True,
+            },
+        ),
+        (
+            {
+                CONF_HOST: "https://[1234::1]",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            },
+            {
+                CONF_HOST: "https://[1234::1]",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+                CONF_PORT: 443,
+                CONF_VERIFY_SSL: True,
+            },
+        ),
+    ],
+)
 async def test_migrate_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     fritz: Mock,
+    old_data: dict,
+    new_data: dict,
 ) -> None:
     """Test migrate config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={
-            CONF_HOST: "10.0.0.1",
-            CONF_PASSWORD: "fake_pass",
-            CONF_USERNAME: "fake_user",
-        },
+        data=old_data,
     )
     entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.fritzbox.async_setup_entry",
+        return_value=True,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 1
     assert entry.minor_version == 2
-    assert entry.data == {
-        CONF_HOST: "http://10.0.0.1",
-        CONF_PASSWORD: "fake_pass",
-        CONF_USERNAME: "fake_user",
-        CONF_PORT: 80,
-        CONF_VERIFY_SSL: True,
-    }
+    assert entry.data == new_data


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reworks the config flow to take an single URL parameter, instead of 3 single parameters for host, port and verify-ssl.
As the library takes a single IP as also an URL (_but without considering the port part_) as the host attribute during init, we need to separate the port from the URL and provide it as a different attribute (_those we can't just take over the URL from the user input_). We increase the minor version of the config entry (_from 1.1 to 1.2_) to allow the automatic config entry migration.
This also brings the advantage to allow the user to define an own port as part of the URL (_eq. `https://abcdefgh.myfritz.net:8265`_) which was a FR (https://github.com/orgs/home-assistant/discussions/2497)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43552
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
