### PR TITLE
Add charge cable and charge port latch sensors to Tessie

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -115,6 +115,13 @@ POWER_SHARE_TYPES = {
     "Home": "home",
 }
 
+CHARGE_CABLE_TYPES = {
+    "IEC": "iec",
+    "SAE": "sae",
+    "GB_AC": "gb_ac",
+    "GB_DC": "gb_dc",
+}
+
 FORWARD_COLLISION_SENSITIVITIES = {
     "Off": "off",
     "Late": "late",
@@ -287,9 +294,14 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="charge_state_conn_charge_cable",
         polling=True,
+        polling_value_fn=lambda value: CHARGE_CABLE_TYPES.get(str(value)),
         streaming_listener=lambda vehicle, callback: vehicle.listen_ChargingCableType(
-            callback
+            lambda value: callback(
+                None if value is None else CHARGE_CABLE_TYPES.get(value)
+            )
         ),
+        options=list(CHARGE_CABLE_TYPES.values()),
+        device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -519,7 +519,13 @@
         }
       },
       "charge_state_conn_charge_cable": {
-        "name": "Charge cable"
+        "name": "Charge cable",
+        "state": {
+          "gb_ac": "GB/AC",
+          "gb_dc": "GB/DC",
+          "iec": "IEC",
+          "sae": "SAE"
+        }
       },
       "charge_state_est_battery_range": {
         "name": "Estimate battery range"

--- a/homeassistant/components/tessie/const.py
+++ b/homeassistant/components/tessie/const.py
@@ -100,6 +100,12 @@ TessieChargeStates = {
     "NoPower": "no_power",
 }
 
+TessieChargePortLatchStates = {
+    "Engaged": "engaged",
+    "Disengaged": "disengaged",
+    "Blocking": "blocking",
+}
+
 
 class TessieWallConnectorStates(IntEnum):
     """Tessie Wall Connector states."""

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -184,8 +184,14 @@
       "battery_power": {
         "default": "mdi:home-battery"
       },
+      "charge_state_charge_port_latch": {
+        "default": "mdi:ev-plug-tesla"
+      },
       "charge_state_charging_state": {
         "default": "mdi:ev-station"
+      },
+      "charge_state_conn_charge_cable": {
+        "default": "mdi:ev-plug-ccs2"
       },
       "charge_state_energy_remaining": {
         "default": "mdi:battery-medium"

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -159,7 +159,7 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
         key="charge_state_charge_port_latch",
         options=list(TessieChargePortLatchStates.values()),
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda value: TessieChargePortLatchStates.get(cast(str, value)),
+        value_fn=lambda value: TessieChargePortLatchStates[cast(str, value)],
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -34,7 +34,12 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util.variance import ignore_variance
 
 from . import TessieConfigEntry
-from .const import ENERGY_HISTORY_FIELDS, TessieChargeStates, TessieWallConnectorStates
+from .const import (
+    ENERGY_HISTORY_FIELDS,
+    TessieChargePortLatchStates,
+    TessieChargeStates,
+    TessieWallConnectorStates,
+)
 from .entity import (
     TessieBatteryEntity,
     TessieEnergyEntity,
@@ -144,6 +149,19 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.ENERGY_STORAGE,
         entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=2,
+    ),
+    TessieSensorEntityDescription(
+        key="charge_state_conn_charge_cable",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    TessieSensorEntityDescription(
+        key="charge_state_charge_port_latch",
+        options=list(TessieChargePortLatchStates.values()),
+        device_class=SensorDeviceClass.ENUM,
+        value_fn=lambda value: TessieChargePortLatchStates.get(cast(str, value)),
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     TessieSensorEntityDescription(
         key="drive_state_speed",

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -352,6 +352,14 @@
       "charge_state_charge_energy_added": {
         "name": "Charge energy added"
       },
+      "charge_state_charge_port_latch": {
+        "name": "Charge port latch",
+        "state": {
+          "blocking": "Blocking",
+          "disengaged": "Disengaged",
+          "engaged": "Engaged"
+        }
+      },
       "charge_state_charge_rate": {
         "name": "Charge rate"
       },
@@ -374,6 +382,9 @@
           "starting": "Starting",
           "stopped": "[%key:common::state::stopped%]"
         }
+      },
+      "charge_state_conn_charge_cable": {
+        "name": "Charge cable"
       },
       "charge_state_energy_remaining": {
         "name": "Energy remaining"

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -2651,7 +2651,14 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'iec',
+        'sae',
+        'gb_ac',
+        'gb_dc',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -2670,7 +2677,7 @@
     'object_id_base': 'Charge cable',
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Charge cable',
     'platform': 'teslemetry',
@@ -2685,27 +2692,41 @@
 # name: test_sensors[sensor.test_charge_cable-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'enum',
       'friendly_name': 'Test Charge cable',
+      'options': list([
+        'iec',
+        'sae',
+        'gb_ac',
+        'gb_dc',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.test_charge_cable',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'IEC',
+    'state': 'iec',
   })
 # ---
 # name: test_sensors[sensor.test_charge_cable-statealt]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'enum',
       'friendly_name': 'Test Charge cable',
+      'options': list([
+        'iec',
+        'sae',
+        'gb_ac',
+        'gb_dc',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.test_charge_cable',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'IEC',
+    'state': 'iec',
   })
 # ---
 # name: test_sensors[sensor.test_charge_energy_added-entry]

--- a/tests/components/tessie/snapshots/test_sensor.ambr
+++ b/tests/components/tessie/snapshots/test_sensor.ambr
@@ -2394,6 +2394,55 @@
     'state': '424.35182592',
   })
 # ---
+# name: test_sensors[sensor.test_charge_cable-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_charge_cable',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charge cable',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charge cable',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_state_conn_charge_cable',
+    'unique_id': 'VINVINVIN-charge_state_conn_charge_cable',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_charge_cable-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Charge cable',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_charge_cable',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'IEC',
+  })
+# ---
 # name: test_sensors[sensor.test_charge_energy_added-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -2449,6 +2498,67 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '18.47',
+  })
+# ---
+# name: test_sensors[sensor.test_charge_port_latch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'engaged',
+        'disengaged',
+        'blocking',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_charge_port_latch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charge port latch',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Charge port latch',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charge_state_charge_port_latch',
+    'unique_id': 'VINVINVIN-charge_state_charge_port_latch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_charge_port_latch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Test Charge port latch',
+      'options': list([
+        'engaged',
+        'disengaged',
+        'blocking',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_charge_port_latch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'engaged',
   })
 # ---
 # name: test_sensors[sensor.test_charge_rate-entry]


### PR DESCRIPTION
## Proposed change

Add two new diagnostic sensor entities to the Tessie integration:

- **Charge cable** (`charge_state_conn_charge_cable`) - A plain text sensor showing the connected charge cable type (e.g., IEC, SAE). Disabled by default.
- **Charge port latch** (`charge_state_charge_port_latch`) - An enum sensor reporting the charge port latch state with options: engaged, disengaged, blocking. Disabled by default.

Both sensors are categorized as diagnostic entities.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43581
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr