### PR TITLE
Handle Mastodon auth fail in coordinator

### DIFF
--- a/homeassistant/components/mastodon/coordinator.py
+++ b/homeassistant/components/mastodon/coordinator.py
@@ -6,13 +6,20 @@ from dataclasses import dataclass
 from datetime import timedelta
 
 from mastodon import Mastodon
-from mastodon.Mastodon import Account, Instance, InstanceV2, MastodonError
+from mastodon.Mastodon import (
+    Account,
+    Instance,
+    InstanceV2,
+    MastodonError,
+    MastodonUnauthorizedError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER
 
 
 @dataclass
@@ -51,6 +58,11 @@ class MastodonCoordinator(DataUpdateCoordinator[Account]):
             account: Account = await self.hass.async_add_executor_job(
                 self.client.account_verify_credentials
             )
+        except MastodonUnauthorizedError as error:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from error
         except MastodonError as ex:
             raise UpdateFailed(ex) from ex
 

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -107,3 +107,25 @@ async def test_migrate(
     assert config_entry.version == MastodonConfigFlow.VERSION
     assert config_entry.minor_version == MastodonConfigFlow.MINOR_VERSION
     assert config_entry.unique_id == "trwnh_mastodon_social"
+
+
+@pytest.mark.parametrize(
+    ("exc", "state"),
+    [
+        (MastodonNotFoundError, ConfigEntryState.SETUP_RETRY),
+        (MastodonUnauthorizedError, ConfigEntryState.SETUP_ERROR),
+    ],
+)
+async def test_coordinator_update_failure(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exc: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test coordinator update failure."""
+    mock_mastodon_client.account_verify_credentials.side_effect = exc
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is state

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -1,7 +1,9 @@
 """Tests for the Mastodon integration."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 from mastodon.Mastodon import (
     MastodonError,
     MastodonNotFoundError,
@@ -19,7 +21,7 @@ from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_device_info(
@@ -117,6 +119,7 @@ async def test_coordinator_general_error(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test general error during coordinator update makes entities unavailable."""
     await setup_integration(hass, mock_config_entry)
@@ -128,7 +131,8 @@ async def test_coordinator_general_error(
 
     mock_mastodon_client.account_verify_credentials.side_effect = MastodonError
 
-    await mock_config_entry.runtime_data.coordinator.async_refresh()
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
@@ -146,6 +150,7 @@ async def test_coordinator_auth_failure_triggers_reauth(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test auth failure during coordinator update triggers reauth flow."""
     await setup_integration(hass, mock_config_entry)
@@ -155,7 +160,8 @@ async def test_coordinator_auth_failure_triggers_reauth(
         MastodonUnauthorizedError
     )
 
-    await mock_config_entry.runtime_data.coordinator.async_refresh()
+    freezer.tick(timedelta(hours=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -2,13 +2,17 @@
 
 from unittest.mock import AsyncMock
 
-from mastodon.Mastodon import MastodonNotFoundError, MastodonUnauthorizedError
+from mastodon.Mastodon import (
+    MastodonError,
+    MastodonNotFoundError,
+    MastodonUnauthorizedError,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.mastodon.config_flow import MastodonConfigFlow
 from homeassistant.components.mastodon.const import CONF_BASE_URL, DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_CLIENT_SECRET
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -109,23 +113,56 @@ async def test_migrate(
     assert config_entry.unique_id == "trwnh_mastodon_social"
 
 
-@pytest.mark.parametrize(
-    ("exc", "state"),
-    [
-        (MastodonNotFoundError, ConfigEntryState.SETUP_RETRY),
-        (MastodonUnauthorizedError, ConfigEntryState.SETUP_ERROR),
-    ],
-)
-async def test_coordinator_update_failure(
+async def test_coordinator_general_error(
     hass: HomeAssistant,
     mock_mastodon_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    exc: Exception,
-    state: ConfigEntryState,
 ) -> None:
-    """Test coordinator update failure."""
-    mock_mastodon_client.account_verify_credentials.side_effect = exc
-
+    """Test general error during coordinator update makes entities unavailable."""
     await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    assert mock_config_entry.state is state
+    state = hass.states.get("binary_sensor.mastodon_trwnh_mastodon_social_bot")
+    assert state is not None
+    assert state.state == "on"
+
+    mock_mastodon_client.account_verify_credentials.side_effect = MastodonError
+
+    await mock_config_entry.runtime_data.coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    state = hass.states.get("binary_sensor.mastodon_trwnh_mastodon_social_bot")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    # No reauth flow should be triggered (unlike auth errors)
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 0
+
+
+async def test_coordinator_auth_failure_triggers_reauth(
+    hass: HomeAssistant,
+    mock_mastodon_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test auth failure during coordinator update triggers reauth flow."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    mock_mastodon_client.account_verify_credentials.side_effect = (
+        MastodonUnauthorizedError
+    )
+
+    await mock_config_entry.runtime_data.coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id

--- a/tests/components/mastodon/test_init.py
+++ b/tests/components/mastodon/test_init.py
@@ -15,7 +15,13 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.mastodon.config_flow import MastodonConfigFlow
 from homeassistant.components.mastodon.const import CONF_BASE_URL, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import CONF_ACCESS_TOKEN, CONF_CLIENT_ID, CONF_CLIENT_SECRET
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -127,7 +133,7 @@ async def test_coordinator_general_error(
 
     state = hass.states.get("binary_sensor.mastodon_trwnh_mastodon_social_bot")
     assert state is not None
-    assert state.state == "on"
+    assert state.state == STATE_ON
 
     mock_mastodon_client.account_verify_credentials.side_effect = MastodonError
 
@@ -139,7 +145,7 @@ async def test_coordinator_general_error(
 
     state = hass.states.get("binary_sensor.mastodon_trwnh_mastodon_social_bot")
     assert state is not None
-    assert state.state == "unavailable"
+    assert state.state == STATE_UNAVAILABLE
 
     # No reauth flow should be triggered (unlike auth errors)
     flows = hass.config_entries.flow.async_progress()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Handle the auth failing on a scheduled coordinator update.

Reauth was only added yesterday so treating it as code quality ready for next release, not a patch.
#163148

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
