### PR TITLE
Add strict typing for BSB-Lan integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -131,6 +131,7 @@ homeassistant.components.bring.*
 homeassistant.components.brother.*
 homeassistant.components.browser.*
 homeassistant.components.bryant_evolution.*
+homeassistant.components.bsblan.*
 homeassistant.components.bthome.*
 homeassistant.components.button.*
 homeassistant.components.calendar.*

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Final, cast
+from typing import Any, Final
 
 from bsblan import BSBLANError, get_hvac_action_category
 
@@ -103,21 +103,21 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return the current temperature."""
         if (current_temp := self.coordinator.data.state.current_temperature) is None:
             return None
-        return cast(float, current_temp.value)
+        return current_temp.value
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if (target_temp := self.coordinator.data.state.target_temperature) is None:
             return None
-        return cast(float, target_temp.value)
+        return target_temp.value
 
     @property
     def _hvac_mode_value(self) -> int | str | None:
         """Return the raw hvac_mode value from the coordinator."""
         if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
             return None
-        return cast(int | str, hvac_mode.value)
+        return hvac_mode.value
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -101,9 +101,9 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if self.coordinator.data.state.current_temperature is None:
+        if (current_temp := self.coordinator.data.state.current_temperature) is None:
             return None
-        return float(self.coordinator.data.state.current_temperature.value)
+        return float(current_temp.value)
 
     @property
     def target_temperature(self) -> float | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from bsblan import BSBLANError, get_hvac_action_category
 
@@ -103,14 +103,14 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return the current temperature."""
         if (current_temp := self.coordinator.data.state.current_temperature) is None:
             return None
-        return float(current_temp.value)
+        return cast(float, current_temp.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if (target_temp := self.coordinator.data.state.target_temperature) is None:
             return None
-        return float(target_temp.value)
+        return cast(float, target_temp.value)
 
     @property
     def _hvac_mode_value(self) -> int | str | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -103,21 +103,22 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return the current temperature."""
         if self.coordinator.data.state.current_temperature is None:
             return None
-        return self.coordinator.data.state.current_temperature.value
+        return float(self.coordinator.data.state.current_temperature.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.coordinator.data.state.target_temperature is None:
+        if (target_temp := self.coordinator.data.state.target_temperature) is None:
             return None
-        return self.coordinator.data.state.target_temperature.value
+        return float(target_temp.value)
 
     @property
     def _hvac_mode_value(self) -> int | str | None:
         """Return the raw hvac_mode value from the coordinator."""
         if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
             return None
-        return hvac_mode.value
+        value: int | str = hvac_mode.value
+        return value
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -117,8 +117,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return the raw hvac_mode value from the coordinator."""
         if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
             return None
-        value: int | str = hvac_mode.value
-        return value
+        return cast(int | str, hvac_mode.value)
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -1,7 +1,10 @@
 """DataUpdateCoordinator for the BSB-Lan integration."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from bsblan import (
     BSBLAN,
@@ -14,13 +17,15 @@ from bsblan import (
     State,
 )
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL_FAST, SCAN_INTERVAL_SLOW
+
+if TYPE_CHECKING:
+    from . import BSBLanConfigEntry
 
 # Filter lists for optimized API calls - only fetch parameters we actually use
 # This significantly reduces response time (~0.2s per parameter saved)
@@ -54,12 +59,12 @@ class BSBLanSlowData:
 class BSBLanCoordinator[T](DataUpdateCoordinator[T]):
     """Base BSB-Lan coordinator."""
 
-    config_entry: ConfigEntry
+    config_entry: BSBLanConfigEntry
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
         name: str,
         update_interval: timedelta,
@@ -81,7 +86,7 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
         """Initialize the BSB-Lan fast coordinator."""
@@ -126,7 +131,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: ConfigEntry,
+        config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
         """Initialize the BSB-Lan slow coordinator."""

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from bsblan import BSBLANError, SetHotWaterParam
 
@@ -124,14 +124,14 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
             current_temp := self.coordinator.data.dhw.dhw_actual_value_top_temperature
         ) is None:
             return None
-        return float(current_temp.value)
+        return cast(float, current_temp.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if (target_temp := self.coordinator.data.dhw.nominal_setpoint) is None:
             return None
-        return float(target_temp.value)
+        return cast(float, target_temp.value)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -123,14 +123,14 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         """Return the current temperature."""
         if self.coordinator.data.dhw.dhw_actual_value_top_temperature is None:
             return None
-        return self.coordinator.data.dhw.dhw_actual_value_top_temperature.value
+        return float(self.coordinator.data.dhw.dhw_actual_value_top_temperature.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.coordinator.data.dhw.nominal_setpoint is None:
             return None
-        return self.coordinator.data.dhw.nominal_setpoint.value
+        return float(self.coordinator.data.dhw.nominal_setpoint.value)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -110,27 +110,28 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation."""
-        if self.coordinator.data.dhw.operating_mode is None:
+        if (operating_mode := self.coordinator.data.dhw.operating_mode) is None:
             return None
         # The operating_mode.value is an integer (0=Off, 1=On, 2=Eco)
-        current_mode_value = self.coordinator.data.dhw.operating_mode.value
-        if isinstance(current_mode_value, int):
-            return BSBLAN_TO_HA_OPERATION_MODE.get(current_mode_value)
+        if isinstance(operating_mode.value, int):
+            return BSBLAN_TO_HA_OPERATION_MODE.get(operating_mode.value)
         return None
 
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if self.coordinator.data.dhw.dhw_actual_value_top_temperature is None:
+        if (
+            current_temp := self.coordinator.data.dhw.dhw_actual_value_top_temperature
+        ) is None:
             return None
-        return float(self.coordinator.data.dhw.dhw_actual_value_top_temperature.value)
+        return float(current_temp.value)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self.coordinator.data.dhw.nominal_setpoint is None:
+        if (target_temp := self.coordinator.data.dhw.nominal_setpoint) is None:
             return None
-        return float(self.coordinator.data.dhw.nominal_setpoint.value)
+        return float(target_temp.value)
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 
 from bsblan import BSBLANError, SetHotWaterParam
 
@@ -124,14 +124,14 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
             current_temp := self.coordinator.data.dhw.dhw_actual_value_top_temperature
         ) is None:
             return None
-        return cast(float, current_temp.value)
+        return current_temp.value
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if (target_temp := self.coordinator.data.dhw.nominal_setpoint) is None:
             return None
-        return cast(float, target_temp.value)
+        return target_temp.value
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/mypy.ini
+++ b/mypy.ini
@@ -1065,6 +1065,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.bsblan.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.bthome.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

improve code quality:

Update lib to give correct types. https://github.com/liudger/python-bsblan/releases

This pull request improves type safety and code quality for the BSB-Lan integration in Home Assistant. The main changes include stricter type checking, code refactoring for clarity, and internal type annotation improvements.

**Type Safety and Typing Improvements:**

* Added a dedicated mypy configuration section for `homeassistant.components.bsblan.*` to enforce strict type checks, including disallowing untyped definitions and calls.
* Registered the `homeassistant.components.bsblan.*` module for strict typing in the `.strict-typing` file.

**Internal Type Annotation and Imports:**

* Updated `coordinator.py` to use a more specific `BSBLanConfigEntry` type instead of the generic `ConfigEntry`, and added `TYPE_CHECKING` imports for type hints. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cR3-R7) [[2]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL17-R29) [[3]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL57-R67) [[4]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL84-R89) [[5]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL129-R134)

**Code Refactoring for Clarity:**

* Refactored property access in `climate.py` and `water_heater.py` to use assignment expressions (`:=`) for cleaner and more readable code, especially when checking for `None` values before accessing attributes. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L104-R113) [[2]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badL113-R134)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
