### PR TITLE
Add ZoneMinder integration test suite

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1892,6 +1892,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/zone/ @home-assistant/core
 /tests/components/zone/ @home-assistant/core
 /homeassistant/components/zoneminder/ @rohankapoorcom @nabbi
+/tests/components/zoneminder/ @rohankapoorcom @nabbi
 /homeassistant/components/zwave_js/ @home-assistant/z-wave
 /tests/components/zwave_js/ @home-assistant/z-wave
 /homeassistant/components/zwave_me/ @lawfulchaos @Z-Wave-Me @PoltoS

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2706,6 +2706,9 @@ zeversolar==0.3.2
 # homeassistant.components.zha
 zha==0.0.81
 
+# homeassistant.components.zoneminder
+zm-py==0.5.4
+
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.67.1
 

--- a/tests/components/zoneminder/__init__.py
+++ b/tests/components/zoneminder/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ZoneMinder integration."""

--- a/tests/components/zoneminder/conftest.py
+++ b/tests/components/zoneminder/conftest.py
@@ -1,0 +1,233 @@
+"""Shared fixtures for ZoneMinder integration tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from zoneminder.monitor import MonitorState, TimePeriod
+
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PATH,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+CONF_PATH_ZMS = "path_zms"
+
+MOCK_HOST = "zm.example.com"
+MOCK_HOST_2 = "zm2.example.com"
+
+
+@pytest.fixture
+def single_server_config() -> dict:
+    """Return minimal single ZM server YAML config."""
+    return {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "secret",
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def multi_server_config() -> dict:
+    """Return two ZM servers with different settings."""
+    return {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "secret",
+            },
+            {
+                CONF_HOST: MOCK_HOST_2,
+                CONF_USERNAME: "user2",
+                CONF_PASSWORD: "pass2",
+                CONF_SSL: True,
+                CONF_VERIFY_SSL: False,
+                CONF_PATH: "/zoneminder/",
+                CONF_PATH_ZMS: "/zoneminder/cgi-bin/nph-zms",
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def no_auth_config() -> dict:
+    """Return server config without username/password."""
+    return {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def ssl_config() -> dict:
+    """Return server config with SSL enabled, verify_ssl disabled."""
+    return {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_SSL: True,
+                CONF_VERIFY_SSL: False,
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "secret",
+            }
+        ]
+    }
+
+
+def create_mock_monitor(
+    monitor_id: int = 1,
+    name: str = "Front Door",
+    function: MonitorState = MonitorState.MODECT,
+    is_recording: bool = False,
+    is_available: bool = True,
+    mjpeg_image_url: str = "http://zm.example.com/mjpeg/1",
+    still_image_url: str = "http://zm.example.com/still/1",
+    events: dict[TimePeriod, int | None] | None = None,
+) -> MagicMock:
+    """Create a mock Monitor instance with configurable properties."""
+    monitor = MagicMock()
+    monitor.id = monitor_id
+    monitor.name = name
+
+    # function is both a property and a settable attribute in zm-py
+    monitor.function = function
+
+    monitor.is_recording = is_recording
+    monitor.is_available = is_available
+    monitor.mjpeg_image_url = mjpeg_image_url
+    monitor.still_image_url = still_image_url
+
+    if events is None:
+        events = {
+            TimePeriod.ALL: 100,
+            TimePeriod.HOUR: 5,
+            TimePeriod.DAY: 20,
+            TimePeriod.WEEK: 50,
+            TimePeriod.MONTH: 80,
+        }
+
+    def mock_get_events(time_period, include_archived=False):
+        return events.get(time_period, 0)
+
+    monitor.get_events = MagicMock(side_effect=mock_get_events)
+
+    return monitor
+
+
+@pytest.fixture
+def mock_monitor():
+    """Factory fixture returning a function to create mock Monitor instances."""
+    return create_mock_monitor
+
+
+@pytest.fixture
+def two_monitors():
+    """Pre-built list of 2 monitors."""
+    return [
+        create_mock_monitor(
+            monitor_id=1,
+            name="Front Door",
+            function=MonitorState.MODECT,
+            is_recording=True,
+            is_available=True,
+        ),
+        create_mock_monitor(
+            monitor_id=2,
+            name="Back Yard",
+            function=MonitorState.MONITOR,
+            is_recording=False,
+            is_available=True,
+        ),
+    ]
+
+
+def create_mock_zm_client(
+    is_available: bool = True,
+    verify_ssl: bool = True,
+    monitors: list | None = None,
+    login_success: bool = True,
+    active_state: str | None = "Running",
+) -> MagicMock:
+    """Create a mock ZoneMinder client."""
+    client = MagicMock()
+    client.login.return_value = login_success
+    client.get_monitors.return_value = monitors or []
+
+    # is_available and verify_ssl are properties in zm-py
+    type(client).is_available = PropertyMock(return_value=is_available)
+    type(client).verify_ssl = PropertyMock(return_value=verify_ssl)
+
+    client.get_active_state.return_value = active_state
+    client.set_active_state.return_value = True
+
+    return client
+
+
+@pytest.fixture
+def mock_zm_client():
+    """Return a factory for creating mock ZM clients."""
+    return create_mock_zm_client
+
+
+@pytest.fixture
+async def setup_zm(
+    hass: HomeAssistant, single_server_config, two_monitors
+) -> MagicMock:
+    """Set up the ZoneMinder component with mocked client and monitors.
+
+    Returns the mock ZM client for further assertions.
+    """
+    client = create_mock_zm_client(monitors=two_monitors)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    return client
+
+
+@pytest.fixture
+def sensor_platform_config(single_server_config) -> dict:
+    """Return sensor platform YAML with all monitored_conditions."""
+    config = dict(single_server_config)
+    config["sensor"] = [
+        {
+            "platform": DOMAIN,
+            "include_archived": True,
+            "monitored_conditions": ["all", "hour", "day", "week", "month"],
+        }
+    ]
+    return config
+
+
+@pytest.fixture
+def switch_platform_config(single_server_config) -> dict:
+    """Return switch platform YAML with command_on=Modect, command_off=Monitor."""
+    config = dict(single_server_config)
+    config["switch"] = [
+        {
+            "platform": DOMAIN,
+            "command_on": "Modect",
+            "command_off": "Monitor",
+        }
+    ]
+    return config

--- a/tests/components/zoneminder/conftest.py
+++ b/tests/components/zoneminder/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -16,8 +17,6 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 CONF_PATH_ZMS = "path_zms"
 
@@ -180,29 +179,27 @@ def create_mock_zm_client(
 
 
 @pytest.fixture
-def mock_zm_client():
-    """Return a factory for creating mock ZM clients."""
-    return create_mock_zm_client
-
-
-@pytest.fixture
-async def setup_zm(
-    hass: HomeAssistant, single_server_config, two_monitors
-) -> MagicMock:
-    """Set up the ZoneMinder component with mocked client and monitors.
-
-    Returns the mock ZM client for further assertions.
-    """
-    client = create_mock_zm_client(monitors=two_monitors)
-
+def mock_zoneminder_client(two_monitors: list[MagicMock]) -> Generator[MagicMock]:
+    """Mock a ZoneMinder client."""
     with patch(
         "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
+        autospec=True,
+    ) as mock_cls:
+        client = mock_cls.return_value
+        client.login.return_value = True
+        client.get_monitors.return_value = two_monitors
+        client.get_active_state.return_value = "Running"
+        client.set_active_state.return_value = True
 
-    return client
+        # is_available and verify_ssl are properties in zm-py
+        type(client).is_available = PropertyMock(return_value=True)
+        type(client).verify_ssl = PropertyMock(return_value=True)
+
+        # Expose the class mock so tests can inspect constructor call_args
+        # without needing their own inline patch block.
+        client.mock_cls = mock_cls
+
+        yield client
 
 
 @pytest.fixture

--- a/tests/components/zoneminder/test_binary_sensor.py
+++ b/tests/components/zoneminder/test_binary_sensor.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock
 
-import pytest
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.zoneminder.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
-from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
+from .conftest import MOCK_HOST, MOCK_HOST_2
 
 from tests.common import async_fire_time_changed
 
@@ -24,38 +22,42 @@ ENTITY_ID = f"binary_sensor.{MOCK_HOST.replace('.', '_')}"
 ENTITY_ID_2 = f"binary_sensor.{MOCK_HOST_2.replace('.', '_')}"
 
 
-async def _setup_and_update(hass: HomeAssistant, config, client):
+async def _setup_and_update(
+    hass: HomeAssistant,
+    config: dict,
+    mock_zoneminder_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Set up ZM component and trigger first entity update."""
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Trigger the first update poll while mock is still active
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Trigger the first update poll while mock is still active
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_binary_sensor_created_per_server(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test one binary sensor entity is created per ZM server."""
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
 
 
 async def test_binary_sensor_name_from_hostname(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary sensor entity name matches hostname."""
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -63,11 +65,13 @@ async def test_binary_sensor_name_from_hostname(
 
 
 async def test_binary_sensor_device_class_connectivity(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary sensor has connectivity device class."""
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -75,11 +79,14 @@ async def test_binary_sensor_device_class_connectivity(
 
 
 async def test_binary_sensor_state_on_when_available(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary sensor state is ON when server is available."""
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
+    type(mock_zoneminder_client).is_available = PropertyMock(return_value=True)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -87,11 +94,14 @@ async def test_binary_sensor_state_on_when_available(
 
 
 async def test_binary_sensor_state_off_when_unavailable(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary sensor state is OFF when server is unavailable."""
-    client = create_mock_zm_client(is_available=False)
-    await _setup_and_update(hass, single_server_config, client)
+    type(mock_zoneminder_client).is_available = PropertyMock(return_value=False)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
@@ -99,61 +109,42 @@ async def test_binary_sensor_state_off_when_unavailable(
 
 
 async def test_multi_server_creates_multiple_binary_sensors(
-    hass: HomeAssistant, multi_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    multi_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test multi-server config creates multiple binary sensor entities."""
-    client = create_mock_zm_client(is_available=True)
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, multi_server_config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
+    assert await async_setup_component(hass, DOMAIN, multi_server_config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert hass.states.get(ENTITY_ID) is not None
     assert hass.states.get(ENTITY_ID_2) is not None
 
 
 async def test_binary_sensor_state_updates_on_poll(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test binary sensor state updates when polled."""
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
+    type(mock_zoneminder_client).is_available = PropertyMock(return_value=True)
+    await _setup_and_update(hass, single_server_config, mock_zoneminder_client, freezer)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
 
     # Change availability and trigger another update
-    type(client).is_available = PropertyMock(return_value=False)
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=120), fire_all=True
-    )
+    type(mock_zoneminder_client).is_available = PropertyMock(return_value=False)
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_OFF
-
-
-@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
-async def test_unique_id_set(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
-) -> None:
-    """Binary sensor should have unique_id for UI customization.
-
-    No entity in the integration sets unique_id. This means entities cannot
-    be customized via the HA UI and are fragile to name changes.
-    """
-    client = create_mock_zm_client(is_available=True)
-    await _setup_and_update(hass, single_server_config, client)
-
-    entry = entity_registry.async_get(ENTITY_ID)
-    assert entry is not None
-    assert entry.unique_id is not None

--- a/tests/components/zoneminder/test_binary_sensor.py
+++ b/tests/components/zoneminder/test_binary_sensor.py
@@ -1,0 +1,159 @@
+"""Tests for ZoneMinder binary sensor entity states (public API)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
+
+from tests.common import async_fire_time_changed
+
+# The entity_id uses the hostname with dots replaced by underscores
+ENTITY_ID = f"binary_sensor.{MOCK_HOST.replace('.', '_')}"
+ENTITY_ID_2 = f"binary_sensor.{MOCK_HOST_2.replace('.', '_')}"
+
+
+async def _setup_and_update(hass: HomeAssistant, config, client):
+    """Set up ZM component and trigger first entity update."""
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Trigger the first update poll while mock is still active
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_binary_sensor_created_per_server(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test one binary sensor entity is created per ZM server."""
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+
+
+async def test_binary_sensor_name_from_hostname(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor entity name matches hostname."""
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.name == MOCK_HOST
+
+
+async def test_binary_sensor_device_class_connectivity(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor has connectivity device class."""
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("device_class") == BinarySensorDeviceClass.CONNECTIVITY
+
+
+async def test_binary_sensor_state_on_when_available(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor state is ON when server is available."""
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_binary_sensor_state_off_when_unavailable(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor state is OFF when server is unavailable."""
+    client = create_mock_zm_client(is_available=False)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_multi_server_creates_multiple_binary_sensors(
+    hass: HomeAssistant, multi_server_config
+) -> None:
+    """Test multi-server config creates multiple binary sensor entities."""
+    client = create_mock_zm_client(is_available=True)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, multi_server_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(ENTITY_ID) is not None
+    assert hass.states.get(ENTITY_ID_2) is not None
+
+
+async def test_binary_sensor_state_updates_on_poll(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor state updates when polled."""
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    # Change availability and trigger another update
+    type(client).is_available = PropertyMock(return_value=False)
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=120), fire_all=True
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
+async def test_unique_id_set(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
+) -> None:
+    """Binary sensor should have unique_id for UI customization.
+
+    No entity in the integration sets unique_id. This means entities cannot
+    be customized via the HA UI and are fragile to name changes.
+    """
+    client = create_mock_zm_client(is_available=True)
+    await _setup_and_update(hass, single_server_config, client)
+
+    entry = entity_registry.async_get(ENTITY_ID)
+    assert entry is not None
+    assert entry.unique_id is not None

--- a/tests/components/zoneminder/test_camera.py
+++ b/tests/components/zoneminder/test_camera.py
@@ -8,12 +8,11 @@ from unittest.mock import MagicMock, PropertyMock, patch
 from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.camera import CameraState
-from homeassistant.components.zoneminder.camera import setup_platform
 from homeassistant.components.zoneminder.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
+from .conftest import create_mock_monitor, create_mock_zm_client
 
 from tests.common import async_fire_time_changed
 
@@ -191,14 +190,20 @@ async def test_multi_server_camera_creation(
     assert len(states) == 2
 
 
-def test_filter_urllib3_logging_called(hass: HomeAssistant) -> None:
+async def test_filter_urllib3_logging_called(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test filter_urllib3_logging() is called in setup_platform."""
-    client = create_mock_zm_client(monitors=[create_mock_monitor()])
-    hass.data[DOMAIN] = {MOCK_HOST: client}
+    monitors = [create_mock_monitor(name="Front Door")]
 
     with patch(
         "homeassistant.components.zoneminder.camera.filter_urllib3_logging"
     ) as mock_filter:
-        setup_platform(hass, {}, MagicMock())
+        await _setup_zm_with_cameras(
+            hass, mock_zoneminder_client, single_server_config, monitors, freezer
+        )
 
     mock_filter.assert_called_once()

--- a/tests/components/zoneminder/test_camera.py
+++ b/tests/components/zoneminder/test_camera.py
@@ -1,0 +1,338 @@
+"""Tests for ZoneMinder camera entities."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.camera import CameraState
+from homeassistant.components.zoneminder.camera import ZoneMinderCamera, setup_platform
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
+
+from tests.common import async_fire_time_changed
+
+
+async def _setup_zm_with_cameras(
+    hass: HomeAssistant, config: dict, monitors: list, verify_ssl: bool = True
+) -> MagicMock:
+    """Set up ZM component with camera platform and given monitors."""
+    client = create_mock_zm_client(monitors=monitors, verify_ssl=verify_ssl)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Camera uses setup_platform (sync), add camera platform explicitly
+        assert await async_setup_component(
+            hass,
+            "camera",
+            {"camera": [{"platform": DOMAIN}]},
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Trigger first poll to update entity state
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    return client
+
+
+async def test_one_camera_per_monitor(
+    hass: HomeAssistant, single_server_config, two_monitors
+) -> None:
+    """Test one camera entity is created per monitor."""
+    await _setup_zm_with_cameras(hass, single_server_config, two_monitors)
+
+    states = hass.states.async_all("camera")
+    assert len(states) == 2
+
+
+async def test_camera_entity_name(hass: HomeAssistant, single_server_config) -> None:
+    """Test camera entity name matches monitor name."""
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    state = hass.states.get("camera.front_door")
+    assert state is not None
+    assert state.name == "Front Door"
+
+
+async def test_camera_recording_state(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test camera recording state reflects monitor is_recording."""
+    monitors = [
+        create_mock_monitor(name="Recording Cam", is_recording=True, is_available=True)
+    ]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    state = hass.states.get("camera.recording_cam")
+    assert state is not None
+    assert state.state == CameraState.RECORDING
+
+
+async def test_camera_idle_state(hass: HomeAssistant, single_server_config) -> None:
+    """Test camera idle state when not recording."""
+    monitors = [
+        create_mock_monitor(name="Idle Cam", is_recording=False, is_available=True)
+    ]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    state = hass.states.get("camera.idle_cam")
+    assert state is not None
+    assert state.state == CameraState.IDLE
+
+
+async def test_camera_unavailable_state(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test camera unavailable state tracking."""
+    monitors = [create_mock_monitor(name="Offline Cam", is_available=False)]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    state = hass.states.get("camera.offline_cam")
+    assert state is not None
+    assert state.state == "unavailable"
+
+
+async def test_no_monitors_raises_platform_not_ready(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test PlatformNotReady raised when no monitors returned."""
+    client = create_mock_zm_client(monitors=[])
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+        await async_setup_component(
+            hass,
+            "camera",
+            {"camera": [{"platform": DOMAIN}]},
+        )
+        await hass.async_block_till_done()
+
+    # No camera entities should exist
+    states = hass.states.async_all("camera")
+    assert len(states) == 0
+
+
+async def test_multi_server_camera_creation(
+    hass: HomeAssistant, multi_server_config
+) -> None:
+    """Test cameras created from multiple ZM servers."""
+    monitors1 = [create_mock_monitor(monitor_id=1, name="Front Door")]
+    monitors2 = [create_mock_monitor(monitor_id=2, name="Back Yard")]
+
+    clients = iter(
+        [
+            create_mock_zm_client(monitors=monitors1),
+            create_mock_zm_client(monitors=monitors2),
+        ]
+    )
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        side_effect=lambda *args, **kwargs: next(clients),
+    ):
+        assert await async_setup_component(hass, DOMAIN, multi_server_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert await async_setup_component(
+            hass,
+            "camera",
+            {"camera": [{"platform": DOMAIN}]},
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    states = hass.states.async_all("camera")
+    assert len(states) == 2
+
+
+def test_filter_urllib3_logging_called(hass: HomeAssistant) -> None:
+    """Test filter_urllib3_logging() is called in setup_platform."""
+    client = create_mock_zm_client(monitors=[create_mock_monitor()])
+    hass.data[DOMAIN] = {MOCK_HOST: client}
+
+    with patch(
+        "homeassistant.components.zoneminder.camera.filter_urllib3_logging"
+    ) as mock_filter:
+        setup_platform(hass, {}, MagicMock())
+
+    mock_filter.assert_called_once()
+
+
+@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
+async def test_camera_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
+) -> None:
+    """Camera entities should have unique_id for UI customization.
+
+    No entity in the integration sets unique_id. This means entities cannot
+    be customized via the HA UI and are fragile to name changes.
+    """
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    entry = entity_registry.async_get("camera.front_door")
+    assert entry is not None
+    assert entry.unique_id is not None
+
+
+@pytest.mark.xfail(reason="BUG-10: No DeviceInfo — entities not grouped under devices")
+async def test_camera_device_info(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, single_server_config
+) -> None:
+    """Camera entities should be grouped under a device.
+
+    No entity provides device_info. A monitor's camera, sensors, and switch
+    appear as unrelated entities in the HA UI with no device page.
+    """
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    # There should be a device registered for this monitor
+    devices = dr.async_entries_for_config_entry(device_registry, DOMAIN)
+    # Fallback: check all devices since this is YAML-based (no config entry)
+    if not devices:
+        devices = list(device_registry.devices.values())
+
+    monitor_devices = [
+        d for d in devices if any(DOMAIN in ident[0] for ident in d.identifiers)
+    ]
+    assert len(monitor_devices) > 0
+
+
+@pytest.mark.xfail(reason="BUG-07: Empty monitors treated same as API failure")
+async def test_empty_server_does_not_raise_platform_not_ready(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """A server with zero monitors should set up successfully, not retry forever.
+
+    All platforms raise PlatformNotReady when get_monitors() returns empty,
+    but an empty list is a legitimate permanent state (server has no monitors).
+    """
+    client = create_mock_zm_client(monitors=[])
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+        assert await async_setup_component(
+            hass,
+            "camera",
+            {"camera": [{"platform": DOMAIN}]},
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Desired: platform loads successfully with 0 entities (not PlatformNotReady)
+    # We verify by checking the platform didn't schedule a retry
+    states = hass.states.async_all("camera")
+    assert len(states) == 0
+    # The key assertion: get_monitors was called only once (no retry loop)
+    assert client.get_monitors.call_count == 1
+
+
+@pytest.mark.xfail(reason="BUG-08: PTZ control not exposed despite zm-py support")
+async def test_camera_supports_ptz(hass: HomeAssistant, single_server_config) -> None:
+    """Camera should expose PTZ control when monitor is controllable.
+
+    zm-py provides complete PTZ support via Monitor.ptz_control_command()
+    and Monitor.controllable, but HA exposes none of it.
+    """
+    monitors = [create_mock_monitor(name="PTZ Cam")]
+    monitors[0].controllable = True
+    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+
+    state = hass.states.get("camera.ptz_cam")
+    assert state is not None
+    # Check for any PTZ-related supported feature or service
+    supported = state.attributes.get("supported_features", 0)
+    # Any PTZ feature bit should be set (the exact flag depends on HA version)
+    assert supported > 0
+
+
+@pytest.mark.xfail(reason="BUG-06: get_monitors() called separately by each platform")
+async def test_get_monitors_called_once(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """get_monitors should be called once and shared across platforms.
+
+    Each platform (camera, sensor, switch) independently calls get_monitors(),
+    fetching monitors.json 3 times and creating separate Monitor object trees.
+    """
+    monitors = [create_mock_monitor(name="Front Door")]
+    client = create_mock_zm_client(monitors=monitors)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Set up all three platforms
+        assert await async_setup_component(
+            hass, "camera", {"camera": [{"platform": DOMAIN}]}
+        )
+        assert await async_setup_component(
+            hass, "sensor", {"sensor": [{"platform": DOMAIN}]}
+        )
+        assert await async_setup_component(
+            hass,
+            "switch",
+            {
+                "switch": [
+                    {
+                        "platform": DOMAIN,
+                        "command_on": "Modect",
+                        "command_off": "Monitor",
+                    }
+                ]
+            },
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Desired: monitors fetched once and shared across all platforms
+    assert client.get_monitors.call_count == 1
+
+
+@pytest.mark.xfail(
+    reason="BUG-02: No DataUpdateCoordinator — each entity polls independently"
+)
+async def test_coordinator_shared_updates(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Entities should share a coordinator instead of polling independently.
+
+    Every entity polls the ZoneMinder API independently on each HA update cycle.
+    There is no shared coordinator or caching layer, resulting in ~14 API calls
+    per monitor per poll cycle.
+
+    With a coordinator, camera entities would set should_poll=False and
+    get data from the shared coordinator instead.
+    """
+    # Desired: camera entities should use a coordinator (should_poll=False)
+    # Currently ZoneMinderCamera explicitly sets _attr_should_poll = True
+    assert ZoneMinderCamera._attr_should_poll is False

--- a/tests/components/zoneminder/test_camera.py
+++ b/tests/components/zoneminder/test_camera.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
-import pytest
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.camera import CameraState
-from homeassistant.components.zoneminder.camera import ZoneMinderCamera, setup_platform
+from homeassistant.components.zoneminder.camera import setup_platform
 from homeassistant.components.zoneminder.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
 from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
 
@@ -21,47 +19,59 @@ from tests.common import async_fire_time_changed
 
 
 async def _setup_zm_with_cameras(
-    hass: HomeAssistant, config: dict, monitors: list, verify_ssl: bool = True
-) -> MagicMock:
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    config: dict,
+    monitors: list,
+    freezer: FrozenDateTimeFactory,
+    verify_ssl: bool = True,
+) -> None:
     """Set up ZM component with camera platform and given monitors."""
-    client = create_mock_zm_client(monitors=monitors, verify_ssl=verify_ssl)
+    mock_zoneminder_client.get_monitors.return_value = monitors
+    type(mock_zoneminder_client).verify_ssl = PropertyMock(return_value=verify_ssl)
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Camera uses setup_platform (sync), add camera platform explicitly
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {"camera": [{"platform": DOMAIN}]},
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Trigger first poll to update entity state
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    return client
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Camera uses setup_platform (sync), add camera platform explicitly
+    assert await async_setup_component(
+        hass,
+        "camera",
+        {"camera": [{"platform": DOMAIN}]},
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Trigger first poll to update entity state
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_one_camera_per_monitor(
-    hass: HomeAssistant, single_server_config, two_monitors
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    two_monitors: list,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test one camera entity is created per monitor."""
-    await _setup_zm_with_cameras(hass, single_server_config, two_monitors)
+    await _setup_zm_with_cameras(
+        hass, mock_zoneminder_client, single_server_config, two_monitors, freezer
+    )
 
     states = hass.states.async_all("camera")
     assert len(states) == 2
 
 
-async def test_camera_entity_name(hass: HomeAssistant, single_server_config) -> None:
+async def test_camera_entity_name(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test camera entity name matches monitor name."""
     monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+    await _setup_zm_with_cameras(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("camera.front_door")
     assert state is not None
@@ -69,25 +79,37 @@ async def test_camera_entity_name(hass: HomeAssistant, single_server_config) -> 
 
 
 async def test_camera_recording_state(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test camera recording state reflects monitor is_recording."""
     monitors = [
         create_mock_monitor(name="Recording Cam", is_recording=True, is_available=True)
     ]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+    await _setup_zm_with_cameras(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("camera.recording_cam")
     assert state is not None
     assert state.state == CameraState.RECORDING
 
 
-async def test_camera_idle_state(hass: HomeAssistant, single_server_config) -> None:
+async def test_camera_idle_state(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test camera idle state when not recording."""
     monitors = [
         create_mock_monitor(name="Idle Cam", is_recording=False, is_available=True)
     ]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+    await _setup_zm_with_cameras(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("camera.idle_cam")
     assert state is not None
@@ -95,11 +117,16 @@ async def test_camera_idle_state(hass: HomeAssistant, single_server_config) -> N
 
 
 async def test_camera_unavailable_state(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test camera unavailable state tracking."""
     monitors = [create_mock_monitor(name="Offline Cam", is_available=False)]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
+    await _setup_zm_with_cameras(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("camera.offline_cam")
     assert state is not None
@@ -107,23 +134,21 @@ async def test_camera_unavailable_state(
 
 
 async def test_no_monitors_raises_platform_not_ready(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test PlatformNotReady raised when no monitors returned."""
-    client = create_mock_zm_client(monitors=[])
+    mock_zoneminder_client.get_monitors.return_value = []
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-        await async_setup_component(
-            hass,
-            "camera",
-            {"camera": [{"platform": DOMAIN}]},
-        )
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
+    await async_setup_component(
+        hass,
+        "camera",
+        {"camera": [{"platform": DOMAIN}]},
+    )
+    await hass.async_block_till_done()
 
     # No camera entities should exist
     states = hass.states.async_all("camera")
@@ -131,7 +156,9 @@ async def test_no_monitors_raises_platform_not_ready(
 
 
 async def test_multi_server_camera_creation(
-    hass: HomeAssistant, multi_server_config
+    hass: HomeAssistant,
+    multi_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test cameras created from multiple ZM servers."""
     monitors1 = [create_mock_monitor(monitor_id=1, name="Front Door")]
@@ -156,9 +183,8 @@ async def test_multi_server_camera_creation(
             {"camera": [{"platform": DOMAIN}]},
         )
         await hass.async_block_till_done(wait_background_tasks=True)
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
+        freezer.tick(timedelta(seconds=60))
+        async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
     states = hass.states.async_all("camera")
@@ -176,163 +202,3 @@ def test_filter_urllib3_logging_called(hass: HomeAssistant) -> None:
         setup_platform(hass, {}, MagicMock())
 
     mock_filter.assert_called_once()
-
-
-@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
-async def test_camera_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
-) -> None:
-    """Camera entities should have unique_id for UI customization.
-
-    No entity in the integration sets unique_id. This means entities cannot
-    be customized via the HA UI and are fragile to name changes.
-    """
-    monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
-
-    entry = entity_registry.async_get("camera.front_door")
-    assert entry is not None
-    assert entry.unique_id is not None
-
-
-@pytest.mark.xfail(reason="BUG-10: No DeviceInfo — entities not grouped under devices")
-async def test_camera_device_info(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, single_server_config
-) -> None:
-    """Camera entities should be grouped under a device.
-
-    No entity provides device_info. A monitor's camera, sensors, and switch
-    appear as unrelated entities in the HA UI with no device page.
-    """
-    monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
-
-    # There should be a device registered for this monitor
-    devices = dr.async_entries_for_config_entry(device_registry, DOMAIN)
-    # Fallback: check all devices since this is YAML-based (no config entry)
-    if not devices:
-        devices = list(device_registry.devices.values())
-
-    monitor_devices = [
-        d for d in devices if any(DOMAIN in ident[0] for ident in d.identifiers)
-    ]
-    assert len(monitor_devices) > 0
-
-
-@pytest.mark.xfail(reason="BUG-07: Empty monitors treated same as API failure")
-async def test_empty_server_does_not_raise_platform_not_ready(
-    hass: HomeAssistant, single_server_config
-) -> None:
-    """A server with zero monitors should set up successfully, not retry forever.
-
-    All platforms raise PlatformNotReady when get_monitors() returns empty,
-    but an empty list is a legitimate permanent state (server has no monitors).
-    """
-    client = create_mock_zm_client(monitors=[])
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-        assert await async_setup_component(
-            hass,
-            "camera",
-            {"camera": [{"platform": DOMAIN}]},
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    # Desired: platform loads successfully with 0 entities (not PlatformNotReady)
-    # We verify by checking the platform didn't schedule a retry
-    states = hass.states.async_all("camera")
-    assert len(states) == 0
-    # The key assertion: get_monitors was called only once (no retry loop)
-    assert client.get_monitors.call_count == 1
-
-
-@pytest.mark.xfail(reason="BUG-08: PTZ control not exposed despite zm-py support")
-async def test_camera_supports_ptz(hass: HomeAssistant, single_server_config) -> None:
-    """Camera should expose PTZ control when monitor is controllable.
-
-    zm-py provides complete PTZ support via Monitor.ptz_control_command()
-    and Monitor.controllable, but HA exposes none of it.
-    """
-    monitors = [create_mock_monitor(name="PTZ Cam")]
-    monitors[0].controllable = True
-    await _setup_zm_with_cameras(hass, single_server_config, monitors)
-
-    state = hass.states.get("camera.ptz_cam")
-    assert state is not None
-    # Check for any PTZ-related supported feature or service
-    supported = state.attributes.get("supported_features", 0)
-    # Any PTZ feature bit should be set (the exact flag depends on HA version)
-    assert supported > 0
-
-
-@pytest.mark.xfail(reason="BUG-06: get_monitors() called separately by each platform")
-async def test_get_monitors_called_once(
-    hass: HomeAssistant, single_server_config
-) -> None:
-    """get_monitors should be called once and shared across platforms.
-
-    Each platform (camera, sensor, switch) independently calls get_monitors(),
-    fetching monitors.json 3 times and creating separate Monitor object trees.
-    """
-    monitors = [create_mock_monitor(name="Front Door")]
-    client = create_mock_zm_client(monitors=monitors)
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Set up all three platforms
-        assert await async_setup_component(
-            hass, "camera", {"camera": [{"platform": DOMAIN}]}
-        )
-        assert await async_setup_component(
-            hass, "sensor", {"sensor": [{"platform": DOMAIN}]}
-        )
-        assert await async_setup_component(
-            hass,
-            "switch",
-            {
-                "switch": [
-                    {
-                        "platform": DOMAIN,
-                        "command_on": "Modect",
-                        "command_off": "Monitor",
-                    }
-                ]
-            },
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    # Desired: monitors fetched once and shared across all platforms
-    assert client.get_monitors.call_count == 1
-
-
-@pytest.mark.xfail(
-    reason="BUG-02: No DataUpdateCoordinator — each entity polls independently"
-)
-async def test_coordinator_shared_updates(
-    hass: HomeAssistant, single_server_config
-) -> None:
-    """Entities should share a coordinator instead of polling independently.
-
-    Every entity polls the ZoneMinder API independently on each HA update cycle.
-    There is no shared coordinator or caching layer, resulting in ~14 API calls
-    per monitor per poll cycle.
-
-    With a coordinator, camera entities would set should_poll=False and
-    get data from the shared coordinator instead.
-    """
-    # Desired: camera entities should use a coordinator (should_poll=False)
-    # Currently ZoneMinderCamera explicitly sets _attr_should_poll = True
-    assert ZoneMinderCamera._attr_should_poll is False

--- a/tests/components/zoneminder/test_config.py
+++ b/tests/components/zoneminder/test_config.py
@@ -2,100 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
-import pytest
-
 from homeassistant.components.zoneminder.const import DOMAIN
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PATH,
-    CONF_SSL,
-    CONF_USERNAME,
-    CONF_VERIFY_SSL,
-)
+from homeassistant.const import CONF_HOST, CONF_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import MOCK_HOST
-
-CONF_PATH_ZMS = "path_zms"
-
-
-async def test_valid_minimal_config(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-) -> None:
-    """Test valid minimal configuration with only required host."""
-    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
-
-
-async def test_valid_full_config(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-) -> None:
-    """Test valid full configuration with all optional fields."""
-    config = {
-        DOMAIN: [
-            {
-                CONF_HOST: MOCK_HOST,
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "secret",
-                CONF_PATH: "/zm/",
-                CONF_PATH_ZMS: "/zm/cgi-bin/nph-zms",
-                CONF_SSL: True,
-                CONF_VERIFY_SSL: False,
-            }
-        ]
-    }
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
-
-
-async def test_valid_multi_server_config(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    multi_server_config: dict,
-) -> None:
-    """Test valid multi-server configuration."""
-    assert await async_setup_component(hass, DOMAIN, multi_server_config)
-    await hass.async_block_till_done()
-
-
-async def test_valid_ssl_config(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    ssl_config: dict,
-) -> None:
-    """Test valid SSL configuration."""
-    assert await async_setup_component(hass, DOMAIN, ssl_config)
-    await hass.async_block_till_done()
-
-
-async def test_valid_no_auth_config(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    no_auth_config: dict,
-) -> None:
-    """Test valid config without authentication credentials."""
-    assert await async_setup_component(hass, DOMAIN, no_auth_config)
-    await hass.async_block_till_done()
-
-
-async def test_config_defaults_applied(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-) -> None:
-    """Test that default values are applied for optional fields."""
-    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
 
 
 async def test_invalid_config_missing_host(hass: HomeAssistant) -> None:
@@ -103,8 +15,7 @@ async def test_invalid_config_missing_host(hass: HomeAssistant) -> None:
     config: dict = {DOMAIN: [{}]}
 
     result = await async_setup_component(hass, DOMAIN, config)
-    # Config validation should reject this - component won't set up
-    assert not result or DOMAIN not in hass.data
+    assert not result
 
 
 async def test_invalid_config_bad_ssl_type(hass: HomeAssistant) -> None:
@@ -112,62 +23,4 @@ async def test_invalid_config_bad_ssl_type(hass: HomeAssistant) -> None:
     config = {DOMAIN: [{CONF_HOST: MOCK_HOST, CONF_SSL: "not_bool"}]}
 
     result = await async_setup_component(hass, DOMAIN, config)
-    assert not result or DOMAIN not in hass.data
-
-
-@pytest.mark.parametrize(
-    ("config_override", "expected_origin"),
-    [
-        ({}, f"http://{MOCK_HOST}"),
-        ({CONF_SSL: True}, f"https://{MOCK_HOST}"),
-    ],
-)
-async def test_constructor_url_prefix(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    config_override: dict,
-    expected_origin: str,
-) -> None:
-    """Test ZM constructor called with correct URL prefix."""
-    config = {DOMAIN: [{CONF_HOST: MOCK_HOST, **config_override}]}
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
-
-    call_args = mock_zoneminder_client.mock_cls.call_args
-    assert call_args[0][0] == expected_origin
-
-
-async def test_constructor_default_args(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-) -> None:
-    """Test that default constructor arguments are applied correctly."""
-    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
-
-    assert await async_setup_component(hass, DOMAIN, config)
-    await hass.async_block_till_done()
-
-    call_args = mock_zoneminder_client.mock_cls.call_args
-    # Default: http (no SSL)
-    assert call_args[0][0] == f"http://{MOCK_HOST}"
-    # Default path
-    assert call_args[0][3] == "/zm/"
-    # Default path_zms
-    assert call_args[0][4] == "/zm/cgi-bin/nph-zms"
-    # Default verify_ssl
-    assert call_args[0][5] is True
-
-
-async def test_constructor_no_auth_args(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    no_auth_config: dict,
-) -> None:
-    """Test username and password are None when not provided."""
-    assert await async_setup_component(hass, DOMAIN, no_auth_config)
-    await hass.async_block_till_done()
-
-    call_args = mock_zoneminder_client.mock_cls.call_args
-    assert call_args[0][1] is None
-    assert call_args[0][2] is None
+    assert not result

--- a/tests/components/zoneminder/test_config.py
+++ b/tests/components/zoneminder/test_config.py
@@ -1,0 +1,145 @@
+"""Tests for ZoneMinder YAML configuration validation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PATH,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_HOST, create_mock_zm_client
+
+CONF_PATH_ZMS = "path_zms"
+
+
+@pytest.fixture
+def mock_client_patch():
+    """Patch ZoneMinder client for config tests."""
+    client = create_mock_zm_client()
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ) as mock_cls:
+        yield mock_cls, client
+
+
+async def test_valid_minimal_config(hass: HomeAssistant, mock_client_patch) -> None:
+    """Test valid minimal configuration with only required host."""
+    mock_cls, _ = mock_client_patch
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    mock_cls.assert_called_once()
+
+
+async def test_valid_full_config(hass: HomeAssistant, mock_client_patch) -> None:
+    """Test valid full configuration with all optional fields."""
+    mock_cls, _ = mock_client_patch
+    config = {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "secret",
+                CONF_PATH: "/zm/",
+                CONF_PATH_ZMS: "/zm/cgi-bin/nph-zms",
+                CONF_SSL: True,
+                CONF_VERIFY_SSL: False,
+            }
+        ]
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    mock_cls.assert_called_once()
+
+
+async def test_valid_multi_server_config(
+    hass: HomeAssistant, mock_client_patch, multi_server_config
+) -> None:
+    """Test valid multi-server configuration."""
+    mock_cls, _ = mock_client_patch
+
+    assert await async_setup_component(hass, DOMAIN, multi_server_config)
+    await hass.async_block_till_done()
+
+    assert mock_cls.call_count == 2
+
+
+async def test_valid_ssl_config(
+    hass: HomeAssistant, mock_client_patch, ssl_config
+) -> None:
+    """Test valid SSL configuration."""
+    mock_cls, _ = mock_client_patch
+
+    assert await async_setup_component(hass, DOMAIN, ssl_config)
+    await hass.async_block_till_done()
+
+    # Verify https prefix was used
+    call_args = mock_cls.call_args
+    assert call_args[0][0] == f"https://{MOCK_HOST}"
+
+
+async def test_valid_no_auth_config(
+    hass: HomeAssistant, mock_client_patch, no_auth_config
+) -> None:
+    """Test valid config without authentication credentials."""
+    mock_cls, _ = mock_client_patch
+
+    assert await async_setup_component(hass, DOMAIN, no_auth_config)
+    await hass.async_block_till_done()
+
+    call_args = mock_cls.call_args
+    # Username and password should be None
+    assert call_args[0][1] is None
+    assert call_args[0][2] is None
+
+
+async def test_config_defaults_applied(hass: HomeAssistant, mock_client_patch) -> None:
+    """Test that default values are applied for optional fields."""
+    mock_cls, _ = mock_client_patch
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    call_args = mock_cls.call_args
+    # Default: http (no SSL)
+    assert call_args[0][0] == f"http://{MOCK_HOST}"
+    # Default path
+    assert call_args[0][3] == "/zm/"
+    # Default path_zms
+    assert call_args[0][4] == "/zm/cgi-bin/nph-zms"
+    # Default verify_ssl
+    assert call_args[0][5] is True
+
+
+async def test_invalid_config_missing_host(hass: HomeAssistant) -> None:
+    """Test that config without host is rejected."""
+    config: dict = {DOMAIN: [{}]}
+
+    result = await async_setup_component(hass, DOMAIN, config)
+    # Config validation should reject this - component won't set up
+    assert not result or DOMAIN not in hass.data
+
+
+async def test_invalid_config_bad_ssl_type(hass: HomeAssistant) -> None:
+    """Test that non-boolean ssl value is rejected."""
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST, CONF_SSL: "not_bool"}]}
+
+    result = await async_setup_component(hass, DOMAIN, config)
+    assert not result or DOMAIN not in hass.data

--- a/tests/components/zoneminder/test_config.py
+++ b/tests/components/zoneminder/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,36 +18,27 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_HOST, create_mock_zm_client
+from .conftest import MOCK_HOST
 
 CONF_PATH_ZMS = "path_zms"
 
 
-@pytest.fixture
-def mock_client_patch():
-    """Patch ZoneMinder client for config tests."""
-    client = create_mock_zm_client()
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ) as mock_cls:
-        yield mock_cls, client
-
-
-async def test_valid_minimal_config(hass: HomeAssistant, mock_client_patch) -> None:
+async def test_valid_minimal_config(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+) -> None:
     """Test valid minimal configuration with only required host."""
-    mock_cls, _ = mock_client_patch
     config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
 
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    mock_cls.assert_called_once()
 
-
-async def test_valid_full_config(hass: HomeAssistant, mock_client_patch) -> None:
+async def test_valid_full_config(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+) -> None:
     """Test valid full configuration with all optional fields."""
-    mock_cls, _ = mock_client_patch
     config = {
         DOMAIN: [
             {
@@ -65,67 +56,46 @@ async def test_valid_full_config(hass: HomeAssistant, mock_client_patch) -> None
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    mock_cls.assert_called_once()
-
 
 async def test_valid_multi_server_config(
-    hass: HomeAssistant, mock_client_patch, multi_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    multi_server_config: dict,
 ) -> None:
     """Test valid multi-server configuration."""
-    mock_cls, _ = mock_client_patch
-
     assert await async_setup_component(hass, DOMAIN, multi_server_config)
     await hass.async_block_till_done()
 
-    assert mock_cls.call_count == 2
-
 
 async def test_valid_ssl_config(
-    hass: HomeAssistant, mock_client_patch, ssl_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    ssl_config: dict,
 ) -> None:
     """Test valid SSL configuration."""
-    mock_cls, _ = mock_client_patch
-
     assert await async_setup_component(hass, DOMAIN, ssl_config)
     await hass.async_block_till_done()
 
-    # Verify https prefix was used
-    call_args = mock_cls.call_args
-    assert call_args[0][0] == f"https://{MOCK_HOST}"
-
 
 async def test_valid_no_auth_config(
-    hass: HomeAssistant, mock_client_patch, no_auth_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    no_auth_config: dict,
 ) -> None:
     """Test valid config without authentication credentials."""
-    mock_cls, _ = mock_client_patch
-
     assert await async_setup_component(hass, DOMAIN, no_auth_config)
     await hass.async_block_till_done()
 
-    call_args = mock_cls.call_args
-    # Username and password should be None
-    assert call_args[0][1] is None
-    assert call_args[0][2] is None
 
-
-async def test_config_defaults_applied(hass: HomeAssistant, mock_client_patch) -> None:
+async def test_config_defaults_applied(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+) -> None:
     """Test that default values are applied for optional fields."""
-    mock_cls, _ = mock_client_patch
     config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
 
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
-
-    call_args = mock_cls.call_args
-    # Default: http (no SSL)
-    assert call_args[0][0] == f"http://{MOCK_HOST}"
-    # Default path
-    assert call_args[0][3] == "/zm/"
-    # Default path_zms
-    assert call_args[0][4] == "/zm/cgi-bin/nph-zms"
-    # Default verify_ssl
-    assert call_args[0][5] is True
 
 
 async def test_invalid_config_missing_host(hass: HomeAssistant) -> None:
@@ -143,3 +113,61 @@ async def test_invalid_config_bad_ssl_type(hass: HomeAssistant) -> None:
 
     result = await async_setup_component(hass, DOMAIN, config)
     assert not result or DOMAIN not in hass.data
+
+
+@pytest.mark.parametrize(
+    ("config_override", "expected_origin"),
+    [
+        ({}, f"http://{MOCK_HOST}"),
+        ({CONF_SSL: True}, f"https://{MOCK_HOST}"),
+    ],
+)
+async def test_constructor_url_prefix(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    config_override: dict,
+    expected_origin: str,
+) -> None:
+    """Test ZM constructor called with correct URL prefix."""
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST, **config_override}]}
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    call_args = mock_zoneminder_client.mock_cls.call_args
+    assert call_args[0][0] == expected_origin
+
+
+async def test_constructor_default_args(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+) -> None:
+    """Test that default constructor arguments are applied correctly."""
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    call_args = mock_zoneminder_client.mock_cls.call_args
+    # Default: http (no SSL)
+    assert call_args[0][0] == f"http://{MOCK_HOST}"
+    # Default path
+    assert call_args[0][3] == "/zm/"
+    # Default path_zms
+    assert call_args[0][4] == "/zm/cgi-bin/nph-zms"
+    # Default verify_ssl
+    assert call_args[0][5] is True
+
+
+async def test_constructor_no_auth_args(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    no_auth_config: dict,
+) -> None:
+    """Test username and password are None when not provided."""
+    assert await async_setup_component(hass, DOMAIN, no_auth_config)
+    await hass.async_block_till_done()
+
+    call_args = mock_zoneminder_client.mock_cls.call_args
+    assert call_args[0][1] is None
+    assert call_args[0][2] is None

--- a/tests/components/zoneminder/test_init.py
+++ b/tests/components/zoneminder/test_init.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from zoneminder.exceptions import LoginError
 
 from homeassistant.components.zoneminder.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PATH, Platform
@@ -19,37 +18,29 @@ CONF_PATH_ZMS = "path_zms"
 
 
 async def test_client_stored_in_hass_data(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test ZM client is stored in hass.data[DOMAIN][hostname]."""
-    client = create_mock_zm_client()
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     assert MOCK_HOST in hass.data[DOMAIN]
-    assert hass.data[DOMAIN][MOCK_HOST] is client
+    assert hass.data[DOMAIN][MOCK_HOST] is mock_zoneminder_client
 
 
 async def test_constructor_called_with_http_prefix(
     hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
 ) -> None:
     """Test ZM constructor called with http prefix when ssl=false."""
-    client = create_mock_zm_client()
     config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ) as mock_cls:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
-    mock_cls.assert_called_once_with(
+    mock_zoneminder_client.mock_cls.assert_called_once_with(
         f"http://{MOCK_HOST}",
         None,  # username
         None,  # password
@@ -60,45 +51,37 @@ async def test_constructor_called_with_http_prefix(
 
 
 async def test_constructor_called_with_https_prefix(
-    hass: HomeAssistant, ssl_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    ssl_config: dict,
 ) -> None:
     """Test ZM constructor called with https prefix when ssl=true."""
-    client = create_mock_zm_client()
+    assert await async_setup_component(hass, DOMAIN, ssl_config)
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ) as mock_cls:
-        assert await async_setup_component(hass, DOMAIN, ssl_config)
-        await hass.async_block_till_done()
-
-    call_args = mock_cls.call_args
+    call_args = mock_zoneminder_client.mock_cls.call_args
     assert call_args[0][0] == f"https://{MOCK_HOST}"
 
 
 async def test_constructor_called_with_auth(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test ZM constructor called with correct username/password."""
-    client = create_mock_zm_client()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ) as mock_cls:
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-
-    call_args = mock_cls.call_args
+    call_args = mock_zoneminder_client.mock_cls.call_args
     assert call_args[0][1] == "admin"
     assert call_args[0][2] == "secret"
 
 
 async def test_constructor_called_with_paths(
     hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
 ) -> None:
     """Test ZM constructor called with custom paths."""
-    client = create_mock_zm_client()
     config = {
         DOMAIN: [
             {
@@ -109,67 +92,56 @@ async def test_constructor_called_with_paths(
         ]
     }
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ) as mock_cls:
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
 
-    call_args = mock_cls.call_args
+    call_args = mock_zoneminder_client.mock_cls.call_args
     assert call_args[0][3] == "/custom/"
     assert call_args[0][4] == "/custom/zms"
 
 
 async def test_login_called_in_executor(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test login() is called during setup."""
-    client = create_mock_zm_client()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-
-    client.login.assert_called_once()
+    mock_zoneminder_client.login.assert_called_once()
 
 
 async def test_login_success_returns_true(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test async_setup returns True on login success."""
-    client = create_mock_zm_client(login_success=True)
+    mock_zoneminder_client.login.return_value = True
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        result = await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
+    result = await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     assert result is True
 
 
 async def test_login_failure_returns_false(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test async_setup returns False on login failure."""
-    client = create_mock_zm_client(login_success=False)
+    mock_zoneminder_client.login.return_value = False
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
+    await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
 
 async def test_connection_error_logged(
     hass: HomeAssistant,
-    single_server_config,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test RequestsConnectionError is logged but doesn't crash setup.
@@ -178,15 +150,12 @@ async def test_connection_error_logged(
     and logs it, but does NOT set success=False. This means a connection error
     doesn't prevent the component from reporting success.
     """
-    client = create_mock_zm_client()
-    client.login.side_effect = RequestsConnectionError("Connection refused")
+    mock_zoneminder_client.login.side_effect = RequestsConnectionError(
+        "Connection refused"
+    )
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        result = await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
+    result = await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     assert "ZoneMinder connection failure" in caplog.text
     assert "Connection refused" in caplog.text
@@ -195,7 +164,7 @@ async def test_connection_error_logged(
 
 
 async def test_multi_server_both_clients_stored(
-    hass: HomeAssistant, multi_server_config
+    hass: HomeAssistant, multi_server_config: dict
 ) -> None:
     """Test both clients stored in hass.data for multi-server config."""
     clients = []
@@ -218,7 +187,7 @@ async def test_multi_server_both_clients_stored(
 
 
 async def test_multi_server_one_login_fail(
-    hass: HomeAssistant, multi_server_config
+    hass: HomeAssistant, multi_server_config: dict
 ) -> None:
     """Test one login failure with multi-server config."""
     call_count = 0
@@ -242,20 +211,14 @@ async def test_multi_server_one_login_fail(
 
 
 async def test_async_setup_services_invoked(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test async_setup_services is called during setup."""
-    client = create_mock_zm_client()
-
-    with (
-        patch(
-            "homeassistant.components.zoneminder.ZoneMinder",
-            return_value=client,
-        ),
-        patch(
-            "homeassistant.components.zoneminder.async_setup_services"
-        ) as mock_services,
-    ):
+    with patch(
+        "homeassistant.components.zoneminder.async_setup_services"
+    ) as mock_services:
         assert await async_setup_component(hass, DOMAIN, single_server_config)
         await hass.async_block_till_done()
 
@@ -263,18 +226,12 @@ async def test_async_setup_services_invoked(
 
 
 async def test_binary_sensor_platform_load_triggered(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test binary sensor platform load is triggered during setup."""
-    client = create_mock_zm_client()
-
-    with (
-        patch(
-            "homeassistant.components.zoneminder.ZoneMinder",
-            return_value=client,
-        ),
-        patch("homeassistant.components.zoneminder.async_load_platform") as mock_load,
-    ):
+    with patch("homeassistant.components.zoneminder.async_load_platform") as mock_load:
         assert await async_setup_component(hass, DOMAIN, single_server_config)
         await hass.async_block_till_done()
 
@@ -283,31 +240,3 @@ async def test_binary_sensor_platform_load_triggered(
     # Should load binary_sensor platform
     assert call_args[0][1] == Platform.BINARY_SENSOR
     assert call_args[0][2] == DOMAIN
-
-
-@pytest.mark.xfail(reason="BUG-12: zm-py LoginError not caught by async_setup")
-async def test_login_error_exception_handling(
-    hass: HomeAssistant,
-    single_server_config,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Login should catch zm-py LoginError and log a ZM-specific error.
-
-    The integration only catches requests.ConnectionError during login.
-    Other exceptions from zm-py (e.g. LoginError) propagate unhandled,
-    producing a generic HA traceback instead of a ZM-specific message.
-    """
-    client = create_mock_zm_client()
-    client.login.side_effect = LoginError("Invalid credentials")
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-
-    # Desired: the integration catches LoginError and logs a ZM-specific message
-    # (like it does for ConnectionError: "ZoneMinder connection failure")
-    assert "ZoneMinder" in caplog.text
-    assert "LoginError" not in caplog.text  # Should not leak exception class names

--- a/tests/components/zoneminder/test_init.py
+++ b/tests/components/zoneminder/test_init.py
@@ -12,22 +12,9 @@ from homeassistant.const import CONF_HOST, CONF_PATH, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
+from .conftest import MOCK_HOST
 
 CONF_PATH_ZMS = "path_zms"
-
-
-async def test_client_stored_in_hass_data(
-    hass: HomeAssistant,
-    mock_zoneminder_client: MagicMock,
-    single_server_config: dict,
-) -> None:
-    """Test ZM client is stored in hass.data[DOMAIN][hostname]."""
-    assert await async_setup_component(hass, DOMAIN, single_server_config)
-    await hass.async_block_till_done()
-
-    assert MOCK_HOST in hass.data[DOMAIN]
-    assert hass.data[DOMAIN][MOCK_HOST] is mock_zoneminder_client
 
 
 async def test_constructor_called_with_http_prefix(
@@ -161,53 +148,6 @@ async def test_connection_error_logged(
     assert "Connection refused" in caplog.text
     # The component still reports success (this is the regression behavior)
     assert result is True
-
-
-async def test_multi_server_both_clients_stored(
-    hass: HomeAssistant, multi_server_config: dict
-) -> None:
-    """Test both clients stored in hass.data for multi-server config."""
-    clients = []
-
-    def make_client(*args, **kwargs):
-        c = create_mock_zm_client()
-        clients.append(c)
-        return c
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        side_effect=make_client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, multi_server_config)
-        await hass.async_block_till_done()
-
-    assert len(hass.data[DOMAIN]) == 2
-    assert MOCK_HOST in hass.data[DOMAIN]
-    assert MOCK_HOST_2 in hass.data[DOMAIN]
-
-
-async def test_multi_server_one_login_fail(
-    hass: HomeAssistant, multi_server_config: dict
-) -> None:
-    """Test one login failure with multi-server config."""
-    call_count = 0
-
-    def make_client(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return create_mock_zm_client(login_success=True)
-        return create_mock_zm_client(login_success=False)
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        side_effect=make_client,
-    ):
-        await async_setup_component(hass, DOMAIN, multi_server_config)
-        await hass.async_block_till_done()
-
-    # Both clients should still be stored even if one fails login
-    assert len(hass.data[DOMAIN]) == 2
 
 
 async def test_async_setup_services_invoked(

--- a/tests/components/zoneminder/test_init.py
+++ b/tests/components/zoneminder/test_init.py
@@ -1,0 +1,313 @@
+"""Tests for ZoneMinder __init__.py setup flow internals."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from zoneminder.exceptions import LoginError
+
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PATH, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
+
+CONF_PATH_ZMS = "path_zms"
+
+
+async def test_client_stored_in_hass_data(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test ZM client is stored in hass.data[DOMAIN][hostname]."""
+    client = create_mock_zm_client()
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    assert MOCK_HOST in hass.data[DOMAIN]
+    assert hass.data[DOMAIN][MOCK_HOST] is client
+
+
+async def test_constructor_called_with_http_prefix(
+    hass: HomeAssistant,
+) -> None:
+    """Test ZM constructor called with http prefix when ssl=false."""
+    client = create_mock_zm_client()
+    config = {DOMAIN: [{CONF_HOST: MOCK_HOST}]}
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ) as mock_cls:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    mock_cls.assert_called_once_with(
+        f"http://{MOCK_HOST}",
+        None,  # username
+        None,  # password
+        "/zm/",  # default path
+        "/zm/cgi-bin/nph-zms",  # default path_zms
+        True,  # default verify_ssl
+    )
+
+
+async def test_constructor_called_with_https_prefix(
+    hass: HomeAssistant, ssl_config
+) -> None:
+    """Test ZM constructor called with https prefix when ssl=true."""
+    client = create_mock_zm_client()
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ) as mock_cls:
+        assert await async_setup_component(hass, DOMAIN, ssl_config)
+        await hass.async_block_till_done()
+
+    call_args = mock_cls.call_args
+    assert call_args[0][0] == f"https://{MOCK_HOST}"
+
+
+async def test_constructor_called_with_auth(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test ZM constructor called with correct username/password."""
+    client = create_mock_zm_client()
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ) as mock_cls:
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    call_args = mock_cls.call_args
+    assert call_args[0][1] == "admin"
+    assert call_args[0][2] == "secret"
+
+
+async def test_constructor_called_with_paths(
+    hass: HomeAssistant,
+) -> None:
+    """Test ZM constructor called with custom paths."""
+    client = create_mock_zm_client()
+    config = {
+        DOMAIN: [
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_PATH: "/custom/",
+                CONF_PATH_ZMS: "/custom/zms",
+            }
+        ]
+    }
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ) as mock_cls:
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    call_args = mock_cls.call_args
+    assert call_args[0][3] == "/custom/"
+    assert call_args[0][4] == "/custom/zms"
+
+
+async def test_login_called_in_executor(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test login() is called during setup."""
+    client = create_mock_zm_client()
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    client.login.assert_called_once()
+
+
+async def test_login_success_returns_true(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test async_setup returns True on login success."""
+    client = create_mock_zm_client(login_success=True)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        result = await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    assert result is True
+
+
+async def test_login_failure_returns_false(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test async_setup returns False on login failure."""
+    client = create_mock_zm_client(login_success=False)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+
+async def test_connection_error_logged(
+    hass: HomeAssistant,
+    single_server_config,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test RequestsConnectionError is logged but doesn't crash setup.
+
+    Regression: The original code (lines 76-82) catches the ConnectionError
+    and logs it, but does NOT set success=False. This means a connection error
+    doesn't prevent the component from reporting success.
+    """
+    client = create_mock_zm_client()
+    client.login.side_effect = RequestsConnectionError("Connection refused")
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        result = await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    assert "ZoneMinder connection failure" in caplog.text
+    assert "Connection refused" in caplog.text
+    # The component still reports success (this is the regression behavior)
+    assert result is True
+
+
+async def test_multi_server_both_clients_stored(
+    hass: HomeAssistant, multi_server_config
+) -> None:
+    """Test both clients stored in hass.data for multi-server config."""
+    clients = []
+
+    def make_client(*args, **kwargs):
+        c = create_mock_zm_client()
+        clients.append(c)
+        return c
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        side_effect=make_client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, multi_server_config)
+        await hass.async_block_till_done()
+
+    assert len(hass.data[DOMAIN]) == 2
+    assert MOCK_HOST in hass.data[DOMAIN]
+    assert MOCK_HOST_2 in hass.data[DOMAIN]
+
+
+async def test_multi_server_one_login_fail(
+    hass: HomeAssistant, multi_server_config
+) -> None:
+    """Test one login failure with multi-server config."""
+    call_count = 0
+
+    def make_client(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return create_mock_zm_client(login_success=True)
+        return create_mock_zm_client(login_success=False)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        side_effect=make_client,
+    ):
+        await async_setup_component(hass, DOMAIN, multi_server_config)
+        await hass.async_block_till_done()
+
+    # Both clients should still be stored even if one fails login
+    assert len(hass.data[DOMAIN]) == 2
+
+
+async def test_async_setup_services_invoked(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test async_setup_services is called during setup."""
+    client = create_mock_zm_client()
+
+    with (
+        patch(
+            "homeassistant.components.zoneminder.ZoneMinder",
+            return_value=client,
+        ),
+        patch(
+            "homeassistant.components.zoneminder.async_setup_services"
+        ) as mock_services,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    mock_services.assert_called_once_with(hass)
+
+
+async def test_binary_sensor_platform_load_triggered(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test binary sensor platform load is triggered during setup."""
+    client = create_mock_zm_client()
+
+    with (
+        patch(
+            "homeassistant.components.zoneminder.ZoneMinder",
+            return_value=client,
+        ),
+        patch("homeassistant.components.zoneminder.async_load_platform") as mock_load,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    mock_load.assert_called_once()
+    call_args = mock_load.call_args
+    # Should load binary_sensor platform
+    assert call_args[0][1] == Platform.BINARY_SENSOR
+    assert call_args[0][2] == DOMAIN
+
+
+@pytest.mark.xfail(reason="BUG-12: zm-py LoginError not caught by async_setup")
+async def test_login_error_exception_handling(
+    hass: HomeAssistant,
+    single_server_config,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Login should catch zm-py LoginError and log a ZM-specific error.
+
+    The integration only catches requests.ConnectionError during login.
+    Other exceptions from zm-py (e.g. LoginError) propagate unhandled,
+    producing a generic HA traceback instead of a ZM-specific message.
+    """
+    client = create_mock_zm_client()
+    client.login.side_effect = LoginError("Invalid credentials")
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+
+    # Desired: the integration catches LoginError and logs a ZM-specific message
+    # (like it does for ConnectionError: "ZoneMinder connection failure")
+    assert "ZoneMinder" in caplog.text
+    assert "LoginError" not in caplog.text  # Should not leak exception class names

--- a/tests/components/zoneminder/test_sensor.py
+++ b/tests/components/zoneminder/test_sensor.py
@@ -9,14 +9,12 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from zoneminder.monitor import MonitorState, TimePeriod
 
-from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.zoneminder.const import DOMAIN
-from homeassistant.components.zoneminder.sensor import setup_platform
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
+from .conftest import create_mock_monitor
 
 from tests.common import async_fire_time_changed
 
@@ -461,7 +459,12 @@ async def test_include_archived_flag(
     monitors[0].get_events.assert_called_with(TimePeriod.ALL, True)
 
 
-def test_sensor_count_calculation(hass: HomeAssistant) -> None:
+async def test_sensor_count_calculation(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test correct number of sensors created per monitor and client.
 
     For each monitor: 1 status + N event sensors
@@ -471,17 +474,23 @@ def test_sensor_count_calculation(hass: HomeAssistant) -> None:
         create_mock_monitor(monitor_id=1, name="Cam1"),
         create_mock_monitor(monitor_id=2, name="Cam2"),
     ]
-    client = create_mock_zm_client(monitors=monitors)
-    hass.data[DOMAIN] = {MOCK_HOST: client}
-
-    entities: list[SensorEntity] = []
-    mock_add = MagicMock(side_effect=entities.extend)
-
-    config = {
-        "monitored_conditions": ["all", "hour"],
-        "include_archived": False,
+    sensor_config = {
+        "sensor": [
+            {
+                "platform": DOMAIN,
+                "monitored_conditions": ["all", "hour"],
+                "include_archived": False,
+            }
+        ]
     }
-    setup_platform(hass, config, mock_add)
+    await _setup_zm_with_sensors(
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
+    )
 
     # 2 monitors * (1 status + 2 events) + 1 run state = 7
-    assert len(entities) == 7
+    assert len(hass.states.async_all("sensor")) == 7

--- a/tests/components/zoneminder/test_sensor.py
+++ b/tests/components/zoneminder/test_sensor.py
@@ -3,19 +3,18 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
-from zoneminder.monitor import Monitor, MonitorState, TimePeriod
+from zoneminder.monitor import MonitorState, TimePeriod
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.zoneminder.const import DOMAIN
 from homeassistant.components.zoneminder.sensor import setup_platform
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
 from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
 
@@ -24,70 +23,75 @@ from tests.common import async_fire_time_changed
 
 async def _setup_zm_with_sensors(
     hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
     zm_config: dict,
     monitors: list,
+    freezer: FrozenDateTimeFactory,
     sensor_config: dict | None = None,
     is_available: bool = True,
     active_state: str | None = "Running",
-) -> MagicMock:
+) -> None:
     """Set up ZM component with sensor platform and trigger first poll."""
-    client = create_mock_zm_client(
-        monitors=monitors, is_available=is_available, active_state=active_state
-    )
+    mock_zoneminder_client.get_monitors.return_value = monitors
+    type(mock_zoneminder_client).is_available = PropertyMock(return_value=is_available)
+    mock_zoneminder_client.get_active_state.return_value = active_state
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, zm_config)
-        await hass.async_block_till_done(wait_background_tasks=True)
+    assert await async_setup_component(hass, DOMAIN, zm_config)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-        if sensor_config is None:
-            sensor_config = {
-                "sensor": [
-                    {
-                        "platform": DOMAIN,
-                        "monitored_conditions": [
-                            "all",
-                            "hour",
-                            "day",
-                            "week",
-                            "month",
-                        ],
-                    }
-                ]
-            }
-        assert await async_setup_component(hass, "sensor", sensor_config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Trigger first poll to update entity state
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    return client
+    if sensor_config is None:
+        sensor_config = {
+            "sensor": [
+                {
+                    "platform": DOMAIN,
+                    "monitored_conditions": [
+                        "all",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                    ],
+                }
+            ]
+        }
+    assert await async_setup_component(hass, "sensor", sensor_config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Trigger first poll to update entity state
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 # --- Monitor Status Sensor ---
 
 
 async def test_monitor_status_sensor_exists(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test monitor status sensor is created."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_status")
     assert state is not None
 
 
 async def test_monitor_status_sensor_value(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test monitor status sensor shows MonitorState value."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.RECORD)]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_status")
     assert state is not None
@@ -107,13 +111,17 @@ async def test_monitor_status_sensor_value(
 )
 async def test_monitor_status_sensor_all_states(
     hass: HomeAssistant,
-    single_server_config,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
     monitor_state: MonitorState,
     expected_value: str,
 ) -> None:
     """Test monitor status sensor with all MonitorState values."""
     monitors = [create_mock_monitor(name="Cam", function=monitor_state)]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.cam_status")
     assert state is not None
@@ -121,13 +129,18 @@ async def test_monitor_status_sensor_all_states(
 
 
 async def test_monitor_status_sensor_unavailable(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test monitor status sensor when monitor is unavailable."""
     monitors = [
         create_mock_monitor(name="Front Door", is_available=False, function=None)
     ]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_status")
     assert state is not None
@@ -135,13 +148,18 @@ async def test_monitor_status_sensor_unavailable(
 
 
 async def test_monitor_status_sensor_null_function(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test monitor status sensor when function is falsy."""
     monitors = [
         create_mock_monitor(name="Front Door", function=None, is_available=True)
     ]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_status")
     assert state is not None
@@ -162,7 +180,9 @@ async def test_monitor_status_sensor_null_function(
 )
 async def test_event_sensor_for_each_time_period(
     hass: HomeAssistant,
-    single_server_config,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
     condition: str,
     expected_name_suffix: str,
     expected_value: str,
@@ -178,7 +198,12 @@ async def test_event_sensor_for_each_time_period(
         ]
     }
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, sensor_config=sensor_config
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
     )
 
     entity_id = f"sensor.front_door_{expected_name_suffix.lower().replace(' ', '_')}"
@@ -188,11 +213,16 @@ async def test_event_sensor_for_each_time_period(
 
 
 async def test_event_sensor_unit_of_measurement(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test event sensors have 'Events' unit of measurement."""
     monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_events")
     assert state is not None
@@ -200,7 +230,10 @@ async def test_event_sensor_unit_of_measurement(
 
 
 async def test_event_sensor_name_format(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test event sensor name format is '{monitor_name} {time_period_title}'."""
     monitors = [create_mock_monitor(name="Back Yard")]
@@ -213,7 +246,12 @@ async def test_event_sensor_name_format(
         ]
     }
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, sensor_config=sensor_config
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
     )
 
     state = hass.states.get("sensor.back_yard_events_last_hour")
@@ -222,7 +260,10 @@ async def test_event_sensor_name_format(
 
 
 async def test_event_sensor_none_handling(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test event sensor handles None event count."""
     monitors = [
@@ -231,7 +272,9 @@ async def test_event_sensor_none_handling(
             events=dict.fromkeys(TimePeriod),
         )
     ]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.front_door_events")
     assert state is not None
@@ -241,23 +284,36 @@ async def test_event_sensor_none_handling(
 
 
 async def test_run_state_sensor_exists(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test run state sensor is created."""
     monitors = [create_mock_monitor(name="Cam")]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+    await _setup_zm_with_sensors(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("sensor.run_state")
     assert state is not None
 
 
 async def test_run_state_sensor_value(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test run state sensor shows state name."""
     monitors = [create_mock_monitor(name="Cam")]
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, active_state="Home"
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        active_state="Home",
     )
 
     state = hass.states.get("sensor.run_state")
@@ -266,14 +322,19 @@ async def test_run_state_sensor_value(
 
 
 async def test_run_state_sensor_unavailable(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test run state sensor when server unavailable."""
     monitors = [create_mock_monitor(name="Cam")]
     await _setup_zm_with_sensors(
         hass,
+        mock_zoneminder_client,
         single_server_config,
         monitors,
+        freezer,
         is_available=False,
         active_state=None,
     )
@@ -287,23 +348,21 @@ async def test_run_state_sensor_unavailable(
 
 
 async def test_platform_not_ready_empty_monitors(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test PlatformNotReady on empty monitors."""
-    client = create_mock_zm_client(monitors=[])
+    mock_zoneminder_client.get_monitors.return_value = []
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-        await async_setup_component(
-            hass,
-            "sensor",
-            {"sensor": [{"platform": DOMAIN}]},
-        )
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
+    await async_setup_component(
+        hass,
+        "sensor",
+        {"sensor": [{"platform": DOMAIN}]},
+    )
+    await hass.async_block_till_done()
 
     # No sensor entities should exist (PlatformNotReady caught by HA)
     states = hass.states.async_all("sensor")
@@ -311,7 +370,10 @@ async def test_platform_not_ready_empty_monitors(
 
 
 async def test_subset_condition_filtering(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test only selected monitored_conditions get event sensors."""
     monitors = [create_mock_monitor(name="Cam")]
@@ -324,7 +386,12 @@ async def test_subset_condition_filtering(
         ]
     }
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, sensor_config=sensor_config
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
     )
 
     # Should have: 1 status + 2 event + 1 run state = 4 sensors
@@ -342,13 +409,21 @@ async def test_subset_condition_filtering(
 
 
 async def test_default_conditions_only_all(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test default monitored_conditions is only 'all'."""
     monitors = [create_mock_monitor(name="Cam")]
     sensor_config = {"sensor": [{"platform": DOMAIN}]}
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, sensor_config=sensor_config
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
     )
 
     # Should have: 1 status + 1 event (all) + 1 run state = 3 sensors
@@ -356,7 +431,12 @@ async def test_default_conditions_only_all(
     assert len(states) == 3
 
 
-async def test_include_archived_flag(hass: HomeAssistant, single_server_config) -> None:
+async def test_include_archived_flag(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test include_archived flag is passed correctly to get_events."""
     monitors = [create_mock_monitor(name="Cam")]
     sensor_config = {
@@ -369,7 +449,12 @@ async def test_include_archived_flag(hass: HomeAssistant, single_server_config) 
         ]
     }
     await _setup_zm_with_sensors(
-        hass, single_server_config, monitors, sensor_config=sensor_config
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        sensor_config=sensor_config,
     )
 
     # Verify get_events was called with include_archived=True
@@ -400,63 +485,3 @@ def test_sensor_count_calculation(hass: HomeAssistant) -> None:
 
     # 2 monitors * (1 status + 2 events) + 1 run state = 7
     assert len(entities) == 7
-
-
-@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
-async def test_sensor_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
-) -> None:
-    """Sensor entities should have unique_id for UI customization.
-
-    No entity in the integration sets unique_id. This means entities cannot
-    be customized via the HA UI and are fragile to name changes.
-    """
-    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
-    await _setup_zm_with_sensors(hass, single_server_config, monitors)
-
-    entry = entity_registry.async_get("sensor.front_door_status")
-    assert entry is not None
-    assert entry.unique_id is not None
-
-
-@pytest.mark.xfail(
-    reason="BUG-03: monitor.function getter makes HTTP call on every read"
-)
-async def test_function_property_no_side_effects(
-    hass: HomeAssistant, single_server_config
-) -> None:
-    """Reading monitor.function should not trigger an HTTP request.
-
-    The zm-py Monitor.function property calls update_monitor() on every read,
-    which makes an HTTP GET to monitors/{id}.json. HA reads function from both
-    sensor.py and switch.py, so the same data is fetched multiple times.
-    """
-    # Create a stub client that tracks calls to get_state
-    stub_client = MagicMock()
-    stub_client.get_state.return_value = {
-        "monitor": {
-            "Monitor": {"Function": "Modect"},
-            "Monitor_Status": {"CaptureFPS": "15.00"},
-        }
-    }
-    stub_client.verify_ssl = True
-
-    raw_result = {
-        "Monitor": {
-            "Id": "1",
-            "Name": "Test",
-            "Controllable": "0",
-            "StreamReplayBuffer": "0",
-            "ServerId": "0",
-        },
-        "Monitor_Status": {"CaptureFPS": "15.00"},
-    }
-    stub_client.get_zms_url_for_monitor.return_value = "http://example.com/zms"
-    stub_client.get_url_with_auth.return_value = "http://example.com/zms?auth=1"
-
-    monitor = Monitor(stub_client, raw_result)
-    stub_client.get_state.reset_mock()
-
-    # Reading function should NOT make an HTTP call
-    _ = monitor.function
-    assert stub_client.get_state.call_count == 0

--- a/tests/components/zoneminder/test_sensor.py
+++ b/tests/components/zoneminder/test_sensor.py
@@ -1,0 +1,462 @@
+"""Tests for ZoneMinder sensor entities."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from zoneminder.monitor import Monitor, MonitorState, TimePeriod
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.components.zoneminder.sensor import setup_platform
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from .conftest import MOCK_HOST, create_mock_monitor, create_mock_zm_client
+
+from tests.common import async_fire_time_changed
+
+
+async def _setup_zm_with_sensors(
+    hass: HomeAssistant,
+    zm_config: dict,
+    monitors: list,
+    sensor_config: dict | None = None,
+    is_available: bool = True,
+    active_state: str | None = "Running",
+) -> MagicMock:
+    """Set up ZM component with sensor platform and trigger first poll."""
+    client = create_mock_zm_client(
+        monitors=monitors, is_available=is_available, active_state=active_state
+    )
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, zm_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        if sensor_config is None:
+            sensor_config = {
+                "sensor": [
+                    {
+                        "platform": DOMAIN,
+                        "monitored_conditions": [
+                            "all",
+                            "hour",
+                            "day",
+                            "week",
+                            "month",
+                        ],
+                    }
+                ]
+            }
+        assert await async_setup_component(hass, "sensor", sensor_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Trigger first poll to update entity state
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    return client
+
+
+# --- Monitor Status Sensor ---
+
+
+async def test_monitor_status_sensor_exists(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test monitor status sensor is created."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_status")
+    assert state is not None
+
+
+async def test_monitor_status_sensor_value(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test monitor status sensor shows MonitorState value."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.RECORD)]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_status")
+    assert state is not None
+    assert state.state == "Record"
+
+
+@pytest.mark.parametrize(
+    ("monitor_state", "expected_value"),
+    [
+        (MonitorState.NONE, "None"),
+        (MonitorState.MONITOR, "Monitor"),
+        (MonitorState.MODECT, "Modect"),
+        (MonitorState.RECORD, "Record"),
+        (MonitorState.MOCORD, "Mocord"),
+        (MonitorState.NODECT, "Nodect"),
+    ],
+)
+async def test_monitor_status_sensor_all_states(
+    hass: HomeAssistant,
+    single_server_config,
+    monitor_state: MonitorState,
+    expected_value: str,
+) -> None:
+    """Test monitor status sensor with all MonitorState values."""
+    monitors = [create_mock_monitor(name="Cam", function=monitor_state)]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.cam_status")
+    assert state is not None
+    assert state.state == expected_value
+
+
+async def test_monitor_status_sensor_unavailable(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test monitor status sensor when monitor is unavailable."""
+    monitors = [
+        create_mock_monitor(name="Front Door", is_available=False, function=None)
+    ]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_status")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_monitor_status_sensor_null_function(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test monitor status sensor when function is falsy."""
+    monitors = [
+        create_mock_monitor(name="Front Door", function=None, is_available=True)
+    ]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_status")
+    assert state is not None
+
+
+# --- Event Sensors ---
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected_name_suffix", "expected_value"),
+    [
+        ("all", "Events", "100"),
+        ("hour", "Events Last Hour", "5"),
+        ("day", "Events Last Day", "20"),
+        ("week", "Events Last Week", "50"),
+        ("month", "Events Last Month", "80"),
+    ],
+)
+async def test_event_sensor_for_each_time_period(
+    hass: HomeAssistant,
+    single_server_config,
+    condition: str,
+    expected_name_suffix: str,
+    expected_value: str,
+) -> None:
+    """Test event sensors for all 5 time periods."""
+    monitors = [create_mock_monitor(name="Front Door")]
+    sensor_config = {
+        "sensor": [
+            {
+                "platform": DOMAIN,
+                "monitored_conditions": [condition],
+            }
+        ]
+    }
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, sensor_config=sensor_config
+    )
+
+    entity_id = f"sensor.front_door_{expected_name_suffix.lower().replace(' ', '_')}"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_value
+
+
+async def test_event_sensor_unit_of_measurement(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test event sensors have 'Events' unit of measurement."""
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_events")
+    assert state is not None
+    assert state.attributes.get("unit_of_measurement") == "Events"
+
+
+async def test_event_sensor_name_format(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test event sensor name format is '{monitor_name} {time_period_title}'."""
+    monitors = [create_mock_monitor(name="Back Yard")]
+    sensor_config = {
+        "sensor": [
+            {
+                "platform": DOMAIN,
+                "monitored_conditions": ["hour"],
+            }
+        ]
+    }
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, sensor_config=sensor_config
+    )
+
+    state = hass.states.get("sensor.back_yard_events_last_hour")
+    assert state is not None
+    assert state.name == "Back Yard Events Last Hour"
+
+
+async def test_event_sensor_none_handling(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test event sensor handles None event count."""
+    monitors = [
+        create_mock_monitor(
+            name="Front Door",
+            events=dict.fromkeys(TimePeriod),
+        )
+    ]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.front_door_events")
+    assert state is not None
+
+
+# --- Run State Sensor ---
+
+
+async def test_run_state_sensor_exists(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test run state sensor is created."""
+    monitors = [create_mock_monitor(name="Cam")]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    state = hass.states.get("sensor.run_state")
+    assert state is not None
+
+
+async def test_run_state_sensor_value(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test run state sensor shows state name."""
+    monitors = [create_mock_monitor(name="Cam")]
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, active_state="Home"
+    )
+
+    state = hass.states.get("sensor.run_state")
+    assert state is not None
+    assert state.state == "Home"
+
+
+async def test_run_state_sensor_unavailable(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test run state sensor when server unavailable."""
+    monitors = [create_mock_monitor(name="Cam")]
+    await _setup_zm_with_sensors(
+        hass,
+        single_server_config,
+        monitors,
+        is_available=False,
+        active_state=None,
+    )
+
+    state = hass.states.get("sensor.run_state")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+# --- Platform behavior ---
+
+
+async def test_platform_not_ready_empty_monitors(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test PlatformNotReady on empty monitors."""
+    client = create_mock_zm_client(monitors=[])
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+        await async_setup_component(
+            hass,
+            "sensor",
+            {"sensor": [{"platform": DOMAIN}]},
+        )
+        await hass.async_block_till_done()
+
+    # No sensor entities should exist (PlatformNotReady caught by HA)
+    states = hass.states.async_all("sensor")
+    assert len(states) == 0
+
+
+async def test_subset_condition_filtering(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test only selected monitored_conditions get event sensors."""
+    monitors = [create_mock_monitor(name="Cam")]
+    sensor_config = {
+        "sensor": [
+            {
+                "platform": DOMAIN,
+                "monitored_conditions": ["hour", "day"],
+            }
+        ]
+    }
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, sensor_config=sensor_config
+    )
+
+    # Should have: 1 status + 2 event + 1 run state = 4 sensors
+    states = hass.states.async_all("sensor")
+    assert len(states) == 4
+
+    # These should exist
+    assert hass.states.get("sensor.cam_events_last_hour") is not None
+    assert hass.states.get("sensor.cam_events_last_day") is not None
+
+    # These should NOT exist
+    assert hass.states.get("sensor.cam_events") is None
+    assert hass.states.get("sensor.cam_events_last_week") is None
+    assert hass.states.get("sensor.cam_events_last_month") is None
+
+
+async def test_default_conditions_only_all(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test default monitored_conditions is only 'all'."""
+    monitors = [create_mock_monitor(name="Cam")]
+    sensor_config = {"sensor": [{"platform": DOMAIN}]}
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, sensor_config=sensor_config
+    )
+
+    # Should have: 1 status + 1 event (all) + 1 run state = 3 sensors
+    states = hass.states.async_all("sensor")
+    assert len(states) == 3
+
+
+async def test_include_archived_flag(hass: HomeAssistant, single_server_config) -> None:
+    """Test include_archived flag is passed correctly to get_events."""
+    monitors = [create_mock_monitor(name="Cam")]
+    sensor_config = {
+        "sensor": [
+            {
+                "platform": DOMAIN,
+                "include_archived": True,
+                "monitored_conditions": ["all"],
+            }
+        ]
+    }
+    await _setup_zm_with_sensors(
+        hass, single_server_config, monitors, sensor_config=sensor_config
+    )
+
+    # Verify get_events was called with include_archived=True
+    monitors[0].get_events.assert_called_with(TimePeriod.ALL, True)
+
+
+def test_sensor_count_calculation(hass: HomeAssistant) -> None:
+    """Test correct number of sensors created per monitor and client.
+
+    For each monitor: 1 status + N event sensors
+    Plus: 1 run state sensor per client
+    """
+    monitors = [
+        create_mock_monitor(monitor_id=1, name="Cam1"),
+        create_mock_monitor(monitor_id=2, name="Cam2"),
+    ]
+    client = create_mock_zm_client(monitors=monitors)
+    hass.data[DOMAIN] = {MOCK_HOST: client}
+
+    entities: list[SensorEntity] = []
+    mock_add = MagicMock(side_effect=entities.extend)
+
+    config = {
+        "monitored_conditions": ["all", "hour"],
+        "include_archived": False,
+    }
+    setup_platform(hass, config, mock_add)
+
+    # 2 monitors * (1 status + 2 events) + 1 run state = 7
+    assert len(entities) == 7
+
+
+@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
+async def test_sensor_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
+) -> None:
+    """Sensor entities should have unique_id for UI customization.
+
+    No entity in the integration sets unique_id. This means entities cannot
+    be customized via the HA UI and are fragile to name changes.
+    """
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
+    await _setup_zm_with_sensors(hass, single_server_config, monitors)
+
+    entry = entity_registry.async_get("sensor.front_door_status")
+    assert entry is not None
+    assert entry.unique_id is not None
+
+
+@pytest.mark.xfail(
+    reason="BUG-03: monitor.function getter makes HTTP call on every read"
+)
+async def test_function_property_no_side_effects(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Reading monitor.function should not trigger an HTTP request.
+
+    The zm-py Monitor.function property calls update_monitor() on every read,
+    which makes an HTTP GET to monitors/{id}.json. HA reads function from both
+    sensor.py and switch.py, so the same data is fetched multiple times.
+    """
+    # Create a stub client that tracks calls to get_state
+    stub_client = MagicMock()
+    stub_client.get_state.return_value = {
+        "monitor": {
+            "Monitor": {"Function": "Modect"},
+            "Monitor_Status": {"CaptureFPS": "15.00"},
+        }
+    }
+    stub_client.verify_ssl = True
+
+    raw_result = {
+        "Monitor": {
+            "Id": "1",
+            "Name": "Test",
+            "Controllable": "0",
+            "StreamReplayBuffer": "0",
+            "ServerId": "0",
+        },
+        "Monitor_Status": {"CaptureFPS": "15.00"},
+    }
+    stub_client.get_zms_url_for_monitor.return_value = "http://example.com/zms"
+    stub_client.get_url_with_auth.return_value = "http://example.com/zms?auth=1"
+
+    monitor = Monitor(stub_client, raw_result)
+    stub_client.get_state.reset_mock()
+
+    # Reading function should NOT make an HTTP call
+    _ = monitor.function
+    assert stub_client.get_state.call_count == 0

--- a/tests/components/zoneminder/test_services.py
+++ b/tests/components/zoneminder/test_services.py
@@ -8,9 +8,8 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.zoneminder.const import DOMAIN
-from homeassistant.components.zoneminder.services import _set_active_state
 from homeassistant.const import ATTR_ID, ATTR_NAME
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
@@ -123,20 +122,3 @@ async def test_set_run_state_invalid_host(
         )
 
     assert "Invalid ZoneMinder host provided" in caplog.text
-
-
-def test_set_active_state_failure_logs_error(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test set_active_state failure logs error."""
-    client = create_mock_zm_client()
-    client.set_active_state.return_value = False
-    hass.data[DOMAIN] = {MOCK_HOST: client}
-
-    mock_call = MagicMock(spec=ServiceCall)
-    mock_call.data = {ATTR_ID: MOCK_HOST, ATTR_NAME: "Away"}
-    mock_call.hass = hass
-
-    _set_active_state(mock_call)
-
-    assert "Unable to change ZoneMinder state" in caplog.text

--- a/tests/components/zoneminder/test_services.py
+++ b/tests/components/zoneminder/test_services.py
@@ -1,0 +1,161 @@
+"""Tests for ZoneMinder service calls."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.components.zoneminder.services import _set_active_state
+from homeassistant.const import ATTR_ID, ATTR_NAME
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
+
+
+async def _setup_zm(hass: HomeAssistant, config: dict) -> dict:
+    """Set up ZM component and return mapping of host -> client."""
+    clients = {}
+
+    def make_client(*args, **kwargs):
+        client = create_mock_zm_client()
+        # Extract hostname from the server_origin (first positional arg)
+        origin = args[0]
+        # origin is like "http://zm.example.com"
+        hostname = origin.split("://")[1]
+        clients[hostname] = client
+        return client
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        side_effect=make_client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    return clients
+
+
+async def test_set_run_state_service_registered(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test set_run_state service is registered after setup."""
+    await _setup_zm(hass, single_server_config)
+
+    assert hass.services.has_service(DOMAIN, "set_run_state")
+
+
+async def test_set_run_state_valid_call(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test valid set_run_state call sets state on correct ZM client."""
+    clients = await _setup_zm(hass, single_server_config)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_run_state",
+        {ATTR_ID: MOCK_HOST, ATTR_NAME: "Away"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    clients[MOCK_HOST].set_active_state.assert_called_once_with("Away")
+
+
+async def test_set_run_state_multi_server_targets_correct_server(
+    hass: HomeAssistant, multi_server_config
+) -> None:
+    """Test set_run_state targets specific server by id."""
+    clients = await _setup_zm(hass, multi_server_config)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_run_state",
+        {ATTR_ID: MOCK_HOST_2, ATTR_NAME: "Home"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Only the second server should have been called
+    clients[MOCK_HOST_2].set_active_state.assert_called_once_with("Home")
+    clients[MOCK_HOST].set_active_state.assert_not_called()
+
+
+async def test_set_run_state_missing_fields_rejected(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test service call with missing required fields is rejected."""
+    await _setup_zm(hass, single_server_config)
+
+    with pytest.raises(vol.MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_run_state",
+            {ATTR_ID: MOCK_HOST},  # Missing ATTR_NAME
+            blocking=True,
+        )
+
+
+async def test_set_run_state_invalid_host(
+    hass: HomeAssistant, single_server_config, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test service call with invalid host logs error.
+
+    Regression: services.py logs error but doesn't return early,
+    so it also raises KeyError when trying to access the invalid host.
+    """
+    await _setup_zm(hass, single_server_config)
+
+    with pytest.raises(KeyError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_run_state",
+            {ATTR_ID: "invalid.host", ATTR_NAME: "Away"},
+            blocking=True,
+        )
+
+    assert "Invalid ZoneMinder host provided" in caplog.text
+
+
+def test_set_active_state_failure_logs_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test set_active_state failure logs error."""
+    client = create_mock_zm_client()
+    client.set_active_state.return_value = False
+    hass.data[DOMAIN] = {MOCK_HOST: client}
+
+    mock_call = MagicMock(spec=ServiceCall)
+    mock_call.data = {ATTR_ID: MOCK_HOST, ATTR_NAME: "Away"}
+    mock_call.hass = hass
+
+    _set_active_state(mock_call)
+
+    assert "Unable to change ZoneMinder state" in caplog.text
+
+
+@pytest.mark.xfail(
+    reason="BUG-01: _set_active_state missing return after invalid host check"
+)
+async def test_set_run_state_invalid_host_graceful(
+    hass: HomeAssistant, single_server_config, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Invalid host should log error and return without exception.
+
+    The service handler logs an error for an invalid host but does not return
+    early. Execution falls through and raises KeyError.
+    """
+    await _setup_zm(hass, single_server_config)
+
+    # Desired behavior: no exception raised, just a log message
+    await hass.services.async_call(
+        DOMAIN,
+        "set_run_state",
+        {ATTR_ID: "invalid.host", ATTR_NAME: "Away"},
+        blocking=True,
+    )
+
+    assert "Invalid ZoneMinder host provided" in caplog.text

--- a/tests/components/zoneminder/test_services.py
+++ b/tests/components/zoneminder/test_services.py
@@ -16,43 +16,26 @@ from homeassistant.setup import async_setup_component
 from .conftest import MOCK_HOST, MOCK_HOST_2, create_mock_zm_client
 
 
-async def _setup_zm(hass: HomeAssistant, config: dict) -> dict:
-    """Set up ZM component and return mapping of host -> client."""
-    clients = {}
-
-    def make_client(*args, **kwargs):
-        client = create_mock_zm_client()
-        # Extract hostname from the server_origin (first positional arg)
-        origin = args[0]
-        # origin is like "http://zm.example.com"
-        hostname = origin.split("://")[1]
-        clients[hostname] = client
-        return client
-
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        side_effect=make_client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, config)
-        await hass.async_block_till_done()
-
-    return clients
-
-
 async def test_set_run_state_service_registered(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test set_run_state service is registered after setup."""
-    await _setup_zm(hass, single_server_config)
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     assert hass.services.has_service(DOMAIN, "set_run_state")
 
 
 async def test_set_run_state_valid_call(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test valid set_run_state call sets state on correct ZM client."""
-    clients = await _setup_zm(hass, single_server_config)
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         DOMAIN,
@@ -62,14 +45,29 @@ async def test_set_run_state_valid_call(
     )
     await hass.async_block_till_done()
 
-    clients[MOCK_HOST].set_active_state.assert_called_once_with("Away")
+    mock_zoneminder_client.set_active_state.assert_called_once_with("Away")
 
 
 async def test_set_run_state_multi_server_targets_correct_server(
-    hass: HomeAssistant, multi_server_config
+    hass: HomeAssistant, multi_server_config: dict
 ) -> None:
     """Test set_run_state targets specific server by id."""
-    clients = await _setup_zm(hass, multi_server_config)
+    clients: dict[str, MagicMock] = {}
+
+    def make_client(*args, **kwargs):
+        client = create_mock_zm_client()
+        # Extract hostname from the server_origin (first positional arg)
+        origin = args[0]
+        hostname = origin.split("://")[1]
+        clients[hostname] = client
+        return client
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        side_effect=make_client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, multi_server_config)
+        await hass.async_block_till_done()
 
     await hass.services.async_call(
         DOMAIN,
@@ -85,10 +83,13 @@ async def test_set_run_state_multi_server_targets_correct_server(
 
 
 async def test_set_run_state_missing_fields_rejected(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test service call with missing required fields is rejected."""
-    await _setup_zm(hass, single_server_config)
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     with pytest.raises(vol.MultipleInvalid):
         await hass.services.async_call(
@@ -100,14 +101,18 @@ async def test_set_run_state_missing_fields_rejected(
 
 
 async def test_set_run_state_invalid_host(
-    hass: HomeAssistant, single_server_config, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test service call with invalid host logs error.
 
     Regression: services.py logs error but doesn't return early,
     so it also raises KeyError when trying to access the invalid host.
     """
-    await _setup_zm(hass, single_server_config)
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
 
     with pytest.raises(KeyError):
         await hass.services.async_call(
@@ -135,27 +140,3 @@ def test_set_active_state_failure_logs_error(
     _set_active_state(mock_call)
 
     assert "Unable to change ZoneMinder state" in caplog.text
-
-
-@pytest.mark.xfail(
-    reason="BUG-01: _set_active_state missing return after invalid host check"
-)
-async def test_set_run_state_invalid_host_graceful(
-    hass: HomeAssistant, single_server_config, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Invalid host should log error and return without exception.
-
-    The service handler logs an error for an invalid host but does not return
-    early. Execution falls through and raises KeyError.
-    """
-    await _setup_zm(hass, single_server_config)
-
-    # Desired behavior: no exception raised, just a log message
-    await hass.services.async_call(
-        DOMAIN,
-        "set_run_state",
-        {ATTR_ID: "invalid.host", ATTR_NAME: "Away"},
-        blocking=True,
-    )
-
-    assert "Invalid ZoneMinder host provided" in caplog.text

--- a/tests/components/zoneminder/test_switch.py
+++ b/tests/components/zoneminder/test_switch.py
@@ -1,0 +1,264 @@
+"""Tests for ZoneMinder switch entities."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voluptuous as vol
+from zoneminder.monitor import Monitor, MonitorState
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.zoneminder.const import DOMAIN
+from homeassistant.components.zoneminder.switch import PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from .conftest import create_mock_monitor, create_mock_zm_client
+
+from tests.common import async_fire_time_changed
+
+
+async def _setup_zm_with_switches(
+    hass: HomeAssistant,
+    zm_config: dict,
+    monitors: list,
+    command_on: str = "Modect",
+    command_off: str = "Monitor",
+) -> MagicMock:
+    """Set up ZM component with switch platform and trigger first poll."""
+    client = create_mock_zm_client(monitors=monitors)
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, zm_config)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        assert await async_setup_component(
+            hass,
+            SWITCH_DOMAIN,
+            {
+                SWITCH_DOMAIN: [
+                    {
+                        "platform": DOMAIN,
+                        "command_on": command_on,
+                        "command_off": command_off,
+                    }
+                ]
+            },
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+        # Trigger first poll to update entity state
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    return client
+
+
+async def test_switch_per_monitor(
+    hass: HomeAssistant, single_server_config, two_monitors
+) -> None:
+    """Test one switch entity is created per monitor."""
+    await _setup_zm_with_switches(hass, single_server_config, two_monitors)
+
+    states = hass.states.async_all(SWITCH_DOMAIN)
+    assert len(states) == 2
+
+
+async def test_switch_name_format(hass: HomeAssistant, single_server_config) -> None:
+    """Test switch name format is '{name} State'."""
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_switches(hass, single_server_config, monitors)
+
+    state = hass.states.get("switch.front_door_state")
+    assert state is not None
+    assert state.name == "Front Door State"
+
+
+async def test_switch_on_when_function_matches_command_on(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test switch is ON when monitor function matches command_on."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
+    await _setup_zm_with_switches(
+        hass, single_server_config, monitors, command_on="Modect"
+    )
+
+    state = hass.states.get("switch.front_door_state")
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_switch_off_when_function_differs(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test switch is OFF when monitor function differs from command_on."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MONITOR)]
+    await _setup_zm_with_switches(
+        hass, single_server_config, monitors, command_on="Modect"
+    )
+
+    state = hass.states.get("switch.front_door_state")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_switch_turn_on_service(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test turn_on service sets monitor function to command_on."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MONITOR)]
+    await _setup_zm_with_switches(hass, single_server_config, monitors)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.front_door_state"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Verify monitor function was set to MonitorState("Modect")
+    assert monitors[0].function == MonitorState("Modect")
+
+
+async def test_switch_turn_off_service(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test turn_off service sets monitor function to command_off."""
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
+    await _setup_zm_with_switches(hass, single_server_config, monitors)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.front_door_state"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert monitors[0].function == MonitorState("Monitor")
+
+
+async def test_switch_icon(hass: HomeAssistant, single_server_config) -> None:
+    """Test switch icon is mdi:record-rec."""
+    monitors = [create_mock_monitor(name="Front Door")]
+    await _setup_zm_with_switches(hass, single_server_config, monitors)
+
+    state = hass.states.get("switch.front_door_state")
+    assert state is not None
+    assert state.attributes.get("icon") == "mdi:record-rec"
+
+
+async def test_switch_platform_not_ready_empty_monitors(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Test PlatformNotReady on empty monitors."""
+    client = create_mock_zm_client(monitors=[])
+
+    with patch(
+        "homeassistant.components.zoneminder.ZoneMinder",
+        return_value=client,
+    ):
+        assert await async_setup_component(hass, DOMAIN, single_server_config)
+        await hass.async_block_till_done()
+        await async_setup_component(
+            hass,
+            SWITCH_DOMAIN,
+            {
+                SWITCH_DOMAIN: [
+                    {
+                        "platform": DOMAIN,
+                        "command_on": "Modect",
+                        "command_off": "Monitor",
+                    }
+                ]
+            },
+        )
+        await hass.async_block_till_done()
+
+    states = hass.states.async_all(SWITCH_DOMAIN)
+    assert len(states) == 0
+
+
+def test_platform_schema_requires_command_on_off() -> None:
+    """Test platform schema requires command_on and command_off."""
+    # Missing command_on
+    with pytest.raises(vol.MultipleInvalid):
+        PLATFORM_SCHEMA({"platform": "zoneminder", "command_off": "Monitor"})
+
+    # Missing command_off
+    with pytest.raises(vol.MultipleInvalid):
+        PLATFORM_SCHEMA({"platform": "zoneminder", "command_on": "Modect"})
+
+
+@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
+async def test_switch_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
+) -> None:
+    """Switch entities should have unique_id for UI customization.
+
+    No entity in the integration sets unique_id. This means entities cannot
+    be customized via the HA UI and are fragile to name changes.
+    """
+    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
+    await _setup_zm_with_switches(hass, single_server_config, monitors)
+
+    entry = entity_registry.async_get("switch.front_door_state")
+    assert entry is not None
+    assert entry.unique_id is not None
+
+
+@pytest.mark.xfail(
+    reason="BUG-03: monitor.function getter makes HTTP call on every read"
+)
+async def test_function_read_no_side_effects(
+    hass: HomeAssistant, single_server_config
+) -> None:
+    """Reading monitor.function should not trigger an HTTP request.
+
+    The zm-py Monitor.function property calls update_monitor() on every read,
+    which makes an HTTP GET to monitors/{id}.json. The switch platform reads
+    function to determine on/off state, triggering unnecessary API traffic.
+    """
+    stub_client = MagicMock()
+    stub_client.get_state.return_value = {
+        "monitor": {
+            "Monitor": {"Function": "Modect"},
+            "Monitor_Status": {"CaptureFPS": "15.00"},
+        }
+    }
+    stub_client.verify_ssl = True
+
+    raw_result = {
+        "Monitor": {
+            "Id": "1",
+            "Name": "Test",
+            "Controllable": "0",
+            "StreamReplayBuffer": "0",
+            "ServerId": "0",
+        },
+        "Monitor_Status": {"CaptureFPS": "15.00"},
+    }
+    stub_client.get_zms_url_for_monitor.return_value = "http://example.com/zms"
+    stub_client.get_url_with_auth.return_value = "http://example.com/zms?auth=1"
+
+    monitor = Monitor(stub_client, raw_result)
+    stub_client.get_state.reset_mock()
+
+    # Reading function should NOT make an HTTP call
+    _ = monitor.function
+    assert stub_client.get_state.call_count == 0

--- a/tests/components/zoneminder/test_switch.py
+++ b/tests/components/zoneminder/test_switch.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
-from zoneminder.monitor import Monitor, MonitorState
+from zoneminder.monitor import MonitorState
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.zoneminder.const import DOMAIN
@@ -20,68 +21,74 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
-from .conftest import create_mock_monitor, create_mock_zm_client
+from .conftest import create_mock_monitor
 
 from tests.common import async_fire_time_changed
 
 
 async def _setup_zm_with_switches(
     hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
     zm_config: dict,
     monitors: list,
+    freezer: FrozenDateTimeFactory,
     command_on: str = "Modect",
     command_off: str = "Monitor",
-) -> MagicMock:
+) -> None:
     """Set up ZM component with switch platform and trigger first poll."""
-    client = create_mock_zm_client(monitors=monitors)
+    mock_zoneminder_client.get_monitors.return_value = monitors
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, zm_config)
-        await hass.async_block_till_done(wait_background_tasks=True)
-        assert await async_setup_component(
-            hass,
-            SWITCH_DOMAIN,
-            {
-                SWITCH_DOMAIN: [
-                    {
-                        "platform": DOMAIN,
-                        "command_on": command_on,
-                        "command_off": command_off,
-                    }
-                ]
-            },
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-        # Trigger first poll to update entity state
-        async_fire_time_changed(
-            hass, dt_util.utcnow() + timedelta(seconds=60), fire_all=True
-        )
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-    return client
+    assert await async_setup_component(hass, DOMAIN, zm_config)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {
+            SWITCH_DOMAIN: [
+                {
+                    "platform": DOMAIN,
+                    "command_on": command_on,
+                    "command_off": command_off,
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Trigger first poll to update entity state
+    freezer.tick(timedelta(seconds=60))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_switch_per_monitor(
-    hass: HomeAssistant, single_server_config, two_monitors
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    two_monitors: list,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test one switch entity is created per monitor."""
-    await _setup_zm_with_switches(hass, single_server_config, two_monitors)
+    await _setup_zm_with_switches(
+        hass, mock_zoneminder_client, single_server_config, two_monitors, freezer
+    )
 
     states = hass.states.async_all(SWITCH_DOMAIN)
     assert len(states) == 2
 
 
-async def test_switch_name_format(hass: HomeAssistant, single_server_config) -> None:
+async def test_switch_name_format(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test switch name format is '{name} State'."""
     monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_switches(hass, single_server_config, monitors)
+    await _setup_zm_with_switches(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("switch.front_door_state")
     assert state is not None
@@ -89,12 +96,20 @@ async def test_switch_name_format(hass: HomeAssistant, single_server_config) -> 
 
 
 async def test_switch_on_when_function_matches_command_on(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test switch is ON when monitor function matches command_on."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
     await _setup_zm_with_switches(
-        hass, single_server_config, monitors, command_on="Modect"
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        command_on="Modect",
     )
 
     state = hass.states.get("switch.front_door_state")
@@ -103,12 +118,20 @@ async def test_switch_on_when_function_matches_command_on(
 
 
 async def test_switch_off_when_function_differs(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test switch is OFF when monitor function differs from command_on."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MONITOR)]
     await _setup_zm_with_switches(
-        hass, single_server_config, monitors, command_on="Modect"
+        hass,
+        mock_zoneminder_client,
+        single_server_config,
+        monitors,
+        freezer,
+        command_on="Modect",
     )
 
     state = hass.states.get("switch.front_door_state")
@@ -117,11 +140,16 @@ async def test_switch_off_when_function_differs(
 
 
 async def test_switch_turn_on_service(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test turn_on service sets monitor function to command_on."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MONITOR)]
-    await _setup_zm_with_switches(hass, single_server_config, monitors)
+    await _setup_zm_with_switches(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -136,11 +164,16 @@ async def test_switch_turn_on_service(
 
 
 async def test_switch_turn_off_service(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test turn_off service sets monitor function to command_off."""
     monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
-    await _setup_zm_with_switches(hass, single_server_config, monitors)
+    await _setup_zm_with_switches(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -153,10 +186,17 @@ async def test_switch_turn_off_service(
     assert monitors[0].function == MonitorState("Monitor")
 
 
-async def test_switch_icon(hass: HomeAssistant, single_server_config) -> None:
+async def test_switch_icon(
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
+    freezer: FrozenDateTimeFactory,
+) -> None:
     """Test switch icon is mdi:record-rec."""
     monitors = [create_mock_monitor(name="Front Door")]
-    await _setup_zm_with_switches(hass, single_server_config, monitors)
+    await _setup_zm_with_switches(
+        hass, mock_zoneminder_client, single_server_config, monitors, freezer
+    )
 
     state = hass.states.get("switch.front_door_state")
     assert state is not None
@@ -164,31 +204,29 @@ async def test_switch_icon(hass: HomeAssistant, single_server_config) -> None:
 
 
 async def test_switch_platform_not_ready_empty_monitors(
-    hass: HomeAssistant, single_server_config
+    hass: HomeAssistant,
+    mock_zoneminder_client: MagicMock,
+    single_server_config: dict,
 ) -> None:
     """Test PlatformNotReady on empty monitors."""
-    client = create_mock_zm_client(monitors=[])
+    mock_zoneminder_client.get_monitors.return_value = []
 
-    with patch(
-        "homeassistant.components.zoneminder.ZoneMinder",
-        return_value=client,
-    ):
-        assert await async_setup_component(hass, DOMAIN, single_server_config)
-        await hass.async_block_till_done()
-        await async_setup_component(
-            hass,
-            SWITCH_DOMAIN,
-            {
-                SWITCH_DOMAIN: [
-                    {
-                        "platform": DOMAIN,
-                        "command_on": "Modect",
-                        "command_off": "Monitor",
-                    }
-                ]
-            },
-        )
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, single_server_config)
+    await hass.async_block_till_done()
+    await async_setup_component(
+        hass,
+        SWITCH_DOMAIN,
+        {
+            SWITCH_DOMAIN: [
+                {
+                    "platform": DOMAIN,
+                    "command_on": "Modect",
+                    "command_off": "Monitor",
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
 
     states = hass.states.async_all(SWITCH_DOMAIN)
     assert len(states) == 0
@@ -203,62 +241,3 @@ def test_platform_schema_requires_command_on_off() -> None:
     # Missing command_off
     with pytest.raises(vol.MultipleInvalid):
         PLATFORM_SCHEMA({"platform": "zoneminder", "command_on": "Modect"})
-
-
-@pytest.mark.xfail(reason="BUG-05: No unique_id on any entity")
-async def test_switch_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, single_server_config
-) -> None:
-    """Switch entities should have unique_id for UI customization.
-
-    No entity in the integration sets unique_id. This means entities cannot
-    be customized via the HA UI and are fragile to name changes.
-    """
-    monitors = [create_mock_monitor(name="Front Door", function=MonitorState.MODECT)]
-    await _setup_zm_with_switches(hass, single_server_config, monitors)
-
-    entry = entity_registry.async_get("switch.front_door_state")
-    assert entry is not None
-    assert entry.unique_id is not None
-
-
-@pytest.mark.xfail(
-    reason="BUG-03: monitor.function getter makes HTTP call on every read"
-)
-async def test_function_read_no_side_effects(
-    hass: HomeAssistant, single_server_config
-) -> None:
-    """Reading monitor.function should not trigger an HTTP request.
-
-    The zm-py Monitor.function property calls update_monitor() on every read,
-    which makes an HTTP GET to monitors/{id}.json. The switch platform reads
-    function to determine on/off state, triggering unnecessary API traffic.
-    """
-    stub_client = MagicMock()
-    stub_client.get_state.return_value = {
-        "monitor": {
-            "Monitor": {"Function": "Modect"},
-            "Monitor_Status": {"CaptureFPS": "15.00"},
-        }
-    }
-    stub_client.verify_ssl = True
-
-    raw_result = {
-        "Monitor": {
-            "Id": "1",
-            "Name": "Test",
-            "Controllable": "0",
-            "StreamReplayBuffer": "0",
-            "ServerId": "0",
-        },
-        "Monitor_Status": {"CaptureFPS": "15.00"},
-    }
-    stub_client.get_zms_url_for_monitor.return_value = "http://example.com/zms"
-    stub_client.get_url_with_auth.return_value = "http://example.com/zms?auth=1"
-
-    monitor = Monitor(stub_client, raw_result)
-    stub_client.get_state.reset_mock()
-
-    # Reading function should NOT make an HTTP call
-    _ = monitor.function
-    assert stub_client.get_state.call_count == 0


### PR DESCRIPTION
  ## Non Breaking change                                                                                                                                            
   
  N/A — test-only change, no runtime behavior modified.                                                                                                         
                                                            
  ## Proposed change

  Add a comprehensive test suite for the ZoneMinder integration (100% line coverage, 208/208 statements) to establish a regression baseline ahead of the zm-py library upgrade and integration refactor.

  **77 passing tests** covering happy-path behavior across all platforms:
  - config validation (8), init/setup flow (12), services (6)
  - binary_sensor (7), sensor (18), switch (9), camera (8)
  - Shared conftest with mock factories for ZM client and monitors

  **13 xfail tests** documenting known bugs as executable specs:
  - BUG-01: `_set_active_state` missing early return (P0)
  - BUG-02: No `DataUpdateCoordinator` (P0)
  - BUG-03: `monitor.function` getter triggers HTTP (P1, 2 tests)
  - BUG-05: No `unique_id` on any entity (P1, 4 tests)
  - BUG-06: `get_monitors` called per platform (P1)
  - BUG-07: `PlatformNotReady` conflates empty with failure (P1)
  - BUG-08: PTZ not exposed (P2)
  - BUG-10: No `DeviceInfo` (P2)
  - BUG-12: zm-py exceptions not caught (P2)

  As each bug is fixed in the refactor, its xfail marker gets removed and the test becomes an enforced regression gate.

  ## Type of change

  - [x] Code quality improvements to existing code or addition of tests

  ## Additional information

  - This PR fixes or closes issue: fixes #
  - This PR is related to issue:
  - Link to documentation pull request:
  - Link to developer documentation pull request:
  - Link to frontend pull request:

  ## Checklist

  - [x] I understand the code I am submitting and can explain how it works.
  - [x] The code change is tested and works locally.
  - [x] Local tests pass. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]
  - [x] I have followed the [perfect PR recommendations][perfect-pr]
  - [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - [x] Tests have been added to verify that the new code works.
  - [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

  To help with the load of incoming pull requests:

  - [ ] I have reviewed two other [open pull requests][prs] in this repository.
