### PR TITLE
Fix flaky fritz update tests caused by class attribute pollution in test fixtures

### DIFF
--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -105,32 +105,52 @@ def fc_class_mock(fc_data):
 @pytest.fixture
 def fh_class_mock():
     """Fixture that sets up a mocked FritzHosts class."""
-    with patch(
-        "homeassistant.components.fritz.coordinator.FritzHosts",
-        new=FritzHosts,
-    ) as result:
-        result.get_mesh_topology = MagicMock(return_value=MOCK_MESH_DATA)
-        result.get_hosts_attributes = MagicMock(return_value=MOCK_HOST_ATTRIBUTES_DATA)
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.FritzHosts",
+            new=FritzHosts,
+        ) as result,
+        patch.object(
+            FritzHosts,
+            "get_mesh_topology",
+            MagicMock(return_value=MOCK_MESH_DATA),
+        ),
+        patch.object(
+            FritzHosts,
+            "get_hosts_attributes",
+            MagicMock(return_value=MOCK_HOST_ATTRIBUTES_DATA),
+        ),
+    ):
         yield result
 
 
 @pytest.fixture
 def fs_class_mock():
     """Fixture that sets up a mocked FritzStatus class."""
-    with patch(
-        "homeassistant.components.fritz.coordinator.FritzStatus",
-        new=FritzStatus,
-    ) as result:
-        result.get_default_connection_service = MagicMock(
-            return_value=MOCK_STATUS_CONNECTION_DATA
-        )
-        result.get_device_info = MagicMock(
-            return_value=ArgumentNamespace(MOCK_STATUS_DEVICE_INFO_DATA)
-        )
-        result.get_monitor_data = MagicMock(return_value={})
-        result.get_cpu_temperatures = MagicMock(return_value=[42, 38])
-        result.get_avm_device_log = MagicMock(
-            return_value=MOCK_STATUS_AVM_DEVICE_LOG_DATA
-        )
-        result.has_wan_enabled = True
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.FritzStatus",
+            new=FritzStatus,
+        ) as result,
+        patch.object(
+            FritzStatus,
+            "get_default_connection_service",
+            MagicMock(return_value=MOCK_STATUS_CONNECTION_DATA),
+        ),
+        patch.object(
+            FritzStatus,
+            "get_device_info",
+            MagicMock(return_value=ArgumentNamespace(MOCK_STATUS_DEVICE_INFO_DATA)),
+        ),
+        patch.object(FritzStatus, "get_monitor_data", MagicMock(return_value={})),
+        patch.object(
+            FritzStatus, "get_cpu_temperatures", MagicMock(return_value=[42, 38])
+        ),
+        patch.object(
+            FritzStatus,
+            "get_avm_device_log",
+            MagicMock(return_value=MOCK_STATUS_AVM_DEVICE_LOG_DATA),
+        ),
+        patch.object(FritzStatus, "has_wan_enabled", True),
+    ):
         yield result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `fs_class_mock` fixture used `patch("...FritzStatus", new=FritzStatus)` and then directly set attributes on the real `FritzStatus` class (e.g., `result.get_device_info = MagicMock(...)`). The patch context manager only restores the module-level name on teardown, it does not undo class attribute modifications.

When `test_no_software_version` overrode `fs_class_mock.get_device_info` with a mock returning "string_version_not_number", this change persisted on the global `FritzStatus` class after fixture teardown. If the update tests ran afterward (without `fs_class_mock`), they hit the polluted class and failed with `installed_version`: 'string_version_not_number' instead of '7.29'.

The fix replaces direct attribute assignment with `patch.object()`, which saves the original attribute at setup and restores it on teardown regardless of any in-test modifications.

Example CI failure: https://github.com/home-assistant/core/actions/runs/22064660453/job/63754091848?pr=163161

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
