### PR TITLE
Fix Z-Wave fan speed

### DIFF
--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -281,8 +281,8 @@ async def test_configurable_speeds_fan(
     percentages_to_zwave_speeds = [
         [[0], [0]],
         [range(1, 34), range(1, 34)],
-        [range(34, 68), range(34, 67)],
-        [range(68, 101), range(67, 100)],
+        [range(34, 67), range(34, 67)],
+        [range(67, 101), range(67, 100)],
     ]
 
     for percentages, zwave_speeds in percentages_to_zwave_speeds:
@@ -407,8 +407,8 @@ async def test_ge_12730_fan(hass: HomeAssistant, client, ge_12730, integration) 
     percentages_to_zwave_speeds = [
         [[0], [0]],
         [range(1, 34), range(1, 34)],
-        [range(34, 68), range(34, 68)],
-        [range(68, 101), range(68, 100)],
+        [range(34, 67), range(34, 68)],
+        [range(67, 101), range(68, 100)],
     ]
 
     for percentages, zwave_speeds in percentages_to_zwave_speeds:
@@ -500,8 +500,8 @@ async def test_jasco_14314_fan(
     percentages_to_zwave_speeds = [
         [[0], [0]],
         [range(1, 34), range(1, 33)],  # percentages 1-33 → zwave 1-32
-        [range(34, 68), range(33, 67)],  # percentages 34-67 → zwave 33-66
-        [range(68, 101), range(67, 100)],  # percentages 68-100 → zwave 67-99
+        [range(34, 67), range(33, 67)],  # percentages 34-66 → zwave 33-66
+        [range(67, 101), range(67, 100)],  # percentages 67-100 → zwave 67-99
     ]
 
     for percentages, zwave_speeds in percentages_to_zwave_speeds:
@@ -597,8 +597,8 @@ async def test_inovelli_lzw36(
     percentages_to_zwave_speeds = [
         [[0], [0]],
         [range(1, 34), range(2, 34)],
-        [range(34, 68), range(34, 67)],
-        [range(68, 101), range(67, 100)],
+        [range(34, 67), range(34, 67)],
+        [range(67, 101), range(67, 100)],
     ]
 
     for percentages, zwave_speeds in percentages_to_zwave_speeds:
@@ -1106,8 +1106,8 @@ async def test_honeywell_39358_fan(
     percentages_to_zwave_speeds = [
         [[0], [0]],
         [range(1, 34), range(1, 33)],
-        [range(34, 68), range(33, 67)],
-        [range(68, 101), range(67, 100)],
+        [range(34, 67), range(33, 67)],
+        [range(67, 101), range(67, 100)],
     ]
 
     for percentages, zwave_speeds in percentages_to_zwave_speeds:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Percentage speeds reported by Z-Wave fans have been corrected to align with other integrations. As a result values may differ slightly, for example a value previously reported as 67% may now appear as 66%.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix Z-Wave fan speed.

It was using custom logic, that was incompatible with other integrations. It is now switched to using standard utils instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
