### PR TITLE
Add reauthentication flow to smarla

### DIFF
--- a/homeassistant/components/smarla/__init__.py
+++ b/homeassistant/components/smarla/__init__.py
@@ -9,7 +9,7 @@ from pysmarlaapi.connection.exceptions import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 from .const import HOST, PLATFORMS
 
@@ -23,16 +23,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: FederwiegeConfigEntry) -
     # Check if token still has access
     try:
         await connection.refresh_token()
-    except (ConnectionException, AuthenticationException) as e:
-        raise ConfigEntryError("Invalid authentication") from e
+    except AuthenticationException as e:
+        raise ConfigEntryAuthFailed("Invalid authentication") from e
+    except ConnectionException as e:
+        raise ConfigEntryNotReady("Unable to connect to server") from e
 
-    federwiege = Federwiege(hass.loop, connection)
+    async def on_auth_failure():
+        entry.async_start_reauth(hass)
+
+    federwiege = Federwiege(hass.loop, connection, on_auth_failure)
     federwiege.register()
 
     entry.runtime_data = federwiege
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Starts a task to keep reconnecting, e.g. when device gets unreachable.
+    # When an authentication error occurs, it automatically stops and calls
+    # the on_auth_failure function.
     federwiege.connect()
 
     return True

--- a/homeassistant/components/smarla/config_flow.py
+++ b/homeassistant/components/smarla/config_flow.py
@@ -50,12 +50,9 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
         return conn.token.serialNumber
 
     async def _validate_input(
-        self, user_input: dict[str, Any] | None
+        self, user_input: dict[str, Any]
     ) -> dict[str, Any] | None:
         """Validate the user input."""
-        if user_input is None:
-            return None
-
         token = user_input[CONF_ACCESS_TOKEN]
         serial_number = await self._handle_token(token=token)
 
@@ -75,12 +72,14 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        validated_info = await self._validate_input(user_input)
-        if validated_info is not None:
-            return self.async_create_entry(
-                title=validated_info["serial_number"],
-                data={CONF_ACCESS_TOKEN: validated_info["token"]},
-            )
+        self.errors = {}
+        if user_input is not None:
+            validated_info = await self._validate_input(user_input)
+            if validated_info is not None:
+                return self.async_create_entry(
+                    title=validated_info["serial_number"],
+                    data={CONF_ACCESS_TOKEN: validated_info["token"]},
+                )
 
         return self.async_show_form(
             step_id="user",
@@ -98,12 +97,14 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm reauthentication dialog."""
-        validated_info = await self._validate_input(user_input)
-        if validated_info is not None:
-            return self.async_update_reload_and_abort(
-                self._get_reauth_entry(),
-                data_updates={CONF_ACCESS_TOKEN: validated_info["token"]},
-            )
+        self.errors = {}
+        if user_input is not None:
+            validated_info = await self._validate_input(user_input)
+            if validated_info is not None:
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates={CONF_ACCESS_TOKEN: validated_info["token"]},
+                )
 
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/homeassistant/components/smarla/config_flow.py
+++ b/homeassistant/components/smarla/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from pysmarlaapi import Connection
@@ -16,7 +17,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 
 from .const import DOMAIN, HOST
 
-STEP_USER_DATA_SCHEMA = vol.Schema({CONF_ACCESS_TOKEN: str})
+STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
 
 
 class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -36,7 +37,10 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             await conn.refresh_token()
-        except ConnectionException, AuthenticationException:
+        except ConnectionException:
+            errors["base"] = "cannot_connect"
+            return errors, None
+        except AuthenticationException:
             errors["base"] = "invalid_auth"
             return errors, None
 
@@ -63,6 +67,39 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Perform reauthentication upon an API authentication error."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm reauthentication dialog."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            raw_token = user_input[CONF_ACCESS_TOKEN]
+            errors, serial_number = await self._handle_token(token=raw_token)
+
+            config_entry = self._get_reauth_entry()
+
+            if not errors and serial_number != config_entry.unique_id:
+                errors["base"] = "serial_number_mismatch"
+
+            if not errors and serial_number is not None:
+                return self.async_update_reload_and_abort(
+                    config_entry,
+                    data_updates={CONF_ACCESS_TOKEN: raw_token},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
         )

--- a/homeassistant/components/smarla/config_flow.py
+++ b/homeassistant/components/smarla/config_flow.py
@@ -12,7 +12,7 @@ from pysmarlaapi.connection.exceptions import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ACCESS_TOKEN
 
 from .const import DOMAIN, HOST
@@ -25,50 +25,67 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _handle_token(self, token: str) -> tuple[dict[str, str], str | None]:
-        """Handle the token input."""
-        errors: dict[str, str] = {}
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        super().__init__()
+        self.errors: dict[str, str] = {}
 
+    async def _handle_token(self, token: str) -> str | None:
+        """Handle the token input."""
         try:
             conn = Connection(url=HOST, token_b64=token)
         except ValueError:
-            errors["base"] = "malformed_token"
-            return errors, None
+            self.errors["base"] = "malformed_token"
+            return None
 
         try:
             await conn.refresh_token()
         except ConnectionException:
-            errors["base"] = "cannot_connect"
-            return errors, None
+            self.errors["base"] = "cannot_connect"
+            return None
         except AuthenticationException:
-            errors["base"] = "invalid_auth"
-            return errors, None
+            self.errors["base"] = "invalid_auth"
+            return None
 
-        return errors, conn.token.serialNumber
+        return conn.token.serialNumber
+
+    async def _validate_input(
+        self, user_input: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Validate the user input."""
+        if user_input is None:
+            return None
+
+        token = user_input[CONF_ACCESS_TOKEN]
+        serial_number = await self._handle_token(token=token)
+
+        if serial_number is not None:
+            await self.async_set_unique_id(serial_number)
+
+            if self.source == SOURCE_REAUTH:
+                self._abort_if_unique_id_mismatch()
+            else:
+                self._abort_if_unique_id_configured()
+
+            return {"token": token, "serial_number": serial_number}
+
+        return None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            raw_token = user_input[CONF_ACCESS_TOKEN]
-            errors, serial_number = await self._handle_token(token=raw_token)
-
-            if not errors and serial_number is not None:
-                await self.async_set_unique_id(serial_number)
-                self._abort_if_unique_id_configured()
-
-                return self.async_create_entry(
-                    title=serial_number,
-                    data={CONF_ACCESS_TOKEN: raw_token},
-                )
+        validated_info = await self._validate_input(user_input)
+        if validated_info is not None:
+            return self.async_create_entry(
+                title=validated_info["serial_number"],
+                data={CONF_ACCESS_TOKEN: validated_info["token"]},
+            )
 
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
+            errors=self.errors,
         )
 
     async def async_step_reauth(
@@ -81,25 +98,15 @@ class SmarlaConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm reauthentication dialog."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            raw_token = user_input[CONF_ACCESS_TOKEN]
-            errors, serial_number = await self._handle_token(token=raw_token)
-
-            config_entry = self._get_reauth_entry()
-
-            if not errors and serial_number != config_entry.unique_id:
-                errors["base"] = "serial_number_mismatch"
-
-            if not errors and serial_number is not None:
-                return self.async_update_reload_and_abort(
-                    config_entry,
-                    data_updates={CONF_ACCESS_TOKEN: raw_token},
-                )
+        validated_info = await self._validate_input(user_input)
+        if validated_info is not None:
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(),
+                data_updates={CONF_ACCESS_TOKEN: validated_info["token"]},
+            )
 
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
+            errors=self.errors,
         )

--- a/homeassistant/components/smarla/quality_scale.yaml
+++ b/homeassistant/components/smarla/quality_scale.yaml
@@ -28,7 +28,7 @@ rules:
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -2,13 +2,13 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unique_id_mismatch": "Please ensure you reconfigure against the same device."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "malformed_token": "Malformed access token",
-      "serial_number_mismatch": "Please ensure you reconfigure against the same device."
+      "malformed_token": "Malformed access token"
     },
     "step": {
       "reauth_confirm": {

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -1,13 +1,24 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "malformed_token": "Malformed access token"
+      "malformed_token": "Malformed access token",
+      "serial_number_mismatch": "Please ensure you reconfigure against the same device."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "access_token": "[%key:common::config_flow::data::access_token%]"
+        },
+        "data_description": {
+          "access_token": "[%key:component::smarla::config::step::user::data_description::access_token%]"
+        }
+      },
       "user": {
         "data": {
           "access_token": "[%key:common::config_flow::data::access_token%]"

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from pysmarlaapi import AuthToken
 from pysmarlaapi.federwiege.services.classes import Property, Service
 import pytest
 
 from homeassistant.components.smarla.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 
-from .const import MOCK_ACCESS_TOKEN_JSON, MOCK_SERIAL_NUMBER, MOCK_USER_INPUT
+from .const import MOCK_ACCESS_TOKEN_JSON, MOCK_USER_INPUT
 
 from tests.common import MockConfigEntry
 
@@ -22,7 +21,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Create a mock config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        unique_id=MOCK_SERIAL_NUMBER,
+        unique_id=MOCK_ACCESS_TOKEN_JSON["serialNumber"],
         source=SOURCE_USER,
         data=MOCK_USER_INPUT,
     )
@@ -36,30 +35,23 @@ def mock_setup_entry() -> Generator:
 
 
 @pytest.fixture
-def mock_connection() -> Generator[MagicMock]:
-    """Patch Connection object."""
-    with (
-        patch(
-            "homeassistant.components.smarla.config_flow.Connection", autospec=True
-        ) as mock_connection,
-        patch(
-            "homeassistant.components.smarla.Connection",
-            mock_connection,
-        ),
-    ):
-        connection = mock_connection.return_value
-        connection.token = AuthToken.from_json(MOCK_ACCESS_TOKEN_JSON)
-        yield connection
+def mock_refresh_token() -> Generator[AsyncMock]:
+    """Mock the refresh token function."""
+    with patch(
+        "homeassistant.components.smarla.Connection.refresh_token",
+        autospec=True,
+    ) as mock_refresh:
+        yield mock_refresh
 
 
 @pytest.fixture
-def mock_federwiege(mock_connection: MagicMock) -> Generator[MagicMock]:
-    """Mock the Federwiege instance."""
+def mock_federwiege_cls(mock_refresh_token: MagicMock) -> Generator[MagicMock]:
+    """Mock the Federwiege class."""
     with patch(
         "homeassistant.components.smarla.Federwiege", autospec=True
-    ) as mock_federwiege:
-        federwiege = mock_federwiege.return_value
-        federwiege.serial_number = MOCK_SERIAL_NUMBER
+    ) as mock_federwiege_cls:
+        mock_federwiege = mock_federwiege_cls.return_value
+        mock_federwiege.serial_number = MOCK_ACCESS_TOKEN_JSON["serialNumber"]
 
         mock_babywiege_service = MagicMock(spec=Service)
         mock_babywiege_service.props = {
@@ -83,13 +75,21 @@ def mock_federwiege(mock_connection: MagicMock) -> Generator[MagicMock]:
         mock_analyser_service.props["activity"].get.return_value = 0
         mock_analyser_service.props["swing_count"].get.return_value = 0
 
-        federwiege.services = {
+        mock_federwiege.services = {
             "babywiege": mock_babywiege_service,
             "analyser": mock_analyser_service,
         }
 
-        federwiege.get_property = MagicMock(
-            side_effect=lambda service, prop: federwiege.services[service].props[prop]
+        mock_federwiege.get_property = MagicMock(
+            side_effect=lambda service, prop: mock_federwiege.services[service].props[
+                prop
+            ]
         )
 
-        yield federwiege
+        yield mock_federwiege_cls
+
+
+@pytest.fixture
+def mock_federwiege(mock_federwiege_cls: MagicMock) -> Generator[MagicMock]:
+    """Mock the Federwiege instance."""
+    return mock_federwiege_cls.return_value

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
+from pysmarlaapi import AuthToken
 from pysmarlaapi.federwiege.services.classes import Property, Service
 import pytest
 
@@ -35,17 +36,30 @@ def mock_setup_entry() -> Generator:
 
 
 @pytest.fixture
-def mock_refresh_token() -> Generator[AsyncMock]:
-    """Mock the refresh token function."""
-    with patch(
-        "homeassistant.components.smarla.Connection.refresh_token",
-        autospec=True,
-    ) as mock_refresh:
-        yield mock_refresh
+def mock_connection() -> Generator[MagicMock]:
+    """Patch Connection object."""
+    with (
+        patch(
+            "homeassistant.components.smarla.config_flow.Connection", autospec=True
+        ) as mock_connection,
+        patch(
+            "homeassistant.components.smarla.Connection",
+            mock_connection,
+        ),
+    ):
+        connection = mock_connection.return_value
+
+        def mocked_connection(url, token_b64: str):
+            connection.token = AuthToken.from_base64(token_b64)
+            return connection
+
+        mock_connection.side_effect = mocked_connection
+
+        yield connection
 
 
 @pytest.fixture
-def mock_federwiege_cls(mock_refresh_token: MagicMock) -> Generator[MagicMock]:
+def mock_federwiege_cls(mock_connection: MagicMock) -> Generator[MagicMock]:
     """Mock the Federwiege class."""
     with patch(
         "homeassistant.components.smarla.Federwiege", autospec=True

--- a/tests/components/smarla/const.py
+++ b/tests/components/smarla/const.py
@@ -5,16 +5,27 @@ import json
 
 from homeassistant.const import CONF_ACCESS_TOKEN
 
+
+def _make_mock_user_input(token_json):
+    access_token = base64.b64encode(json.dumps(token_json).encode()).decode()
+    return {CONF_ACCESS_TOKEN: access_token}
+
+
 MOCK_ACCESS_TOKEN_JSON = {
     "refreshToken": "test",
     "appIdentifier": "HA-test",
     "serialNumber": "ABCD",
 }
+MOCK_USER_INPUT = _make_mock_user_input(MOCK_ACCESS_TOKEN_JSON)
 
-MOCK_SERIAL_NUMBER = MOCK_ACCESS_TOKEN_JSON["serialNumber"]
+MOCK_ACCESS_TOKEN_JSON_RECONFIGURE = {
+    **MOCK_ACCESS_TOKEN_JSON,
+    "refreshToken": "reconfiguretest",
+}
+MOCK_USER_INPUT_RECONFIGURE = _make_mock_user_input(MOCK_ACCESS_TOKEN_JSON_RECONFIGURE)
 
-MOCK_ACCESS_TOKEN = base64.b64encode(
-    json.dumps(MOCK_ACCESS_TOKEN_JSON).encode()
-).decode()
-
-MOCK_USER_INPUT = {CONF_ACCESS_TOKEN: MOCK_ACCESS_TOKEN}
+MOCK_ACCESS_TOKEN_JSON_MISMATCH = {
+    **MOCK_ACCESS_TOKEN_JSON_RECONFIGURE,
+    "serialNumber": "DCBA",
+}
+MOCK_USER_INPUT_MISMATCH = _make_mock_user_input(MOCK_ACCESS_TOKEN_JSON_MISMATCH)

--- a/tests/components/smarla/test_config_flow.py
+++ b/tests/components/smarla/test_config_flow.py
@@ -167,6 +167,6 @@ async def test_reauth_mismatch(
         user_input=MOCK_USER_INPUT_MISMATCH,
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
-    assert result["errors"] == {"base": "serial_number_mismatch"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+    assert mock_config_entry.data == MOCK_USER_INPUT

--- a/tests/components/smarla/test_config_flow.py
+++ b/tests/components/smarla/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test config flow for Swing2Sleep Smarla integration."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 from pysmarlaapi.connection.exceptions import (
     AuthenticationException,
@@ -23,7 +23,7 @@ from .const import (
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
 async def test_config_flow(hass: HomeAssistant) -> None:
     """Test creating a config entry."""
     result = await hass.config_entries.flow.async_init(
@@ -45,7 +45,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     assert result["result"].unique_id == MOCK_ACCESS_TOKEN_JSON["serialNumber"]
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
 async def test_malformed_token(hass: HomeAssistant) -> None:
     """Test we show user form on malformed token input."""
     with patch(
@@ -79,12 +79,12 @@ async def test_malformed_token(hass: HomeAssistant) -> None:
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_validation_exception(
     hass: HomeAssistant,
-    mock_refresh_token: AsyncMock,
+    mock_connection: MagicMock,
     exception: type[Exception],
     error_key: str,
 ) -> None:
     """Test we show user form on validation exception."""
-    mock_refresh_token.side_effect = exception
+    mock_connection.refresh_token.side_effect = exception
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -92,7 +92,7 @@ async def test_validation_exception(
         data=MOCK_USER_INPUT,
     )
 
-    mock_refresh_token.side_effect = None
+    mock_connection.refresh_token.side_effect = None
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -106,7 +106,7 @@ async def test_validation_exception(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
 async def test_device_exists_abort(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -124,7 +124,7 @@ async def test_device_exists_abort(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
 async def test_reauth_successful(
     mock_config_entry: MockConfigEntry,
     hass: HomeAssistant,
@@ -148,7 +148,7 @@ async def test_reauth_successful(
     assert mock_config_entry.data == MOCK_USER_INPUT_RECONFIGURE
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
 async def test_reauth_mismatch(
     mock_config_entry: MockConfigEntry,
     hass: HomeAssistant,

--- a/tests/components/smarla/test_config_flow.py
+++ b/tests/components/smarla/test_config_flow.py
@@ -1,8 +1,11 @@
 """Test config flow for Swing2Sleep Smarla integration."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-from pysmarlaapi.connection.exceptions import AuthenticationException
+from pysmarlaapi.connection.exceptions import (
+    AuthenticationException,
+    ConnectionException,
+)
 import pytest
 
 from homeassistant.components.smarla.const import DOMAIN
@@ -10,12 +13,17 @@ from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import MOCK_SERIAL_NUMBER, MOCK_USER_INPUT
+from .const import (
+    MOCK_ACCESS_TOKEN_JSON,
+    MOCK_USER_INPUT,
+    MOCK_USER_INPUT_MISMATCH,
+    MOCK_USER_INPUT_RECONFIGURE,
+)
 
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
 async def test_config_flow(hass: HomeAssistant) -> None:
     """Test creating a config entry."""
     result = await hass.config_entries.flow.async_init(
@@ -32,12 +40,12 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MOCK_SERIAL_NUMBER
+    assert result["title"] == MOCK_ACCESS_TOKEN_JSON["serialNumber"]
     assert result["data"] == MOCK_USER_INPUT
-    assert result["result"].unique_id == MOCK_SERIAL_NUMBER
+    assert result["result"].unique_id == MOCK_ACCESS_TOKEN_JSON["serialNumber"]
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
 async def test_malformed_token(hass: HomeAssistant) -> None:
     """Test we show user form on malformed token input."""
     with patch(
@@ -61,10 +69,22 @@ async def test_malformed_token(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
+@pytest.mark.parametrize(
+    ("exception", "error_key"),
+    [
+        (AuthenticationException, "invalid_auth"),
+        (ConnectionException, "cannot_connect"),
+    ],
+)
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_invalid_auth(hass: HomeAssistant, mock_connection: MagicMock) -> None:
-    """Test we show user form on invalid auth."""
-    mock_connection.refresh_token.side_effect = AuthenticationException
+async def test_validation_exception(
+    hass: HomeAssistant,
+    mock_refresh_token: AsyncMock,
+    exception: type[Exception],
+    error_key: str,
+) -> None:
+    """Test we show user form on validation exception."""
+    mock_refresh_token.side_effect = exception
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -72,11 +92,11 @@ async def test_invalid_auth(hass: HomeAssistant, mock_connection: MagicMock) -> 
         data=MOCK_USER_INPUT,
     )
 
-    mock_connection.refresh_token.side_effect = None
+    mock_refresh_token.side_effect = None
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "invalid_auth"}
+    assert result["errors"] == {"base": error_key}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -86,7 +106,7 @@ async def test_invalid_auth(hass: HomeAssistant, mock_connection: MagicMock) -> 
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-@pytest.mark.usefixtures("mock_setup_entry", "mock_connection")
+@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
 async def test_device_exists_abort(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
@@ -102,3 +122,51 @@ async def test_device_exists_abort(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+async def test_reauth_successful(
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+) -> None:
+    """Test a successful reauthentication flow."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_USER_INPUT_RECONFIGURE,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == MOCK_USER_INPUT_RECONFIGURE
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_refresh_token")
+async def test_reauth_mismatch(
+    mock_config_entry: MockConfigEntry,
+    hass: HomeAssistant,
+) -> None:
+    """Test a reauthentication flow with mismatched serial number."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_USER_INPUT_MISMATCH,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "serial_number_mismatch"}

--- a/tests/components/smarla/test_init.py
+++ b/tests/components/smarla/test_init.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from pysmarlaapi.connection.exceptions import AuthenticationException
+from pysmarlaapi.connection.exceptions import (
+    AuthenticationException,
+    ConnectionException,
+)
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
@@ -13,13 +16,41 @@ from . import setup_integration
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("exception", "expected_state"),
+    [
+        (AuthenticationException, ConfigEntryState.SETUP_ERROR),
+        (ConnectionException, ConfigEntryState.SETUP_RETRY),
+    ],
+)
 @pytest.mark.usefixtures("mock_federwiege")
-async def test_init_invalid_auth(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_connection: MagicMock
+async def test_init_exception(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_refresh_token: MagicMock,
+    exception: type[Exception],
+    expected_state: ConfigEntryState,
 ) -> None:
-    """Test init invalid authentication behavior."""
-    mock_connection.refresh_token.side_effect = AuthenticationException
+    """Test init config setup exception."""
+    mock_refresh_token.side_effect = exception
 
     assert not await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is expected_state
+
+
+async def test_init_auth_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_federwiege_cls: MagicMock,
+) -> None:
+    """Test behavior on invalid authentication during runtime."""
+    assert await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert not any(mock_config_entry.async_get_active_flows(hass, {"reauth"}))
+
+    auth_failed_cb = mock_federwiege_cls.call_args.args[2]
+    await auth_failed_cb()
+    await hass.async_block_till_done()
+    assert any(mock_config_entry.async_get_active_flows(hass, {"reauth"}))

--- a/tests/components/smarla/test_init.py
+++ b/tests/components/smarla/test_init.py
@@ -1,5 +1,6 @@
 """Test switch platform for Swing2Sleep Smarla integration."""
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import MagicMock
 
 from pysmarlaapi.connection.exceptions import (
@@ -39,18 +40,32 @@ async def test_init_exception(
     assert mock_config_entry.state is expected_state
 
 
-async def test_init_auth_failure(
+async def test_init_auth_failure_during_runtime(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_federwiege_cls: MagicMock,
 ) -> None:
     """Test behavior on invalid authentication during runtime."""
-    assert await setup_integration(hass, mock_config_entry)
+    invalid_auth_callback: Callable[[], Awaitable[None]] | None = None
 
+    def mocked_federwiege(_1, _2, callback):
+        nonlocal invalid_auth_callback
+        invalid_auth_callback = callback
+        return mock_federwiege_cls.return_value
+
+    # Mock Federwiege class to gather authentication failure callback
+    mock_federwiege_cls.side_effect = mocked_federwiege
+
+    assert await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # Check that config entry has no active reauth flows
     assert not any(mock_config_entry.async_get_active_flows(hass, {"reauth"}))
 
-    auth_failed_cb = mock_federwiege_cls.call_args.args[2]
-    await auth_failed_cb()
+    # Simulate authentication failure during runtime
+    assert invalid_auth_callback is not None
+    await invalid_auth_callback()
     await hass.async_block_till_done()
+
+    # Check that a reauth flow has been started
     assert any(mock_config_entry.async_get_active_flows(hass, {"reauth"}))

--- a/tests/components/smarla/test_init.py
+++ b/tests/components/smarla/test_init.py
@@ -28,12 +28,12 @@ from tests.common import MockConfigEntry
 async def test_init_exception(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_refresh_token: MagicMock,
+    mock_connection: MagicMock,
     exception: type[Exception],
     expected_state: ConfigEntryState,
 ) -> None:
     """Test init config setup exception."""
-    mock_refresh_token.side_effect = exception
+    mock_connection.refresh_token.side_effect = exception
 
     assert not await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I implemented differentiation between authentication and connection errors.
Further I added a reauthentication flow for the smarla integration in case of an authentication failure.

Tests have been added accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
