### PR TITLE
Add "Sleeping" class to sensors

### DIFF
--- a/homeassistant/components/bayesian/strings.json
+++ b/homeassistant/components/bayesian/strings.json
@@ -259,6 +259,7 @@
         "problem": "[%key:component::binary_sensor::entity_component::problem::name%]",
         "running": "[%key:component::binary_sensor::entity_component::running::name%]",
         "safety": "[%key:component::binary_sensor::entity_component::safety::name%]",
+        "sleeping": "[%key:component::binary_sensor::entity_component::sleeping::name%]",
         "smoke": "[%key:component::binary_sensor::entity_component::smoke::name%]",
         "sound": "[%key:component::binary_sensor::entity_component::sound::name%]",
         "tamper": "[%key:component::binary_sensor::entity_component::tamper::name%]",

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -99,6 +99,9 @@ class BinarySensorDeviceClass(StrEnum):
     # On means unsafe, Off means safe
     SAFETY = "safety"
 
+    # On means sleeping, Off means awake
+    SLEEPING = "sleeping"
+    
     # On means smoke detected, Off means no smoke (clear)
     SMOKE = "smoke"
 

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -101,7 +101,7 @@ class BinarySensorDeviceClass(StrEnum):
 
     # On means sleeping, Off means awake
     SLEEPING = "sleeping"
-    
+
     # On means smoke detected, Off means no smoke (clear)
     SMOKE = "smoke"
 

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -67,6 +67,8 @@ CONF_IS_UNSAFE = "is_unsafe"
 CONF_IS_NOT_UNSAFE = "is_not_unsafe"
 CONF_IS_SMOKE = "is_smoke"
 CONF_IS_NO_SMOKE = "is_no_smoke"
+CONF_IS_SLEEPING = "is_sleeping"
+CONF_IS_NOT_SLEEPING = "is_not_sleeping"
 CONF_IS_SOUND = "is_sound"
 CONF_IS_NO_SOUND = "is_no_sound"
 CONF_IS_TAMPERED = "is_tampered"
@@ -99,6 +101,7 @@ IS_ON = [
     CONF_IS_PROBLEM,
     CONF_IS_RUNNING,
     CONF_IS_SMOKE,
+    CONF_IS_SLEEPING,
     CONF_IS_SOUND,
     CONF_IS_TAMPERED,
     CONF_IS_UPDATE,
@@ -130,6 +133,7 @@ IS_OFF = [
     CONF_IS_NO_PROBLEM,
     CONF_IS_NOT_RUNNING,
     CONF_IS_NO_SMOKE,
+    CONF_IS_NOT_SLEEPING,
     CONF_IS_NO_SOUND,
     CONF_IS_NO_UPDATE,
     CONF_IS_NO_VIBRATION,
@@ -224,6 +228,10 @@ ENTITY_CONDITIONS = {
     BinarySensorDeviceClass.SAFETY: [
         {CONF_TYPE: CONF_IS_UNSAFE},
         {CONF_TYPE: CONF_IS_NOT_UNSAFE},
+    ],
+    BinarySensorDeviceClass.SLEEPING: [
+        {CONF_TYPE: CONF_IS_SLEEPING},
+        {CONF_TYPE: CONF_IS_NOT_SLEEPING},
     ],
     BinarySensorDeviceClass.SMOKE: [
         {CONF_TYPE: CONF_IS_SMOKE},

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -59,6 +59,8 @@ CONF_UNSAFE = "unsafe"
 CONF_NOT_UNSAFE = "not_unsafe"
 CONF_SMOKE = "smoke"
 CONF_NO_SMOKE = "no_smoke"
+CONF_IS_SLEEPING = "is_sleeping"
+CONF_IS_NOT_SLEEPING = "is_awake"
 CONF_SOUND = "sound"
 CONF_NO_SOUND = "no_sound"
 CONF_TAMPERED = "tampered"
@@ -163,6 +165,10 @@ ENTITY_TRIGGERS = {
     BinarySensorDeviceClass.SMOKE: [
         {CONF_TYPE: CONF_SMOKE},
         {CONF_TYPE: CONF_NO_SMOKE},
+    ],
+    BinarySensorDeviceClass.SLEEPING: [
+        {CONF_TYPE: CONF_IS_SLEEPING},
+        {CONF_TYPE: CONF_IS_NOT_SLEEPING},
     ],
     BinarySensorDeviceClass.SOUND: [
         {CONF_TYPE: CONF_SOUND},

--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -138,16 +138,16 @@
         "on": "mdi:alert-circle"
       }
     },
-    "smoke": {
-      "default": "mdi:smoke-detector-variant",
-      "state": {
-        "on": "mdi:smoke-detector-variant-alert"
-      }
-    },
     "sleeping": {
       "default": "mdi:bed-outline",
       "state": {
         "on": "mdi:bed-clock"
+      }
+    },
+    "smoke": {
+      "default": "mdi:smoke-detector-variant",
+      "state": {
+        "on": "mdi:smoke-detector-variant-alert"
       }
     },
     "sound": {

--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -144,6 +144,12 @@
         "on": "mdi:smoke-detector-variant-alert"
       }
     },
+    "sleeping": {
+      "default": "mdi:bed-outline",
+      "state": {
+        "on": "mdi:bed-clock"
+      }
+    },
     "sound": {
       "default": "mdi:music-note-off",
       "state": {

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -40,6 +40,7 @@
       "is_not_powered": "{entity_name} is not powered",
       "is_not_present": "{entity_name} is not present",
       "is_not_running": "{entity_name} is not running",
+      "is_not_sleeping": "{entity_name} is awake",
       "is_not_tampered": "{entity_name} is not detecting tampering",
       "is_not_unsafe": "{entity_name} is safe",
       "is_occupied": "{entity_name} is occupied",
@@ -51,9 +52,8 @@
       "is_present": "{entity_name} is present",
       "is_problem": "{entity_name} is detecting problem",
       "is_running": "{entity_name} is running",
-      "is_smoke": "{entity_name} is detecting smoke",
       "is_sleeping": "{entity_name} is sleeping",
-      "is_not_sleeping": "{entity_name} is awake",
+      "is_smoke": "{entity_name} is detecting smoke",
       "is_sound": "{entity_name} is detecting sound",
       "is_tampered": "{entity_name} is detecting tampering",
       "is_unsafe": "{entity_name} is unsafe",
@@ -280,18 +280,18 @@
         "on": "Unsafe"
       }
     },
-    "smoke": {
-      "name": "Smoke",
-      "state": {
-        "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
-        "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
-      }
-    },
     "sleeping": {
       "name": "Sleeping",
       "state": {
         "off": "Awake",
         "on": "Asleep"
+      }
+    },
+    "smoke": {
+      "name": "Smoke",
+      "state": {
+        "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
+        "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
       }
     },
     "sound": {

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -52,6 +52,8 @@
       "is_problem": "{entity_name} is detecting problem",
       "is_running": "{entity_name} is running",
       "is_smoke": "{entity_name} is detecting smoke",
+      "is_sleeping": "{entity_name} is sleeping",
+      "is_not_sleeping": "{entity_name} is awake",
       "is_sound": "{entity_name} is detecting sound",
       "is_tampered": "{entity_name} is detecting tampering",
       "is_unsafe": "{entity_name} is unsafe",
@@ -283,6 +285,13 @@
       "state": {
         "off": "[%key:component::binary_sensor::entity_component::gas::state::off%]",
         "on": "[%key:component::binary_sensor::entity_component::gas::state::on%]"
+      }
+    },
+    "sleeping": {
+      "name": "Sleeping",
+      "state": {
+        "off": "Awake",
+        "on": "Asleep"
       }
     },
     "sound": {

--- a/homeassistant/components/random/strings.json
+++ b/homeassistant/components/random/strings.json
@@ -71,6 +71,7 @@
         "problem": "[%key:component::binary_sensor::entity_component::problem::name%]",
         "running": "[%key:component::binary_sensor::entity_component::running::name%]",
         "safety": "[%key:component::binary_sensor::entity_component::safety::name%]",
+        "sleeping": "[%key:component::binary_sensor::entity_component::sleeping::name%]",
         "smoke": "[%key:component::binary_sensor::entity_component::smoke::name%]",
         "sound": "[%key:component::binary_sensor::entity_component::sound::name%]",
         "tamper": "[%key:component::binary_sensor::entity_component::tamper::name%]",

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -205,6 +205,7 @@
         "problem": "[%key:component::binary_sensor::entity_component::problem::name%]",
         "running": "[%key:component::binary_sensor::entity_component::running::name%]",
         "safety": "[%key:component::binary_sensor::entity_component::safety::name%]",
+        "sleeping": "[%key:component::binary_sensor::entity_component::sleeping::name%]",
         "smoke": "[%key:component::binary_sensor::entity_component::smoke::name%]",
         "sound": "[%key:component::binary_sensor::entity_component::sound::name%]",
         "tamper": "[%key:component::binary_sensor::entity_component::tamper::name%]",

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -1091,6 +1091,7 @@
         "problem": "[%key:component::binary_sensor::entity_component::problem::name%]",
         "running": "[%key:component::binary_sensor::entity_component::running::name%]",
         "safety": "[%key:component::binary_sensor::entity_component::safety::name%]",
+        "sleeping": "[%key:component::binary_sensor::entity_component::sleeping::name%]",
         "smoke": "[%key:component::binary_sensor::entity_component::smoke::name%]",
         "sound": "[%key:component::binary_sensor::entity_component::sound::name%]",
         "tamper": "[%key:component::binary_sensor::entity_component::tamper::name%]",


### PR DESCRIPTION
## Proposed change
Bayesian sensors are amazing to check if someone is asleep, but there was no class for sleeping. This change adds that small change, so you can now have "is asleep" or "is awake" on your sensors!

<img width="589" height="111" alt="image" src="https://github.com/user-attachments/assets/91b38ccf-23d8-45f4-8a71-962bc4dd195a" />

<img width="572" height="86" alt="image" src="https://github.com/user-attachments/assets/499ce054-56a8-421d-814e-5cd82c82f6b8" />

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ X ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: -
- This PR is related to issue: -
- Link to documentation pull request: -
- Link to developer documentation pull request: -
- Link to frontend pull request: - 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ X ] I understand the code I am submitting and can explain how it works.
- [ X ] The code change is tested and works locally.
- [ X ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ X ] There is no commented out code in this PR.
- [ X ] I have followed the [development checklist][dev-checklist]
- [ X ] I have followed the [perfect PR recommendations][perfect-pr]
- [ X ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [  ] Tests have been added to verify that the new code works.
- [ X ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
