### PR TITLE
Add auto_off, delay_off and delay_on in GUI for template binary_sensor

### DIFF
--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -57,7 +57,12 @@ from .alarm_control_panel import (
     TemplateCodeFormat,
     async_create_preview_alarm_control_panel,
 )
-from .binary_sensor import async_create_preview_binary_sensor
+from .binary_sensor import (
+    CONF_AUTO_OFF,
+    CONF_DELAY_OFF,
+    CONF_DELAY_ON,
+    async_create_preview_binary_sensor,
+)
 from .const import (
     CONF_ADVANCED_OPTIONS,
     CONF_AVAILABILITY,
@@ -192,6 +197,18 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
                     ),
                 ),
             }
+
+        schema |= {
+            vol.Optional(CONF_AUTO_OFF): selector.TextSelector(
+                selector.TextSelectorConfig()
+            ),
+            vol.Optional(CONF_DELAY_OFF): selector.TextSelector(
+                selector.TextSelectorConfig()
+            ),
+            vol.Optional(CONF_DELAY_ON): selector.TextSelector(
+                selector.TextSelectorConfig()
+            ),
+        }
 
     if domain == Platform.BUTTON:
         schema |= {

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -56,12 +56,18 @@
       },
       "binary_sensor": {
         "data": {
+          "auto_off": "Auto off",
+          "delay_off": "Delay off",
+          "delay_on": "Delay on",
           "device_class": "[%key:component::template::common::device_class%]",
           "device_id": "[%key:common::config_flow::data::device%]",
           "name": "[%key:common::config_flow::data::name%]",
           "state": "[%key:component::template::common::state%]"
         },
         "data_description": {
+          "auto_off": "Requires a trigger. After how much time the entity should turn off after it rendered `on`.",
+          "delay_off": "The amount of time (e.g. `0:00:05`) the template state must be not met before this sensor will switch to `off`. This can also be a template.",
+          "delay_on": "The amount of time (e.g. `0:00:05`) the template state must be met before this sensor will switch to `on`. This can also be a template.",
           "device_id": "[%key:component::template::common::device_id_description%]",
           "state": "The sensor is `on` if the template evaluates as `True`, `yes`, `on`, `enable` or a positive number. Any other value will render it as `off`."
         },
@@ -608,10 +614,16 @@
       },
       "binary_sensor": {
         "data": {
+          "auto_off": "[%key:component::template::config::step::binary_sensor::data::auto_off%]",
+          "delay_off": "[%key:component::template::config::step::binary_sensor::data::delay_off%]",
+          "delay_on": "[%key:component::template::config::step::binary_sensor::data::delay_on%]",
           "device_id": "[%key:common::config_flow::data::device%]",
           "state": "[%key:component::template::common::state%]"
         },
         "data_description": {
+          "auto_off": "[%key:component::template::config::step::binary_sensor::data_description::auto_off%]",
+          "delay_off": "[%key:component::template::config::step::binary_sensor::data_description::delay_off%]",
+          "delay_on": "[%key:component::template::config::step::binary_sensor::data_description::delay_on%]",
           "device_id": "[%key:component::template::common::device_id_description%]",
           "state": "[%key:component::template::config::step::binary_sensor::data_description::state%]"
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support to configure options `auto_off`, `delay_on`, `delay_off` for template helper binary sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
