### PR TITLE
Fix HDFury volt symbol

### DIFF
--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -164,10 +164,10 @@
         "name": "Relay"
       },
       "tx0plus5": {
-        "name": "TX0 force +5v"
+        "name": "TX0 force +5V"
       },
       "tx1plus5": {
-        "name": "TX1 force +5v"
+        "name": "TX1 force +5V"
       }
     }
   },

--- a/tests/components/hdfury/snapshots/test_switch.ambr
+++ b/tests/components/hdfury/snapshots/test_switch.ambr
@@ -755,12 +755,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'TX0 force +5v',
+    'object_id_base': 'TX0 force +5V',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'TX0 force +5v',
+    'original_name': 'TX0 force +5V',
     'platform': 'hdfury',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -773,7 +773,7 @@
 # name: test_switch_entities[switch.hdfury_vrroom_02_tx0_force_5v-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'HDFury VRROOM-02 TX0 force +5v',
+      'friendly_name': 'HDFury VRROOM-02 TX0 force +5V',
     }),
     'context': <ANY>,
     'entity_id': 'switch.hdfury_vrroom_02_tx0_force_5v',
@@ -804,12 +804,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'TX1 force +5v',
+    'object_id_base': 'TX1 force +5V',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'TX1 force +5v',
+    'original_name': 'TX1 force +5V',
     'platform': 'hdfury',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -822,7 +822,7 @@
 # name: test_switch_entities[switch.hdfury_vrroom_02_tx1_force_5v-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'HDFury VRROOM-02 TX1 force +5v',
+      'friendly_name': 'HDFury VRROOM-02 TX1 force +5V',
     }),
     'context': <ANY>,
     'entity_id': 'switch.hdfury_vrroom_02_tx1_force_5v',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes the incorrect symbol for volts.
As noted by @NoRi2909 in this review: https://github.com/home-assistant/core/pull/162988#discussion_r2807446370

Since the PR was already merged this PR will rectify this finding.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
