### PR TITLE
Prototype to add cover speed and speed presets 

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -33,7 +33,13 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN, INTENT_CLOSE_COVER, INTENT_OPEN_COVER  # noqa: F401
+from .const import (  # noqa: F401
+    ATTR_PRESET_MODE,
+    ATTR_SPEED,
+    DOMAIN,
+    INTENT_CLOSE_COVER,
+    INTENT_OPEN_COVER,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +48,13 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 SCAN_INTERVAL = timedelta(seconds=15)
+
+SPEED_PRESET_FIELDS = {
+    vol.Optional(ATTR_SPEED): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+    vol.Optional(ATTR_PRESET_MODE): cv.string,
+}
+
+SPEED_PRESET_SCHEMA = cv.make_entity_service_schema(SPEED_PRESET_FIELDS)
 
 
 class CoverState(StrEnum):
@@ -87,11 +100,15 @@ class CoverEntityFeature(IntFlag):
     CLOSE_TILT = 32
     STOP_TILT = 64
     SET_TILT_POSITION = 128
+    SET_SPEED = 256
+    PRESET_MODE = 512
 
 
 ATTR_CURRENT_POSITION = "current_position"
 ATTR_CURRENT_TILT_POSITION = "current_tilt_position"
 ATTR_POSITION = "position"
+ATTR_PRESET_MODE = "preset_mode"
+ATTR_SPEED = "speed"
 ATTR_TILT_POSITION = "tilt_position"
 
 
@@ -110,20 +127,29 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     await component.async_setup(config)
 
     component.async_register_entity_service(
-        SERVICE_OPEN_COVER, None, "async_open_cover", [CoverEntityFeature.OPEN]
+        SERVICE_OPEN_COVER,
+        SPEED_PRESET_SCHEMA,
+        "async_open_cover",
+        [CoverEntityFeature.OPEN],
     )
 
     component.async_register_entity_service(
-        SERVICE_CLOSE_COVER, None, "async_close_cover", [CoverEntityFeature.CLOSE]
+        SERVICE_CLOSE_COVER,
+        SPEED_PRESET_SCHEMA,
+        "async_close_cover",
+        [CoverEntityFeature.CLOSE],
     )
 
     component.async_register_entity_service(
         SERVICE_SET_COVER_POSITION,
-        {
-            vol.Required(ATTR_POSITION): vol.All(
-                vol.Coerce(int), vol.Range(min=0, max=100)
-            )
-        },
+        cv.make_entity_service_schema(
+            {
+                vol.Required(ATTR_POSITION): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=100)
+                ),
+                **SPEED_PRESET_FIELDS,
+            }
+        ),
         "async_set_cover_position",
         [CoverEntityFeature.SET_POSITION],
     )
@@ -141,14 +167,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     component.async_register_entity_service(
         SERVICE_OPEN_COVER_TILT,
-        None,
+        SPEED_PRESET_SCHEMA,
         "async_open_cover_tilt",
         [CoverEntityFeature.OPEN_TILT],
     )
 
     component.async_register_entity_service(
         SERVICE_CLOSE_COVER_TILT,
-        None,
+        SPEED_PRESET_SCHEMA,
         "async_close_cover_tilt",
         [CoverEntityFeature.CLOSE_TILT],
     )
@@ -162,11 +188,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     component.async_register_entity_service(
         SERVICE_SET_COVER_TILT_POSITION,
-        {
-            vol.Required(ATTR_TILT_POSITION): vol.All(
-                vol.Coerce(int), vol.Range(min=0, max=100)
-            )
-        },
+        cv.make_entity_service_schema(
+            {
+                vol.Required(ATTR_TILT_POSITION): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=100)
+                ),
+                **SPEED_PRESET_FIELDS,
+            }
+        ),
         "async_set_cover_tilt_position",
         [CoverEntityFeature.SET_TILT_POSITION],
     )
@@ -218,6 +247,9 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_is_closing: bool | None = None
     _attr_is_opening: bool | None = None
     _attr_state: None = None
+    _attr_speed: int | None = None
+    _attr_preset_mode: str | None = None
+    _attr_preset_modes: list[str] | None = None
     _attr_supported_features: CoverEntityFeature | None
 
     _cover_is_last_toggle_direction_open = True
@@ -248,6 +280,24 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         return None
 
     @property
+    def speed(self) -> int | None:
+        """Return current cover speed percentage if known."""
+
+        return self._attr_speed
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode if supported."""
+
+        return self._attr_preset_mode
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Return available preset modes if supported."""
+
+        return self._attr_preset_modes
+
+    @property
     @final
     def state(self) -> str | None:
         """Return the state of the cover."""
@@ -267,13 +317,19 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @property
     def state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
-        data = {}
+        data: dict[str, Any] = {}
 
         if (current := self.current_cover_position) is not None:
             data[ATTR_CURRENT_POSITION] = current
 
         if (current_tilt := self.current_cover_tilt_position) is not None:
             data[ATTR_CURRENT_TILT_POSITION] = current_tilt
+
+        if (speed := self.speed) is not None:
+            data[ATTR_SPEED] = speed
+
+        if (preset_mode := self.preset_mode) is not None:
+            data[ATTR_PRESET_MODE] = preset_mode
 
         return data
 
@@ -358,6 +414,24 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Move the cover to a specific position."""
         await self.hass.async_add_executor_job(
             ft.partial(self.set_cover_position, **kwargs)
+        )
+
+    def set_speed(self, **kwargs: Any) -> None:
+        """Set the cover speed percentage."""
+        raise NotImplementedError
+
+    async def async_set_speed(self, **kwargs: Any) -> None:
+        """Set the cover speed percentage."""
+        await self.hass.async_add_executor_job(ft.partial(self.set_speed, **kwargs))
+
+    def set_preset_mode(self, **kwargs: Any) -> None:
+        """Set the cover preset mode."""
+        raise NotImplementedError
+
+    async def async_set_preset_mode(self, **kwargs: Any) -> None:
+        """Set the cover preset mode."""
+        await self.hass.async_add_executor_job(
+            ft.partial(self.set_preset_mode, **kwargs)
         )
 
     def stop_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -35,6 +35,7 @@ from homeassistant.util.hass_dict import HassKey
 
 from .const import (  # noqa: F401
     ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
     ATTR_SPEED,
     DOMAIN,
     INTENT_CLOSE_COVER,

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -49,6 +49,9 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA
 PLATFORM_SCHEMA_BASE = cv.PLATFORM_SCHEMA_BASE
 SCAN_INTERVAL = timedelta(seconds=15)
 
+SERVICE_SET_COVER_PRESET_MODE = "set_cover_preset_mode"
+SERVICE_SET_COVER_SPEED = "set_cover_speed"
+
 SPEED_PRESET_FIELDS = {
     vol.Optional(ATTR_SPEED): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
     vol.Optional(ATTR_PRESET_MODE): cv.string,
@@ -108,6 +111,7 @@ ATTR_CURRENT_POSITION = "current_position"
 ATTR_CURRENT_TILT_POSITION = "current_tilt_position"
 ATTR_POSITION = "position"
 ATTR_PRESET_MODE = "preset_mode"
+ATTR_PRESET_MODES = "preset_modes"
 ATTR_SPEED = "speed"
 ATTR_TILT_POSITION = "tilt_position"
 
@@ -207,6 +211,30 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         [CoverEntityFeature.OPEN_TILT | CoverEntityFeature.CLOSE_TILT],
     )
 
+    component.async_register_entity_service(
+        SERVICE_SET_COVER_SPEED,
+        cv.make_entity_service_schema(
+            {
+                vol.Required(ATTR_SPEED): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=100)
+                ),
+            }
+        ),
+        "async_set_speed",
+        [CoverEntityFeature.SET_SPEED],
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SET_COVER_PRESET_MODE,
+        cv.make_entity_service_schema(
+            {
+                vol.Required(ATTR_PRESET_MODE): cv.string,
+            }
+        ),
+        "async_set_preset_mode",
+        [CoverEntityFeature.PRESET_MODE],
+    )
+
     return True
 
 
@@ -240,6 +268,8 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """Base class for cover entities."""
 
     entity_description: CoverEntityDescription
+    _entity_component_unrecorded_attributes = frozenset({ATTR_PRESET_MODES})
+
     _attr_current_cover_position: int | None = None
     _attr_current_cover_tilt_position: int | None = None
     _attr_device_class: CoverDeviceClass | None
@@ -296,6 +326,17 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return available preset modes if supported."""
 
         return self._attr_preset_modes
+
+    @property
+    def capability_attributes(self) -> dict[str, list[str] | None]:
+        """Return capability attributes."""
+        attrs: dict[str, list[str] | None] = {}
+        supported_features = self.supported_features
+
+        if CoverEntityFeature.PRESET_MODE in supported_features:
+            attrs[ATTR_PRESET_MODES] = self.preset_modes
+
+        return attrs
 
     @property
     @final

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -110,9 +110,6 @@ class CoverEntityFeature(IntFlag):
 ATTR_CURRENT_POSITION = "current_position"
 ATTR_CURRENT_TILT_POSITION = "current_tilt_position"
 ATTR_POSITION = "position"
-ATTR_PRESET_MODE = "preset_mode"
-ATTR_PRESET_MODES = "preset_modes"
-ATTR_SPEED = "speed"
 ATTR_TILT_POSITION = "tilt_position"
 
 
@@ -312,13 +309,11 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @property
     def speed(self) -> int | None:
         """Return current cover speed percentage if known."""
-
         return self._attr_speed
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode if supported."""
-
         return self._attr_preset_mode
 
     @property
@@ -457,22 +452,22 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             ft.partial(self.set_cover_position, **kwargs)
         )
 
-    def set_speed(self, **kwargs: Any) -> None:
+    def set_speed(self, speed: int) -> None:
         """Set the cover speed percentage."""
         raise NotImplementedError
 
-    async def async_set_speed(self, **kwargs: Any) -> None:
+    async def async_set_speed(self, speed: int) -> None:
         """Set the cover speed percentage."""
-        await self.hass.async_add_executor_job(ft.partial(self.set_speed, **kwargs))
+        await self.hass.async_add_executor_job(ft.partial(self.set_speed, speed))
 
-    def set_preset_mode(self, **kwargs: Any) -> None:
+    def set_preset_mode(self, preset_mode: str) -> None:
         """Set the cover preset mode."""
         raise NotImplementedError
 
-    async def async_set_preset_mode(self, **kwargs: Any) -> None:
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the cover preset mode."""
         await self.hass.async_add_executor_job(
-            ft.partial(self.set_preset_mode, **kwargs)
+            ft.partial(self.set_preset_mode, preset_mode)
         )
 
     def stop_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/cover/const.py
+++ b/homeassistant/components/cover/const.py
@@ -2,5 +2,9 @@
 
 DOMAIN = "cover"
 
+# Speed/preset support
+ATTR_SPEED = "speed"
+ATTR_PRESET_MODE = "preset_mode"
+
 INTENT_OPEN_COVER = "HassOpenCover"
 INTENT_CLOSE_COVER = "HassCloseCover"

--- a/homeassistant/components/cover/const.py
+++ b/homeassistant/components/cover/const.py
@@ -3,8 +3,9 @@
 DOMAIN = "cover"
 
 # Speed/preset support
-ATTR_SPEED = "speed"
 ATTR_PRESET_MODE = "preset_mode"
+ATTR_PRESET_MODES = "preset_modes"
+ATTR_SPEED = "speed"
 
 INTENT_OPEN_COVER = "HassOpenCover"
 INTENT_CLOSE_COVER = "HassCloseCover"

--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -6,6 +6,16 @@ open_cover:
       domain: cover
       supported_features:
         - cover.CoverEntityFeature.OPEN
+  fields:
+    preset_mode:
+      selector:
+        text: {}
+    speed:
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 close_cover:
   target:
@@ -13,6 +23,16 @@ close_cover:
       domain: cover
       supported_features:
         - cover.CoverEntityFeature.CLOSE
+  fields:
+    preset_mode:
+      selector:
+        text: {}
+    speed:
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 toggle:
   target:
@@ -36,6 +56,15 @@ set_cover_position:
           min: 0
           max: 100
           unit_of_measurement: "%"
+    preset_mode:
+      selector:
+        text: {}
+    speed:
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 stop_cover:
   target:
@@ -50,6 +79,16 @@ open_cover_tilt:
       domain: cover
       supported_features:
         - cover.CoverEntityFeature.OPEN_TILT
+  fields:
+    preset_mode:
+      selector:
+        text: {}
+    speed:
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 close_cover_tilt:
   target:
@@ -57,6 +96,16 @@ close_cover_tilt:
       domain: cover
       supported_features:
         - cover.CoverEntityFeature.CLOSE_TILT
+  fields:
+    preset_mode:
+      selector:
+        text: {}
+    speed:
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
 
 toggle_cover_tilt:
   target:
@@ -75,6 +124,15 @@ set_cover_tilt_position:
   fields:
     tilt_position:
       required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    preset_mode:
+      selector:
+        text: {}
+    speed:
       selector:
         number:
           min: 0

--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -145,3 +145,30 @@ stop_cover_tilt:
       domain: cover
       supported_features:
         - cover.CoverEntityFeature.STOP_TILT
+
+set_cover_speed:
+  target:
+    entity:
+      domain: cover
+      supported_features:
+        - cover.CoverEntityFeature.SET_SPEED
+  fields:
+    speed:
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+
+set_cover_preset_mode:
+  target:
+    entity:
+      domain: cover
+      supported_features:
+        - cover.CoverEntityFeature.PRESET_MODE
+  fields:
+    preset_mode:
+      required: true
+      selector:
+        text: {}

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -175,6 +175,26 @@
       },
       "name": "Set tilt position"
     },
+    "set_cover_preset_mode": {
+      "description": "Sets the preset mode for a cover.",
+      "fields": {
+        "preset_mode": {
+          "description": "The preset mode to set.",
+          "name": "Preset mode"
+        }
+      },
+      "name": "Set preset mode"
+    },
+    "set_cover_speed": {
+      "description": "Sets the speed for a cover.",
+      "fields": {
+        "speed": {
+          "description": "The speed percentage to set.",
+          "name": "Speed"
+        }
+      },
+      "name": "Set speed"
+    },
     "stop_cover": {
       "description": "Stops the cover movement.",
       "name": "[%key:common::action::stop%]"

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -85,18 +85,58 @@
   "services": {
     "close_cover": {
       "description": "Closes a cover.",
+      "fields": {
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
+        }
+      },
       "name": "[%key:common::action::close%]"
     },
     "close_cover_tilt": {
       "description": "Tilts a cover to close.",
+      "fields": {
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
+        }
+      },
       "name": "Close tilt"
     },
     "open_cover": {
       "description": "Opens a cover.",
+      "fields": {
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
+        }
+      },
       "name": "[%key:common::action::open%]"
     },
     "open_cover_tilt": {
       "description": "Tilts a cover open.",
+      "fields": {
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
+        }
+      },
       "name": "Open tilt"
     },
     "set_cover_position": {
@@ -105,6 +145,14 @@
         "position": {
           "description": "Target position.",
           "name": "Position"
+        },
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
         }
       },
       "name": "Set position"
@@ -112,6 +160,14 @@
     "set_cover_tilt_position": {
       "description": "Moves a cover tilt to a specific position.",
       "fields": {
+        "preset_mode": {
+          "description": "Preset mode if supported.",
+          "name": "Preset mode"
+        },
+        "speed": {
+          "description": "Speed percentage (0-100) if supported.",
+          "name": "Speed"
+        },
         "tilt_position": {
           "description": "Target tilt positition.",
           "name": "Tilt position"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a prototype implementation of what was proposed in https://github.com/home-assistant/architecture/discussions/789#discussioncomment-15760704, adding speed in percent and presets for speed to the cover integration. It is a prototype without any tests. As I don't have a full overview of how the lower levels of HA architecture fit together it might not be implemented correctly, I loosely aligned it with what I found in other base integrations, just let me know. Also, I did generate the services.yaml part so this might be completely off.

Feedback is definitely welcome. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/789#discussioncomment-15760704
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
