### PR TITLE
Add meraki dashboard integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1010,6 +1010,8 @@ build.json @home-assistant/supervisor
 /tests/components/melissa/ @kennedyshead
 /homeassistant/components/melnor/ @vanstinator
 /tests/components/melnor/ @vanstinator
+/homeassistant/components/meraki_dashboard/ @cappern
+/tests/components/meraki_dashboard/ @cappern
 /homeassistant/components/met/ @danielhiversen
 /tests/components/met/ @danielhiversen
 /homeassistant/components/met_eireann/ @DylanGore

--- a/homeassistant/brands/cisco.json
+++ b/homeassistant/brands/cisco.json
@@ -1,5 +1,11 @@
 {
   "domain": "cisco",
   "name": "Cisco",
-  "integrations": ["cisco_ios", "cisco_mobility_express", "cisco_webex_teams"]
+  "integrations": [
+    "cisco_ios",
+    "cisco_mobility_express",
+    "cisco_webex_teams",
+    "meraki",
+    "meraki_dashboard"
+  ]
 }

--- a/homeassistant/components/meraki/__init__.py
+++ b/homeassistant/components/meraki/__init__.py
@@ -1,1 +1,39 @@
-"""The meraki component."""
+"""The Meraki integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_SECRET, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, discovery
+
+from .const import CONF_VALIDATOR, DOMAIN
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the Meraki integration."""
+    hass.data.setdefault(DOMAIN, {})
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Meraki from a config entry."""
+    await discovery.async_load_platform(
+        hass,
+        Platform.DEVICE_TRACKER,
+        DOMAIN,
+        {
+            CONF_VALIDATOR: entry.data[CONF_VALIDATOR],
+            CONF_SECRET: entry.data[CONF_SECRET],
+        },
+        {},
+    )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Meraki config entry."""
+    return True

--- a/homeassistant/components/meraki/__init__.py
+++ b/homeassistant/components/meraki/__init__.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SECRET, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, discovery
 
-from .const import CONF_VALIDATOR, DOMAIN
+from .const import CONF_SECRET, CONF_VALIDATOR, DOMAIN
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/homeassistant/components/meraki/config_flow.py
+++ b/homeassistant/components/meraki/config_flow.py
@@ -1,0 +1,36 @@
+"""Config flow for Meraki."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_SECRET
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import CONF_VALIDATOR, DOMAIN
+
+
+class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Meraki."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            return self.async_create_entry(title="Meraki", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_VALIDATOR): str,
+                vol.Required(CONF_SECRET): str,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/homeassistant/components/meraki/config_flow.py
+++ b/homeassistant/components/meraki/config_flow.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_SECRET
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_VALIDATOR, DOMAIN
+from .const import CONF_SECRET, CONF_VALIDATOR, DOMAIN
 
 
 class MerakiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/meraki/const.py
+++ b/homeassistant/components/meraki/const.py
@@ -1,10 +1,9 @@
 """Constants for the Meraki integration."""
 
-from homeassistant.const import CONF_SECRET
-
 DOMAIN = "meraki"
 
 CONF_VALIDATOR = "validator"
+CONF_SECRET = "secret"
 
 URL = "/api/meraki"
 ACCEPTED_VERSIONS = ["2.0", "2.1"]

--- a/homeassistant/components/meraki/const.py
+++ b/homeassistant/components/meraki/const.py
@@ -1,0 +1,18 @@
+"""Constants for the Meraki integration."""
+
+from homeassistant.const import CONF_SECRET
+
+DOMAIN = "meraki"
+
+CONF_VALIDATOR = "validator"
+
+URL = "/api/meraki"
+ACCEPTED_VERSIONS = ["2.0", "2.1"]
+
+__all__ = [
+    "ACCEPTED_VERSIONS",
+    "CONF_SECRET",
+    "CONF_VALIDATOR",
+    "DOMAIN",
+    "URL",
+]

--- a/homeassistant/components/meraki/device_tracker.py
+++ b/homeassistant/components/meraki/device_tracker.py
@@ -18,10 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-CONF_VALIDATOR = "validator"
-CONF_SECRET = "secret"
-URL = "/api/meraki"
-ACCEPTED_VERSIONS = ["2.0", "2.1"]
+from .const import ACCEPTED_VERSIONS, CONF_SECRET, CONF_VALIDATOR, URL
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +36,9 @@ async def async_setup_scanner(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> bool:
     """Set up an endpoint for the Meraki tracker."""
+    if discovery_info is not None:
+        config = discovery_info
+
     hass.http.register_view(MerakiView(config, async_see))
 
     return True

--- a/homeassistant/components/meraki/manifest.json
+++ b/homeassistant/components/meraki/manifest.json
@@ -2,8 +2,12 @@
   "domain": "meraki",
   "name": "Meraki",
   "codeowners": [],
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "documentation": "https://www.home-assistant.io/integrations/meraki",
   "iot_class": "cloud_polling",
-  "quality_scale": "legacy"
+  "quality_scale": "legacy",
+  "config_flow": true,
+  "single_config_entry": true
 }

--- a/homeassistant/components/meraki/manifest.json
+++ b/homeassistant/components/meraki/manifest.json
@@ -2,12 +2,10 @@
   "domain": "meraki",
   "name": "Meraki",
   "codeowners": [],
-  "dependencies": [
-    "http"
-  ],
+  "config_flow": true,
+  "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/meraki",
   "iot_class": "cloud_polling",
   "quality_scale": "legacy",
-  "config_flow": true,
   "single_config_entry": true
 }

--- a/homeassistant/components/meraki/strings.json
+++ b/homeassistant/components/meraki/strings.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "secret": "Secret",
+          "validator": "Validator"
+        },
+        "description": "Set the validator and secret used by your Meraki CMX server",
+        "title": "Set up Meraki"
+      }
+    }
+  }
+}

--- a/homeassistant/components/meraki_dashboard/__init__.py
+++ b/homeassistant/components/meraki_dashboard/__init__.py
@@ -1,0 +1,91 @@
+"""The Meraki Dashboard integration."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import MerakiDashboardApi
+from .const import (
+    CONF_INCLUDED_CLIENTS,
+    CONF_TRACK_BLUETOOTH_CLIENTS,
+    CONF_TRACK_CLIENTS,
+    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+    DEFAULT_TRACK_BLUETOOTH_CLIENTS,
+    DEFAULT_TRACK_CLIENTS,
+    DEFAULT_TRACK_INFRASTRUCTURE_DEVICES,
+    DOMAIN,
+)
+from .coordinator import (
+    MerakiDashboardConfigEntry,
+    MerakiDashboardDataUpdateCoordinator,
+)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+ALL_PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+]
+
+
+def _enabled_platforms(entry: ConfigEntry) -> list[Platform]:
+    """Determine enabled platforms from config entry options."""
+    platforms: list[Platform] = []
+    if entry.options.get(
+        CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS
+    ) or entry.options.get(
+        CONF_TRACK_BLUETOOTH_CLIENTS, DEFAULT_TRACK_BLUETOOTH_CLIENTS
+    ):
+        platforms.append(Platform.DEVICE_TRACKER)
+    if entry.options.get(CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS):
+        platforms.append(Platform.SENSOR)
+    if entry.options.get(
+        CONF_TRACK_INFRASTRUCTURE_DEVICES, DEFAULT_TRACK_INFRASTRUCTURE_DEVICES
+    ):
+        platforms.append(Platform.BINARY_SENSOR)
+        platforms.append(Platform.BUTTON)
+        if Platform.SENSOR not in platforms:
+            platforms.append(Platform.SENSOR)
+    return platforms
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: MerakiDashboardConfigEntry
+) -> bool:
+    """Set up Meraki Dashboard from a config entry."""
+    track_clients = entry.options.get(CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS)
+    track_bluetooth_clients = entry.options.get(
+        CONF_TRACK_BLUETOOTH_CLIENTS, DEFAULT_TRACK_BLUETOOTH_CLIENTS
+    )
+    track_infrastructure_devices = entry.options.get(
+        CONF_TRACK_INFRASTRUCTURE_DEVICES, DEFAULT_TRACK_INFRASTRUCTURE_DEVICES
+    )
+    api = MerakiDashboardApi(async_get_clientsession(hass), entry.data[CONF_API_KEY])
+    coordinator = MerakiDashboardDataUpdateCoordinator(
+        hass,
+        entry,
+        api,
+        track_clients=track_clients,
+        track_bluetooth_clients=track_bluetooth_clients,
+        track_infrastructure_devices=track_infrastructure_devices,
+        included_clients={
+            client_mac
+            for client_mac in entry.options.get(CONF_INCLUDED_CLIENTS, [])
+            if isinstance(client_mac, str)
+        },
+    )
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    if platforms := _enabled_platforms(entry):
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, ALL_PLATFORMS)

--- a/homeassistant/components/meraki_dashboard/api.py
+++ b/homeassistant/components/meraki_dashboard/api.py
@@ -1,0 +1,316 @@
+"""API client for the Meraki Dashboard integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from aiohttp import ClientError, ClientSession
+
+from .const import DEFAULT_BASE_URL, DEFAULT_PER_PAGE, DEFAULT_TIMESPAN_SECONDS
+
+
+class MerakiDashboardApiError(Exception):
+    """Raised when the Meraki Dashboard API returns an error."""
+
+
+class MerakiDashboardApiAuthError(MerakiDashboardApiError):
+    """Raised when the Meraki Dashboard API credentials are invalid."""
+
+
+class MerakiDashboardApiConnectionError(MerakiDashboardApiError):
+    """Raised when the Meraki Dashboard API cannot be reached."""
+
+
+class MerakiDashboardApiRateLimitError(MerakiDashboardApiError):
+    """Raised when the Meraki Dashboard API rate limit is hit."""
+
+    def __init__(self, retry_after: float | None) -> None:
+        """Initialize the error."""
+        super().__init__("Rate limited")
+        self.retry_after = retry_after
+
+
+class MerakiDashboardApi:
+    """Meraki Dashboard API client."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        api_key: str,
+        base_url: str = DEFAULT_BASE_URL,
+    ) -> None:
+        """Initialize the API client."""
+        self._session = session
+        self._api_key = api_key.strip()
+        self._base_url = base_url.rstrip("/")
+
+    async def _async_get(
+        self, path: str, params: Mapping[str, Any] | None = None
+    ) -> Any:
+        """Perform a GET request against the Meraki Dashboard API."""
+        url = f"{self._base_url}/{path.lstrip('/')}"
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "X-Cisco-Meraki-API-Key": self._api_key,
+            "Accept": "application/json",
+        }
+        for attempt in range(5):
+            try:
+                response = await self._session.get(
+                    url,
+                    headers=headers,
+                    params=params,
+                    allow_redirects=False,
+                )
+            except ClientError as err:
+                raise MerakiDashboardApiConnectionError("Cannot connect") from err
+
+            async with response:
+                if response.status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise MerakiDashboardApiError(
+                            "Redirect without location header"
+                        )
+                    url = location
+                    params = None
+                    continue
+
+                if response.status in (401, 403):
+                    raise MerakiDashboardApiAuthError("Invalid API key")
+                if response.status == 429:
+                    retry_after = _retry_after_seconds(
+                        response.headers.get("Retry-After")
+                    )
+                    if attempt == 4:
+                        raise MerakiDashboardApiRateLimitError(retry_after)
+                    await asyncio.sleep(
+                        retry_after if retry_after is not None else min(2**attempt, 30)
+                    )
+                    continue
+                if response.status >= 400:
+                    raise MerakiDashboardApiError(
+                        f"Request failed with status {response.status}"
+                    )
+                if response.status == 204:
+                    return None
+                return await response.json()
+
+        raise MerakiDashboardApiError("Too many redirects")
+
+    async def _async_post(
+        self, path: str, body: Mapping[str, Any] | None = None
+    ) -> Any:
+        """Perform a POST request against the Meraki Dashboard API."""
+        url = f"{self._base_url}/{path.lstrip('/')}"
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "X-Cisco-Meraki-API-Key": self._api_key,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        for attempt in range(5):
+            try:
+                response = await self._session.post(
+                    url,
+                    headers=headers,
+                    json=body,
+                    allow_redirects=False,
+                )
+            except ClientError as err:
+                raise MerakiDashboardApiConnectionError("Cannot connect") from err
+
+            async with response:
+                if response.status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location")
+                    if not location:
+                        raise MerakiDashboardApiError(
+                            "Redirect without location header"
+                        )
+                    url = location
+                    continue
+
+                if response.status in (401, 403):
+                    raise MerakiDashboardApiAuthError("Invalid API key")
+                if response.status == 429:
+                    retry_after = _retry_after_seconds(
+                        response.headers.get("Retry-After")
+                    )
+                    if attempt == 4:
+                        raise MerakiDashboardApiRateLimitError(retry_after)
+                    await asyncio.sleep(
+                        retry_after if retry_after is not None else min(2**attempt, 30)
+                    )
+                    continue
+                if response.status >= 400:
+                    raise MerakiDashboardApiError(
+                        f"Request failed with status {response.status}"
+                    )
+
+                if not response.content_length:
+                    return None
+                return await response.json()
+
+        raise MerakiDashboardApiError("Too many redirects")
+
+    async def async_get_organizations(self) -> list[dict[str, Any]]:
+        """Return organizations available to the API key."""
+        organizations = await self._async_get("/organizations")
+        if not isinstance(organizations, list):
+            raise MerakiDashboardApiError("Unexpected organizations payload")
+        return organizations
+
+    async def async_get_networks(self, organization_id: str) -> list[dict[str, Any]]:
+        """Return networks for a Meraki organization."""
+        networks = await self._async_get(f"/organizations/{organization_id}/networks")
+        if not isinstance(networks, list):
+            raise MerakiDashboardApiError("Unexpected networks payload")
+        return networks
+
+    async def async_get_network_clients(
+        self,
+        network_id: str,
+        *,
+        timespan: int = DEFAULT_TIMESPAN_SECONDS,
+        per_page: int = DEFAULT_PER_PAGE,
+    ) -> list[dict[str, Any]]:
+        """Return clients for a Meraki network."""
+        clients = await self._async_get(
+            f"/networks/{network_id}/clients",
+            params={"timespan": timespan, "perPage": per_page},
+        )
+        if not isinstance(clients, list):
+            raise MerakiDashboardApiError("Unexpected clients payload")
+        return clients
+
+    async def async_get_network_bluetooth_clients(
+        self,
+        network_id: str,
+        *,
+        timespan: int = DEFAULT_TIMESPAN_SECONDS,
+        per_page: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Return Bluetooth clients for a Meraki network."""
+        clients = await self._async_get(
+            f"/networks/{network_id}/bluetoothClients",
+            params={"timespan": timespan, "perPage": per_page},
+        )
+        if not isinstance(clients, list):
+            raise MerakiDashboardApiError("Unexpected Bluetooth clients payload")
+        return clients
+
+    async def async_get_organization_devices_statuses(
+        self, organization_id: str
+    ) -> list[dict[str, Any]]:
+        """Return device statuses for an organization."""
+        statuses = await self._async_get(
+            f"/organizations/{organization_id}/devices/statuses"
+        )
+        if not isinstance(statuses, list):
+            raise MerakiDashboardApiError("Unexpected device statuses payload")
+        return statuses
+
+    async def async_get_device_clients(
+        self,
+        serial: str,
+        *,
+        timespan: int = DEFAULT_TIMESPAN_SECONDS,
+    ) -> list[dict[str, Any]]:
+        """Return clients for a single device."""
+        clients = await self._async_get(
+            f"/devices/{serial}/clients",
+            params={"timespan": timespan},
+        )
+        if not isinstance(clients, list):
+            raise MerakiDashboardApiError("Unexpected device clients payload")
+        return clients
+
+    async def async_get_device_wireless_status(self, serial: str) -> dict[str, Any]:
+        """Return wireless status for an access point."""
+        status = await self._async_get(f"/devices/{serial}/wireless/status")
+        if not isinstance(status, dict):
+            raise MerakiDashboardApiError("Unexpected wireless status payload")
+        return status
+
+    async def async_get_device_switch_ports_statuses(
+        self,
+        serial: str,
+        *,
+        timespan: int = DEFAULT_TIMESPAN_SECONDS,
+    ) -> list[dict[str, Any]]:
+        """Return switch port statuses for a switch."""
+        ports = await self._async_get(
+            f"/devices/{serial}/switch/ports/statuses",
+            params={"timespan": timespan},
+        )
+        if not isinstance(ports, list):
+            raise MerakiDashboardApiError("Unexpected switch port statuses payload")
+        return ports
+
+    async def async_get_device_appliance_performance(
+        self, serial: str
+    ) -> dict[str, Any] | None:
+        """Return appliance performance for an MX firewall."""
+        performance = await self._async_get(f"/devices/{serial}/appliance/performance")
+        if performance is None:
+            return None
+        if not isinstance(performance, dict):
+            raise MerakiDashboardApiError("Unexpected appliance performance payload")
+        return performance
+
+    async def async_get_organization_wireless_channel_utilization_by_device(
+        self,
+        organization_id: str,
+        network_id: str,
+        *,
+        timespan: int = DEFAULT_TIMESPAN_SECONDS,
+    ) -> list[dict[str, Any]]:
+        """Return channel utilization by AP device for a network."""
+        utilization = await self._async_get(
+            f"/organizations/{organization_id}/wireless/devices/channelUtilization/byDevice",
+            params={
+                "networkIds[]": network_id,
+                "timespan": timespan,
+                "interval": 300,
+                "perPage": 1000,
+            },
+        )
+        if not isinstance(utilization, list):
+            raise MerakiDashboardApiError("Unexpected channel utilization payload")
+        return utilization
+
+    async def async_reboot_device(self, serial: str) -> dict[str, Any] | None:
+        """Reboot a device by serial."""
+        result = await self._async_post(f"/devices/{serial}/reboot")
+        if result is None:
+            return None
+        if not isinstance(result, dict):
+            raise MerakiDashboardApiError("Unexpected reboot payload")
+        return result
+
+    async def async_ping_device(
+        self, serial: str, count: int = 3
+    ) -> dict[str, Any] | None:
+        """Queue ping-device live tool for a device."""
+        result = await self._async_post(
+            f"/devices/{serial}/liveTools/pingDevice",
+            {"count": count},
+        )
+        if result is None:
+            return None
+        if not isinstance(result, dict):
+            raise MerakiDashboardApiError("Unexpected ping payload")
+        return result
+
+
+def _retry_after_seconds(raw_retry_after: str | None) -> float | None:
+    """Parse Retry-After header to seconds."""
+    if raw_retry_after is None:
+        return None
+    try:
+        retry_after = float(raw_retry_after)
+    except ValueError:
+        return None
+    return retry_after if retry_after > 0 else None

--- a/homeassistant/components/meraki_dashboard/binary_sensor.py
+++ b/homeassistant/components/meraki_dashboard/binary_sensor.py
@@ -1,0 +1,99 @@
+"""Binary sensors for Meraki Dashboard infrastructure devices."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import (
+    MerakiDashboardConfigEntry,
+    MerakiDashboardDataUpdateCoordinator,
+    MerakiDashboardInfrastructureDevice,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MerakiDashboardConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Meraki Dashboard infrastructure device entities."""
+    coordinator = config_entry.runtime_data
+    tracked_serials: set[str] = set()
+
+    @callback
+    def async_add_new_entities() -> None:
+        latest_devices = set(coordinator.data.infrastructure_devices)
+        entities = [
+            MerakiDashboardDeviceStatusBinarySensor(coordinator, serial)
+            for serial in latest_devices - tracked_serials
+        ]
+
+        tracked_serials.update(latest_devices)
+        if entities:
+            async_add_entities(entities)
+
+    async_add_new_entities()
+    config_entry.async_on_unload(coordinator.async_add_listener(async_add_new_entities))
+
+
+class MerakiDashboardDeviceStatusBinarySensor(
+    CoordinatorEntity[MerakiDashboardDataUpdateCoordinator], BinarySensorEntity
+):
+    """Representation of a Meraki infrastructure device status."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: MerakiDashboardDataUpdateCoordinator, serial: str
+    ) -> None:
+        """Initialize the infrastructure status entity."""
+        super().__init__(coordinator)
+        self._serial = serial
+        self._attr_unique_id = f"{serial}_connectivity"
+
+    @property
+    def _device(self) -> MerakiDashboardInfrastructureDevice | None:
+        """Return device data."""
+        return self.coordinator.data.infrastructure_devices.get(self._serial)
+
+    @property
+    def name(self) -> str:
+        """Return name of the entity."""
+        if (device := self._device) is None:
+            return self._serial
+        return device.name or device.serial
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is currently connected."""
+        return self._device is not None and self._device.status == "online"
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return device information for the infrastructure device."""
+        if (device := self._device) is None:
+            return None
+        connections = set()
+        if device.mac:
+            connections.add((CONNECTION_NETWORK_MAC, device.mac))
+        return DeviceInfo(
+            identifiers={(DOMAIN, device.serial)},
+            connections=connections,
+            manufacturer="Cisco Meraki",
+            model=device.model,
+            name=device.name or device.serial,
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return extra state attributes."""
+        return {}

--- a/homeassistant/components/meraki_dashboard/button.py
+++ b/homeassistant/components/meraki_dashboard/button.py
@@ -1,0 +1,161 @@
+"""Buttons for Meraki Dashboard infrastructure devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import (
+    MerakiDashboardApiAuthError,
+    MerakiDashboardApiConnectionError,
+    MerakiDashboardApiError,
+)
+from .const import DOMAIN
+from .coordinator import (
+    MerakiDashboardConfigEntry,
+    MerakiDashboardDataUpdateCoordinator,
+    MerakiDashboardInfrastructureDevice,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class MerakiDashboardButtonDescription(ButtonEntityDescription):
+    """Description for Meraki Dashboard button entities."""
+
+    action: str
+
+
+BUTTONS: tuple[MerakiDashboardButtonDescription, ...] = (
+    MerakiDashboardButtonDescription(
+        key="reboot",
+        device_class=ButtonDeviceClass.RESTART,
+        entity_category=EntityCategory.CONFIG,
+        action="reboot",
+    ),
+    MerakiDashboardButtonDescription(
+        key="ping",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        action="ping",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MerakiDashboardConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Meraki Dashboard button entities."""
+    coordinator = config_entry.runtime_data
+    tracked_unique_ids: set[str] = set()
+
+    @callback
+    def async_add_new_entities() -> None:
+        entities: list[MerakiDashboardDeviceActionButton] = []
+        for serial in coordinator.data.infrastructure_devices:
+            for description in BUTTONS:
+                unique_id = f"{serial}_{description.key}"
+                if unique_id in tracked_unique_ids:
+                    continue
+                tracked_unique_ids.add(unique_id)
+                entities.append(
+                    MerakiDashboardDeviceActionButton(coordinator, serial, description)
+                )
+
+        if entities:
+            async_add_entities(entities)
+
+    async_add_new_entities()
+    config_entry.async_on_unload(coordinator.async_add_listener(async_add_new_entities))
+
+
+class MerakiDashboardDeviceActionButton(
+    CoordinatorEntity[MerakiDashboardDataUpdateCoordinator], ButtonEntity
+):
+    """Representation of a Meraki infrastructure action button."""
+
+    _attr_has_entity_name = True
+    entity_description: MerakiDashboardButtonDescription
+
+    def __init__(
+        self,
+        coordinator: MerakiDashboardDataUpdateCoordinator,
+        serial: str,
+        description: MerakiDashboardButtonDescription,
+    ) -> None:
+        """Initialize action button."""
+        super().__init__(coordinator)
+        self._serial = serial
+        self.entity_description = description
+        self._attr_unique_id = f"{serial}_{description.key}"
+        self._last_result: str | None = None
+
+    @property
+    def _device(self) -> MerakiDashboardInfrastructureDevice | None:
+        """Return current device details."""
+        return self.coordinator.data.infrastructure_devices.get(self._serial)
+
+    @property
+    def name(self) -> str:
+        """Return entity name."""
+        if self.entity_description.key == "reboot":
+            return "Reboot"
+        return "Ping"
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self._device is not None and super().available
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return linked device info."""
+        if (device := self._device) is None:
+            return None
+        connections = set()
+        if device.mac:
+            connections.add((CONNECTION_NETWORK_MAC, device.mac))
+        return DeviceInfo(
+            identifiers={(DOMAIN, device.serial)},
+            connections=connections,
+            manufacturer="Cisco Meraki",
+            model=device.model,
+            name=device.name or device.serial,
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        return {"last_result": self._last_result}
+
+    async def async_press(self) -> None:
+        """Press the action button."""
+        try:
+            if self.entity_description.action == "reboot":
+                result = await self.coordinator.api.async_reboot_device(self._serial)
+                self._last_result = (
+                    "queued" if result is None else str(result.get("success"))
+                )
+            else:
+                result = await self.coordinator.api.async_ping_device(self._serial)
+                self._last_result = (
+                    "queued" if result is None else str(result.get("status"))
+                )
+        except MerakiDashboardApiAuthError as err:
+            raise HomeAssistantError("Authentication failed") from err
+        except MerakiDashboardApiConnectionError as err:
+            raise HomeAssistantError("Cannot connect to Meraki") from err
+        except MerakiDashboardApiError as err:
+            raise HomeAssistantError(f"Meraki API error: {err}") from err

--- a/homeassistant/components/meraki_dashboard/config_flow.py
+++ b/homeassistant/components/meraki_dashboard/config_flow.py
@@ -1,0 +1,355 @@
+"""Config flow for Meraki Dashboard."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .api import (
+    MerakiDashboardApi,
+    MerakiDashboardApiAuthError,
+    MerakiDashboardApiConnectionError,
+    MerakiDashboardApiError,
+)
+from .const import (
+    CONF_INCLUDED_CLIENTS,
+    CONF_NETWORK_ID,
+    CONF_NETWORK_NAME,
+    CONF_ORGANIZATION_ID,
+    CONF_TRACK_BLUETOOTH_CLIENTS,
+    CONF_TRACK_CLIENTS,
+    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+    DEFAULT_TIMESPAN_SECONDS,
+    DEFAULT_TRACK_BLUETOOTH_CLIENTS,
+    DEFAULT_TRACK_CLIENTS,
+    DEFAULT_TRACK_INFRASTRUCTURE_DEVICES,
+    DOMAIN,
+)
+
+
+class MerakiDashboardConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Meraki Dashboard."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._api_key: str | None = None
+        self._organizations: dict[str, str] = {}
+        self._organization_id: str | None = None
+        self._networks: dict[str, str] = {}
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> MerakiDashboardOptionsFlow:
+        """Get the options flow for this handler."""
+        return MerakiDashboardOptionsFlow()
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._api_key = user_input[CONF_API_KEY].strip()
+            api = MerakiDashboardApi(async_get_clientsession(self.hass), self._api_key)
+            try:
+                organizations = await api.async_get_organizations()
+            except MerakiDashboardApiAuthError:
+                errors["base"] = "invalid_auth"
+            except MerakiDashboardApiConnectionError:
+                errors["base"] = "cannot_connect"
+            except MerakiDashboardApiError:
+                errors["base"] = "unknown"
+            else:
+                self._organizations = {
+                    organization["id"]: organization["name"]
+                    for organization in organizations
+                    if "id" in organization and "name" in organization
+                }
+                if not self._organizations:
+                    errors["base"] = "no_organizations"
+                elif len(self._organizations) == 1:
+                    self._organization_id = next(iter(self._organizations))
+                    return await self._async_step_load_networks()
+                else:
+                    return await self.async_step_organization()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
+            errors=errors,
+        )
+
+    async def async_step_organization(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select Meraki organization."""
+        if user_input is not None:
+            self._organization_id = user_input[CONF_ORGANIZATION_ID]
+            return await self._async_step_load_networks()
+
+        organizations = [
+            SelectOptionDict(value=org_id, label=org_name)
+            for org_id, org_name in sorted(
+                self._organizations.items(), key=lambda item: item[1]
+            )
+        ]
+
+        return self.async_show_form(
+            step_id="organization",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ORGANIZATION_ID): SelectSelector(
+                        SelectSelectorConfig(
+                            options=organizations, mode=SelectSelectorMode.DROPDOWN
+                        )
+                    ),
+                }
+            ),
+        )
+
+    async def _async_step_load_networks(self) -> ConfigFlowResult:
+        """Load Meraki networks for selected organization."""
+        if self._api_key is None or self._organization_id is None:
+            return self.async_abort(reason="unknown")
+
+        api = MerakiDashboardApi(async_get_clientsession(self.hass), self._api_key)
+        try:
+            networks = await api.async_get_networks(self._organization_id)
+        except MerakiDashboardApiAuthError:
+            return self.async_abort(reason="invalid_auth")
+        except MerakiDashboardApiConnectionError:
+            return self.async_abort(reason="cannot_connect")
+        except MerakiDashboardApiError:
+            return self.async_abort(reason="unknown")
+
+        self._networks = {
+            network["id"]: network["name"]
+            for network in networks
+            if "id" in network and "name" in network
+        }
+        if not self._networks:
+            return self.async_abort(reason="no_networks")
+
+        return await self.async_step_network()
+
+    async def async_step_network(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select Meraki network."""
+        if user_input is not None and self._api_key and self._organization_id:
+            if not (
+                user_input[CONF_TRACK_CLIENTS]
+                or user_input[CONF_TRACK_BLUETOOTH_CLIENTS]
+                or user_input[CONF_TRACK_INFRASTRUCTURE_DEVICES]
+            ):
+                return self.async_show_form(
+                    step_id="network",
+                    data_schema=self._network_schema(),
+                    errors={"base": "at_least_one_enabled"},
+                )
+            network_id = user_input[CONF_NETWORK_ID]
+            await self.async_set_unique_id(network_id)
+            self._abort_if_unique_id_configured()
+            network_name = self._networks[network_id]
+
+            return self.async_create_entry(
+                title=network_name,
+                data={
+                    CONF_API_KEY: self._api_key,
+                    CONF_ORGANIZATION_ID: self._organization_id,
+                    CONF_NETWORK_ID: network_id,
+                    CONF_NETWORK_NAME: network_name,
+                },
+                options={
+                    CONF_TRACK_CLIENTS: user_input[CONF_TRACK_CLIENTS],
+                    CONF_TRACK_BLUETOOTH_CLIENTS: user_input[
+                        CONF_TRACK_BLUETOOTH_CLIENTS
+                    ],
+                    CONF_TRACK_INFRASTRUCTURE_DEVICES: user_input[
+                        CONF_TRACK_INFRASTRUCTURE_DEVICES
+                    ],
+                    CONF_INCLUDED_CLIENTS: [],
+                },
+            )
+
+        return self.async_show_form(
+            step_id="network", data_schema=self._network_schema()
+        )
+
+    def _network_schema(self) -> vol.Schema:
+        """Return schema for network selection step."""
+        networks = [
+            SelectOptionDict(value=network_id, label=network_name)
+            for network_id, network_name in sorted(
+                self._networks.items(), key=lambda item: item[1]
+            )
+        ]
+
+        return vol.Schema(
+            {
+                vol.Required(CONF_NETWORK_ID): SelectSelector(
+                    SelectSelectorConfig(
+                        options=networks, mode=SelectSelectorMode.DROPDOWN
+                    )
+                ),
+                vol.Required(CONF_TRACK_CLIENTS, default=DEFAULT_TRACK_CLIENTS): bool,
+                vol.Required(
+                    CONF_TRACK_BLUETOOTH_CLIENTS,
+                    default=DEFAULT_TRACK_BLUETOOTH_CLIENTS,
+                ): bool,
+                vol.Required(
+                    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+                    default=DEFAULT_TRACK_INFRASTRUCTURE_DEVICES,
+                ): bool,
+            }
+        )
+
+
+class MerakiDashboardOptionsFlow(OptionsFlowWithReload):
+    """Handle options for Meraki Dashboard."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage options."""
+        client_options = await self._async_get_client_options()
+        if user_input is not None:
+            if not (
+                user_input[CONF_TRACK_CLIENTS]
+                or user_input[CONF_TRACK_BLUETOOTH_CLIENTS]
+                or user_input[CONF_TRACK_INFRASTRUCTURE_DEVICES]
+            ):
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=self._options_schema(client_options),
+                    errors={"base": "at_least_one_enabled"},
+                )
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self._options_schema(client_options),
+        )
+
+    def _options_schema(self, client_options: list[SelectOptionDict]) -> vol.Schema:
+        """Build options schema."""
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_TRACK_CLIENTS,
+                    default=self.config_entry.options.get(
+                        CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_TRACK_BLUETOOTH_CLIENTS,
+                    default=self.config_entry.options.get(
+                        CONF_TRACK_BLUETOOTH_CLIENTS,
+                        DEFAULT_TRACK_BLUETOOTH_CLIENTS,
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+                    default=self.config_entry.options.get(
+                        CONF_TRACK_INFRASTRUCTURE_DEVICES,
+                        DEFAULT_TRACK_INFRASTRUCTURE_DEVICES,
+                    ),
+                ): bool,
+                vol.Required(
+                    CONF_INCLUDED_CLIENTS,
+                    default=self.config_entry.options.get(CONF_INCLUDED_CLIENTS, []),
+                ): SelectSelector(
+                    SelectSelectorConfig(
+                        options=client_options,
+                        mode=SelectSelectorMode.DROPDOWN,
+                        multiple=True,
+                    )
+                ),
+            }
+        )
+
+    async def _async_get_client_options(self) -> list[SelectOptionDict]:
+        """Build list of selectable clients for tracker inclusion."""
+        api = MerakiDashboardApi(
+            async_get_clientsession(self.hass),
+            self.config_entry.data[CONF_API_KEY],
+        )
+        clients: list[dict[str, Any]] = []
+        bluetooth_clients: list[dict[str, Any]] = []
+
+        if self.config_entry.options.get(CONF_TRACK_CLIENTS, DEFAULT_TRACK_CLIENTS):
+            try:
+                clients = await api.async_get_network_clients(
+                    self.config_entry.data[CONF_NETWORK_ID],
+                    timespan=DEFAULT_TIMESPAN_SECONDS,
+                )
+            except (
+                MerakiDashboardApiAuthError,
+                MerakiDashboardApiConnectionError,
+                MerakiDashboardApiError,
+            ):
+                clients = []
+
+        if self.config_entry.options.get(
+            CONF_TRACK_BLUETOOTH_CLIENTS, DEFAULT_TRACK_BLUETOOTH_CLIENTS
+        ):
+            try:
+                bluetooth_clients = await api.async_get_network_bluetooth_clients(
+                    self.config_entry.data[CONF_NETWORK_ID],
+                    timespan=DEFAULT_TIMESPAN_SECONDS,
+                )
+            except (
+                MerakiDashboardApiAuthError,
+                MerakiDashboardApiConnectionError,
+                MerakiDashboardApiError,
+            ):
+                bluetooth_clients = []
+
+        options_by_mac: dict[str, SelectOptionDict] = {}
+        for client in clients:
+            mac = format_mac(client.get("mac", ""))
+            if not mac:
+                continue
+            if mac in options_by_mac:
+                continue
+            label = (
+                client.get("description")
+                or client.get("dhcpHostname")
+                or client.get("mdnsName")
+                or mac
+            )
+            options_by_mac[mac] = SelectOptionDict(value=mac, label=f"{label} ({mac})")
+
+        for bluetooth_client in bluetooth_clients:
+            mac = format_mac(bluetooth_client.get("mac", ""))
+            if not mac or mac in options_by_mac:
+                continue
+            label = (
+                bluetooth_client.get("name")
+                or bluetooth_client.get("deviceName")
+                or mac
+            )
+            options_by_mac[mac] = SelectOptionDict(value=mac, label=f"{label} ({mac})")
+
+        return sorted(options_by_mac.values(), key=lambda option: option["label"])

--- a/homeassistant/components/meraki_dashboard/const.py
+++ b/homeassistant/components/meraki_dashboard/const.py
@@ -1,0 +1,24 @@
+"""Constants for the Meraki Dashboard integration."""
+
+from datetime import timedelta
+from typing import Final
+
+DOMAIN: Final = "meraki_dashboard"
+
+CONF_NETWORK_ID: Final = "network_id"
+CONF_NETWORK_NAME: Final = "network_name"
+CONF_ORGANIZATION_ID: Final = "organization_id"
+
+DEFAULT_BASE_URL: Final = "https://api.meraki.com/api/v1"
+DEFAULT_TIMESPAN_SECONDS: Final = 300
+DEFAULT_PER_PAGE: Final = 5000
+UPDATE_INTERVAL: Final = timedelta(minutes=5)
+
+CONF_TRACK_CLIENTS: Final = "track_clients"
+CONF_TRACK_BLUETOOTH_CLIENTS: Final = "track_bluetooth_clients"
+CONF_TRACK_INFRASTRUCTURE_DEVICES: Final = "track_infrastructure_devices"
+CONF_INCLUDED_CLIENTS: Final = "included_clients"
+
+DEFAULT_TRACK_CLIENTS: Final = True
+DEFAULT_TRACK_BLUETOOTH_CLIENTS: Final = False
+DEFAULT_TRACK_INFRASTRUCTURE_DEVICES: Final = True

--- a/homeassistant/components/meraki_dashboard/coordinator.py
+++ b/homeassistant/components/meraki_dashboard/coordinator.py
@@ -1,0 +1,624 @@
+"""DataUpdateCoordinator for Meraki Dashboard."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from dataclasses import dataclass
+import logging
+from typing import Any, cast
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import (
+    MerakiDashboardApi,
+    MerakiDashboardApiAuthError,
+    MerakiDashboardApiConnectionError,
+    MerakiDashboardApiError,
+    MerakiDashboardApiRateLimitError,
+)
+from .const import (
+    CONF_NETWORK_ID,
+    CONF_ORGANIZATION_ID,
+    DEFAULT_TIMESPAN_SECONDS,
+    DOMAIN,
+    UPDATE_INTERVAL,
+)
+
+_LOGGER = logging.getLogger(__name__)
+RATE_LIMIT_ISSUE_ID = "rate_limited"
+
+
+@dataclass(slots=True)
+class MerakiDashboardClient:
+    """Representation of a network client from Meraki."""
+
+    mac: str
+    status: str | None
+    description: str | None
+    dhcp_hostname: str | None
+    mdns_name: str | None
+    manufacturer: str | None
+    ip_address: str | None
+    ip6_address: str | None
+    recent_device_name: str | None
+    recent_device_serial: str | None
+    recent_device_connection: str | None
+    last_seen: int | None
+    first_seen: int | None
+    ssid: str | None
+    vlan: str | None
+    named_vlan: str | None
+    switchport: str | None
+
+
+@dataclass(slots=True)
+class MerakiDashboardInfrastructureDevice:
+    """Representation of infrastructure device from Meraki."""
+
+    serial: str
+    name: str | None
+    model: str | None
+    mac: str | None
+    product_type: str | None
+    status: str | None
+    network_id: str | None
+    public_ip: str | None
+    lan_ip: str | None
+    gateway: str | None
+    ip_type: str | None
+    primary_dns: str | None
+    secondary_dns: str | None
+    last_reported_at: str | None
+    wireless_clients: int | None
+    ap_enabled_ssids: int | None
+    ap_channels_in_use: str | None
+    ap_bands_in_use: str | None
+    ap_channels_2_4ghz: str | None
+    ap_channels_5ghz: str | None
+    ap_channels_6ghz: str | None
+    ap_channel_utilization_2_4ghz: float | None
+    ap_channel_utilization_5ghz: float | None
+    ap_channel_utilization_6ghz: float | None
+    switch_total_ports: int | None
+    switch_connected_ports: int | None
+    switch_connected_clients: int | None
+    switch_active_poe_ports: int | None
+    appliance_clients: int | None
+    appliance_performance_score: float | None
+
+
+@dataclass(slots=True)
+class MerakiDashboardData:
+    """Combined data model for Meraki Dashboard integration."""
+
+    clients: dict[str, MerakiDashboardClient]
+    infrastructure_devices: dict[str, MerakiDashboardInfrastructureDevice]
+
+
+type MerakiDashboardConfigEntry = ConfigEntry[MerakiDashboardDataUpdateCoordinator]
+
+
+class MerakiDashboardDataUpdateCoordinator(DataUpdateCoordinator[MerakiDashboardData]):
+    """Coordinate Meraki Dashboard updates."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: MerakiDashboardConfigEntry,
+        api: MerakiDashboardApi,
+        *,
+        track_clients: bool,
+        track_bluetooth_clients: bool,
+        track_infrastructure_devices: bool,
+        included_clients: set[str],
+    ) -> None:
+        """Initialize coordinator."""
+        self.api = api
+        self.network_id = config_entry.data[CONF_NETWORK_ID]
+        self.organization_id = config_entry.data[CONF_ORGANIZATION_ID]
+        self.track_clients = track_clients
+        self.track_bluetooth_clients = track_bluetooth_clients
+        self.track_infrastructure_devices = track_infrastructure_devices
+        self.included_clients = included_clients
+        super().__init__(
+            hass,
+            logger=_LOGGER,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+            config_entry=config_entry,
+        )
+
+    async def _async_update_data(self) -> MerakiDashboardData:
+        """Fetch latest data from API endpoint."""
+        try:
+            clients: list[dict[str, Any]] = []
+            bluetooth_clients: list[dict[str, Any]] = []
+            if self.track_clients and self.track_bluetooth_clients:
+                clients, bluetooth_clients = await asyncio.gather(
+                    self.api.async_get_network_clients(
+                        self.network_id,
+                        timespan=DEFAULT_TIMESPAN_SECONDS,
+                    ),
+                    self.api.async_get_network_bluetooth_clients(
+                        self.network_id,
+                        timespan=DEFAULT_TIMESPAN_SECONDS,
+                    ),
+                )
+            elif self.track_clients:
+                clients = await self.api.async_get_network_clients(
+                    self.network_id,
+                    timespan=DEFAULT_TIMESPAN_SECONDS,
+                )
+            elif self.track_bluetooth_clients:
+                bluetooth_clients = await self.api.async_get_network_bluetooth_clients(
+                    self.network_id,
+                    timespan=DEFAULT_TIMESPAN_SECONDS,
+                )
+
+            device_statuses: list[dict[str, Any]] = []
+            if self.track_infrastructure_devices:
+                device_statuses = (
+                    await self.api.async_get_organization_devices_statuses(
+                        self.organization_id
+                    )
+                )
+            ir.async_delete_issue(self.hass, DOMAIN, RATE_LIMIT_ISSUE_ID)
+        except MerakiDashboardApiAuthError as err:
+            raise ConfigEntryAuthFailed("Invalid API key") from err
+        except MerakiDashboardApiRateLimitError as err:
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                RATE_LIMIT_ISSUE_ID,
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key=RATE_LIMIT_ISSUE_ID,
+            )
+            raise UpdateFailed("Meraki API rate limit reached") from err
+        except MerakiDashboardApiConnectionError as err:
+            raise UpdateFailed("Cannot connect") from err
+        except MerakiDashboardApiError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+        mapped_clients: dict[str, MerakiDashboardClient] = {}
+        for client in clients:
+            mac_address = format_mac(client.get("mac", ""))
+            if not mac_address:
+                continue
+            if self.included_clients and mac_address not in self.included_clients:
+                continue
+
+            mapped_clients[mac_address] = MerakiDashboardClient(
+                mac=mac_address,
+                status=client.get("status"),
+                description=client.get("description"),
+                dhcp_hostname=client.get("dhcpHostname"),
+                mdns_name=client.get("mdnsName"),
+                manufacturer=client.get("manufacturer"),
+                ip_address=client.get("ip"),
+                ip6_address=client.get("ip6"),
+                recent_device_name=client.get("recentDeviceName"),
+                recent_device_serial=client.get("recentDeviceSerial"),
+                recent_device_connection=client.get("recentDeviceConnection"),
+                last_seen=client.get("lastSeen"),
+                first_seen=client.get("firstSeen"),
+                ssid=client.get("ssid"),
+                vlan=client.get("vlan"),
+                named_vlan=client.get("namedVlan"),
+                switchport=client.get("switchport"),
+            )
+
+        for bluetooth_client in bluetooth_clients:
+            mac_address = format_mac(bluetooth_client.get("mac", ""))
+            if not mac_address:
+                continue
+            if self.included_clients and mac_address not in self.included_clients:
+                continue
+
+            existing_client = mapped_clients.get(mac_address)
+            bluetooth_name = bluetooth_client.get("name") or bluetooth_client.get(
+                "deviceName"
+            )
+            bluetooth_last_seen = bluetooth_client.get("lastSeen")
+            if existing_client is not None:
+                existing_client.status = "Online"
+                if not existing_client.description:
+                    existing_client.description = bluetooth_name
+                if not existing_client.manufacturer:
+                    existing_client.manufacturer = bluetooth_client.get("manufacturer")
+                if (
+                    isinstance(existing_client.last_seen, int)
+                    and isinstance(bluetooth_last_seen, int)
+                    and bluetooth_last_seen > existing_client.last_seen
+                ) or (
+                    existing_client.last_seen is None
+                    and isinstance(bluetooth_last_seen, int)
+                ):
+                    existing_client.last_seen = bluetooth_last_seen
+                if not existing_client.recent_device_connection:
+                    existing_client.recent_device_connection = "Bluetooth"
+                continue
+
+            mapped_clients[mac_address] = MerakiDashboardClient(
+                mac=mac_address,
+                status="Online",
+                description=bluetooth_name,
+                dhcp_hostname=None,
+                mdns_name=bluetooth_client.get("deviceName"),
+                manufacturer=bluetooth_client.get("manufacturer"),
+                ip_address=None,
+                ip6_address=None,
+                recent_device_name=None,
+                recent_device_serial=None,
+                recent_device_connection="Bluetooth",
+                last_seen=bluetooth_last_seen,
+                first_seen=None,
+                ssid=None,
+                vlan=None,
+                named_vlan=None,
+                switchport=None,
+            )
+
+        raw_infrastructure_devices: dict[str, dict[str, Any]] = {}
+        for device in device_statuses:
+            serial = device.get("serial")
+            if not serial or device.get("networkId") != self.network_id:
+                continue
+
+            product_type = device.get("productType")
+            if product_type not in {"switch", "appliance", "wireless"}:
+                continue
+
+            raw_infrastructure_devices[serial] = device
+
+        infrastructure_details = await self._async_fetch_infrastructure_details(
+            raw_infrastructure_devices
+        )
+
+        mapped_devices = {
+            serial: MerakiDashboardInfrastructureDevice(
+                serial=serial,
+                name=device.get("name"),
+                model=device.get("model"),
+                mac=format_mac(device.get("mac", "")) or None,
+                product_type=cast(str | None, device.get("productType")),
+                status=device.get("status"),
+                network_id=device.get("networkId"),
+                public_ip=device.get("publicIp"),
+                lan_ip=device.get("lanIp"),
+                gateway=device.get("gateway"),
+                ip_type=device.get("ipType"),
+                primary_dns=device.get("primaryDns"),
+                secondary_dns=device.get("secondaryDns"),
+                last_reported_at=device.get("lastReportedAt"),
+                wireless_clients=infrastructure_details.get(serial, {}).get(
+                    "wireless_clients"
+                ),
+                ap_enabled_ssids=infrastructure_details.get(serial, {}).get(
+                    "ap_enabled_ssids"
+                ),
+                ap_channels_in_use=infrastructure_details.get(serial, {}).get(
+                    "ap_channels_in_use"
+                ),
+                ap_bands_in_use=infrastructure_details.get(serial, {}).get(
+                    "ap_bands_in_use"
+                ),
+                ap_channels_2_4ghz=infrastructure_details.get(serial, {}).get(
+                    "ap_channels_2_4ghz"
+                ),
+                ap_channels_5ghz=infrastructure_details.get(serial, {}).get(
+                    "ap_channels_5ghz"
+                ),
+                ap_channels_6ghz=infrastructure_details.get(serial, {}).get(
+                    "ap_channels_6ghz"
+                ),
+                ap_channel_utilization_2_4ghz=infrastructure_details.get(
+                    serial, {}
+                ).get("ap_channel_utilization_2_4ghz"),
+                ap_channel_utilization_5ghz=infrastructure_details.get(serial, {}).get(
+                    "ap_channel_utilization_5ghz"
+                ),
+                ap_channel_utilization_6ghz=infrastructure_details.get(serial, {}).get(
+                    "ap_channel_utilization_6ghz"
+                ),
+                switch_total_ports=infrastructure_details.get(serial, {}).get(
+                    "switch_total_ports"
+                ),
+                switch_connected_ports=infrastructure_details.get(serial, {}).get(
+                    "switch_connected_ports"
+                ),
+                switch_connected_clients=infrastructure_details.get(serial, {}).get(
+                    "switch_connected_clients"
+                ),
+                switch_active_poe_ports=infrastructure_details.get(serial, {}).get(
+                    "switch_active_poe_ports"
+                ),
+                appliance_clients=infrastructure_details.get(serial, {}).get(
+                    "appliance_clients"
+                ),
+                appliance_performance_score=infrastructure_details.get(serial, {}).get(
+                    "appliance_performance_score"
+                ),
+            )
+            for serial, device in raw_infrastructure_devices.items()
+        }
+
+        return MerakiDashboardData(
+            clients=mapped_clients,
+            infrastructure_devices=mapped_devices,
+        )
+
+    async def _async_fetch_infrastructure_details(
+        self, devices: dict[str, dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch infrastructure details by product type."""
+        details: dict[str, dict[str, Any]] = {serial: {} for serial in devices}
+        wireless_channel_utilization = (
+            await self._async_get_wireless_channel_utilization(devices)
+        )
+
+        tasks: list[Awaitable[None]] = []
+        for serial, device in devices.items():
+            match device.get("productType"):
+                case "wireless":
+                    tasks.append(
+                        self._async_fetch_wireless_details(
+                            serial, details, wireless_channel_utilization
+                        )
+                    )
+                case "switch":
+                    tasks.append(self._async_fetch_switch_details(serial, details))
+                case "appliance":
+                    tasks.append(self._async_fetch_appliance_details(serial, details))
+
+        if tasks:
+            await asyncio.gather(*tasks)
+
+        return details
+
+    async def _async_get_wireless_channel_utilization(
+        self, devices: dict[str, dict[str, Any]]
+    ) -> dict[str, dict[str, float]]:
+        """Fetch wireless channel utilization for wireless devices."""
+        if not any(
+            device.get("productType") == "wireless" for device in devices.values()
+        ):
+            return {}
+
+        try:
+            utilization_entries = await (
+                self.api.async_get_organization_wireless_channel_utilization_by_device(
+                    self.organization_id,
+                    self.network_id,
+                    timespan=DEFAULT_TIMESPAN_SECONDS,
+                )
+            )
+        except MerakiDashboardApiAuthError:
+            raise
+        except (MerakiDashboardApiConnectionError, MerakiDashboardApiError) as err:
+            _LOGGER.debug("Unable to fetch channel utilization data: %s", err)
+            return {}
+
+        return self._parse_wireless_channel_utilization(utilization_entries)
+
+    def _parse_wireless_channel_utilization(
+        self, utilization_entries: list[dict[str, Any]]
+    ) -> dict[str, dict[str, float]]:
+        """Parse wireless utilization response indexed by serial and band."""
+        wireless_channel_utilization: dict[str, dict[str, float]] = {}
+
+        for entry in utilization_entries:
+            serial = entry.get("serial")
+            if not isinstance(serial, str):
+                continue
+            by_band = entry.get("byBand")
+            if not isinstance(by_band, list):
+                continue
+
+            band_data: dict[str, float] = {}
+            for band_entry in by_band:
+                if not isinstance(band_entry, dict):
+                    continue
+                band = band_entry.get("band")
+                if not isinstance(band, str):
+                    continue
+                total = band_entry.get("total")
+                percentage = (
+                    total.get("percentage") if isinstance(total, dict) else None
+                )
+                if isinstance(percentage, int | float):
+                    band_data[band] = float(percentage)
+
+            if band_data:
+                wireless_channel_utilization[serial] = band_data
+
+        return wireless_channel_utilization
+
+    async def _async_fetch_wireless_details(
+        self,
+        serial: str,
+        details: dict[str, dict[str, Any]],
+        wireless_channel_utilization: dict[str, dict[str, float]],
+    ) -> None:
+        """Fetch optional details for a wireless device."""
+        if (
+            clients := await self._async_call_optional(
+                serial,
+                "device clients",
+                self.api.async_get_device_clients(
+                    serial, timespan=DEFAULT_TIMESPAN_SECONDS
+                ),
+            )
+        ) is not None:
+            details[serial]["wireless_clients"] = len(clients)
+
+        if (
+            status := await self._async_call_optional(
+                serial,
+                "wireless status",
+                self.api.async_get_device_wireless_status(serial),
+            )
+        ) is None:
+            return
+
+        enabled_sets = self._extract_enabled_service_sets(status)
+        details[serial]["ap_enabled_ssids"] = len(enabled_sets)
+
+        if channels := self._format_channels(enabled_sets):
+            details[serial]["ap_channels_in_use"] = channels
+        if bands := self._format_bands(enabled_sets):
+            details[serial]["ap_bands_in_use"] = bands
+
+        for band_name, details_key in (
+            ("2.4", "ap_channels_2_4ghz"),
+            ("5", "ap_channels_5ghz"),
+            ("6", "ap_channels_6ghz"),
+        ):
+            if channels_for_band := self._format_channels(enabled_sets, band_name):
+                details[serial][details_key] = channels_for_band
+
+        self._apply_channel_utilization(
+            details[serial], wireless_channel_utilization.get(serial)
+        )
+
+    def _extract_enabled_service_sets(
+        self, status: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Return enabled service sets from the wireless status payload."""
+        service_sets = status.get("basicServiceSets")
+        if not isinstance(service_sets, list):
+            return []
+        return [
+            entry
+            for entry in service_sets
+            if isinstance(entry, dict) and entry.get("enabled") is True
+        ]
+
+    def _format_channels(
+        self, enabled_sets: list[dict[str, Any]], band_name: str | None = None
+    ) -> str | None:
+        """Format unique channels from enabled SSIDs."""
+        channels = sorted(
+            {
+                str(channel)
+                for entry in enabled_sets
+                if (channel := entry.get("channel")) is not None
+                and (
+                    band_name is None
+                    or (
+                        isinstance(entry.get("band"), str)
+                        and cast(str, entry["band"]).startswith(band_name)
+                    )
+                )
+            },
+            key=int,
+        )
+        if not channels:
+            return None
+        return ", ".join(channels)
+
+    def _format_bands(self, enabled_sets: list[dict[str, Any]]) -> str | None:
+        """Format unique bands from enabled SSIDs."""
+        bands = sorted(
+            {
+                str(band)
+                for entry in enabled_sets
+                if (band := entry.get("band")) is not None
+            }
+        )
+        if not bands:
+            return None
+        return ", ".join(bands)
+
+    def _apply_channel_utilization(
+        self, device_details: dict[str, Any], band_utilization: dict[str, float] | None
+    ) -> None:
+        """Apply channel utilization values for known bands."""
+        if not band_utilization:
+            return
+        if "2.4" in band_utilization:
+            device_details["ap_channel_utilization_2_4ghz"] = band_utilization["2.4"]
+        if "5" in band_utilization:
+            device_details["ap_channel_utilization_5ghz"] = band_utilization["5"]
+        if "6" in band_utilization:
+            device_details["ap_channel_utilization_6ghz"] = band_utilization["6"]
+
+    async def _async_fetch_switch_details(
+        self, serial: str, details: dict[str, dict[str, Any]]
+    ) -> None:
+        """Fetch optional details for a switch device."""
+        if (
+            ports := await self._async_call_optional(
+                serial,
+                "switch port statuses",
+                self.api.async_get_device_switch_ports_statuses(
+                    serial, timespan=DEFAULT_TIMESPAN_SECONDS
+                ),
+            )
+        ) is None:
+            return
+
+        details[serial]["switch_total_ports"] = len(ports)
+        details[serial]["switch_connected_ports"] = sum(
+            1 for port in ports if port.get("status") == "Connected"
+        )
+        details[serial]["switch_connected_clients"] = sum(
+            client_count
+            for port in ports
+            if isinstance((client_count := port.get("clientCount")), int)
+        )
+        details[serial]["switch_active_poe_ports"] = sum(
+            1
+            for port in ports
+            if isinstance(port.get("poe"), dict)
+            and port["poe"].get("isAllocated") is True
+        )
+
+    async def _async_fetch_appliance_details(
+        self, serial: str, details: dict[str, dict[str, Any]]
+    ) -> None:
+        """Fetch optional details for an appliance device."""
+        if (
+            clients := await self._async_call_optional(
+                serial,
+                "device clients",
+                self.api.async_get_device_clients(
+                    serial, timespan=DEFAULT_TIMESPAN_SECONDS
+                ),
+            )
+        ) is not None:
+            details[serial]["appliance_clients"] = len(clients)
+
+        if (
+            performance := await self._async_call_optional(
+                serial,
+                "appliance performance",
+                self.api.async_get_device_appliance_performance(serial),
+            )
+        ) is None:
+            return
+
+        perf_score = performance.get("perfScore")
+        if isinstance(perf_score, float | int):
+            details[serial]["appliance_performance_score"] = float(perf_score)
+
+    async def _async_call_optional(
+        self,
+        serial: str,
+        endpoint: str,
+        coro: Awaitable[Any],
+    ) -> Any | None:
+        """Call optional endpoint and suppress non-auth errors."""
+        try:
+            return await coro
+        except MerakiDashboardApiAuthError:
+            raise
+        except (MerakiDashboardApiConnectionError, MerakiDashboardApiError) as err:
+            _LOGGER.debug("Unable to fetch %s for device %s: %s", endpoint, serial, err)
+            return None

--- a/homeassistant/components/meraki_dashboard/device_tracker.py
+++ b/homeassistant/components/meraki_dashboard/device_tracker.py
@@ -1,0 +1,136 @@
+"""Device tracker platform for Meraki Dashboard."""
+
+from __future__ import annotations
+
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_NETWORK_ID
+from .coordinator import (
+    MerakiDashboardClient,
+    MerakiDashboardConfigEntry,
+    MerakiDashboardDataUpdateCoordinator,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MerakiDashboardConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Meraki Dashboard device tracker entities."""
+    coordinator = config_entry.runtime_data
+    tracked_clients: set[str] = set()
+
+    @callback
+    def async_add_new_entities() -> None:
+        latest_clients = set(coordinator.data.clients)
+        entities = [
+            MerakiDashboardDeviceTrackerEntity(
+                coordinator=coordinator,
+                network_id=config_entry.data[CONF_NETWORK_ID],
+                mac_address=mac_address,
+            )
+            for mac_address in latest_clients - tracked_clients
+        ]
+        tracked_clients.update(latest_clients)
+        if entities:
+            async_add_entities(entities)
+
+    async_add_new_entities()
+    config_entry.async_on_unload(coordinator.async_add_listener(async_add_new_entities))
+
+
+class MerakiDashboardDeviceTrackerEntity(
+    CoordinatorEntity[MerakiDashboardDataUpdateCoordinator], ScannerEntity
+):
+    """Representation of a Meraki Dashboard network client."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MerakiDashboardDataUpdateCoordinator,
+        network_id: str,
+        mac_address: str,
+    ) -> None:
+        """Initialize the device tracker entity."""
+        super().__init__(coordinator)
+        self._mac_address = mac_address
+        self._attr_unique_id = f"{network_id}_{mac_address}"
+        self._attr_mac_address = mac_address
+
+    @property
+    def _client(self) -> MerakiDashboardClient | None:
+        """Return the current client data."""
+        return self.coordinator.data.clients.get(self._mac_address)
+
+    @property
+    def name(self) -> str:
+        """Return the entity name."""
+        if (client := self._client) is None:
+            return self._mac_address
+        return (
+            client.description or client.dhcp_hostname or client.mdns_name or client.mac
+        )
+
+    @property
+    def source_type(self) -> SourceType:
+        """Return the source type."""
+        return SourceType.ROUTER
+
+    @property
+    def is_connected(self) -> bool:
+        """Return whether this client is connected."""
+        return self._client is not None and self._client.status == "Online"
+
+    @property
+    def ip_address(self) -> str | None:
+        """Return the IP address."""
+        if (client := self._client) is None:
+            return None
+        return client.ip_address
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Enable entity by default."""
+        return True
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | int | None]:
+        """Return extra state attributes."""
+        if (client := self._client) is None:
+            return {}
+
+        connection_summary = None
+        if (
+            client.recent_device_name
+            and client.recent_device_serial
+            and client.recent_device_connection
+        ):
+            connection_summary = (
+                f"{client.recent_device_connection} via "
+                f"{client.recent_device_name} ({client.recent_device_serial})"
+            )
+
+        return {
+            "manufacturer": client.manufacturer,
+            "ip6": client.ip6_address,
+            "connection_summary": connection_summary,
+            "connection_type": client.recent_device_connection,
+            "connected_via_device_name": client.recent_device_name,
+            "connected_via_device_serial": client.recent_device_serial,
+            "connected_via_ssid": client.ssid,
+            "connected_via_vlan": client.vlan,
+            "connected_via_named_vlan": client.named_vlan,
+            "connected_via_switchport": client.switchport,
+            "recent_device_name": client.recent_device_name,
+            "recent_device_serial": client.recent_device_serial,
+            "recent_device_connection": client.recent_device_connection,
+            "first_seen": client.first_seen,
+            "last_seen": client.last_seen,
+            "ssid": client.ssid,
+            "vlan": client.vlan,
+        }

--- a/homeassistant/components/meraki_dashboard/diagnostics.py
+++ b/homeassistant/components/meraki_dashboard/diagnostics.py
@@ -1,0 +1,58 @@
+"""Diagnostics support for Meraki Dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant
+
+from .coordinator import MerakiDashboardConfigEntry
+
+TO_REDACT = {
+    CONF_API_KEY,
+    "ip",
+    "ip6",
+    "ip_address",
+    "ip6_address",
+    "mac",
+    "public_ip",
+    "lan_ip",
+    "gateway",
+    "primary_dns",
+    "secondary_dns",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: MerakiDashboardConfigEntry
+) -> dict[str, object]:
+    """Return diagnostics for a config entry."""
+    coordinator = config_entry.runtime_data
+
+    clients = {mac: asdict(client) for mac, client in coordinator.data.clients.items()}
+    infrastructure_devices = {
+        serial: asdict(device)
+        for serial, device in coordinator.data.infrastructure_devices.items()
+    }
+
+    return async_redact_data(
+        {
+            "config_entry": config_entry.as_dict(),
+            "coordinator": {
+                "network_id": coordinator.network_id,
+                "organization_id": coordinator.organization_id,
+                "track_clients": coordinator.track_clients,
+                "track_infrastructure_devices": (
+                    coordinator.track_infrastructure_devices
+                ),
+                "included_clients": sorted(coordinator.included_clients),
+            },
+            "clients_count": len(clients),
+            "infrastructure_devices_count": len(infrastructure_devices),
+            "clients": clients,
+            "infrastructure_devices": infrastructure_devices,
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/meraki_dashboard/manifest.json
+++ b/homeassistant/components/meraki_dashboard/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "meraki_dashboard",
+  "name": "Meraki Dashboard",
+  "codeowners": ["@cappern"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/meraki_dashboard",
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "quality_scale": "bronze"
+}

--- a/homeassistant/components/meraki_dashboard/quality_scale.yaml
+++ b/homeassistant/components/meraki_dashboard/quality_scale.yaml
@@ -1,0 +1,80 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: The integration has no actions.
+  appropriate-polling:
+    status: done
+    comment: Meraki data in this endpoint updates at most every five minutes.
+  brands: done
+  common-modules: done
+  config-flow: done
+  config-flow-test-coverage: done
+  dependency-transparency:
+    status: exempt
+    comment: Integration uses built-in aiohttp and no external runtime dependency.
+  docs-actions:
+    status: exempt
+    comment: The integration has no actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: Meraki clients are polled.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: The integration has no actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: The integration has no options flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates:
+    status: exempt
+    comment: Coordinator-based update pattern is used.
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: todo
+  diagnostics: todo
+  discovery: todo
+  discovery-update-info: todo
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category:
+    status: exempt
+    comment: Device tracker entities do not use an entity category.
+  entity-device-class:
+    status: exempt
+    comment: Device tracker entities do not have a device class.
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/meraki_dashboard/sensor.py
+++ b/homeassistant/components/meraki_dashboard/sensor.py
@@ -1,0 +1,468 @@
+"""Diagnostic sensors for Meraki Dashboard infrastructure devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import (
+    MerakiDashboardConfigEntry,
+    MerakiDashboardDataUpdateCoordinator,
+    MerakiDashboardInfrastructureDevice,
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class MerakiDashboardSensorEntityDescription(SensorEntityDescription):
+    """Description for Meraki Dashboard diagnostic sensors."""
+
+    value_key: str
+    product_types: set[str] | None = None
+
+
+SENSORS: tuple[MerakiDashboardSensorEntityDescription, ...] = (
+    MerakiDashboardSensorEntityDescription(
+        key="serial",
+        name="Serial",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="serial",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="model",
+        name="Model",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="model",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="mac",
+        name="MAC",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="mac",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="product_type",
+        name="Product type",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="product_type",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="status",
+        name="Status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="status",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="network_id",
+        name="Network ID",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="network_id",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="public_ip",
+        name="Public IP",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="public_ip",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="lan_ip",
+        name="LAN IP",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="lan_ip",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="gateway",
+        name="Gateway",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="gateway",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ip_type",
+        name="IP type",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ip_type",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="primary_dns",
+        name="Primary DNS",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="primary_dns",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="secondary_dns",
+        name="Secondary DNS",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="secondary_dns",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="last_reported_at",
+        name="Last reported at",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="last_reported_at",
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="wireless_clients",
+        name="Wireless clients",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="wireless_clients",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_enabled_ssids",
+        name="Enabled SSIDs",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_enabled_ssids",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channels_in_use",
+        name="Channels in use",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channels_in_use",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_bands_in_use",
+        name="Bands in use",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_bands_in_use",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channels_2_4ghz",
+        name="2.4 GHz channels",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channels_2_4ghz",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channels_5ghz",
+        name="5 GHz channels",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channels_5ghz",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channels_6ghz",
+        name="6 GHz channels",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channels_6ghz",
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channel_utilization_2_4ghz",
+        name="2.4 GHz channel utilization",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channel_utilization_2_4ghz",
+        native_unit_of_measurement=PERCENTAGE,
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channel_utilization_5ghz",
+        name="5 GHz channel utilization",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channel_utilization_5ghz",
+        native_unit_of_measurement=PERCENTAGE,
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="ap_channel_utilization_6ghz",
+        name="6 GHz channel utilization",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="ap_channel_utilization_6ghz",
+        native_unit_of_measurement=PERCENTAGE,
+        product_types={"wireless"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="switch_total_ports",
+        name="Total ports",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="switch_total_ports",
+        product_types={"switch"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="switch_connected_ports",
+        name="Connected ports",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="switch_connected_ports",
+        product_types={"switch"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="switch_connected_clients",
+        name="Switch clients",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="switch_connected_clients",
+        product_types={"switch"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="switch_active_poe_ports",
+        name="Active PoE ports",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="switch_active_poe_ports",
+        product_types={"switch"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="appliance_clients",
+        name="Firewall clients",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="appliance_clients",
+        product_types={"appliance"},
+    ),
+    MerakiDashboardSensorEntityDescription(
+        key="appliance_performance_score",
+        name="Performance score",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_key="appliance_performance_score",
+        product_types={"appliance"},
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: MerakiDashboardConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Meraki Dashboard diagnostic sensors."""
+    coordinator = config_entry.runtime_data
+    async_add_entities([MerakiDashboardTopologySensor(coordinator)])
+    tracked_unique_ids: set[str] = set()
+
+    @callback
+    def async_add_new_entities() -> None:
+        entities: list[MerakiDashboardInfrastructureSensor] = []
+        for serial, device in coordinator.data.infrastructure_devices.items():
+            for description in SENSORS:
+                if (
+                    description.product_types is not None
+                    and device.product_type not in description.product_types
+                ):
+                    continue
+                unique_id = f"{serial}_{description.key}"
+                if unique_id in tracked_unique_ids:
+                    continue
+                tracked_unique_ids.add(unique_id)
+                entities.append(
+                    MerakiDashboardInfrastructureSensor(
+                        coordinator=coordinator,
+                        serial=serial,
+                        description=description,
+                    )
+                )
+
+        if entities:
+            async_add_entities(entities)
+
+    async_add_new_entities()
+    config_entry.async_on_unload(coordinator.async_add_listener(async_add_new_entities))
+
+
+class MerakiDashboardInfrastructureSensor(
+    CoordinatorEntity[MerakiDashboardDataUpdateCoordinator], SensorEntity
+):
+    """Diagnostic sensor bound to a Meraki infrastructure device."""
+
+    _attr_has_entity_name = True
+    entity_description: MerakiDashboardSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: MerakiDashboardDataUpdateCoordinator,
+        serial: str,
+        description: MerakiDashboardSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._serial = serial
+        self.entity_description = description
+        self._attr_unique_id = f"{serial}_{description.key}"
+
+    @property
+    def _device(self) -> MerakiDashboardInfrastructureDevice | None:
+        """Return current device data."""
+        return self.coordinator.data.infrastructure_devices.get(self._serial)
+
+    @property
+    def available(self) -> bool:
+        """Return if sensor is available."""
+        return self._device is not None and super().available
+
+    @property
+    def native_value(self) -> str | int | float | None:
+        """Return sensor value."""
+        if (device := self._device) is None:
+            return None
+        value: Any = getattr(device, self.entity_description.value_key)
+        if value is None:
+            return None
+        if isinstance(value, str | int | float):
+            return value
+        return str(value)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Return linked device info."""
+        if (device := self._device) is None:
+            return None
+        connections = set()
+        if device.mac:
+            connections.add((CONNECTION_NETWORK_MAC, device.mac))
+        return DeviceInfo(
+            identifiers={(DOMAIN, device.serial)},
+            connections=connections,
+            manufacturer="Cisco Meraki",
+            model=device.model,
+            name=device.name or device.serial,
+        )
+
+
+class MerakiDashboardTopologySensor(
+    CoordinatorEntity[MerakiDashboardDataUpdateCoordinator], SensorEntity
+):
+    """Topology graph data for Meraki devices and clients."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Topology nodes"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:graph-outline"
+
+    def __init__(self, coordinator: MerakiDashboardDataUpdateCoordinator) -> None:
+        """Initialize the topology sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.network_id}_topology"
+
+    @property
+    def native_value(self) -> int:
+        """Return number of nodes in the current topology."""
+        nodes, _ = self._build_topology()
+        return len(nodes)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return topology graph data."""
+        nodes, edges = self._build_topology()
+        return {"nodes": nodes, "edges": edges}
+
+    def _build_topology(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Build nodes and edges for topology rendering."""
+        nodes: list[dict[str, Any]] = []
+        edges: list[dict[str, Any]] = []
+        node_ids: set[str] = set()
+        edge_ids: set[tuple[str, str, str]] = set()
+        infra_by_serial = self.coordinator.data.infrastructure_devices
+        lan_ip_to_serial = {
+            device.lan_ip: serial
+            for serial, device in infra_by_serial.items()
+            if device.lan_ip
+        }
+
+        for serial, device in infra_by_serial.items():
+            node_ids.add(serial)
+            nodes.append(
+                {
+                    "id": serial,
+                    "label": device.name or serial,
+                    "kind": device.product_type or "infrastructure",
+                    "status": device.status,
+                    "serial": serial,
+                }
+            )
+
+        # Build infrastructure uplink edges. We infer parent from each device
+        # gateway and match it against known LAN IPs of infrastructure devices.
+        for serial, device in infra_by_serial.items():
+            if not device.gateway:
+                continue
+            if not (parent_serial := lan_ip_to_serial.get(device.gateway)):
+                continue
+            if parent_serial == serial:
+                continue
+
+            edge_key = (serial, parent_serial, "uplink")
+            if edge_key in edge_ids:
+                continue
+            edge_ids.add(edge_key)
+
+            edges.append(
+                {
+                    "from": serial,
+                    "to": parent_serial,
+                    "edge_type": "uplink",
+                    "connection_type": "Uplink",
+                    "gateway": device.gateway,
+                }
+            )
+
+        for mac, client in self.coordinator.data.clients.items():
+            client_label = (
+                client.description or client.dhcp_hostname or client.mdns_name or mac
+            )
+            node_ids.add(mac)
+            nodes.append(
+                {
+                    "id": mac,
+                    "label": client_label,
+                    "kind": "client",
+                    "status": client.status,
+                    "mac": mac,
+                }
+            )
+
+            if not client.recent_device_serial:
+                continue
+            serial = client.recent_device_serial
+            if serial not in node_ids:
+                node_ids.add(serial)
+                nodes.append(
+                    {
+                        "id": serial,
+                        "label": client.recent_device_name or serial,
+                        "kind": "upstream",
+                        "status": None,
+                        "serial": serial,
+                    }
+                )
+            edge_key = (mac, serial, "access")
+            if edge_key in edge_ids:
+                continue
+            edge_ids.add(edge_key)
+            edges.append(
+                {
+                    "from": mac,
+                    "to": serial,
+                    "edge_type": "access",
+                    "connection_type": client.recent_device_connection,
+                    "link_speed_mbps": self._parse_link_speed_mbps(
+                        client.recent_device_connection
+                    ),
+                    "ssid": client.ssid,
+                    "vlan": client.vlan,
+                    "switchport": client.switchport,
+                }
+            )
+
+        return nodes, edges
+
+    @staticmethod
+    def _parse_link_speed_mbps(connection_type: str | None) -> int | None:
+        """Parse link speed in Mbps from a connection type string."""
+        if not connection_type:
+            return None
+        match = re.search(
+            r"(\d+(?:\.\d+)?)\s*([GM])bps", connection_type, re.IGNORECASE
+        )
+        if not match:
+            return None
+        speed = float(match.group(1))
+        unit = match.group(2).upper()
+        if unit == "G":
+            speed *= 1000
+        return int(speed)

--- a/homeassistant/components/meraki_dashboard/strings.json
+++ b/homeassistant/components/meraki_dashboard/strings.json
@@ -1,0 +1,78 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "Invalid authentication",
+      "no_networks": "No networks were found for this organization",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "at_least_one_enabled": "At least one integration target must be enabled",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "Invalid authentication",
+      "no_organizations": "No organizations were found for this API key",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "network": {
+        "data": {
+          "network_id": "Network",
+          "track_bluetooth_clients": "Bluetooth clients",
+          "track_clients": "Clients",
+          "track_infrastructure_devices": "Infrastructure devices"
+        },
+        "data_description": {
+          "network_id": "The Meraki network to monitor.",
+          "track_bluetooth_clients": "Track Bluetooth clients as device trackers.",
+          "track_clients": "Track network clients as device trackers.",
+          "track_infrastructure_devices": "Track APs, switches, and firewalls as connectivity sensors."
+        }
+      },
+      "organization": {
+        "data": {
+          "organization_id": "Organization"
+        },
+        "data_description": {
+          "organization_id": "The Meraki organization to use for this integration."
+        }
+      },
+      "user": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "API key used to authenticate with the Meraki Dashboard API."
+        },
+        "description": "Enter your Meraki Dashboard API key."
+      }
+    }
+  },
+  "issues": {
+    "rate_limited": {
+      "description": "Home Assistant is being rate limited by the Meraki Dashboard API. Data updates may be delayed until the rate limit window resets.",
+      "title": "Meraki Dashboard API rate limit reached"
+    }
+  },
+  "options": {
+    "error": {
+      "at_least_one_enabled": "[%key:component::meraki_dashboard::config::error::at_least_one_enabled%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "included_clients": "Tracked client devices",
+          "track_bluetooth_clients": "[%key:component::meraki_dashboard::config::step::network::data::track_bluetooth_clients%]",
+          "track_clients": "[%key:component::meraki_dashboard::config::step::network::data::track_clients%]",
+          "track_infrastructure_devices": "[%key:component::meraki_dashboard::config::step::network::data::track_infrastructure_devices%]"
+        },
+        "data_description": {
+          "included_clients": "Select which client devices should be created as device trackers. Leave empty to include all clients.",
+          "track_bluetooth_clients": "[%key:component::meraki_dashboard::config::step::network::data_description::track_bluetooth_clients%]",
+          "track_clients": "[%key:component::meraki_dashboard::config::step::network::data_description::track_clients%]",
+          "track_infrastructure_devices": "[%key:component::meraki_dashboard::config::step::network::data_description::track_infrastructure_devices%]"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -416,6 +416,8 @@ FLOWS = {
         "media_extractor",
         "melcloud",
         "melnor",
+        "meraki",
+        "meraki_dashboard",
         "met",
         "met_eireann",
         "meteo_france",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -999,6 +999,18 @@
           "config_flow": false,
           "iot_class": "cloud_push",
           "name": "Cisco Webex Teams"
+        },
+        "meraki": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Meraki"
+        },
+        "meraki_dashboard": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Meraki Dashboard"
         }
       }
     },
@@ -3997,12 +4009,6 @@
           "name": "Melnor RainCloud"
         }
       }
-    },
-    "meraki": {
-      "name": "Meraki",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "cloud_polling"
     },
     "message_bird": {
       "name": "MessageBird",

--- a/tests/components/meraki/test_config_flow.py
+++ b/tests/components/meraki/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Meraki config flow."""
 
-from homeassistant.components.meraki.const import CONF_VALIDATOR, DOMAIN
-from homeassistant.const import CONF_SECRET
+from homeassistant.components.meraki.const import CONF_SECRET, CONF_VALIDATOR, DOMAIN
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry

--- a/tests/components/meraki/test_config_flow.py
+++ b/tests/components/meraki/test_config_flow.py
@@ -1,0 +1,38 @@
+"""Test the Meraki config flow."""
+
+from homeassistant.components.meraki.const import CONF_VALIDATOR, DOMAIN
+from homeassistant.const import CONF_SECRET
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_flow(hass) -> None:
+    """Test the full user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_VALIDATOR: "validator", CONF_SECRET: "secret"},
+    )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Meraki"
+    assert result2["data"] == {CONF_VALIDATOR: "validator", CONF_SECRET: "secret"}
+
+
+async def test_single_instance(hass) -> None:
+    """Test only one instance is allowed."""
+    MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -6,16 +6,11 @@ import json
 from aiohttp.test_utils import TestClient
 import pytest
 
-from homeassistant.components import device_tracker
-from homeassistant.components.device_tracker import legacy
-from homeassistant.components.meraki.device_tracker import (
-    CONF_SECRET,
-    CONF_VALIDATOR,
-    URL,
-)
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.components.meraki.const import CONF_VALIDATOR, DOMAIN, URL
+from homeassistant.const import CONF_SECRET
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 from tests.typing import ClientSessionGenerator
 
@@ -26,24 +21,19 @@ async def meraki_client(
     hass_client: ClientSessionGenerator,
 ) -> TestClient:
     """Meraki mock client."""
-    assert await async_setup_component(
-        hass,
-        device_tracker.DOMAIN,
-        {
-            device_tracker.DOMAIN: {
-                CONF_PLATFORM: "meraki",
-                CONF_VALIDATOR: "validator",
-                CONF_SECRET: "secret",
-            }
-        },
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_VALIDATOR: "validator", CONF_SECRET: "secret"},
     )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
     return await hass_client()
 
 
 async def test_invalid_or_missing_data(
-    mock_device_tracker_conf: list[legacy.Device], meraki_client
+    meraki_client,
 ) -> None:
     """Test validator with invalid or missing data."""
     req = await meraki_client.get(URL)
@@ -90,7 +80,7 @@ async def test_invalid_or_missing_data(
 
 
 async def test_data_will_be_saved(
-    mock_device_tracker_conf: list[legacy.Device], hass: HomeAssistant, meraki_client
+    hass: HomeAssistant, meraki_client
 ) -> None:
     """Test with valid data."""
     data = {

--- a/tests/components/meraki_dashboard/__init__.py
+++ b/tests/components/meraki_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Meraki Dashboard integration."""

--- a/tests/components/meraki_dashboard/conftest.py
+++ b/tests/components/meraki_dashboard/conftest.py
@@ -1,0 +1,68 @@
+"""Fixtures for Meraki Dashboard tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.meraki_dashboard.const import (
+    CONF_INCLUDED_CLIENTS,
+    CONF_NETWORK_ID,
+    CONF_NETWORK_NAME,
+    CONF_ORGANIZATION_ID,
+    CONF_TRACK_BLUETOOTH_CLIENTS,
+    CONF_TRACK_CLIENTS,
+    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+    DOMAIN,
+)
+from homeassistant.const import CONF_API_KEY
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth_clients() -> Generator[None]:
+    """Mock Bluetooth client API calls for tests by default."""
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_bluetooth_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_network_bluetooth_clients",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_setup_entry() -> None:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.meraki_dashboard.async_setup_entry",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="HQ",
+        data={
+            CONF_API_KEY: "test-api-key",
+            CONF_ORGANIZATION_ID: "1234",
+            CONF_NETWORK_ID: "L_1111",
+            CONF_NETWORK_NAME: "HQ",
+        },
+        unique_id="L_1111",
+        options={
+            CONF_TRACK_CLIENTS: True,
+            CONF_TRACK_BLUETOOTH_CLIENTS: False,
+            CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+            CONF_INCLUDED_CLIENTS: [],
+        },
+    )

--- a/tests/components/meraki_dashboard/test_api.py
+++ b/tests/components/meraki_dashboard/test_api.py
@@ -1,0 +1,83 @@
+"""Test Meraki Dashboard API client."""
+
+from __future__ import annotations
+
+from typing import Self
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.meraki_dashboard.api import (
+    MerakiDashboardApi,
+    MerakiDashboardApiRateLimitError,
+)
+
+
+class _MockResponse:
+    """Minimal aiohttp response mock."""
+
+    def __init__(
+        self,
+        status: int,
+        payload: object | None = None,
+        headers: dict[str, str] | None = None,
+        content_length: int | None = 1,
+    ) -> None:
+        """Initialize mock response."""
+        self.status = status
+        self._payload = payload
+        self.headers = headers or {}
+        self.content_length = content_length
+
+    async def __aenter__(self) -> Self:
+        """Enter async context."""
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        """Exit async context."""
+        return False
+
+    async def json(self) -> object:
+        """Return payload."""
+        return self._payload
+
+
+async def test_get_retries_on_rate_limit_then_succeeds() -> None:
+    """Test GET retries when API returns 429."""
+    session = AsyncMock()
+    session.get = AsyncMock(
+        side_effect=[
+            _MockResponse(429, headers={"Retry-After": "1"}),
+            _MockResponse(200, payload=[]),
+        ]
+    )
+    api = MerakiDashboardApi(session, "api-key")
+
+    with patch(
+        "homeassistant.components.meraki_dashboard.api.asyncio.sleep",
+        AsyncMock(),
+    ) as mock_sleep:
+        organizations = await api.async_get_organizations()
+
+    assert organizations == []
+    mock_sleep.assert_awaited_once_with(1.0)
+
+
+async def test_get_raises_rate_limit_after_retries() -> None:
+    """Test GET raises if API keeps returning 429."""
+    session = AsyncMock()
+    session.get = AsyncMock(
+        side_effect=[_MockResponse(429, headers={"Retry-After": "2"}) for _ in range(5)]
+    )
+    api = MerakiDashboardApi(session, "api-key")
+
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.api.asyncio.sleep",
+            AsyncMock(),
+        ) as mock_sleep,
+        pytest.raises(MerakiDashboardApiRateLimitError),
+    ):
+        await api.async_get_organizations()
+
+    assert mock_sleep.await_count == 4

--- a/tests/components/meraki_dashboard/test_binary_sensor.py
+++ b/tests/components/meraki_dashboard/test_binary_sensor.py
@@ -1,0 +1,148 @@
+"""Test Meraki Dashboard binary sensors."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_infrastructure_device_sensors(
+    hass,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test binary sensors for AP, switch, and firewall devices."""
+    device_statuses = [
+        {
+            "name": "AP-Outdoor",
+            "serial": "Q2QD-3ZAQ-N9YE",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "wireless",
+            "model": "MR44",
+            "lanIp": "192.168.99.2",
+        },
+        {
+            "name": "Core-Switch",
+            "serial": "Q2SW-AAAA-BBBB",
+            "networkId": "L_1111",
+            "status": "offline",
+            "productType": "switch",
+            "model": "MS250",
+            "lanIp": "192.168.99.3",
+        },
+        {
+            "name": "MX-Firewall",
+            "serial": "Q2MX-CCCC-DDDD",
+            "networkId": "L_1111",
+            "status": "alerting",
+            "productType": "appliance",
+            "model": "MX85",
+            "lanIp": "192.168.99.1",
+        },
+        {
+            "name": "Ignored-Camera",
+            "serial": "Q2CM-EEEE-FFFF",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "camera",
+            "model": "MV12",
+        },
+        {
+            "name": "Other-Network-Switch",
+            "serial": "Q2SW-OTHER-NET",
+            "networkId": "L_9999",
+            "status": "online",
+            "productType": "switch",
+            "model": "MS120",
+        },
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_wireless_channel_utilization_by_device",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    binary_sensor_entries = [
+        entry for entry in entries if entry.domain == "binary_sensor"
+    ]
+    assert len(binary_sensor_entries) == 3
+
+    ap_entity_id = next(
+        entry.entity_id
+        for entry in binary_sensor_entries
+        if entry.original_name == "AP-Outdoor"
+    )
+    switch_entity_id = next(
+        entry.entity_id
+        for entry in binary_sensor_entries
+        if entry.original_name == "Core-Switch"
+    )
+    fw_entity_id = next(
+        entry.entity_id
+        for entry in binary_sensor_entries
+        if entry.original_name == "MX-Firewall"
+    )
+
+    ap_state = hass.states.get(ap_entity_id)
+    switch_state = hass.states.get(switch_entity_id)
+    fw_state = hass.states.get(fw_entity_id)
+
+    assert ap_state is not None
+    assert ap_state.state == "on"
+    assert "product_type" not in ap_state.attributes
+    assert "status" not in ap_state.attributes
+
+    assert switch_state is not None
+    assert switch_state.state == "off"
+    assert "product_type" not in switch_state.attributes
+    assert "status" not in switch_state.attributes
+
+    assert fw_state is not None
+    assert fw_state.state == "off"
+    assert "product_type" not in fw_state.attributes
+    assert "status" not in fw_state.attributes
+
+    assert device_registry.async_get_device(
+        identifiers={("meraki_dashboard", "Q2QD-3ZAQ-N9YE")}
+    )
+    assert device_registry.async_get_device(
+        identifiers={("meraki_dashboard", "Q2SW-AAAA-BBBB")}
+    )
+    assert device_registry.async_get_device(
+        identifiers={("meraki_dashboard", "Q2MX-CCCC-DDDD")}
+    )

--- a/tests/components/meraki_dashboard/test_button.py
+++ b/tests/components/meraki_dashboard/test_button.py
@@ -1,0 +1,97 @@
+"""Test Meraki Dashboard action buttons."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_infrastructure_buttons(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test reboot and ping buttons for infrastructure devices."""
+    device_statuses = [
+        {
+            "name": "AP-Outdoor",
+            "serial": "Q2QD-3ZAQ-N9YE",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "wireless",
+            "model": "MR44",
+            "lanIp": "192.168.99.2",
+        }
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_wireless_channel_utilization_by_device",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.api.MerakiDashboardApi.async_reboot_device",
+            AsyncMock(return_value={"success": True}),
+        ) as mock_reboot,
+        patch(
+            "homeassistant.components.meraki_dashboard.api.MerakiDashboardApi.async_ping_device",
+            AsyncMock(return_value={"status": "queued"}),
+        ) as mock_ping,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        entries = er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        reboot_button = next(
+            entry
+            for entry in entries
+            if entry.domain == "button" and entry.original_name == "Reboot"
+        )
+        ping_button = next(
+            entry
+            for entry in entries
+            if entry.domain == "button" and entry.original_name == "Ping"
+        )
+
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": reboot_button.entity_id},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "button",
+            "press",
+            {"entity_id": ping_button.entity_id},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_reboot.assert_awaited_once_with("Q2QD-3ZAQ-N9YE")
+    mock_ping.assert_awaited_once_with("Q2QD-3ZAQ-N9YE")

--- a/tests/components/meraki_dashboard/test_config_flow.py
+++ b/tests/components/meraki_dashboard/test_config_flow.py
@@ -1,0 +1,193 @@
+"""Test the Meraki Dashboard config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.meraki_dashboard.api import MerakiDashboardApiAuthError
+from homeassistant.components.meraki_dashboard.const import (
+    CONF_INCLUDED_CLIENTS,
+    CONF_NETWORK_ID,
+    CONF_NETWORK_NAME,
+    CONF_ORGANIZATION_ID,
+    CONF_TRACK_BLUETOOTH_CLIENTS,
+    CONF_TRACK_CLIENTS,
+    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+    DOMAIN,
+)
+from homeassistant.const import CONF_API_KEY
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+
+async def test_full_flow(hass, mock_setup_entry: None) -> None:
+    """Test the complete config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_organizations",
+            AsyncMock(return_value=[{"id": "1234", "name": "Home Org"}]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_networks",
+            AsyncMock(return_value=[{"id": "L_1111", "name": "HQ"}]),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_API_KEY: "api-key"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "network"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_NETWORK_ID: "L_1111",
+            CONF_TRACK_CLIENTS: True,
+            CONF_TRACK_BLUETOOTH_CLIENTS: False,
+            CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "HQ"
+    assert result["data"] == {
+        CONF_API_KEY: "api-key",
+        CONF_ORGANIZATION_ID: "1234",
+        CONF_NETWORK_ID: "L_1111",
+        CONF_NETWORK_NAME: "HQ",
+    }
+    assert result["options"] == {
+        CONF_TRACK_CLIENTS: True,
+        CONF_TRACK_BLUETOOTH_CLIENTS: False,
+        CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+        CONF_INCLUDED_CLIENTS: [],
+    }
+
+
+async def test_flow_invalid_auth(hass, mock_setup_entry: None) -> None:
+    """Test config flow with invalid authentication."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    with patch(
+        "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_organizations",
+        AsyncMock(side_effect=MerakiDashboardApiAuthError("Invalid API key")),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_API_KEY: "invalid"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_flow_duplicate_network(
+    hass, mock_setup_entry: None, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test duplicate network handling."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_organizations",
+            AsyncMock(return_value=[{"id": "1234", "name": "Home Org"}]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_networks",
+            AsyncMock(return_value=[{"id": "L_1111", "name": "HQ"}]),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_API_KEY: "api-key"},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_NETWORK_ID: "L_1111",
+            CONF_TRACK_CLIENTS: True,
+            CONF_TRACK_BLUETOOTH_CLIENTS: False,
+            CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_options_flow(
+    hass, mock_setup_entry: None, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test options flow for selecting integration targets."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_network_clients",
+        AsyncMock(
+            return_value=[
+                {
+                    "mac": "22:33:44:55:66:77",
+                    "description": "Miles phone",
+                }
+            ]
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(
+            mock_config_entry.entry_id
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TRACK_CLIENTS: False,
+                CONF_TRACK_BLUETOOTH_CLIENTS: False,
+                CONF_TRACK_INFRASTRUCTURE_DEVICES: False,
+                CONF_INCLUDED_CLIENTS: [],
+            },
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "at_least_one_enabled"}
+
+    with patch(
+        "homeassistant.components.meraki_dashboard.config_flow.MerakiDashboardApi.async_get_network_clients",
+        AsyncMock(
+            return_value=[
+                {
+                    "mac": "22:33:44:55:66:77",
+                    "description": "Miles phone",
+                }
+            ]
+        ),
+    ):
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_TRACK_CLIENTS: False,
+                CONF_TRACK_BLUETOOTH_CLIENTS: False,
+                CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+                CONF_INCLUDED_CLIENTS: ["22:33:44:55:66:77"],
+            },
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_TRACK_CLIENTS: False,
+        CONF_TRACK_BLUETOOTH_CLIENTS: False,
+        CONF_TRACK_INFRASTRUCTURE_DEVICES: True,
+        CONF_INCLUDED_CLIENTS: ["22:33:44:55:66:77"],
+    }

--- a/tests/components/meraki_dashboard/test_coordinator.py
+++ b/tests/components/meraki_dashboard/test_coordinator.py
@@ -1,0 +1,55 @@
+"""Test Meraki Dashboard coordinator behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from homeassistant.components.meraki_dashboard.api import (
+    MerakiDashboardApiRateLimitError,
+)
+from homeassistant.components.meraki_dashboard.coordinator import (
+    RATE_LIMIT_ISSUE_ID,
+    MerakiDashboardDataUpdateCoordinator,
+)
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.common import MockConfigEntry
+
+
+async def test_rate_limit_creates_issue_and_recovers(
+    hass, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test rate limit creates a repairs issue and is cleared on recovery."""
+    api = Mock()
+    api.async_get_network_clients = AsyncMock(
+        side_effect=MerakiDashboardApiRateLimitError(2.0)
+    )
+    api.async_get_network_bluetooth_clients = AsyncMock(return_value=[])
+    api.async_get_organization_devices_statuses = AsyncMock(return_value=[])
+
+    coordinator = MerakiDashboardDataUpdateCoordinator(
+        hass,
+        mock_config_entry,
+        api,
+        track_clients=True,
+        track_bluetooth_clients=False,
+        track_infrastructure_devices=True,
+        included_clients=set(),
+    )
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    issue_registry = ir.async_get(hass)
+    assert issue_registry.async_get_issue("meraki_dashboard", RATE_LIMIT_ISSUE_ID)
+
+    api.async_get_network_clients = AsyncMock(return_value=[])
+    api.async_get_network_bluetooth_clients = AsyncMock(return_value=[])
+    await coordinator._async_update_data()
+
+    assert (
+        issue_registry.async_get_issue("meraki_dashboard", RATE_LIMIT_ISSUE_ID) is None
+    )

--- a/tests/components/meraki_dashboard/test_device_tracker.py
+++ b/tests/components/meraki_dashboard/test_device_tracker.py
@@ -1,0 +1,238 @@
+"""Test Meraki Dashboard device tracker."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.meraki_dashboard.const import (
+    CONF_INCLUDED_CLIENTS,
+    CONF_TRACK_BLUETOOTH_CLIENTS,
+    CONF_TRACK_CLIENTS,
+    CONF_TRACK_INFRASTRUCTURE_DEVICES,
+)
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_device_tracker_entities(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test Meraki Dashboard device tracker entities are created."""
+    clients = [
+        {
+            "mac": "22:33:44:55:66:77",
+            "description": "Miles phone",
+            "dhcpHostname": "miles-phone",
+            "status": "Online",
+            "ip": "1.2.3.4",
+            "ip6": "2001:db8::1",
+            "manufacturer": "Apple",
+            "recentDeviceName": "AP-Living",
+            "recentDeviceSerial": "Q2QD-3ZAQ-N9YE",
+            "recentDeviceConnection": "Wireless",
+            "ssid": "Home-WiFi",
+            "vlan": "400",
+            "namedVlan": "IoT",
+            "switchport": None,
+            "lastSeen": 1700000000,
+            "firstSeen": 1699990000,
+        },
+        {
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "description": "Kitchen TV",
+            "status": "Offline",
+            "ip": "1.2.3.5",
+            "manufacturer": "Samsung",
+        },
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=clients),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    tracker_entities = [entry for entry in entities if entry.domain == "device_tracker"]
+    assert len(tracker_entities) == 2
+
+    online_entity_id = next(
+        entry.entity_id
+        for entry in tracker_entities
+        if entry.original_name == "Miles phone"
+    )
+    offline_entity_id = next(
+        entry.entity_id
+        for entry in tracker_entities
+        if entry.original_name == "Kitchen TV"
+    )
+
+    online_state = hass.states.get(online_entity_id)
+    offline_state = hass.states.get(offline_entity_id)
+
+    assert online_state is not None
+    assert offline_state is not None
+    assert online_state.state == "home"
+    assert offline_state.state == "not_home"
+    assert online_state.attributes["ip"] == "1.2.3.4"
+    assert online_state.attributes["connection_type"] == "Wireless"
+    assert online_state.attributes["connected_via_device_name"] == "AP-Living"
+    assert online_state.attributes["connected_via_device_serial"] == "Q2QD-3ZAQ-N9YE"
+    assert online_state.attributes["connected_via_ssid"] == "Home-WiFi"
+    assert online_state.attributes["connected_via_vlan"] == "400"
+    assert online_state.attributes["connected_via_named_vlan"] == "IoT"
+
+
+async def test_device_tracker_entities_filtered_by_included_clients(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test only selected client MACs are included as device trackers."""
+    clients = [
+        {
+            "mac": "22:33:44:55:66:77",
+            "description": "Miles phone",
+            "status": "Online",
+            "ip": "1.2.3.4",
+        },
+        {
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "description": "Kitchen TV",
+            "status": "Offline",
+            "ip": "1.2.3.5",
+        },
+    ]
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={CONF_INCLUDED_CLIENTS: ["22:33:44:55:66:77"]},
+    )
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=clients),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    tracker_entities = [entry for entry in entities if entry.domain == "device_tracker"]
+    assert len(tracker_entities) == 1
+    assert tracker_entities[0].original_name == "Miles phone"
+
+
+async def test_bluetooth_client_creates_device_tracker_entity(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test Bluetooth clients are tracked as device tracker entities."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={
+            CONF_TRACK_CLIENTS: False,
+            CONF_TRACK_BLUETOOTH_CLIENTS: True,
+            CONF_TRACK_INFRASTRUCTURE_DEVICES: False,
+            CONF_INCLUDED_CLIENTS: [],
+        },
+    )
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_bluetooth_clients",
+            AsyncMock(
+                return_value=[
+                    {
+                        "mac": "11:22:33:44:55:66",
+                        "name": "Headphones",
+                        "deviceName": "Bose QuietComfort 35",
+                        "manufacturer": "Bose",
+                        "lastSeen": 1700001000,
+                    }
+                ]
+            ),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    tracker_entities = [entry for entry in entities if entry.domain == "device_tracker"]
+    assert len(tracker_entities) == 1
+    assert tracker_entities[0].original_name == "Headphones"
+
+    state = hass.states.get(tracker_entities[0].entity_id)
+    assert state is not None
+    assert state.state == "home"
+    assert state.attributes["connection_type"] == "Bluetooth"

--- a/tests/components/meraki_dashboard/test_diagnostics.py
+++ b/tests/components/meraki_dashboard/test_diagnostics.py
@@ -1,0 +1,84 @@
+"""Test Meraki Dashboard diagnostics."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_config_entry_diagnostics_redacts_sensitive_data(
+    hass,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test diagnostics redacts sensitive data."""
+    clients = [
+        {
+            "mac": "22:33:44:55:66:77",
+            "description": "Miles phone",
+            "status": "Online",
+            "ip": "1.2.3.4",
+            "ip6": "2001:db8::1",
+        }
+    ]
+    device_statuses = [
+        {
+            "name": "Core-Switch",
+            "serial": "Q2SW-AAAA-BBBB",
+            "mac": "b8:ab:61:e4:4e:7c",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "switch",
+            "model": "MS250",
+            "publicIp": "84.210.215.192",
+            "lanIp": "192.168.2.150",
+            "gateway": "192.168.2.1",
+            "primaryDns": "192.168.2.2",
+            "secondaryDns": "192.168.2.3",
+        }
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=clients),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert result["config_entry"]["data"]["api_key"] == "**REDACTED**"
+    assert result["clients"]["22:33:44:55:66:77"]["ip_address"] == "**REDACTED**"
+    assert result["clients"]["22:33:44:55:66:77"]["mac"] == "**REDACTED**"
+    assert (
+        result["infrastructure_devices"]["Q2SW-AAAA-BBBB"]["public_ip"]
+        == "**REDACTED**"
+    )

--- a/tests/components/meraki_dashboard/test_sensor.py
+++ b/tests/components/meraki_dashboard/test_sensor.py
@@ -1,0 +1,393 @@
+"""Test Meraki Dashboard diagnostic sensors."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.meraki_dashboard.api import MerakiDashboardApiError
+from homeassistant.const import PERCENTAGE
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+async def test_infrastructure_diagnostic_sensors(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test diagnostic sensors are created under infrastructure devices."""
+    device_statuses = [
+        {
+            "name": "AP-Outdoor",
+            "serial": "Q4CD-XAPS-SNAW",
+            "mac": "b8:ab:61:e4:4e:7c",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "switch",
+            "model": "MS130-12X",
+            "publicIp": "84.210.215.192",
+            "lanIp": "192.168.2.150",
+            "gateway": "192.168.2.1",
+            "ipType": "static",
+            "primaryDns": "192.168.2.2",
+            "secondaryDns": "Unknown",
+            "lastReportedAt": "2026-02-16T11:04:55Z",
+        }
+    ]
+    switch_ports_statuses = [
+        {
+            "portId": "1",
+            "status": "Connected",
+            "clientCount": 2,
+            "poe": {"isAllocated": True},
+        },
+        {
+            "portId": "2",
+            "status": "Disconnected",
+            "clientCount": 0,
+            "poe": {"isAllocated": False},
+        },
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=switch_ports_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_wireless_channel_utilization_by_device",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    sensor_entries = [entry for entry in entries if entry.domain == "sensor"]
+    assert len(sensor_entries) == 18
+
+    serial_sensor = next(
+        entry.entity_id for entry in sensor_entries if entry.original_name == "Serial"
+    )
+    status_sensor = next(
+        entry.entity_id for entry in sensor_entries if entry.original_name == "Status"
+    )
+    public_ip_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "Public IP"
+    )
+    total_ports_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "Total ports"
+    )
+    connected_clients_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "Switch clients"
+    )
+
+    assert hass.states.get(serial_sensor).state == "Q4CD-XAPS-SNAW"
+    assert hass.states.get(status_sensor).state == "online"
+    assert hass.states.get(public_ip_sensor).state == "84.210.215.192"
+    assert hass.states.get(total_ports_sensor).state == "2"
+    assert hass.states.get(connected_clients_sensor).state == "2"
+
+    topology_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "Topology nodes"
+    )
+    topology_state = hass.states.get(topology_sensor)
+    assert topology_state is not None
+    assert topology_state.state == "1"
+    assert topology_state.attributes["nodes"][0]["id"] == "Q4CD-XAPS-SNAW"
+
+
+async def test_ap_channel_diagnostic_sensors(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test AP channel diagnostic sensors for 2.4/5/6 GHz interfaces."""
+    device_statuses = [
+        {
+            "name": "AP-Outdoor",
+            "serial": "Q2QD-3ZAQ-N9YE",
+            "mac": "b8:ab:61:e4:4e:7c",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "wireless",
+            "model": "CW9166",
+        }
+    ]
+    wireless_status = {
+        "basicServiceSets": [
+            {"enabled": True, "band": "2.4 GHz", "channel": 1},
+            {"enabled": True, "band": "5 GHz", "channel": 44},
+            {"enabled": True, "band": "6 GHz", "channel": 37},
+        ]
+    }
+    channel_utilization = [
+        {
+            "serial": "Q2QD-3ZAQ-N9YE",
+            "byBand": [
+                {"band": "2.4", "total": {"percentage": 21.5}},
+                {"band": "5", "total": {"percentage": 34.2}},
+                {"band": "6", "total": {"percentage": 17.8}},
+            ],
+        }
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value=wireless_status),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_wireless_channel_utilization_by_device",
+            AsyncMock(return_value=channel_utilization),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    sensor_entries = [entry for entry in entries if entry.domain == "sensor"]
+
+    channel_24_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "2.4 GHz channels"
+    )
+    channel_5_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "5 GHz channels"
+    )
+    channel_6_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "6 GHz channels"
+    )
+    utilization_24_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "2.4 GHz channel utilization"
+    )
+    utilization_5_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "5 GHz channel utilization"
+    )
+    utilization_6_sensor = next(
+        entry.entity_id
+        for entry in sensor_entries
+        if entry.original_name == "6 GHz channel utilization"
+    )
+
+    assert hass.states.get(channel_24_sensor).state == "1"
+    assert hass.states.get(channel_5_sensor).state == "44"
+    assert hass.states.get(channel_6_sensor).state == "37"
+    assert hass.states.get(utilization_24_sensor).state == "21.5"
+    assert hass.states.get(utilization_5_sensor).state == "34.2"
+    assert hass.states.get(utilization_6_sensor).state == "17.8"
+    assert (
+        hass.states.get(utilization_24_sensor).attributes["unit_of_measurement"]
+        == PERCENTAGE
+    )
+
+
+async def test_optional_device_detail_failure_does_not_break_setup(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test setup still works when optional detail endpoint fails."""
+    device_statuses = [
+        {
+            "name": "Core-Switch",
+            "serial": "Q2SW-AAAA-BBBB",
+            "mac": "b8:ab:61:e4:4e:7c",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "switch",
+            "model": "MS250",
+        }
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(side_effect=MerakiDashboardApiError("failed")),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert any(
+        entry.domain == "sensor" and entry.original_name == "Serial"
+        for entry in entries
+    )
+
+
+async def test_topology_sensor_builds_uplink_chain(
+    hass, mock_config_entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> None:
+    """Test topology includes both access and uplink edges."""
+    clients = [
+        {
+            "mac": "22:33:44:55:66:77",
+            "description": "Camera-1",
+            "status": "Online",
+            "recentDeviceSerial": "Q2AP-AAAA-BBBB",
+            "recentDeviceName": "AP-Living",
+            "recentDeviceConnection": "Wireless",
+            "ssid": "Home-WiFi",
+            "vlan": "400",
+        }
+    ]
+    device_statuses = [
+        {
+            "name": "AP-Living",
+            "serial": "Q2AP-AAAA-BBBB",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "wireless",
+            "model": "MR44",
+            "lanIp": "192.168.2.20",
+            "gateway": "192.168.2.1",
+        },
+        {
+            "name": "MX-FW",
+            "serial": "Q2FW-CCCC-DDDD",
+            "networkId": "L_1111",
+            "status": "online",
+            "productType": "appliance",
+            "model": "MX85",
+            "lanIp": "192.168.2.1",
+        },
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_network_clients",
+            AsyncMock(return_value=clients),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_devices_statuses",
+            AsyncMock(return_value=device_statuses),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_switch_ports_statuses",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_clients",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_wireless_status",
+            AsyncMock(return_value={"basicServiceSets": []}),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_device_appliance_performance",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.meraki_dashboard.coordinator.MerakiDashboardApi.async_get_organization_wireless_channel_utilization_by_device",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    topology_entity = next(
+        entry.entity_id
+        for entry in entries
+        if entry.domain == "sensor" and entry.original_name == "Topology nodes"
+    )
+    topology_state = hass.states.get(topology_entity)
+    assert topology_state is not None
+    edges = topology_state.attributes["edges"]
+
+    assert any(
+        edge["from"] == "22:33:44:55:66:77"
+        and edge["to"] == "Q2AP-AAAA-BBBB"
+        and edge["edge_type"] == "access"
+        for edge in edges
+    )
+    assert any(
+        edge["from"] == "Q2AP-AAAA-BBBB"
+        and edge["to"] == "Q2FW-CCCC-DDDD"
+        and edge["edge_type"] == "uplink"
+        for edge in edges
+    )


### PR DESCRIPTION
## Proposed change

This PR adds a new integration, `meraki_dashboard`, for Cisco Meraki Dashboard API.

What is included:
- New config flow with API key, organization, and network selection
- Coordinator-based polling for clients and infrastructure devices
- Device tracker entities for network clients and Bluetooth clients
- Infrastructure connectivity binary sensors
- Infrastructure diagnostic sensors
- Infrastructure action buttons
- Diagnostics support with sensitive data redaction
- Rate-limit handling with Repairs issue creation
- Full integration scaffolding (`manifest`, `strings`, translations, quality scale) and generated files

Why a separate domain:
- This introduces `meraki_dashboard` as a dedicated integration domain for dashboard API telemetry/features and avoids changing existing `meraki` behavior unexpectedly.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
