### PR TITLE
Add reauth to Mastodon

### DIFF
--- a/homeassistant/components/mastodon/__init__.py
+++ b/homeassistant/components/mastodon/__init__.py
@@ -9,6 +9,7 @@ from mastodon.Mastodon import (
     Mastodon,
     MastodonError,
     MastodonNotFoundError,
+    MastodonUnauthorizedError,
 )
 
 from homeassistant.const import (
@@ -18,7 +19,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
@@ -48,6 +49,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MastodonConfigEntry) -> 
             entry,
         )
 
+    except MastodonUnauthorizedError as error:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed",
+        ) from error
     except MastodonError as ex:
         raise ConfigEntryNotReady("Failed to connect") from ex
 

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -60,6 +60,11 @@ def base_url_from_url(url: str) -> str:
     return str(URL(url).origin())
 
 
+def remove_email_link(account_name: str) -> str:
+    """Remove email link from account name."""
+    return account_name.replace("@", "&#64;")
+
+
 class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow."""
 
@@ -180,8 +185,12 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._get_reauth_entry(),
                     data_updates={CONF_ACCESS_TOKEN: user_input[CONF_ACCESS_TOKEN]},
                 )
+        account_name = self._get_reauth_entry().title
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=REAUTH_SCHEMA,
             errors=errors,
+            description_placeholders={
+                "account_name": remove_email_link(account_name),
+            },
         )

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from mastodon.Mastodon import (
@@ -43,6 +44,15 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
     }
 )
+REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(
+            CONF_ACCESS_TOKEN,
+        ): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
+    }
+)
+
+EXAMPLE_URL = "https://mastodon.social"
 
 
 def base_url_from_url(url: str) -> str:
@@ -56,24 +66,31 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
+    base_url: str | None = None
+    client_id: str | None = None
+    client_secret: str | None = None
+    access_token: str | None = None
+
     def check_connection(
         self,
-        base_url: str,
-        client_id: str,
-        client_secret: str,
-        access_token: str,
     ) -> tuple[
         InstanceV2 | Instance | None,
         Account | None,
         dict[str, str],
     ]:
         """Check connection to the Mastodon instance."""
+
+        assert self.base_url is not None
+        assert self.client_id is not None
+        assert self.client_secret is not None
+        assert self.access_token is not None
+
         try:
             client = create_mastodon_client(
-                base_url,
-                client_id,
-                client_secret,
-                access_token,
+                self.base_url,
+                self.client_id,
+                self.client_secret,
+                self.access_token,
             )
             try:
                 instance = client.instance_v2()
@@ -117,12 +134,13 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             user_input[CONF_BASE_URL] = base_url_from_url(user_input[CONF_BASE_URL])
 
+            self.base_url = user_input[CONF_BASE_URL]
+            self.client_id = user_input[CONF_CLIENT_ID]
+            self.client_secret = user_input[CONF_CLIENT_SECRET]
+            self.access_token = user_input[CONF_ACCESS_TOKEN]
+
             instance, account, errors = await self.hass.async_add_executor_job(
-                self.check_connection,
-                user_input[CONF_BASE_URL],
-                user_input[CONF_CLIENT_ID],
-                user_input[CONF_CLIENT_SECRET],
-                user_input[CONF_ACCESS_TOKEN],
+                self.check_connection
             )
 
             if not errors:
@@ -137,5 +155,39 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.show_user_form(
             user_input,
             errors,
-            description_placeholders={"example_url": "https://mastodon.social"},
+            description_placeholders={"example_url": EXAMPLE_URL},
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauth upon an API authentication error."""
+        self.base_url = entry_data[CONF_BASE_URL]
+        self.client_id = entry_data[CONF_CLIENT_ID]
+        self.client_secret = entry_data[CONF_CLIENT_SECRET]
+        self.access_token = entry_data[CONF_ACCESS_TOKEN]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauth dialog."""
+        errors: dict[str, str] = {}
+        if user_input:
+            self.access_token = user_input[CONF_ACCESS_TOKEN]
+            instance, account, errors = await self.hass.async_add_executor_job(
+                self.check_connection
+            )
+            if not errors:
+                name = construct_mastodon_username(instance, account)
+                await self.async_set_unique_id(slugify(name))
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_ACCESS_TOKEN: user_input[CONF_ACCESS_TOKEN]},
+                )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=REAUTH_SCHEMA,
+            errors=errors,
         )

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -62,6 +62,8 @@ def base_url_from_url(url: str) -> str:
 
 def remove_email_link(account_name: str) -> str:
     """Remove email link from account name."""
+
+    # Replaces the @ with a HTML entity to prevent mailto links.
     return account_name.replace("@", "&#64;")
 
 

--- a/homeassistant/components/mastodon/config_flow.py
+++ b/homeassistant/components/mastodon/config_flow.py
@@ -66,10 +66,10 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 2
 
-    base_url: str | None = None
-    client_id: str | None = None
-    client_secret: str | None = None
-    access_token: str | None = None
+    base_url: str
+    client_id: str
+    client_secret: str
+    access_token: str
 
     def check_connection(
         self,
@@ -79,12 +79,6 @@ class MastodonConfigFlow(ConfigFlow, domain=DOMAIN):
         dict[str, str],
     ]:
         """Check connection to the Mastodon instance."""
-
-        assert self.base_url is not None
-        assert self.client_id is not None
-        assert self.client_secret is not None
-        assert self.access_token is not None
-
         try:
             client = create_mastodon_client(
                 self.base_url,

--- a/homeassistant/components/mastodon/manifest.json
+++ b/homeassistant/components/mastodon/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["mastodon"],
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["Mastodon.py==2.1.2"]
 }

--- a/homeassistant/components/mastodon/quality_scale.yaml
+++ b/homeassistant/components/mastodon/quality_scale.yaml
@@ -34,10 +34,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow:
-    status: todo
-    comment: |
-      Waiting to move to oAuth.
+  reauthentication-flow: done
   test-coverage: done
   # Gold
   devices: done

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -19,7 +19,7 @@
         "data_description": {
           "access_token": "[%key:component::mastodon::config::step::user::data_description::access_token%]"
         },
-        "description": "Please reauthenticate with Mastodon."
+        "description": "Please reauthenticate {account_name} with Mastodon."
       },
       "user": {
         "data": {

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -3,9 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "wrong_account": "You have to use the same account that was used to configure the integration."
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "network_error": "The Mastodon instance was not found.",

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -1,7 +1,11 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "wrong_account": "You have to use the same account that was used to configure the integration."
     },
     "error": {
       "network_error": "The Mastodon instance was not found.",
@@ -9,6 +13,15 @@
       "unknown": "Unknown error occurred when connecting to the Mastodon instance."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "access_token": "[%key:common::config_flow::data::access_token%]"
+        },
+        "data_description": {
+          "access_token": "[%key:component::mastodon::config::step::user::data_description::access_token%]"
+        },
+        "description": "Please reauthenticate with Mastodon."
+      },
       "user": {
         "data": {
           "access_token": "[%key:common::config_flow::data::access_token%]",

--- a/homeassistant/components/mastodon/strings.json
+++ b/homeassistant/components/mastodon/strings.json
@@ -3,7 +3,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "wrong_account": "You have to use the same account that was used to configure the integration."
     },
     "error": {
       "network_error": "The Mastodon instance was not found.",
@@ -80,6 +81,9 @@
     }
   },
   "exceptions": {
+    "auth_failed": {
+      "message": "Authentication failed, please reauthenticate with Mastodon."
+    },
     "idempotency_key_too_short": {
       "message": "Idempotency key must be at least 4 characters long."
     },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add reauth flow to Mastodon.

Forthcoming features will require additional scopes, which generates a new access token, to allow easy use of the new features introducing the reauth flow.
The reauth only requires the access token, secrets do not change when scope is changed.

This also completes silver quality scale so updating that (docs not required as per https://github.com/home-assistant/home-assistant.io/pull/43572#issuecomment-3908422537)

Given Mastodon's distributed instances oAuth flow is hard to implement, it is still on my backlog but introducing reauth will at least give better user experience today.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
