### PR TITLE
Add flow rate (stat_rate) tracking for gas and water

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -173,6 +173,9 @@ class GasSourceType(TypedDict):
 
     stat_energy_from: str
 
+    # Instantaneous flow rate: m³/h, L/min, etc.
+    stat_rate: NotRequired[str]
+
     # statistic_id of costs ($) incurred from the gas meter
     # If set to None and entity_energy_price or number_energy_price are configured,
     # an EnergyCostSensor will be automatically created
@@ -189,6 +192,9 @@ class WaterSourceType(TypedDict):
     type: Literal["water"]
 
     stat_energy_from: str
+
+    # Instantaneous flow rate: L/min, gal/min, m³/h, etc.
+    stat_rate: NotRequired[str]
 
     # statistic_id of costs ($) incurred from the water meter
     # If set to None and entity_energy_price or number_energy_price are configured,
@@ -440,6 +446,7 @@ GAS_SOURCE_SCHEMA = vol.Schema(
     {
         vol.Required("type"): "gas",
         vol.Required("stat_energy_from"): str,
+        vol.Optional("stat_rate"): str,
         vol.Optional("stat_cost"): vol.Any(str, None),
         # entity_energy_from was removed in HA Core 2022.10
         vol.Remove("entity_energy_from"): vol.Any(str, None),
@@ -451,6 +458,7 @@ WATER_SOURCE_SCHEMA = vol.Schema(
     {
         vol.Required("type"): "water",
         vol.Required("stat_energy_from"): str,
+        vol.Optional("stat_rate"): str,
         vol.Optional("stat_cost"): vol.Any(str, None),
         vol.Optional("entity_energy_price"): vol.Any(str, None),
         vol.Optional("number_energy_price"): vol.Any(vol.Coerce(float), None),

--- a/homeassistant/components/energy/strings.json
+++ b/homeassistant/components/energy/strings.json
@@ -44,6 +44,10 @@
       "description": "[%key:component::energy::issues::entity_unexpected_unit_energy_price::description%]",
       "title": "[%key:component::energy::issues::entity_unexpected_unit_energy::title%]"
     },
+    "entity_unexpected_unit_volume_flow_rate": {
+      "description": "The following entities do not have an expected unit of measurement (either of {flow_rate_units}):",
+      "title": "[%key:component::energy::issues::entity_unexpected_unit_energy::title%]"
+    },
     "entity_unexpected_unit_water": {
       "description": "The following entities do not have the expected unit of measurement (either of {water_units}):",
       "title": "[%key:component::energy::issues::entity_unexpected_unit_energy::title%]"

--- a/tests/components/energy/test_validate_flow_rate.py
+++ b/tests/components/energy/test_validate_flow_rate.py
@@ -1,0 +1,617 @@
+"""Test flow rate (stat_rate) validation for gas and water sources."""
+
+import pytest
+
+from homeassistant.components.energy import validate
+from homeassistant.components.energy.data import EnergyManager
+from homeassistant.const import UnitOfVolumeFlowRate
+from homeassistant.core import HomeAssistant
+
+FLOW_RATE_UNITS_STRING = ", ".join(tuple(UnitOfVolumeFlowRate))
+
+
+@pytest.fixture(autouse=True)
+async def setup_energy_for_validation(
+    mock_energy_manager: EnergyManager,
+) -> EnergyManager:
+    """Ensure energy manager is set up for validation tests."""
+    return mock_energy_manager
+
+
+async def test_validation_gas_flow_rate_valid(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas with valid flow rate sensor."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                    "stat_rate": "sensor.gas_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_flow_rate",
+        "1.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_flow_rate_wrong_unit(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas with flow rate sensor having wrong unit."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                    "stat_rate": "sensor.gas_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_flow_rate",
+        "1.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": "beers",
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "entity_unexpected_unit_volume_flow_rate",
+                    "affected_entities": {("sensor.gas_flow_rate", "beers")},
+                    "translation_placeholders": {
+                        "flow_rate_units": FLOW_RATE_UNITS_STRING
+                    },
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_flow_rate_wrong_state_class(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas with flow rate sensor having wrong state class."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                    "stat_rate": "sensor.gas_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_flow_rate",
+        "1.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "entity_unexpected_state_class",
+                    "affected_entities": {("sensor.gas_flow_rate", "total_increasing")},
+                    "translation_placeholders": None,
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_flow_rate_entity_missing(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas with missing flow rate sensor."""
+    mock_get_metadata["sensor.missing_flow_rate"] = None
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                    "stat_rate": "sensor.missing_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "statistics_not_defined",
+                    "affected_entities": {("sensor.missing_flow_rate", None)},
+                    "translation_placeholders": None,
+                },
+                {
+                    "type": "entity_not_defined",
+                    "affected_entities": {("sensor.missing_flow_rate", None)},
+                    "translation_placeholders": None,
+                },
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_without_flow_rate(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas without flow rate sensor still works."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_flow_rate_valid(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating water with valid flow rate sensor."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                    "stat_rate": "sensor.water_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.water_flow_rate",
+        "2.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_flow_rate_wrong_unit(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating water with flow rate sensor having wrong unit."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                    "stat_rate": "sensor.water_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.water_flow_rate",
+        "2.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": "beers",
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "entity_unexpected_unit_volume_flow_rate",
+                    "affected_entities": {("sensor.water_flow_rate", "beers")},
+                    "translation_placeholders": {
+                        "flow_rate_units": FLOW_RATE_UNITS_STRING
+                    },
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_flow_rate_wrong_state_class(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating water with flow rate sensor having wrong state class."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                    "stat_rate": "sensor.water_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.water_flow_rate",
+        "2.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "entity_unexpected_state_class",
+                    "affected_entities": {
+                        ("sensor.water_flow_rate", "total_increasing")
+                    },
+                    "translation_placeholders": None,
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_flow_rate_entity_missing(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating water with missing flow rate sensor."""
+    mock_get_metadata["sensor.missing_flow_rate"] = None
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                    "stat_rate": "sensor.missing_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "statistics_not_defined",
+                    "affected_entities": {("sensor.missing_flow_rate", None)},
+                    "translation_placeholders": None,
+                },
+                {
+                    "type": "entity_not_defined",
+                    "affected_entities": {("sensor.missing_flow_rate", None)},
+                    "translation_placeholders": None,
+                },
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_without_flow_rate(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating water without flow rate sensor still works."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[]],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_flow_rate_different_units(
+    hass: HomeAssistant, mock_energy_manager, mock_get_metadata
+) -> None:
+    """Test validating gas with flow rate sensors using different valid units."""
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption_1",
+                    "stat_rate": "sensor.gas_flow_m3h",
+                },
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption_2",
+                    "stat_rate": "sensor.gas_flow_lmin",
+                },
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption_1",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption_2",
+        "20.20",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_flow_m3h",
+        "1.5",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
+            "state_class": "measurement",
+        },
+    )
+    hass.states.async_set(
+        "sensor.gas_flow_lmin",
+        "25.0",
+        {
+            "device_class": "volume_flow_rate",
+            "unit_of_measurement": UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+            "state_class": "measurement",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [[], []],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_gas_flow_rate_recorder_untracked(
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
+    """Test validating gas with flow rate sensor not tracked by recorder."""
+    mock_is_entity_recorded["sensor.untracked_flow_rate"] = False
+
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "gas",
+                    "stat_energy_from": "sensor.gas_consumption",
+                    "stat_rate": "sensor.untracked_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.gas_consumption",
+        "10.10",
+        {
+            "device_class": "gas",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "recorder_untracked",
+                    "affected_entities": {("sensor.untracked_flow_rate", None)},
+                    "translation_placeholders": None,
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }
+
+
+async def test_validation_water_flow_rate_recorder_untracked(
+    hass: HomeAssistant, mock_energy_manager, mock_is_entity_recorded, mock_get_metadata
+) -> None:
+    """Test validating water with flow rate sensor not tracked by recorder."""
+    mock_is_entity_recorded["sensor.untracked_flow_rate"] = False
+
+    await mock_energy_manager.async_update(
+        {
+            "energy_sources": [
+                {
+                    "type": "water",
+                    "stat_energy_from": "sensor.water_consumption",
+                    "stat_rate": "sensor.untracked_flow_rate",
+                }
+            ]
+        }
+    )
+    hass.states.async_set(
+        "sensor.water_consumption",
+        "10.10",
+        {
+            "device_class": "water",
+            "unit_of_measurement": "m³",
+            "state_class": "total_increasing",
+        },
+    )
+
+    result = await validate.async_validate(hass)
+    assert result.as_dict() == {
+        "energy_sources": [
+            [
+                {
+                    "type": "recorder_untracked",
+                    "affected_entities": {("sensor.untracked_flow_rate", None)},
+                    "translation_placeholders": None,
+                }
+            ]
+        ],
+        "device_consumption": [],
+        "device_consumption_water": [],
+    }


### PR DESCRIPTION
## Summary

This mirrors how `stat_rate` is already used for power tracking in grid/solar/battery sources. Gas and water meters can optionally track instantaneous flow rate (m³/h, L/min, gal/min, etc.) alongside their cumulative consumption statistics.

- Add `stat_rate` field to `GasSourceType` and `WaterSourceType` TypedDicts and their voluptuous schemas to support optional flow rate tracking
- Add validation for flow rate statistics using `volume_flow_rate` device class and `UnitOfVolumeFlowRate` units, reusing the existing `_async_validate_power_stat` helper
- Add `entity_unexpected_unit_volume_flow_rate` issue string for validation errors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional context
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/29693

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
