### PR TITLE
Fix CI partial run glob expansion without reintroducing template injection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,9 +169,8 @@ jobs:
 
           if [[ "${INTEGRATION_CHANGES}" != "[]" ]];
           then
-            # Create a file glob for the integrations
-            integrations_glob=$(echo "${INTEGRATION_CHANGES}" | jq -cSr '. | join(",")')
-            [[ "${integrations_glob}" == *","* ]] && integrations_glob="{${integrations_glob}}"
+            # Create a space-separated list of integrations
+            integrations_glob=$(echo "${INTEGRATION_CHANGES}" | jq -r '. | join(" ")')
 
             # Create list of testable integrations
             possible_integrations=$(echo "${INTEGRATION_CHANGES}" | jq -cSr '.[]')
@@ -190,9 +189,8 @@ jobs:
             # Test group count should be 1, we don't split partial tests
             test_group_count=1
 
-            # Create a file glob for the integrations tests
-            tests_glob=$(echo "${tests}" | jq -cSr '. | join(",")')
-            [[ "${tests_glob}" == *","* ]] && tests_glob="{${tests_glob}}"
+            # Create a space-separated list of test integrations
+            tests_glob=$(echo "${tests}" | jq -r '. | join(" ")')
 
             mariadb_groups="[]"
             postgresql_groups="[]"
@@ -716,7 +714,7 @@ jobs:
         run: |
           . venv/bin/activate
           python --version
-          pylint --ignore-missing-annotations=y homeassistant/components/${INTEGRATIONS_GLOB}
+          pylint --ignore-missing-annotations=y $(printf "homeassistant/components/%s " ${INTEGRATIONS_GLOB})
 
   pylint-tests:
     name: Check pylint on tests
@@ -769,7 +767,7 @@ jobs:
         run: |
           . venv/bin/activate
           python --version
-          pylint tests/components/${TESTS_GLOB}
+          pylint $(printf "tests/components/%s " ${TESTS_GLOB})
 
   mypy:
     name: Check mypy
@@ -837,7 +835,7 @@ jobs:
         run: |
           . venv/bin/activate
           python --version
-          mypy homeassistant/components/${INTEGRATIONS_GLOB}
+          mypy $(printf "homeassistant/components/%s " ${INTEGRATIONS_GLOB})
 
   prepare-pytest-full:
     name: Split tests for full run


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Fix broken partial pylint/mypy CI runs caused by bash brace expansion not working with environment variables
- The security hardening in #163076 correctly moved `${{ }}` template expressions to env vars to prevent injection, but brace expansion (`{a,b,c}`) happens before variable expansion in bash's evaluation order, so the glob pattern is never expanded
- Replace brace-expansion patterns with space-separated integration names and use `printf` to build paths in consumer steps

The previous approach built a bash brace-expansion pattern like `{foo,bar,baz}` and relied on `${{ }}` template substitution to inject it literally into the script before bash parsed it. The security hardening moved this to an environment variable, but `${VAR}` expansion happens *after* brace expansion in bash's order of operations, so the braces are treated as literal characters.

The solution in this PR is secure because:
- No `${{ }}` template expressions are used in `run:` scripts (prevents template injection)
- No `eval` is used (prevents command injection from variable content)
- `printf` only formats strings, it doesn't execute anything
- Integration names are alphanumeric + underscore only, safe for word splitting

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
