### PR TITLE
Refactor HTML5 integration to use aiohttp instead of requests

### DIFF
--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, NotRequired, TypedDict, cast
 from urllib.parse import urlparse
 import uuid
 
-from aiohttp import web
+from aiohttp import ClientSession, web
 from aiohttp.hdrs import AUTHORIZATION
 import jwt
 from py_vapid import Vapid
@@ -203,8 +203,9 @@ async def async_get_service(
     hass.http.register_view(HTML5PushRegistrationView(registrations, json_path))
     hass.http.register_view(HTML5PushCallbackView(registrations))
 
+    session = async_get_clientsession(hass)
     return HTML5NotificationService(
-        hass, vapid_prv_key, vapid_email, registrations, json_path
+        hass, session, vapid_prv_key, vapid_email, registrations, json_path
     )
 
 
@@ -420,12 +421,14 @@ class HTML5NotificationService(BaseNotificationService):
     def __init__(
         self,
         hass: HomeAssistant,
+        session: ClientSession,
         vapid_prv: str,
         vapid_email: str,
         registrations: dict[str, Registration],
         json_path: str,
     ) -> None:
         """Initialize the service."""
+        self.session = session
         self._vapid_prv = vapid_prv
         self._vapid_email = vapid_email
         self.registrations = registrations
@@ -530,9 +533,9 @@ class HTML5NotificationService(BaseNotificationService):
                 payload[ATTR_TAG],
                 subscription["keys"]["auth"],
             )
-            session = async_get_clientsession(self.hass)
+
             webpusher = WebPusher(
-                cast(dict[str, Any], info["subscription"]), aiohttp_session=session
+                cast(dict[str, Any], info["subscription"]), aiohttp_session=self.session
             )
 
             endpoint = urlparse(subscription["endpoint"])

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -565,7 +565,7 @@ class HTML5NotificationService(BaseNotificationService):
                 _LOGGER.error(
                     "There was an issue sending the notification %s: %s",
                     response.status,
-                    response.text,
+                    await response.text(),
                 )
 
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from contextlib import suppress
 from datetime import datetime, timedelta
-from functools import partial
 from http import HTTPStatus
 import json
 import logging
@@ -35,6 +34,7 @@ from homeassistant.const import ATTR_NAME, URL_ROOT
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.json import save_json
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import ensure_unique_string
@@ -456,22 +456,18 @@ class HTML5NotificationService(BaseNotificationService):
         """Return a dictionary of registered targets."""
         return {registration: registration for registration in self.registrations}
 
-    def dismiss(self, **kwargs: Any) -> None:
-        """Dismisses a notification."""
-        data: dict[str, Any] | None = kwargs.get(ATTR_DATA)
-        tag: str = data.get(ATTR_TAG, "") if data else ""
-        payload = {ATTR_TAG: tag, ATTR_DISMISS: True, ATTR_DATA: {}}
-
-        self._push_message(payload, **kwargs)
-
-    async def async_dismiss(self, **kwargs) -> None:
+    async def async_dismiss(self, **kwargs: Any) -> None:
         """Dismisses a notification.
 
         This method must be run in the event loop.
         """
-        await self.hass.async_add_executor_job(partial(self.dismiss, **kwargs))
+        data: dict[str, Any] | None = kwargs.get(ATTR_DATA)
+        tag: str = data.get(ATTR_TAG, "") if data else ""
+        payload = {ATTR_TAG: tag, ATTR_DISMISS: True, ATTR_DATA: {}}
 
-    def send_message(self, message: str = "", **kwargs: Any) -> None:
+        await self._push_message(payload, **kwargs)
+
+    async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
         tag = str(uuid.uuid4())
         payload: dict[str, Any] = {
@@ -503,9 +499,9 @@ class HTML5NotificationService(BaseNotificationService):
         ):
             payload[ATTR_DATA][ATTR_URL] = URL_ROOT
 
-        self._push_message(payload, **kwargs)
+        await self._push_message(payload, **kwargs)
 
-    def _push_message(self, payload: dict[str, Any], **kwargs: Any) -> None:
+    async def _push_message(self, payload: dict[str, Any], **kwargs: Any) -> None:
         """Send the message."""
 
         timestamp = int(time.time())
@@ -534,8 +530,10 @@ class HTML5NotificationService(BaseNotificationService):
                 payload[ATTR_TAG],
                 subscription["keys"]["auth"],
             )
-
-            webpusher = WebPusher(cast(dict[str, Any], info["subscription"]))
+            session = async_get_clientsession(self.hass)
+            webpusher = WebPusher(
+                cast(dict[str, Any], info["subscription"]), aiohttp_session=session
+            )
 
             endpoint = urlparse(subscription["endpoint"])
             vapid_claims = {
@@ -545,14 +543,15 @@ class HTML5NotificationService(BaseNotificationService):
             }
             vapid_headers = Vapid.from_string(self._vapid_prv).sign(vapid_claims)
             vapid_headers.update({"urgency": priority, "priority": priority})
-            response = webpusher.send(
+
+            response = await webpusher.send_async(
                 data=json.dumps(payload), headers=vapid_headers, ttl=ttl
             )
 
             if TYPE_CHECKING:
                 assert not isinstance(response, str)
 
-            if response.status_code == HTTPStatus.GONE:
+            if response.status == HTTPStatus.GONE:
                 _LOGGER.info("Notification channel has expired")
                 reg = self.registrations.pop(target)
                 try:
@@ -562,10 +561,10 @@ class HTML5NotificationService(BaseNotificationService):
                     _LOGGER.error("Error saving registration")
                 else:
                     _LOGGER.info("Configuration saved")
-            elif response.status_code >= HTTPStatus.BAD_REQUEST:
+            elif response.status >= HTTPStatus.BAD_REQUEST:
                 _LOGGER.error(
                     "There was an issue sending the notification %s: %s",
-                    response.status_code,
+                    response.status,
                     response.text,
                 )
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -555,7 +555,9 @@ class HTML5NotificationService(BaseNotificationService):
                 _LOGGER.info("Notification channel has expired")
                 reg = self.registrations.pop(target)
                 try:
-                    save_json(self.registrations_json_path, self.registrations)
+                    await self.hass.async_add_executor_job(
+                        save_json, self.registrations_json_path, self.registrations
+                    )
                 except HomeAssistantError:
                     self.registrations[target] = reg
                     _LOGGER.error("Error saving registration")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`pywebpush` actually supports injecting an aiohttp client session, so I refactored the integration to send messages asynchronously 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
