### PR TITLE
Update availability of entities when connection changes

### DIFF
--- a/homeassistant/components/smarla/entity.py
+++ b/homeassistant/components/smarla/entity.py
@@ -1,7 +1,7 @@
 """Common base for entities."""
 
 from dataclasses import dataclass
-from typing import Any
+import logging
 
 from pysmarlaapi import Federwiege
 
@@ -9,6 +9,8 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
 from .const import DEVICE_MODEL_NAME, DOMAIN, MANUFACTURER_NAME
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -30,6 +32,7 @@ class SmarlaBaseEntity(Entity):
     def __init__(self, federwiege: Federwiege, desc: SmarlaEntityDescription) -> None:
         """Initialise the entity."""
         self.entity_description = desc
+        self._federwiege = federwiege
         self._property = federwiege.get_property(desc.service, desc.property)
         self._attr_unique_id = f"{federwiege.serial_number}-{desc.key}"
         self._attr_device_info = DeviceInfo(
@@ -39,15 +42,35 @@ class SmarlaBaseEntity(Entity):
             manufacturer=MANUFACTURER_NAME,
             serial_number=federwiege.serial_number,
         )
+        self._unavailable_logged = False
 
-    async def on_change(self, value: Any):
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._federwiege.available
+
+    async def on_availability_change(self, _) -> None:
+        """Handle availability changes."""
+        if not self.available and not self._unavailable_logged:
+            _LOGGER.info("Entity %s is unavailable", self.entity_id)
+            self._unavailable_logged = True
+        elif self.available and self._unavailable_logged:
+            _LOGGER.info("Entity %s is back online", self.entity_id)
+            self._unavailable_logged = False
+
+        # Notify ha that state changed
+        self.async_write_ha_state()
+
+    async def on_change(self, _):
         """Notify ha when state changes."""
         self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Run when this Entity has been added to HA."""
+        await self._federwiege.add_listener(self.on_availability_change)
         await self._property.add_listener(self.on_change)
 
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
         await self._property.remove_listener(self.on_change)
+        await self._federwiege.remove_listener(self.on_availability_change)

--- a/homeassistant/components/smarla/entity.py
+++ b/homeassistant/components/smarla/entity.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from pysmarlaapi import Federwiege
 
@@ -49,7 +50,7 @@ class SmarlaBaseEntity(Entity):
         """Return True if entity is available."""
         return self._federwiege.available
 
-    async def on_availability_change(self, _) -> None:
+    async def on_availability_change(self, available: bool) -> None:
         """Handle availability changes."""
         if not self.available and not self._unavailable_logged:
             _LOGGER.info("Entity %s is unavailable", self.entity_id)
@@ -61,7 +62,7 @@ class SmarlaBaseEntity(Entity):
         # Notify ha that state changed
         self.async_write_ha_state()
 
-    async def on_change(self, _):
+    async def on_change(self, value: Any) -> None:
         """Notify ha when state changes."""
         self.async_write_ha_state()
 

--- a/homeassistant/components/smarla/quality_scale.yaml
+++ b/homeassistant/components/smarla/quality_scale.yaml
@@ -24,9 +24,9 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
   test-coverage: done

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -66,6 +66,7 @@ def mock_federwiege_cls(mock_connection: MagicMock) -> Generator[MagicMock]:
     ) as mock_federwiege_cls:
         mock_federwiege = mock_federwiege_cls.return_value
         mock_federwiege.serial_number = MOCK_ACCESS_TOKEN_JSON["serialNumber"]
+        mock_federwiege.available = True
 
         mock_babywiege_service = MagicMock(spec=Service)
         mock_babywiege_service.props = {

--- a/tests/components/smarla/test_entity.py
+++ b/tests/components/smarla/test_entity.py
@@ -1,0 +1,86 @@
+"""Test Smarla entities."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration, update_property_listeners
+
+from tests.common import MockConfigEntry
+
+TEST_ENTITY_ID = "switch.smarla"
+
+
+async def test_entity_availability(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_federwiege: MagicMock,
+) -> None:
+    """Test entity state when device becomes unavailable/available."""
+    assert await setup_integration(hass, mock_config_entry)
+
+    # Initially available
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    # Simulate device becoming unavailable
+    mock_federwiege.available = False
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+
+    # Verify state reflects unavailable
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # Simulate device becoming available again
+    mock_federwiege.available = True
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+
+    # Verify state reflects available again
+    state = hass.states.get(TEST_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+async def test_entity_unavailable_logging(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    mock_federwiege: MagicMock,
+) -> None:
+    """Test logging when device becomes unavailable/available."""
+    assert await setup_integration(hass, mock_config_entry)
+
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+
+    # Verify that log exists when device becomes unavailable
+    mock_federwiege.available = False
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+    assert "is unavailable" in caplog.text
+
+    # Verify that we only log once
+    caplog.clear()
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+    assert "is unavailable" not in caplog.text
+
+    # Verify that log exists when device comes back online
+    mock_federwiege.available = True
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+    assert "back online" in caplog.text
+
+    # Verify that we only log once
+    caplog.clear()
+    await update_property_listeners(mock_federwiege)
+    await hass.async_block_till_done()
+    assert "back online" not in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update availability accordingly to the connection state of the end device.
Python API library (pysmarlaapi) logs once when end device connects or disconnects or the connection to the web server is lost entirely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
