### PR TITLE
update for code quality

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -130,6 +130,7 @@ homeassistant.components.bring.*
 homeassistant.components.brother.*
 homeassistant.components.browser.*
 homeassistant.components.bryant_evolution.*
+homeassistant.components.bsblan.*
 homeassistant.components.bthome.*
 homeassistant.components.button.*
 homeassistant.components.calendar.*

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -21,7 +21,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util.enum import try_parse_enum
 
 from . import BSBLanConfigEntry, BSBLanData
 from .const import ATTR_TARGET_TEMPERATURE, DOMAIN
@@ -102,14 +101,14 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return the current temperature."""
         if self.coordinator.data.state.current_temperature is None:
             return None
-        return self.coordinator.data.state.current_temperature.value
+        return float(self.coordinator.data.state.current_temperature.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.coordinator.data.state.target_temperature is None:
-            return None
-        return self.coordinator.data.state.target_temperature.value
+        if (target_temp := self.coordinator.data.state.target_temperature) is None:
+            return None  # type: ignore[unreachable]
+        return float(target_temp.value)
 
     @property
     def _hvac_mode_value(self) -> int | str | None:
@@ -123,10 +122,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return hvac operation ie. heat, cool mode."""
         if (hvac_mode_value := self._hvac_mode_value) is None:
             return None
-        # BSB-Lan returns integer values: 0=off, 1=auto, 2=eco, 3=heat
-        if isinstance(hvac_mode_value, int):
-            return BSBLAN_TO_HA_HVAC_MODE.get(hvac_mode_value)
-        return try_parse_enum(HVACMode, hvac_mode_value)
+        return BSBLAN_TO_HA_HVAC_MODE.get(int(hvac_mode_value))
 
     @property
     def hvac_action(self) -> HVACAction | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -70,7 +70,6 @@ async def async_setup_entry(
 class BSBLANClimate(BSBLanEntity, ClimateEntity):
     """Defines a BSBLAN climate device."""
 
-    _attr_has_entity_name = True
     _attr_name = None
     # Determine preset modes
     _attr_supported_features = (

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -1,7 +1,10 @@
 """DataUpdateCoordinator for the BSB-Lan integration."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from bsblan import (
     BSBLAN,
@@ -14,7 +17,6 @@ from bsblan import (
     State,
 )
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -32,6 +34,9 @@ DHW_STATE_INCLUDE = [
     "dhw_actual_value_top_temperature",
 ]
 DHW_CONFIG_INCLUDE = ["reduced_setpoint", "nominal_setpoint_max"]
+
+if TYPE_CHECKING:
+    from . import BSBLanConfigEntry
 
 
 @dataclass
@@ -54,12 +59,12 @@ class BSBLanSlowData:
 class BSBLanCoordinator[T](DataUpdateCoordinator[T]):
     """Base BSB-Lan coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: BSBLanConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
         name: str,
         update_interval: timedelta,
@@ -81,7 +86,7 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
         """Initialize the BSB-Lan fast coordinator."""
@@ -105,12 +110,15 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
 
         except BSBLANAuthError as err:
             raise ConfigEntryAuthFailed(
-                "Authentication failed for BSB-Lan device"
+                translation_domain=DOMAIN,
+                translation_key="coordinator_auth_error",
             ) from err
         except BSBLANConnectionError as err:
             host = self.config_entry.data[CONF_HOST]
             raise UpdateFailed(
-                f"Error while establishing connection with BSB-Lan device at {host}"
+                translation_domain=DOMAIN,
+                translation_key="coordinator_connection_error",
+                translation_placeholders={"host": host},
             ) from err
 
         return BSBLanFastData(
@@ -126,7 +134,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
         """Initialize the BSB-Lan slow coordinator."""

--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -34,6 +34,7 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
                 if data.info.device_identification
                 else None
             ),
+            model_id=f"{data.info.controller_family.value}_{data.info.controller_variant.value}",
             sw_version=data.device.version,
             configuration_url=f"http://{host}",
         )

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -73,6 +73,12 @@
     "config_entry_not_loaded": {
       "message": "The device `{device_name}` is not currently loaded or available"
     },
+    "coordinator_auth_error": {
+      "message": "Authentication failed for BSB-Lan device"
+    },
+    "coordinator_connection_error": {
+      "message": "Error while establishing connection with BSB-Lan device at {host}"
+    },
     "end_time_before_start_time": {
       "message": "End time ({end_time}) must be after start time ({start_time})"
     },
@@ -87,9 +93,6 @@
     },
     "set_operation_mode_error": {
       "message": "An error occurred while setting the operation mode"
-    },
-    "set_preset_mode_error": {
-      "message": "Can't set preset mode to {preset_mode} when HVAC mode is not set to auto"
     },
     "set_schedule_failed": {
       "message": "Failed to set hot water schedule: {error}"

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -63,6 +63,7 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
     """Defines a BSBLAN water heater entity."""
 
     _attr_name = None
+    _attr_operation_list = list(HA_TO_BSBLAN_OPERATION_MODE.keys())
     _attr_supported_features = (
         WaterHeaterEntityFeature.TARGET_TEMPERATURE
         | WaterHeaterEntityFeature.OPERATION_MODE
@@ -73,7 +74,6 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         """Initialize BSBLAN water heater."""
         super().__init__(data.fast_coordinator, data.slow_coordinator, data)
         self._attr_unique_id = format_mac(data.device.MAC)
-        self._attr_operation_list = list(HA_TO_BSBLAN_OPERATION_MODE.keys())
 
         # Set temperature unit
         self._attr_temperature_unit = data.fast_coordinator.client.get_temperature_unit

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -125,14 +125,14 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         """Return the current temperature."""
         if self.coordinator.data.dhw.dhw_actual_value_top_temperature is None:
             return None
-        return self.coordinator.data.dhw.dhw_actual_value_top_temperature.value
+        return float(self.coordinator.data.dhw.dhw_actual_value_top_temperature.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.coordinator.data.dhw.nominal_setpoint is None:
             return None
-        return self.coordinator.data.dhw.nominal_setpoint.value
+        return float(self.coordinator.data.dhw.nominal_setpoint.value)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -1055,6 +1055,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.bsblan.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.bthome.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -17,7 +17,6 @@ import pytest
 
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
-from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -81,16 +80,3 @@ def mock_bsblan() -> Generator[MagicMock]:
         bsblan.get_temperature_unit = "°C"
 
         yield bsblan
-
-
-@pytest.fixture
-async def init_integration(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_bsblan: MagicMock
-) -> MockConfigEntry:
-    """Set up the bsblan integration for testing."""
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    return mock_config_entry

--- a/tests/components/bsblan/test_diagnostics.py
+++ b/tests/components/bsblan/test_diagnostics.py
@@ -15,12 +15,15 @@ async def test_diagnostics(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     hass_client: ClientSessionGenerator,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     diagnostics_data = await get_diagnostics_for_config_entry(
-        hass, hass_client, init_integration
+        hass, hass_client, mock_config_entry
     )
     assert diagnostics_data == snapshot

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -6,7 +6,6 @@ from bsblan import BSBLANAuthError, BSBLANConnectionError, BSBLANError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -29,7 +28,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update code quality:

This pull request introduces several improvements and refactors to the BSBLan integration in Home Assistant, focusing on stricter type checking, improved error handling, and code modernization. It also updates tests to align with the new structure and enhances the reliability and maintainability of the integration.

**Type Safety and Code Quality Improvements:**

- Added the `bsblan` integration to `.strict-typing` and updated `mypy.ini` to enforce stricter type checks, including disallowing untyped definitions and calls. [[1]](diffhunk://#diff-d9bcf7c2f04b55fcc3f6529f74fe9bb719eb16a2dc994beece5e6db31e180767R133) [[2]](diffhunk://#diff-6f2d4ba9ca9a357d31014946667b7bed1bfdbc6d2530afc77778fa0a36bee457R1058-R1067)
- Refactored coordinator classes and related type annotations to use the correct `BSBLanConfigEntry` type, improving type safety and code clarity. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cR3-R7) [[2]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cR38-R40) [[3]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL57-R67) [[4]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL84-R89) [[5]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL129-R137)

**Error Handling and Localization:**

- Enhanced error handling in the coordinator by using translation keys and placeholders for authentication and connection errors, and updated `strings.json` accordingly for better localization and user feedback. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL108-R121) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R76-R81)

**Code Modernization and Cleanup:**

- Updated temperature property accessors in both `climate.py` and `water_heater.py` to always return `float` values, ensuring consistent types. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L106-R111) [[2]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badL128-R135)
- Simplified and modernized `hvac_mode` property logic in `climate.py` by removing unnecessary enum parsing and directly mapping integer values.
- Removed unused imports and redundant code for improved maintainability. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L24) [[2]](diffhunk://#diff-75a9935d2cfa130ae2018b6cb999bbd98582efa7ba03478836e062337ae22cc4L20) [[3]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L9)

**Entity and Device Metadata Enhancements:**

- Added a `model_id` to device info and ensured operation modes are set as a class attribute in the water heater entity for better device identification and Home Assistant UI support. [[1]](diffhunk://#diff-165306a2f9f11d57d4b9a641c93f3c9034be0d671a20827825a965edb3a32fb7R37) [[2]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badR66) [[3]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badL76)

**Test Adjustments:**

- Refactored test fixtures and test setup to match the new integration structure and removed unused or redundant test code. [[1]](diffhunk://#diff-75a9935d2cfa130ae2018b6cb999bbd98582efa7ba03478836e062337ae22cc4L84-L96) [[2]](diffhunk://#diff-dcb27593a08fcaefd81d7fe4d4ccbd47aeb22141194db760f07d51c2215f6c89L18-R27) [[3]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L32)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
