### PR TITLE
Fix Control4 HVAC action mapping for multi-stage and idle states

### DIFF
--- a/homeassistant/components/control4/climate.py
+++ b/homeassistant/components/control4/climate.py
@@ -62,11 +62,12 @@ C4_TO_HA_HVAC_MODE = {
 
 HA_TO_C4_HVAC_MODE = {v: k for k, v in C4_TO_HA_HVAC_MODE.items()}
 
-# Map the five known Control4 HVAC states to Home Assistant HVAC actions
+# Map Control4 HVAC states to Home Assistant HVAC actions
 C4_TO_HA_HVAC_ACTION = {
     "off": HVACAction.OFF,
     "heat": HVACAction.HEATING,
     "cool": HVACAction.COOLING,
+    "idle": HVACAction.IDLE,
     "dry": HVACAction.DRYING,
     "fan": HVACAction.FAN,
 }
@@ -248,8 +249,14 @@ class Control4Climate(Control4Entity, ClimateEntity):
         c4_state = data.get(CONTROL4_HVAC_STATE)
         if c4_state is None:
             return None
-        # Convert state to lowercase for mapping
         action = C4_TO_HA_HVAC_ACTION.get(str(c4_state).lower())
+        # Substring match for multi-stage systems that report
+        # e.g. "Stage 1 Heat", "Stage 2 Cool"
+        if action is None:
+            if "heat" in str(c4_state).lower():
+                action = HVACAction.HEATING
+            elif "cool" in str(c4_state).lower():
+                action = HVACAction.COOLING
         if action is None:
             _LOGGER.debug("Unknown HVAC state received from Control4: %s", c4_state)
         return action

--- a/tests/components/control4/test_climate.py
+++ b/tests/components/control4/test_climate.py
@@ -113,6 +113,21 @@ async def test_climate_entities(
             HVACAction.FAN,
             id="fan",
         ),
+        pytest.param(
+            _make_climate_data(hvac_state="Idle"),
+            HVACAction.IDLE,
+            id="idle",
+        ),
+        pytest.param(
+            _make_climate_data(hvac_state="Stage 1 Heat"),
+            HVACAction.HEATING,
+            id="stage_1_heat",
+        ),
+        pytest.param(
+            _make_climate_data(hvac_state="Stage 2 Cool", hvac_mode="Cool"),
+            HVACAction.COOLING,
+            id="stage_2_cool",
+        ),
     ],
 )
 @pytest.mark.usefixtures(


### PR DESCRIPTION
## Proposed change
Some Control4 thermostat drivers report HVAC_STATE as "Stage 1 Heat" or "Stage 2 Cool" rather than simple "Heat"/"Cool", causing hvac_action to return None. Add substring matching as a fallback for these multi-stage values, following the same pattern used by the HACS Control4 integration. Now seeing orange glows while heating on my climate dashboard.

Also add missing "idle" mapping to HVACAction.IDLE.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
