### PR TITLE
Keep integration even if services are offline

### DIFF
--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -1,13 +1,22 @@
 """The Jellyfin integration."""
 
+from contextlib import suppress
 from typing import Any
 
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 
 from .client_wrapper import CannotConnect, InvalidAuth, create_client, validate_input
-from .const import CONF_CLIENT_DEVICE_ID, DEFAULT_NAME, DOMAIN, PLATFORMS
+from .const import (
+    CONF_CLIENT_DEVICE_ID,
+    DEFAULT_NAME,
+    DOMAIN,
+    PLATFORMS,
+    SERVER_KEY_ID,
+    SERVER_KEY_NAME,
+    SERVER_KEY_VERSION,
+)
 from .coordinator import JellyfinConfigEntry, JellyfinDataUpdateCoordinator
 
 
@@ -25,17 +34,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> 
 
     try:
         user_id, connect_result = await validate_input(hass, dict(entry.data), client)
-    except CannotConnect as ex:
-        raise ConfigEntryNotReady("Cannot connect to Jellyfin server") from ex
+        api_server = connect_result["Servers"][0]
+        # Use entry.entry_id for consistent device identification
+        # Store actual server info separately
+        server_info: dict[str, Any] = {
+            SERVER_KEY_ID: entry.entry_id,
+            SERVER_KEY_NAME: api_server.get("Name", "Jellyfin"),
+            SERVER_KEY_VERSION: api_server.get("Version"),
+        }
+    except CannotConnect:
+        # Connection failed - create fresh client to avoid partial state
+        client = create_client(device_id=device_id, device_name=device_name)
+        server_info = {
+            SERVER_KEY_ID: entry.entry_id,
+            SERVER_KEY_NAME: entry.title or "Jellyfin",
+            SERVER_KEY_VERSION: None,
+        }
+        user_id = entry.entry_id
+        connected = False
     except InvalidAuth as ex:
         raise ConfigEntryAuthFailed(ex) from ex
-
-    server_info: dict[str, Any] = connect_result["Servers"][0]
+    else:
+        connected = True
 
     coordinator = JellyfinDataUpdateCoordinator(
-        hass, entry, client, server_info, user_id
+        hass, entry, client, server_info, user_id, connected
     )
-    await coordinator.async_config_entry_first_refresh()
+
+    with suppress(Exception):
+        await coordinator.async_config_entry_first_refresh()
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -21,7 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_URL): str,
+        vol.Required(
+            CONF_URL,
+            description={"suggested_value": "http://192.168.1.x:8096"},
+        ): str,
         vol.Required(CONF_USERNAME): str,
         vol.Optional(CONF_PASSWORD, default=""): str,
     }

--- a/homeassistant/components/jellyfin/const.py
+++ b/homeassistant/components/jellyfin/const.py
@@ -19,6 +19,11 @@ CONF_CLIENT_DEVICE_ID: Final = "client_device_id"
 
 DEFAULT_NAME: Final = "Jellyfin"
 
+UPDATE_INTERVAL_CONNECTED: Final = 30  # seconds - normal polling when connected
+UPDATE_INTERVAL_DISCONNECTED: Final = (
+    600  # seconds (10 min) - slower polling when disconnected
+)
+
 ITEM_KEY_COLLECTION_TYPE: Final = "CollectionType"
 ITEM_KEY_ID: Final = "Id"
 ITEM_KEY_IMAGE_TAGS: Final = "ImageTags"
@@ -26,6 +31,10 @@ ITEM_KEY_INDEX_NUMBER: Final = "IndexNumber"
 ITEM_KEY_MEDIA_SOURCES: Final = "MediaSources"
 ITEM_KEY_MEDIA_TYPE: Final = "MediaType"
 ITEM_KEY_NAME: Final = "Name"
+
+SERVER_KEY_ID: Final = "id"
+SERVER_KEY_NAME: Final = "name"
+SERVER_KEY_VERSION: Final = "version"
 
 ITEM_TYPE_ALBUM: Final = "MusicAlbum"
 ITEM_TYPE_ARTIST: Final = "MusicArtist"

--- a/homeassistant/components/jellyfin/coordinator.py
+++ b/homeassistant/components/jellyfin/coordinator.py
@@ -8,10 +8,22 @@ from typing import Any
 from jellyfin_apiclient_python import JellyfinClient
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_CLIENT_DEVICE_ID, DOMAIN, LOGGER, USER_APP_NAME
+from .client_wrapper import CannotConnect, InvalidAuth, _connect
+from .const import (
+    CONF_CLIENT_DEVICE_ID,
+    DOMAIN,
+    LOGGER,
+    SERVER_KEY_ID,
+    SERVER_KEY_NAME,
+    SERVER_KEY_VERSION,
+    UPDATE_INTERVAL_CONNECTED,
+    UPDATE_INTERVAL_DISCONNECTED,
+    USER_APP_NAME,
+)
 
 type JellyfinConfigEntry = ConfigEntry[JellyfinDataUpdateCoordinator]
 
@@ -28,31 +40,65 @@ class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         api_client: JellyfinClient,
         system_info: dict[str, Any],
         user_id: str,
+        connected: bool = True,
     ) -> None:
         """Initialize the coordinator."""
+        interval = (
+            UPDATE_INTERVAL_CONNECTED if connected else UPDATE_INTERVAL_DISCONNECTED
+        )
         super().__init__(
             hass=hass,
             logger=LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
-            update_interval=timedelta(seconds=10),
+            update_interval=timedelta(seconds=interval),
         )
         self.api_client = api_client
-        self.server_id: str = system_info["Id"]
-        self.server_name: str = system_info["Name"]
-        self.server_version: str | None = system_info.get("Version")
+        self.server_id: str = system_info.get(SERVER_KEY_ID, config_entry.entry_id)
+        self.server_name: str = system_info.get(SERVER_KEY_NAME, "Jellyfin")
+        self.server_version: str | None = system_info.get(SERVER_KEY_VERSION)
         self.client_device_id: str = config_entry.data[CONF_CLIENT_DEVICE_ID]
         self.user_id: str = user_id
+        self.connected: bool = connected
 
         self.session_ids: set[str] = set()
         self.remote_session_ids: set[str] = set()
         self.device_ids: set[str] = set()
 
+    def _reconnect(self) -> tuple[str, dict[str, Any]]:
+        """Attempt to reconnect to the Jellyfin server."""
+        return _connect(
+            self.api_client,
+            self.config_entry.data[CONF_URL],
+            self.config_entry.data[CONF_USERNAME],
+            self.config_entry.data[CONF_PASSWORD],
+        )
+
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
         """Get the latest data from Jellyfin."""
-        sessions = await self.hass.async_add_executor_job(
-            self.api_client.jellyfin.sessions
-        )
+        if not self.connected:
+            try:
+                user_id, connect_result = await self.hass.async_add_executor_job(
+                    self._reconnect
+                )
+                self.connected = True
+                # Keep server_id as entry_id for consistent device identification
+                api_server = connect_result["Servers"][0]
+                self.server_name = api_server.get("Name", "Jellyfin")
+                self.server_version = api_server.get("Version")
+                self.user_id = user_id
+                self.update_interval = timedelta(seconds=UPDATE_INTERVAL_CONNECTED)
+            except (CannotConnect, InvalidAuth, Exception) as err:
+                raise UpdateFailed(f"Server unreachable: {err}") from err
+
+        try:
+            sessions = await self.hass.async_add_executor_job(
+                self.api_client.jellyfin.sessions
+            )
+        except (KeyError, CannotConnect, InvalidAuth, Exception) as err:
+            self.connected = False
+            self.update_interval = timedelta(seconds=UPDATE_INTERVAL_DISCONNECTED)
+            raise UpdateFailed(f"Error fetching Jellyfin sessions: {err}") from err
 
         if sessions is None:
             return {}

--- a/homeassistant/components/jellyfin/diagnostics.py
+++ b/homeassistant/components/jellyfin/diagnostics.py
@@ -28,6 +28,7 @@ async def async_get_config_entry_diagnostics(
             "id": coordinator.server_id,
             "name": coordinator.server_name,
             "version": coordinator.server_version,
+            "connected": coordinator.connected,
         },
         "sessions": [
             {
@@ -41,6 +42,6 @@ async def async_get_config_entry_diagnostics(
                 "now_playing": session_data.get("NowPlayingItem"),
                 "play_state": session_data.get("PlayState"),
             }
-            for session_id, session_data in coordinator.data.items()
+            for session_id, session_data in (coordinator.data or {}).items()
         ],
     }

--- a/homeassistant/components/jellyfin/media_player.py
+++ b/homeassistant/components/jellyfin/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.components.media_player import (
     SearchMediaQuery,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import IntegrationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.dt import parse_datetime
 
@@ -39,7 +40,7 @@ async def async_setup_entry(
     def handle_coordinator_update() -> None:
         """Add media player per session."""
         entities: list[MediaPlayerEntity] = []
-        for session_id in coordinator.data:
+        for session_id in coordinator.data or {}:
             if session_id not in coordinator.session_ids:
                 entity: MediaPlayerEntity = JellyfinMediaPlayer(coordinator, session_id)
                 LOGGER.debug("Creating media player for session: %s", session_id)
@@ -215,56 +216,80 @@ class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
 
     def media_seek(self, position: float) -> None:
         """Send seek command."""
-        self.coordinator.api_client.jellyfin.remote_seek(
-            self.session_id, int(position * 10000000)
-        )
+        try:
+            self.coordinator.api_client.jellyfin.remote_seek(
+                self.session_id, int(position * 10000000)
+            )
+        except IntegrationError as err:
+            _LOGGER.error("Failed to seek media: %s", err)
 
     def media_pause(self) -> None:
         """Send pause command."""
-        self.coordinator.api_client.jellyfin.remote_pause(self.session_id)
-        self._attr_state = MediaPlayerState.PAUSED
-        self.schedule_update_ha_state()
+        try:
+            self.coordinator.api_client.jellyfin.remote_pause(self.session_id)
+            self._attr_state = MediaPlayerState.PAUSED
+            self.schedule_update_ha_state()
+        except IntegrationError as err:
+            _LOGGER.error("Failed to pause media: %s", err)
 
     def media_play(self) -> None:
         """Send play command."""
-        self.coordinator.api_client.jellyfin.remote_unpause(self.session_id)
-        self._attr_state = MediaPlayerState.PLAYING
-        self.schedule_update_ha_state()
+        try:
+            self.coordinator.api_client.jellyfin.remote_unpause(self.session_id)
+            self._attr_state = MediaPlayerState.PLAYING
+            self.schedule_update_ha_state()
+        except IntegrationError as err:
+            _LOGGER.error("Failed to play media: %s", err)
 
     def media_play_pause(self) -> None:
         """Send the PlayPause command to the session."""
-        self.coordinator.api_client.jellyfin.remote_playpause(self.session_id)
+        try:
+            self.coordinator.api_client.jellyfin.remote_playpause(self.session_id)
+        except IntegrationError as err:
+            _LOGGER.error("Failed to toggle play/pause: %s", err)
 
     def media_stop(self) -> None:
         """Send stop command."""
-        self.coordinator.api_client.jellyfin.remote_stop(self.session_id)
-        self._attr_state = MediaPlayerState.IDLE
-        self.schedule_update_ha_state()
+        try:
+            self.coordinator.api_client.jellyfin.remote_stop(self.session_id)
+            self._attr_state = MediaPlayerState.IDLE
+            self.schedule_update_ha_state()
+        except IntegrationError as err:
+            _LOGGER.error("Failed to stop media: %s", err)
 
     def play_media(
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play a piece of media."""
-        self.coordinator.api_client.jellyfin.remote_play_media(
-            self.session_id, [media_id]
-        )
+        try:
+            self.coordinator.api_client.jellyfin.remote_play_media(
+                self.session_id, [media_id]
+            )
+        except IntegrationError as err:
+            _LOGGER.error("Failed to play media: %s", err)
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self.coordinator.api_client.jellyfin.remote_set_volume(
-            self.session_id, int(volume * 100)
-        )
-        self._attr_volume_level = volume
-        self.schedule_update_ha_state()
+        try:
+            self.coordinator.api_client.jellyfin.remote_set_volume(
+                self.session_id, int(volume * 100)
+            )
+            self._attr_volume_level = volume
+            self.schedule_update_ha_state()
+        except IntegrationError as err:
+            _LOGGER.error("Failed to set volume level: %s", err)
 
     def mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
-        if mute:
-            self.coordinator.api_client.jellyfin.remote_mute(self.session_id)
-        else:
-            self.coordinator.api_client.jellyfin.remote_unmute(self.session_id)
-        self._attr_is_volume_muted = mute
-        self.schedule_update_ha_state()
+        try:
+            if mute:
+                self.coordinator.api_client.jellyfin.remote_mute(self.session_id)
+            else:
+                self.coordinator.api_client.jellyfin.remote_unmute(self.session_id)
+            self._attr_is_volume_muted = mute
+            self.schedule_update_ha_state()
+        except IntegrationError as err:
+            _LOGGER.error("Failed to mute volume: %s", err)
 
     async def async_browse_media(
         self,

--- a/homeassistant/components/jellyfin/media_source.py
+++ b/homeassistant/components/jellyfin/media_source.py
@@ -55,9 +55,17 @@ _LOGGER = logging.getLogger(__name__)
 async def async_get_media_source(hass: HomeAssistant) -> MediaSource:
     """Set up Jellyfin media source."""
     # Currently only a single Jellyfin server is supported
-    entry: JellyfinConfigEntry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator = entry.runtime_data
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        raise ValueError("No Jellyfin config entry found")
 
+    entry: JellyfinConfigEntry = entries[0]
+
+    # Handle case where entry isn't fully loaded yet (startup timing)
+    if not hasattr(entry, "runtime_data"):
+        raise ValueError("Jellyfin config entry is not yet fully loaded")
+
+    coordinator = entry.runtime_data
     return JellyfinSource(hass, coordinator.api_client, entry)
 
 

--- a/homeassistant/components/jellyfin/remote.py
+++ b/homeassistant/components/jellyfin/remote.py
@@ -3,22 +3,19 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-import time
+import logging
 from typing import Any
 
-from homeassistant.components.remote import (
-    ATTR_DELAY_SECS,
-    ATTR_NUM_REPEATS,
-    DEFAULT_DELAY_SECS,
-    DEFAULT_NUM_REPEATS,
-    RemoteEntity,
-)
+from homeassistant.components.remote import RemoteEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import IntegrationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import LOGGER
 from .coordinator import JellyfinConfigEntry, JellyfinDataUpdateCoordinator
 from .entity import JellyfinClientEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -33,7 +30,7 @@ async def async_setup_entry(
     def handle_coordinator_update() -> None:
         """Add remote per session."""
         entities: list[RemoteEntity] = []
-        for session_id, session_data in coordinator.data.items():
+        for session_id, session_data in (coordinator.data or {}).items():
             if (
                 session_id not in coordinator.remote_session_ids
                 and session_data["SupportsRemoteControl"]
@@ -68,12 +65,10 @@ class JellyfinRemote(JellyfinClientEntity, RemoteEntity):
 
     def send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to the client."""
-        num_repeats = kwargs.get(ATTR_NUM_REPEATS, DEFAULT_NUM_REPEATS)
-        delay = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
-
-        for _ in range(num_repeats):
-            for single_command in command:
+        for single_command in command:
+            try:
                 self.coordinator.api_client.jellyfin.command(
                     self.session_id, single_command
                 )
-                time.sleep(delay)
+            except IntegrationError as err:
+                _LOGGER.error("Failed to send command '%s': %s", single_command, err)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the server goes offline the integration is marked as failed to setup and that entities are no longer provided. It is not uncommon to turn off a server when not in used. These changes removes a sleep during command call and rely on the coordinator instead to check for changes and make the entities unavailable instead. Earlier approach tries to reconnect every 30 second which create a lot of uneccessery error codes in the logs. It also prevent the integration from allowing multiple servers so this could be an initial step for multi server support. The PR include a raise on the polling from 10s to 30seconds (but most likely possible to raise higher)  and a retry timer on 10 minutes.

Also added a helper text to the setup to clarify that http:// is required in the host url.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163187
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
