### PR TITLE
dwd_weather_warnings: Filter expired warnings

### DIFF
--- a/homeassistant/components/dwd_weather_warnings/sensor.py
+++ b/homeassistant/components/dwd_weather_warnings/sensor.py
@@ -11,6 +11,7 @@ Wetterwarnungen (Stufe 1)
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -95,13 +96,25 @@ class DwdWeatherWarningsSensor(
             entry_type=DeviceEntryType.SERVICE,
         )
 
+    def _filter_expired_warnings(
+        self, warnings: list[dict[str, Any]] | None
+    ) -> list[dict[str, Any]]:
+        if warnings is None:
+            return []
+
+        now = datetime.now(UTC)
+        return [warning for warning in warnings if warning[API_ATTR_WARNING_END] > now]
+
     @property
     def native_value(self) -> int | None:
         """Return the state of the sensor."""
         if self.entity_description.key == CURRENT_WARNING_SENSOR:
-            return self.coordinator.api.current_warning_level
+            warnings = self.coordinator.api.current_warnings
+        else:
+            warnings = self.coordinator.api.expected_warnings
 
-        return self.coordinator.api.expected_warning_level
+        warnings = self._filter_expired_warnings(warnings)
+        return max((w.get(API_ATTR_WARNING_LEVEL, 0) for w in warnings), default=0)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -117,6 +130,7 @@ class DwdWeatherWarningsSensor(
         else:
             searched_warnings = self.coordinator.api.expected_warnings
 
+        searched_warnings = self._filter_expired_warnings(searched_warnings)
         data[ATTR_WARNING_COUNT] = len(searched_warnings)
 
         for i, warning in enumerate(searched_warnings, 1):

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -1,9 +1,23 @@
 """Tests for Deutscher Wetterdienst (DWD) Weather Warnings integration."""
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 from homeassistant.components.dwd_weather_warnings.const import (
+    API_ATTR_WARNING_COLOR,
+    API_ATTR_WARNING_DESCRIPTION,
+    API_ATTR_WARNING_END,
+    API_ATTR_WARNING_HEADLINE,
+    API_ATTR_WARNING_INSTRUCTION,
+    API_ATTR_WARNING_LEVEL,
+    API_ATTR_WARNING_NAME,
+    API_ATTR_WARNING_PARAMETERS,
+    API_ATTR_WARNING_START,
+    API_ATTR_WARNING_TYPE,
+    ATTR_WARNING_COUNT,
     CONF_REGION_DEVICE_TRACKER,
+    CONF_REGION_IDENTIFIER,
+    CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.components.dwd_weather_warnings.coordinator import (
@@ -18,6 +32,22 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from . import init_integration
 
 from tests.common import MockConfigEntry
+
+
+def _warning(level: int, end_time: datetime) -> dict[str, object]:
+    """Return a warning payload for tests."""
+    return {
+        API_ATTR_WARNING_NAME: f"Warning {level}",
+        API_ATTR_WARNING_TYPE: level,
+        API_ATTR_WARNING_LEVEL: level,
+        API_ATTR_WARNING_HEADLINE: f"Headline {level}",
+        API_ATTR_WARNING_DESCRIPTION: "Description",
+        API_ATTR_WARNING_INSTRUCTION: "Instruction",
+        API_ATTR_WARNING_START: end_time - timedelta(hours=1),
+        API_ATTR_WARNING_END: end_time,
+        API_ATTR_WARNING_PARAMETERS: {},
+        API_ATTR_WARNING_COLOR: "#ffffff",
+    }
 
 
 async def test_load_unload_entry(
@@ -136,3 +166,36 @@ async def test_load_valid_device_tracker(
 
     assert mock_tracker_entry.state is ConfigEntryState.LOADED
     assert isinstance(mock_tracker_entry.runtime_data, DwdWeatherWarningsCoordinator)
+
+
+async def test_filter_expired_warnings(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_dwdwfsapi: MagicMock
+) -> None:
+    """Test expired-warning filtering."""
+    now = datetime.now(UTC)
+    mock_dwdwfsapi.data_valid = True
+    mock_dwdwfsapi.warncell_id = "803000000"
+    mock_dwdwfsapi.warncell_name = "Test region"
+    mock_dwdwfsapi.current_warnings = [
+        _warning(4, now - timedelta(minutes=30)),
+        _warning(2, now + timedelta(minutes=30)),
+    ]
+    mock_dwdwfsapi.expected_warnings = []
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_REGION_IDENTIFIER: "803000000"},
+        unique_id="803000000",
+    )
+    await init_integration(hass, entry)
+
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, f"{entry.unique_id}-{CURRENT_WARNING_SENSOR}"
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "2"
+    assert state.attributes[ATTR_WARNING_COUNT] == 1
+    assert "warning_2" not in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This adds functionality to filter DWD warnings after they have expired. Sometimes warnings are kept in the API even though their end date is in the past, which many users (including me) consider a bug.

~~As discussed in #150737, this functionality is off by default in order not to break existing use-cases and can be enabled during set-up and after the fact from the integration settings.~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #150737
- Related to: #103352
- ~~Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43557~~

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- ~~[x] Documentation added/updated for [www.home-assistant.io][docs-repository]~~

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
