### PR TITLE
Migrate SleepIQ sensors to entity descriptions

### DIFF
--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -1,10 +1,17 @@
-"""Support for SleepIQ Sensor."""
+"""Support for SleepIQ sensors."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from asyncsleepiq import SleepIQBed, SleepIQSleeper
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -13,7 +20,28 @@ from .const import DOMAIN, PRESSURE, SLEEP_NUMBER
 from .coordinator import SleepIQData, SleepIQDataUpdateCoordinator
 from .entity import SleepIQSleeperEntity
 
-SENSORS = [PRESSURE, SLEEP_NUMBER]
+
+@dataclass(frozen=True, kw_only=True)
+class SleepIQSensorEntityDescription(SensorEntityDescription):
+    """Describes SleepIQ sensor entity."""
+
+    value_fn: Callable[[SleepIQSleeper], float | int | None]
+
+
+SENSORS: tuple[SleepIQSensorEntityDescription, ...] = (
+    SleepIQSensorEntityDescription(
+        key=PRESSURE,
+        translation_key="pressure",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda sleeper: sleeper.pressure,
+    ),
+    SleepIQSensorEntityDescription(
+        key=SLEEP_NUMBER,
+        translation_key="sleep_number",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda sleeper: sleeper.sleep_number,
+    ),
+)
 
 
 async def async_setup_entry(
@@ -24,33 +52,32 @@ async def async_setup_entry(
     """Set up the SleepIQ bed sensors."""
     data: SleepIQData = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        SleepIQSensorEntity(data.data_coordinator, bed, sleeper, sensor_type)
+        SleepIQSensorEntity(data.data_coordinator, bed, sleeper, description)
         for bed in data.client.beds.values()
         for sleeper in bed.sleepers
-        for sensor_type in SENSORS
+        for description in SENSORS
     )
 
 
 class SleepIQSensorEntity(
     SleepIQSleeperEntity[SleepIQDataUpdateCoordinator], SensorEntity
 ):
-    """Representation of an SleepIQ Entity with CoordinatorEntity."""
+    """Representation of a SleepIQ sensor."""
 
-    _attr_icon = "mdi:bed"
+    entity_description: SleepIQSensorEntityDescription
 
     def __init__(
         self,
         coordinator: SleepIQDataUpdateCoordinator,
         bed: SleepIQBed,
         sleeper: SleepIQSleeper,
-        sensor_type: str,
+        description: SleepIQSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        self.sensor_type = sensor_type
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        super().__init__(coordinator, bed, sleeper, sensor_type)
+        super().__init__(coordinator, bed, sleeper, description.key)
+        self.entity_description = description
 
     @callback
     def _async_update_attrs(self) -> None:
         """Update sensor attributes."""
-        self._attr_native_value = getattr(self.sleeper, self.sensor_type)
+        self._attr_native_value = self.entity_description.value_fn(self.sleeper)

--- a/homeassistant/components/sleepiq/sensor.py
+++ b/homeassistant/components/sleepiq/sensor.py
@@ -74,8 +74,8 @@ class SleepIQSensorEntity(
         description: SleepIQSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, bed, sleeper, description.key)
         self.entity_description = description
+        super().__init__(coordinator, bed, sleeper, description.key)
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/tests/components/sleepiq/snapshots/test_sensor.ambr
+++ b/tests/components/sleepiq/snapshots/test_sensor.ambr
@@ -32,7 +32,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'pressure',
     'unique_id': '43219_pressure',
     'unit_of_measurement': None,
   })
@@ -85,7 +85,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'sleep_number',
     'unique_id': '43219_sleep_number',
     'unit_of_measurement': None,
   })
@@ -138,7 +138,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'pressure',
     'unique_id': '98765_pressure',
     'unit_of_measurement': None,
   })
@@ -191,7 +191,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'sleep_number',
     'unique_id': '98765_sleep_number',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
## Proposed change

Refactors the existing SleepIQ sensors (pressure and sleep_number) to use the SensorEntityDescription pattern. This improves code maintainability and consistency with other Home Assistant integrations.

This is a prerequisite PR for adding sleep health metrics support.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: N/A (no user-facing changes)
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr