### PR TITLE
Removed more warnings from Fritz tests

### DIFF
--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -86,7 +86,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: FritzConfigEntry) -> bo
     avm_wrapper = entry.runtime_data
 
     fritz_data = hass.data[FRITZ_DATA_KEY]
-    fritz_data.tracked.pop(avm_wrapper.unique_id)
+
+    if avm_wrapper.unique_id in fritz_data.tracked:
+        fritz_data.tracked.pop(avm_wrapper.unique_id)
 
     if not bool(fritz_data.tracked):
         hass.data.pop(FRITZ_DATA_KEY)

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -198,7 +198,7 @@ async def test_wol_button_absent_for_non_lan_device(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    assert hass.states.get("button.printer_wake_on_lan")
+    assert hass.states.get("button.printer_wake_on_lan") is None
 
 
 async def test_cleanup_button(

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -30,6 +30,7 @@ async def test_button_setup(
     entity_registry: er.EntityRegistry,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test setup of Fritz!Tools buttons."""
@@ -59,6 +60,7 @@ async def test_buttons(
     wrapper_method: str,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools buttons."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -68,9 +70,9 @@ async def test_buttons(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    button = hass.states.get(entity_id)
-    assert button
-    assert button.state == STATE_UNKNOWN
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_UNKNOWN
+
     with patch(
         f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}"
     ) as mock_press_action:
@@ -82,8 +84,8 @@ async def test_buttons(
         )
         mock_press_action.assert_called_once()
 
-        button = hass.states.get(entity_id)
-        assert button.state != STATE_UNKNOWN
+        assert (state := hass.states.get(entity_id))
+        assert state.state != STATE_UNKNOWN
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -91,6 +93,7 @@ async def test_wol_button(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools wake on LAN button."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -101,9 +104,9 @@ async def test_wol_button(
 
     assert entry.state is ConfigEntryState.LOADED
 
-    button = hass.states.get("button.printer_wake_on_lan")
-    assert button
-    assert button.state == STATE_UNKNOWN
+    assert (state := hass.states.get("button.printer_wake_on_lan"))
+    assert state.state == STATE_UNKNOWN
+
     with patch(
         "homeassistant.components.fritz.coordinator.AvmWrapper.async_wake_on_lan"
     ) as mock_press_action:
@@ -115,8 +118,8 @@ async def test_wol_button(
         )
         mock_press_action.assert_called_once_with("AA:BB:CC:00:11:22")
 
-        button = hass.states.get("button.printer_wake_on_lan")
-        assert button.state != STATE_UNKNOWN
+        assert (state := hass.states.get("button.printer_wake_on_lan"))
+        assert state.state != STATE_UNKNOWN
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -125,6 +128,7 @@ async def test_wol_button_new_device(
     freezer: FrozenDateTimeFactory,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test WoL button is created for new device at runtime."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -154,6 +158,7 @@ async def test_wol_button_absent_for_mesh_slave(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test WoL button not created if interviewed box is in slave mode."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -167,8 +172,7 @@ async def test_wol_button_absent_for_mesh_slave(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    button = hass.states.get("button.printer_wake_on_lan")
-    assert button is None
+    assert hass.states.get("button.printer_wake_on_lan") is None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -176,6 +180,7 @@ async def test_wol_button_absent_for_non_lan_device(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test WoL button not created if interviewed device is not connected via LAN."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -193,8 +198,7 @@ async def test_wol_button_absent_for_non_lan_device(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    button = hass.states.get("button.printer_wake_on_lan")
-    assert button is None
+    assert hass.states.get("button.printer_wake_on_lan")
 
 
 async def test_cleanup_button(
@@ -203,6 +207,7 @@ async def test_cleanup_button(
     entity_registry: er.EntityRegistry,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test cleanup of orphan devices."""
 

--- a/tests/components/fritz/test_image.py
+++ b/tests/components/fritz/test_image.py
@@ -125,8 +125,8 @@ async def test_image_entity(
         "friendly_name": "Mock Title GuestWifi",
     }
 
-    entity_entry = entity_registry.async_get("image.mock_title_guestwifi")
-    assert entity_entry.unique_id == "1c_ed_6f_12_34_11_guestwifi_qr_code"
+    assert (state := entity_registry.async_get("image.mock_title_guestwifi"))
+    assert state.unique_id == "1c_ed_6f_12_34_11_guestwifi_qr_code"
 
     # test image download
     client = await hass_client()
@@ -187,6 +187,8 @@ async def test_image_update_unavailable(
 ) -> None:
     """Test image update when fritzbox is unavailable."""
 
+    entity_id = "image.mock_title_guestwifi"
+
     # setup component with image platform only
     with patch(
         "homeassistant.components.fritz.PLATFORMS",
@@ -199,8 +201,7 @@ async def test_image_update_unavailable(
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
-    state = hass.states.get("image.mock_title_guestwifi")
-    assert state
+    assert hass.states.get(entity_id)
 
     # fritzbox becomes unavailable
     fc_class_mock().call_action_side_effect(ReadTimeout)
@@ -209,7 +210,7 @@ async def test_image_update_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    state = hass.states.get("image.mock_title_guestwifi")
+    assert (state := hass.states.get(entity_id))
     assert state.state == STATE_UNKNOWN
 
     # fritzbox is available again
@@ -219,5 +220,5 @@ async def test_image_update_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    state = hass.states.get("image.mock_title_guestwifi")
+    assert (state := hass.states.get(entity_id))
     assert state.state != STATE_UNKNOWN

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -25,7 +25,12 @@ from .const import MOCK_USER_DATA
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
+async def test_setup(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
     """Test setup and unload of Fritz!Tools."""
 
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
@@ -40,7 +45,10 @@ async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
 
 
 async def test_options_reload(
-    hass: HomeAssistant, fc_class_mock, fh_class_mock
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test reload of Fritz!Tools, when options changed."""
 
@@ -109,7 +117,11 @@ async def test_setup_fail(hass: HomeAssistant, error) -> None:
 
 
 async def test_upnp_missing(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, fc_class_mock, fh_class_mock
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test UPNP configuration is missing."""
 
@@ -139,6 +151,7 @@ async def test_execute_action_while_shutdown(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools actions executed during shutdown of HomeAssistant."""
 

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -49,6 +49,7 @@ async def test_sensor_update_fail(
     freezer: FrozenDateTimeFactory,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test failed update of Fritz!Tools sensors."""
 

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -68,6 +68,7 @@ async def test_service_set_guest_wifi_password_unknown_parameter(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service set_guest_wifi_password with unknown parameter."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -98,6 +99,7 @@ async def test_service_set_guest_wifi_password_service_not_supported(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service set_guest_wifi_password with connection error."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -149,6 +151,7 @@ async def test_service_dial(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service dial."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -180,6 +183,7 @@ async def test_service_dial_unknown_parameter(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service dial with unknown parameters."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -212,6 +216,7 @@ async def test_service_dial_wrong_parameter(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service dial with unknown parameters."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -261,6 +266,7 @@ async def test_service_dial_service_not_supported(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test service dial with connection error."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -293,6 +299,7 @@ async def test_service_dial_failed(
     caplog: pytest.LogCaptureFixture,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test dial service when the dial help is disabled."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -325,6 +332,7 @@ async def test_service_dial_failed(
 async def test_service_dial_unloaded(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    fs_class_mock,
 ) -> None:
     """Test service dial."""
     assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -290,6 +290,7 @@ async def test_switch_no_profile_entities_list(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools switches with no profile entities."""
 
@@ -312,6 +313,7 @@ async def test_switch_no_mesh_wifi_uplink(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools switches when no mesh WiFi uplink."""
 
@@ -330,6 +332,7 @@ async def test_switch_device_no_wan_access(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools switches when device has no WAN access."""
 
@@ -355,6 +358,7 @@ async def test_switch_device_no_ip_address(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
 ) -> None:
     """Test Fritz!Tools switches when device has no IP address."""
 
@@ -398,6 +402,7 @@ async def test_switch_turn_on_off(
     hass: HomeAssistant,
     fc_class_mock,
     fh_class_mock,
+    fs_class_mock,
     entity_id: str,
     wrapper_method: str,
     state_value: str,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
```
2026-02-17 12:16:45.255 ERROR    MainThread homeassistant.config_entries:config_entries.py:1022 Error unloading entry Mock Title for fritz
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/config_entries.py", line 1004, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/fritz/__init__.py", line 90, in async_unload_entry
    fritz_data.tracked.pop(avm_wrapper.unique_id)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '1C:ED:6F:12:34:11'
```

```
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/fritzconnection/lib/fritzstatus.py", line 409, in get_cpu_temperatures
    url = f"{self.fc.http_interface.router_url}/query.lua"
             ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FritzConnectionMock' object has no attribute 'http_interface'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
