### PR TITLE
Handle gateway issues during setup in EnOcean integration

### DIFF
--- a/homeassistant/components/enocean/__init__.py
+++ b/homeassistant/components/enocean/__init__.py
@@ -1,5 +1,6 @@
 """Support for EnOcean devices."""
 
+from serial import SerialException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -45,10 +46,9 @@ async def async_setup_entry(
     """Set up an EnOcean dongle for the given entry."""
     try:
         usb_dongle = EnOceanDongle(hass, config_entry.data[CONF_DEVICE])
-        await usb_dongle.async_setup()
-    except Exception as err:
+    except SerialException as err:
         raise ConfigEntryNotReady(f"Failed to set up EnOcean dongle: {err}") from err
-
+    await usb_dongle.async_setup()
     config_entry.runtime_data = usb_dongle
 
     return True

--- a/homeassistant/components/enocean/__init__.py
+++ b/homeassistant/components/enocean/__init__.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_DEVICE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -42,8 +43,12 @@ async def async_setup_entry(
     hass: HomeAssistant, config_entry: EnOceanConfigEntry
 ) -> bool:
     """Set up an EnOcean dongle for the given entry."""
-    usb_dongle = EnOceanDongle(hass, config_entry.data[CONF_DEVICE])
-    await usb_dongle.async_setup()
+    try:
+        usb_dongle = EnOceanDongle(hass, config_entry.data[CONF_DEVICE])
+        await usb_dongle.async_setup()
+    except Exception as err:
+        raise ConfigEntryNotReady(f"Failed to set up EnOcean dongle: {err}") from err
+
     config_entry.runtime_data = usb_dongle
 
     return True

--- a/tests/components/enocean/conftest.py
+++ b/tests/components/enocean/conftest.py
@@ -1,0 +1,24 @@
+"""Fixtures for EnOcean integration tests."""
+
+from typing import Final
+
+import pytest
+
+from homeassistant.components.enocean.const import DOMAIN
+from homeassistant.const import CONF_DEVICE
+
+from tests.common import MockConfigEntry
+
+ENTRY_CONFIG: Final[dict[str, str]] = {
+    CONF_DEVICE: "/dev/ttyUSB0",
+}
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device_chip_id",
+        data=ENTRY_CONFIG,
+    )

--- a/tests/components/enocean/test_init.py
+++ b/tests/components/enocean/test_init.py
@@ -1,4 +1,4 @@
-"""Test ViCare migration."""
+"""Test the EnOcean integration."""
 
 from unittest.mock import patch
 
@@ -10,18 +10,14 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
-# Device migration test can be removed in 2025.4.0
 async def test_device_not_connected(
-    hass: HomeAssistant,
-    # device_registry: dr.DeviceRegistry,
-    # entity_registry: er.EntityRegistry,
-    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test that a config entry is not ready if the device is not connected."""
     mock_config_entry.add_to_hass(hass)
 
     with patch(
-        "enocean.communicators.serialcommunicator.SerialCommunicator.__init__",
+        "homeassistant.components.enocean.dongle.SerialCommunicator",
         side_effect=SerialException("Device not found"),
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/enocean/test_init.py
+++ b/tests/components/enocean/test_init.py
@@ -1,0 +1,30 @@
+"""Test ViCare migration."""
+
+from unittest.mock import patch
+
+from serial import SerialException
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+# Device migration test can be removed in 2025.4.0
+async def test_device_not_connected(
+    hass: HomeAssistant,
+    # device_registry: dr.DeviceRegistry,
+    # entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a config entry is not ready if the device is not connected."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "enocean.communicators.serialcommunicator.SerialCommunicator.__init__",
+        side_effect=SerialException("Device not found"),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Delay init by catching exception during initial setup when gateway is no longer connected (serial path not found).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
