### PR TITLE
Fix remote calendar event handling of events within the same update period

### DIFF
--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -1,9 +1,10 @@
 """Calendar platform for a Remote Calendar."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
 from ical.event import Event
+from ical.timeline import Timeline, materialize_timeline
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
@@ -19,6 +20,14 @@ _LOGGER = logging.getLogger(__name__)
 
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
+
+# Every coordinator update refresh, we materialize a timeline of upcoming
+# events for determinig state. This is done in the background to avoid blocking
+# the event loop. When a state update happens we can scan for active events on
+# the materialized timeline. These parameters control the max lookahead which
+# just needs to cover the between the last update and the next update.
+MAX_LOOKAHEAD_EVENTS = 20
+MAX_LOOKAHEAD_TIME = timedelta(days=365)
 
 
 async def async_setup_entry(
@@ -48,12 +57,18 @@ class RemoteCalendarEntity(
         super().__init__(coordinator)
         self._attr_name = entry.data[CONF_CALENDAR_NAME]
         self._attr_unique_id = entry.entry_id
-        self._event: CalendarEvent | None = None
+        self._timeline: Timeline | None = None
 
     @property
     def event(self) -> CalendarEvent | None:
         """Return the next upcoming event."""
-        return self._event
+        if self._timeline is None:
+            return None
+        now = dt_util.now()
+        events = self._timeline.active_after(now)
+        if event := next(events, None):
+            return _get_calendar_event(event)
+        return None
 
     async def async_get_events(
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
@@ -79,14 +94,18 @@ class RemoteCalendarEntity(
         """
         await super().async_update()
 
-        def next_event() -> CalendarEvent | None:
+        def _get_timeline() -> Timeline | None:
+            """Return a materialized timeline with upcoming events."""
             now = dt_util.now()
-            events = self.coordinator.data.timeline_tz(now.tzinfo).active_after(now)
-            if event := next(events, None):
-                return _get_calendar_event(event)
-            return None
+            timeline = self.coordinator.data.timeline_tz(now.tzinfo)
+            return materialize_timeline(
+                timeline,
+                start=now,
+                stop=now + MAX_LOOKAHEAD_TIME,
+                max_number_of_events=MAX_LOOKAHEAD_EVENTS,
+            )
 
-        self._event = await self.hass.async_add_executor_job(next_event)
+        self._timeline = await self.hass.async_add_executor_job(_get_timeline)
 
 
 def _get_calendar_event(event: Event) -> CalendarEvent:

--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -22,10 +22,10 @@ _LOGGER = logging.getLogger(__name__)
 PARALLEL_UPDATES = 0
 
 # Every coordinator update refresh, we materialize a timeline of upcoming
-# events for determinig state. This is done in the background to avoid blocking
+# events for determining state. This is done in the background to avoid blocking
 # the event loop. When a state update happens we can scan for active events on
-# the materialized timeline. These parameters control the max lookahead which
-# just needs to cover the between the last update and the next update.
+# the materialized timeline. These parameters control the maximum lookahead
+# window and number of events we materialize from the calendar.
 MAX_LOOKAHEAD_EVENTS = 20
 MAX_LOOKAHEAD_TIME = timedelta(days=365)
 


### PR DESCRIPTION
Related to issue #162219

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix remote calendar event handling of events within the same update period. This is a partial revert of #159058 to ensure we reflect updates.

For background: We kind of flip-flopped back and forth between two bugs either (a) missing upcoming updates (only looking at one event during data updates) in the name of performance or (b) correctly handling upcoming updates but doing lots of work for large calendars while evaluating entity state. How instead we materialize a small portion of the calendar in the background, then access a small number of events when evaluating state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162219
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
