### PR TITLE
Update json fixture to reflect response from current LHM versions

### DIFF
--- a/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
+++ b/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
@@ -20,6 +20,7 @@
           "Min": "",
           "Value": "",
           "Max": "",
+          "HardwareId": "/motherboard",
           "ImageURL": "images_icon/mainboard.png",
           "Children": [
             {
@@ -28,6 +29,7 @@
               "Min": "",
               "Value": "",
               "Max": "",
+              "HardwareId": "/lpc/nct6687d/0",
               "ImageURL": "images_icon/chip.png",
               "Children": [
                 {
@@ -46,6 +48,9 @@
                       "Max": "12,096 V",
                       "SensorId": "/lpc/nct6687d/0/voltage/0",
                       "Type": "Voltage",
+                      "RawMin": "12,048 V",
+                      "RawValue": "12,072 V",
+                      "RawMax": "12,096 V",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     },
@@ -57,6 +62,9 @@
                       "Max": "5,050 V",
                       "SensorId": "/lpc/nct6687d/0/voltage/1",
                       "Type": "Voltage",
+                      "RawMin": "5,020 V",
+                      "RawValue": "5,030 V",
+                      "RawMax": "5,050 V",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     },
@@ -68,6 +76,9 @@
                       "Max": "1,318 V",
                       "SensorId": "/lpc/nct6687d/0/voltage/2",
                       "Type": "Voltage",
+                      "RawMin": "1,310 V",
+                      "RawValue": "1,312 V",
+                      "RawMax": "1,318 V",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     }
@@ -89,6 +100,9 @@
                       "Max": "68,0 °C",
                       "SensorId": "/lpc/nct6687d/0/temperature/0",
                       "Type": "Temperature",
+                      "RawMin": "39,0 °C",
+                      "RawValue": "55,0 °C",
+                      "RawMax": "68,0 °C",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     },
@@ -100,6 +114,9 @@
                       "Max": "46,5 °C",
                       "SensorId": "/lpc/nct6687d/0/temperature/1",
                       "Type": "Temperature",
+                      "RawMin": "32,5 °C",
+                      "RawValue": "45,5 °C",
+                      "RawMax": "46,5 °C",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     }
@@ -121,6 +138,9 @@
                       "Max": "0 RPM",
                       "SensorId": "/lpc/nct6687d/0/fan/0",
                       "Type": "Fan",
+                      "RawMin": "0 RPM",
+                      "RawValue": "0 RPM",
+                      "RawMax": "0 RPM",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     },
@@ -132,6 +152,9 @@
                       "Max": "0 RPM",
                       "SensorId": "/lpc/nct6687d/0/fan/1",
                       "Type": "Fan",
+                      "RawMin": "0 RPM",
+                      "RawValue": "0 RPM",
+                      "RawMax": "0 RPM",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     },
@@ -143,6 +166,9 @@
                       "Max": "-",
                       "SensorId": "/lpc/nct6687d/0/fan/2",
                       "Type": "Fan",
+                      "RawMin": "-",
+                      "RawValue": "-",
+                      "RawMax": "-",
                       "ImageURL": "images/transparent.png",
                       "Children": []
                     }
@@ -158,6 +184,7 @@
           "Min": "",
           "Value": "",
           "Max": "",
+          "HardwareId": "/amdcpu/0",
           "ImageURL": "images_icon/cpu.png",
           "Children": [
             {
@@ -176,6 +203,9 @@
                   "Max": "1,173 V",
                   "SensorId": "/amdcpu/0/voltage/2",
                   "Type": "Voltage",
+                  "RawMin": "0,452 V",
+                  "RawValue": "1,083 V",
+                  "RawMax": "1,173 V",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -187,6 +217,9 @@
                   "Max": "1,306 V",
                   "SensorId": "/amdcpu/0/voltage/3",
                   "Type": "Voltage",
+                  "RawMin": "1,305 V",
+                  "RawValue": "1,305 V",
+                  "RawMax": "1,306 V",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -208,6 +241,9 @@
                   "Max": "70,1 W",
                   "SensorId": "/amdcpu/0/power/0",
                   "Type": "Power",
+                  "RawMin": "25,1 W",
+                  "RawValue": "39,6 W",
+                  "RawMax": "70,1 W",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -229,6 +265,9 @@
                   "Max": "69,1 °C",
                   "SensorId": "/amdcpu/0/temperature/2",
                   "Type": "Temperature",
+                  "RawMin": "39,4 °C",
+                  "RawValue": "55,5 °C",
+                  "RawMax": "69,1 °C",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -240,6 +279,9 @@
                   "Max": "74,0 °C",
                   "SensorId": "/amdcpu/0/temperature/3",
                   "Type": "Temperature",
+                  "RawMin": "38,4 °C",
+                  "RawValue": "52,8 °C",
+                  "RawMax": "74,0 °C",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -261,6 +303,9 @@
                   "Max": "55,8 %",
                   "SensorId": "/amdcpu/0/load/0",
                   "Type": "Load",
+                  "RawMin": "0,0 %",
+                  "RawValue": "9,1 %",
+                  "RawMax": "55,8 %",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -274,6 +319,7 @@
           "Min": "",
           "Value": "",
           "Max": "",
+          "HardwareId": "/gpu-nvidia/0",
           "ImageURL": "images_icon/nvidia.png",
           "Children": [
             {
@@ -292,6 +338,9 @@
                   "Max": "66,6 W",
                   "SensorId": "/gpu-nvidia/0/power/0",
                   "Type": "Power",
+                  "RawMin": "4,1 W",
+                  "RawValue": "59,6 W",
+                  "RawMax": "66,6 W",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -313,6 +362,9 @@
                   "Max": "2805,0 MHz",
                   "SensorId": "/gpu-nvidia/0/clock/0",
                   "Type": "Clock",
+                  "RawMin": "210,0 MHz",
+                  "RawValue": "2805,0 MHz",
+                  "RawMax": "2805,0 MHz",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -324,6 +376,9 @@
                   "Max": "11502,0 MHz",
                   "SensorId": "/gpu-nvidia/0/clock/4",
                   "Type": "Clock",
+                  "RawMin": "405,0 MHz",
+                  "RawValue": "11252,0 MHz",
+                  "RawMax": "11502,0 MHz",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -345,6 +400,9 @@
                   "Max": "37,0 °C",
                   "SensorId": "/gpu-nvidia/0/temperature/0",
                   "Type": "Temperature",
+                  "RawMin": "25,0 °C",
+                  "RawValue": "36,0 °C",
+                  "RawMax": "37,0 °C",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -356,6 +414,9 @@
                   "Max": "43,3 °C",
                   "SensorId": "/gpu-nvidia/0/temperature/2",
                   "Type": "Temperature",
+                  "RawMin": "32,5 °C",
+                  "RawValue": "43,0 °C",
+                  "RawMax": "43,3 °C",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -377,6 +438,9 @@
                   "Max": "19,0 %",
                   "SensorId": "/gpu-nvidia/0/load/0",
                   "Type": "Load",
+                  "RawMin": "0,0 %",
+                  "RawValue": "5,0 %",
+                  "RawMax": "19,0 %",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -388,6 +452,9 @@
                   "Max": "49,0 %",
                   "SensorId": "/gpu-nvidia/0/load/1",
                   "Type": "Load",
+                  "RawMin": "0,0 %",
+                  "RawValue": "0,0 %",
+                  "RawMax": "49,0 %",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -399,6 +466,9 @@
                   "Max": "99,0 %",
                   "SensorId": "/gpu-nvidia/0/load/2",
                   "Type": "Load",
+                  "RawMin": "0,0 %",
+                  "RawValue": "97,0 %",
+                  "RawMax": "99,0 %",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -420,6 +490,9 @@
                   "Max": "0 RPM",
                   "SensorId": "/gpu-nvidia/0/fan/1",
                   "Type": "Fan",
+                  "RawMin": "0 RPM",
+                  "RawValue": "0 RPM",
+                  "RawMax": "0 RPM",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 },
@@ -431,6 +504,9 @@
                   "Max": "0 RPM",
                   "SensorId": "/gpu-nvidia/0/fan/2",
                   "Type": "Fan",
+                  "RawMin": "0 RPM",
+                  "RawValue": "0 RPM",
+                  "RawMax": "0 RPM",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }
@@ -448,10 +524,13 @@
                   "id": 43,
                   "Text": "GPU PCIe Tx",
                   "Min": "0,0 KB/s",
-                  "Value": "166,1 MB/s",
-                  "Max": "2422,8 MB/s",
+                  "Value": "278,6 MB/s",
+                  "Max": "357,6 MB/s",
                   "SensorId": "/gpu-nvidia/0/throughput/1",
                   "Type": "Throughput",
+                  "RawMin": "0,0 B/s",
+                  "RawValue": "292149200,0 B/s",
+                  "RawMax": "374999000,0 B/s",
                   "ImageURL": "images/transparent.png",
                   "Children": []
                 }

--- a/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
+++ b/tests/components/libre_hardware_monitor/snapshots/test_sensor.ambr
@@ -1298,24 +1298,24 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'test_entry_id_gpu-nvidia-0-throughput-1',
-    'unit_of_measurement': 'MB/s',
+    'unit_of_measurement': 'KB/s',
   })
 # ---
 # name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
-      'max_value': '2422.8',
+      'max_value': '366210.0',
       'min_value': '0.0',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': 'MB/s',
+      'unit_of_measurement': 'KB/s',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '166.1',
+    'state': '285302.0',
   })
 # ---
 # name: test_sensors_are_created[sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_video_engine_load-entry]
@@ -1737,17 +1737,17 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
-        'max_value': '2422.8',
+        'max_value': '366210.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': 'MB/s',
+        'unit_of_measurement': 'KB/s',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': '166.1',
+      'state': '285302.0',
     }),
   ])
 # ---
@@ -2115,17 +2115,17 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         'friendly_name': '[GAMING-PC] NVIDIA GeForce RTX 4080 SUPER GPU PCIe Tx Throughput',
-        'max_value': '2422.8',
+        'max_value': '366210.0',
         'min_value': '0.0',
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-        'unit_of_measurement': 'MB/s',
+        'unit_of_measurement': 'KB/s',
       }),
       'context': <ANY>,
       'entity_id': 'sensor.gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput',
       'last_changed': <ANY>,
       'last_reported': <ANY>,
       'last_updated': <ANY>,
-      'state': '166.1',
+      'state': '285302.0',
     }),
   ])
 # ---

--- a/tests/components/libre_hardware_monitor/test_init.py
+++ b/tests/components/libre_hardware_monitor/test_init.py
@@ -29,7 +29,7 @@ async def test_migration_to_unique_ids(
     legacy_config_entry_v1.add_to_hass(hass)
 
     # Set up devices with legacy device ID
-    legacy_device_ids = ["amdcpu-0", "gpu-nvidia-0", "lpc-nct6687d-0"]
+    legacy_device_ids = ["amdcpu-0", "gpu-nvidia-0", "motherboard"]
     for device_id in legacy_device_ids:
         device_registry.async_get_or_create(
             config_entry_id=legacy_config_entry_v1.entry_id,

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -243,8 +243,9 @@ async def _mock_orphaned_device(
 ) -> DeviceEntry:
     await init_integration(hass, mock_config_entry)
 
-    removed_device = "lpc-nct6687d-0"
+    removed_device = "gpu-nvidia-0"
     previous_data = mock_lhm_client.get_data.return_value
+    assert removed_device in previous_data.main_device_ids_and_names
 
     mock_lhm_client.get_data.return_value = LibreHardwareMonitorData(
         computer_name=mock_lhm_client.get_data.return_value.computer_name,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Current versions of Libre Hardware Monitor provide two additional properties in the API response.

1. A `HardwareId` for each hardware node
2. Raw values for each sensor node without automatic unit conversions (see https://github.com/home-assistant/core/issues/154139)

This PR updates the json fixture to reflect an up-to-date response of the API.
Subsequently, the tests are also updated to reflect that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
