### PR TITLE
Add Trane Local integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1737,6 +1737,8 @@ build.json @home-assistant/supervisor
 /tests/components/trafikverket_train/ @gjohansson-ST
 /homeassistant/components/trafikverket_weatherstation/ @gjohansson-ST
 /tests/components/trafikverket_weatherstation/ @gjohansson-ST
+/homeassistant/components/trane/ @bdraco
+/tests/components/trane/ @bdraco
 /homeassistant/components/transmission/ @engrbm87 @JPHutchins @andrew-codechimp
 /tests/components/transmission/ @engrbm87 @JPHutchins @andrew-codechimp
 /homeassistant/components/trend/ @jpbede

--- a/homeassistant/brands/american_standard.json
+++ b/homeassistant/brands/american_standard.json
@@ -1,0 +1,5 @@
+{
+  "domain": "american_standard",
+  "name": "American Standard",
+  "integrations": ["nexia", "trane"]
+}

--- a/homeassistant/brands/trane.json
+++ b/homeassistant/brands/trane.json
@@ -1,0 +1,5 @@
+{
+  "domain": "trane",
+  "name": "Trane",
+  "integrations": ["nexia", "trane"]
+}

--- a/homeassistant/components/trane/__init__.py
+++ b/homeassistant/components/trane/__init__.py
@@ -1,0 +1,52 @@
+"""Integration for Trane Local thermostats."""
+
+from __future__ import annotations
+
+from steamloop import (
+    AuthenticationError,
+    SteamloopConnectionError,
+    ThermostatConnection,
+)
+
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+
+from .const import CONF_SECRET_KEY, DOMAIN, PLATFORMS
+from .types import TraneConfigEntry
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> bool:
+    """Set up Trane Local from a config entry."""
+    conn = ThermostatConnection(
+        entry.data[CONF_HOST],
+        secret_key=entry.data[CONF_SECRET_KEY],
+    )
+
+    try:
+        await conn.connect()
+        await conn.login()
+    except (SteamloopConnectionError, TimeoutError) as err:
+        await conn.disconnect()
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from err
+    except AuthenticationError as err:
+        await conn.disconnect()
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="authentication_failed",
+        ) from err
+
+    conn.start_background_tasks()
+    entry.runtime_data = conn
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> bool:
+    """Unload a Trane Local config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    await entry.runtime_data.disconnect()
+    return unload_ok

--- a/homeassistant/components/trane/__init__.py
+++ b/homeassistant/components/trane/__init__.py
@@ -11,8 +11,9 @@ from steamloop import (
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_SECRET_KEY, DOMAIN, PLATFORMS
+from .const import CONF_SECRET_KEY, DOMAIN, MANUFACTURER, PLATFORMS
 from .types import TraneConfigEntry
 
 
@@ -41,6 +42,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> boo
 
     conn.start_background_tasks()
     entry.runtime_data = conn
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer=MANUFACTURER,
+        name="Thermostat",
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/trane/__init__.py
+++ b/homeassistant/components/trane/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> boo
     try:
         await conn.connect()
         await conn.login()
-    except (SteamloopConnectionError, TimeoutError) as err:
+    except SteamloopConnectionError, TimeoutError as err:
         await conn.disconnect()
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,

--- a/homeassistant/components/trane/__init__.py
+++ b/homeassistant/components/trane/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> boo
     try:
         await conn.connect()
         await conn.login()
-    except SteamloopConnectionError, TimeoutError as err:
+    except (SteamloopConnectionError, TimeoutError) as err:
         await conn.disconnect()
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,

--- a/homeassistant/components/trane/__init__.py
+++ b/homeassistant/components/trane/__init__.py
@@ -48,7 +48,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TraneConfigEntry) -> boo
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         manufacturer=MANUFACTURER,
-        name="Thermostat",
+        translation_key="thermostat",
+        translation_placeholders={"host": entry.data[CONF_HOST]},
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/trane/config_flow.py
+++ b/homeassistant/components/trane/config_flow.py
@@ -1,0 +1,62 @@
+"""Config flow for the Trane Local integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from steamloop import PairingError, SteamloopConnectionError, ThermostatConnection
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
+
+from .const import CONF_SECRET_KEY, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+    }
+)
+
+
+class TraneConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Trane Local."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the user step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            self._async_abort_entries_match({CONF_HOST: host})
+            conn = ThermostatConnection(host, secret_key="")
+            try:
+                await conn.connect()
+                await conn.pair()
+            except (SteamloopConnectionError, PairingError):
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception during pairing")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title=f"Thermostat ({host})",
+                    data={
+                        CONF_HOST: host,
+                        CONF_SECRET_KEY: conn.secret_key,
+                    },
+                )
+            finally:
+                await conn.disconnect()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )

--- a/homeassistant/components/trane/config_flow.py
+++ b/homeassistant/components/trane/config_flow.py
@@ -39,7 +39,7 @@ class TraneConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 await conn.connect()
                 await conn.pair()
-            except (SteamloopConnectionError, PairingError):
+            except SteamloopConnectionError, PairingError:
                 errors["base"] = "cannot_connect"
             except Exception:
                 _LOGGER.exception("Unexpected exception during pairing")

--- a/homeassistant/components/trane/const.py
+++ b/homeassistant/components/trane/const.py
@@ -1,0 +1,11 @@
+"""Constants for the Trane Local integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "trane"
+
+PLATFORMS = [Platform.SWITCH]
+
+CONF_SECRET_KEY = "secret_key"
+
+MANUFACTURER = "Trane"

--- a/homeassistant/components/trane/entity.py
+++ b/homeassistant/components/trane/entity.py
@@ -1,0 +1,81 @@
+"""Base entity for the Trane Local integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from steamloop import ThermostatConnection, Zone
+
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, MANUFACTURER
+
+
+class TraneEntity(Entity):
+    """Base class for all Trane entities."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, conn: ThermostatConnection) -> None:
+        """Initialize the entity."""
+        self._conn = conn
+
+    async def async_added_to_hass(self) -> None:
+        """Register event callback when added to hass."""
+        self.async_on_remove(self._conn.add_event_callback(self._handle_event))
+
+    @callback
+    def _handle_event(self, _event: dict[str, Any]) -> None:
+        """Handle a thermostat event."""
+        self.async_write_ha_state()
+
+
+class TraneThermostatEntity(TraneEntity):
+    """Base class for Trane thermostat-level entities."""
+
+    def __init__(
+        self,
+        conn: ThermostatConnection,
+        entry_id: str,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(conn)
+        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            manufacturer=MANUFACTURER,
+            name="Thermostat",
+        )
+
+
+class TraneZoneEntity(TraneEntity):
+    """Base class for Trane zone-level entities."""
+
+    def __init__(
+        self,
+        conn: ThermostatConnection,
+        entry_id: str,
+        zone: Zone,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(conn)
+        self._zone_id = zone.zone_id
+        self._attr_unique_id = f"{entry_id}_{zone.zone_id}_{unique_id_suffix}"
+        zone_name = zone.name or f"Zone {zone.zone_id}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{entry_id}_{zone.zone_id}")},
+            manufacturer=MANUFACTURER,
+            name=zone_name,
+            suggested_area=zone_name,
+            via_device=(DOMAIN, entry_id),
+        )
+
+    @property
+    def _zone(self) -> Zone:
+        """Return the current zone state."""
+        return self._conn.state.zones[self._zone_id]

--- a/homeassistant/components/trane/entity.py
+++ b/homeassistant/components/trane/entity.py
@@ -40,21 +40,26 @@ class TraneZoneEntity(TraneEntity):
         self,
         conn: ThermostatConnection,
         entry_id: str,
-        zone: Zone,
+        zone_id: str,
         unique_id_suffix: str,
     ) -> None:
         """Initialize the entity."""
         super().__init__(conn)
-        self._zone_id = zone.zone_id
-        self._attr_unique_id = f"{entry_id}_{zone.zone_id}_{unique_id_suffix}"
-        zone_name = zone.name or f"Zone {zone.zone_id}"
+        self._zone_id = zone_id
+        self._attr_unique_id = f"{entry_id}_{zone_id}_{unique_id_suffix}"
+        zone_name = self._zone.name or f"Zone {zone_id}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{entry_id}_{zone.zone_id}")},
+            identifiers={(DOMAIN, f"{entry_id}_{zone_id}")},
             manufacturer=MANUFACTURER,
             name=zone_name,
             suggested_area=zone_name,
             via_device=(DOMAIN, entry_id),
         )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the zone is available."""
+        return self._zone_id in self._conn.state.zones
 
     @property
     def _zone(self) -> Zone:

--- a/homeassistant/components/trane/entity.py
+++ b/homeassistant/components/trane/entity.py
@@ -33,25 +33,6 @@ class TraneEntity(Entity):
         self.async_write_ha_state()
 
 
-class TraneThermostatEntity(TraneEntity):
-    """Base class for Trane thermostat-level entities."""
-
-    def __init__(
-        self,
-        conn: ThermostatConnection,
-        entry_id: str,
-        unique_id_suffix: str,
-    ) -> None:
-        """Initialize the entity."""
-        super().__init__(conn)
-        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry_id)},
-            manufacturer=MANUFACTURER,
-            name="Thermostat",
-        )
-
-
 class TraneZoneEntity(TraneEntity):
     """Base class for Trane zone-level entities."""
 

--- a/homeassistant/components/trane/icons.json
+++ b/homeassistant/components/trane/icons.json
@@ -1,0 +1,12 @@
+{
+  "entity": {
+    "switch": {
+      "hold": {
+        "default": "mdi:timer",
+        "state": {
+          "on": "mdi:timer-off"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/trane/manifest.json
+++ b/homeassistant/components/trane/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "trane",
+  "name": "Trane Local",
+  "codeowners": ["@bdraco"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/trane",
+  "integration_type": "hub",
+  "iot_class": "local_push",
+  "loggers": ["steamloop"],
+  "quality_scale": "bronze",
+  "requirements": ["steamloop==1.1.0"]
+}

--- a/homeassistant/components/trane/manifest.json
+++ b/homeassistant/components/trane/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["steamloop"],
   "quality_scale": "bronze",
-  "requirements": ["steamloop==1.1.0"]
+  "requirements": ["steamloop==1.2.0"]
 }

--- a/homeassistant/components/trane/quality_scale.yaml
+++ b/homeassistant/components/trane/quality_scale.yaml
@@ -1,0 +1,72 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      No custom actions are defined.
+  appropriate-polling:
+    status: exempt
+    comment: |
+      This is a local push integration that uses event callbacks.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      No custom actions are defined.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      No custom actions are defined.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: todo
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: todo
+  test-coverage: todo
+
+  # Gold
+  devices: todo
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/trane/quality_scale.yaml
+++ b/homeassistant/components/trane/quality_scale.yaml
@@ -34,8 +34,8 @@ rules:
     comment: |
       No custom actions are defined.
   config-entry-unloading: done
-  docs-configuration-parameters: todo
-  docs-installation-parameters: todo
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
   entity-unavailable: todo
   integration-owner: done
   log-when-unavailable: todo
@@ -48,13 +48,16 @@ rules:
   diagnostics: todo
   discovery-update-info: todo
   discovery: todo
-  docs-data-update: todo
+  docs-data-update:
+    status: exempt
+    comment: |
+      Local push integration, no polling interval to document.
   docs-examples: todo
   docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
+  docs-supported-devices: done
+  docs-supported-functions: done
   docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-use-cases: done
   dynamic-devices: todo
   entity-category: todo
   entity-device-class: todo

--- a/homeassistant/components/trane/quality_scale.yaml
+++ b/homeassistant/components/trane/quality_scale.yaml
@@ -48,10 +48,7 @@ rules:
   diagnostics: todo
   discovery-update-info: todo
   discovery: todo
-  docs-data-update:
-    status: exempt
-    comment: |
-      Local push integration, no polling interval to document.
+  docs-data-update: done
   docs-examples: todo
   docs-known-limitations: todo
   docs-supported-devices: done

--- a/homeassistant/components/trane/quality_scale.yaml
+++ b/homeassistant/components/trane/quality_scale.yaml
@@ -44,7 +44,7 @@ rules:
   test-coverage: todo
 
   # Gold
-  devices: todo
+  devices: done
   diagnostics: todo
   discovery-update-info: todo
   discovery: todo

--- a/homeassistant/components/trane/quality_scale.yaml
+++ b/homeassistant/components/trane/quality_scale.yaml
@@ -39,7 +39,7 @@ rules:
   entity-unavailable: todo
   integration-owner: done
   log-when-unavailable: todo
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: todo
   test-coverage: todo
 
@@ -59,9 +59,9 @@ rules:
   entity-category: todo
   entity-device-class: todo
   entity-disabled-by-default: todo
-  entity-translations: todo
-  exception-translations: todo
-  icon-translations: todo
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices: todo

--- a/homeassistant/components/trane/strings.json
+++ b/homeassistant/components/trane/strings.json
@@ -1,22 +1,22 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "description": "Put the thermostat in pairing mode (Menu > Settings > Network > Advanced Setup > Remote Connection > Pair). The thermostat must have a static IP address assigned.",
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]"
-        },
-        "data_description": {
-          "host": "The IP address of the thermostat"
-        }
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "The IP address of the thermostat"
+        },
+        "description": "Put the thermostat in pairing mode (Menu > Settings > Network > Advanced Setup > Remote Connection > Pair). The thermostat must have a static IP address assigned."
+      }
     }
   },
   "entity": {
@@ -27,11 +27,11 @@
     }
   },
   "exceptions": {
-    "cannot_connect": {
-      "message": "Failed to connect to thermostat"
-    },
     "authentication_failed": {
       "message": "Authentication failed with thermostat"
+    },
+    "cannot_connect": {
+      "message": "Failed to connect to thermostat"
     }
   }
 }

--- a/homeassistant/components/trane/strings.json
+++ b/homeassistant/components/trane/strings.json
@@ -19,6 +19,11 @@
       }
     }
   },
+  "device": {
+    "thermostat": {
+      "name": "Thermostat ({host})"
+    }
+  },
   "entity": {
     "switch": {
       "hold": {

--- a/homeassistant/components/trane/strings.json
+++ b/homeassistant/components/trane/strings.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Put the thermostat in pairing mode (Menu > Settings > Network > Advanced Setup > Remote Connection > Pair). The thermostat must have a static IP address assigned.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "The IP address of the thermostat"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "entity": {
+    "switch": {
+      "hold": {
+        "name": "Hold"
+      }
+    }
+  },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Failed to connect to thermostat"
+    },
+    "authentication_failed": {
+      "message": "Authentication failed with thermostat"
+    }
+  }
+}

--- a/homeassistant/components/trane/switch.py
+++ b/homeassistant/components/trane/switch.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .entity import TraneZoneEntity
 from .types import TraneConfigEntry
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/trane/switch.py
+++ b/homeassistant/components/trane/switch.py
@@ -1,0 +1,51 @@
+"""Switch platform for the Trane Local integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from steamloop import HoldType, ThermostatConnection
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import TraneZoneEntity
+from .types import TraneConfigEntry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: TraneConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Trane Local switch entities."""
+    conn = config_entry.runtime_data
+    async_add_entities(
+        TraneHoldSwitch(conn, config_entry.entry_id, zone_id)
+        for zone_id in conn.state.zones
+    )
+
+
+class TraneHoldSwitch(TraneZoneEntity, SwitchEntity):
+    """Switch to control the hold mode of a thermostat zone."""
+
+    _attr_translation_key = "hold"
+
+    def __init__(self, conn: ThermostatConnection, entry_id: str, zone_id: str) -> None:
+        """Initialize the hold switch."""
+        zone = conn.state.zones[zone_id]
+        super().__init__(conn, entry_id, zone, "hold")
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the zone is in permanent hold."""
+        return self._zone.hold_type == HoldType.MANUAL
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable permanent hold."""
+        self._conn.set_temperature_setpoint(self._zone_id, hold_type=HoldType.MANUAL)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Return to schedule."""
+        self._conn.set_temperature_setpoint(self._zone_id, hold_type=HoldType.SCHEDULE)

--- a/homeassistant/components/trane/switch.py
+++ b/homeassistant/components/trane/switch.py
@@ -36,8 +36,7 @@ class TraneHoldSwitch(TraneZoneEntity, SwitchEntity):
 
     def __init__(self, conn: ThermostatConnection, entry_id: str, zone_id: str) -> None:
         """Initialize the hold switch."""
-        zone = conn.state.zones[zone_id]
-        super().__init__(conn, entry_id, zone, "hold")
+        super().__init__(conn, entry_id, zone_id, "hold")
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/trane/types.py
+++ b/homeassistant/components/trane/types.py
@@ -1,0 +1,7 @@
+"""Types for the Trane Local integration."""
+
+from steamloop import ThermostatConnection
+
+from homeassistant.config_entries import ConfigEntry
+
+type TraneConfigEntry = ConfigEntry[ThermostatConnection]

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -731,6 +731,7 @@ FLOWS = {
         "trafikverket_ferry",
         "trafikverket_train",
         "trafikverket_weatherstation",
+        "trane",
         "transmission",
         "triggercmd",
         "tuya",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -731,7 +731,6 @@ FLOWS = {
         "trafikverket_ferry",
         "trafikverket_train",
         "trafikverket_weatherstation",
-        "trane",
         "transmission",
         "triggercmd",
         "tuya",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -303,6 +303,23 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "american_standard": {
+      "name": "American Standard",
+      "integrations": {
+        "nexia": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Nexia/American Standard/Trane"
+        },
+        "trane": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_push",
+          "name": "Trane Local"
+        }
+      }
+    },
     "amp_motorization": {
       "name": "AMP Motorization",
       "integration_type": "virtual",
@@ -474,7 +491,10 @@
     },
     "aqara": {
       "name": "Aqara",
-      "iot_standards": ["matter", "zigbee"]
+      "iot_standards": [
+        "matter",
+        "zigbee"
+      ]
     },
     "aquacell": {
       "name": "AquaCell",
@@ -1321,7 +1341,9 @@
           "name": "devolo Home Network"
         }
       },
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "dexcom": {
       "name": "Dexcom",
@@ -1669,7 +1691,9 @@
     },
     "eltako": {
       "name": "Eltako",
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "elv": {
       "name": "ELV PCA",
@@ -1879,7 +1903,9 @@
     },
     "eve": {
       "name": "Eve",
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "evergy": {
       "name": "Evergy",
@@ -2196,7 +2222,9 @@
     },
     "frient": {
       "name": "Frient",
-      "iot_standards": ["zigbee"]
+      "iot_standards": [
+        "zigbee"
+      ]
     },
     "fritzbox": {
       "name": "FRITZ!",
@@ -2698,7 +2726,9 @@
     },
     "heatit": {
       "name": "Heatit",
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "heatmiser": {
       "name": "Heatmiser",
@@ -2719,7 +2749,10 @@
     },
     "heiman": {
       "name": "Heiman",
-      "iot_standards": ["matter", "zigbee"]
+      "iot_standards": [
+        "matter",
+        "zigbee"
+      ]
     },
     "heiwa": {
       "name": "Heiwa",
@@ -2728,7 +2761,9 @@
     },
     "heltun": {
       "name": "HELTUN",
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "here_travel_time": {
       "name": "HERE Travel Time",
@@ -2850,7 +2885,9 @@
     },
     "homeseer": {
       "name": "HomeSeer",
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "homevolt": {
       "name": "Homevolt",
@@ -3128,7 +3165,10 @@
     },
     "inovelli": {
       "name": "Inovelli",
-      "iot_standards": ["zigbee", "zwave"]
+      "iot_standards": [
+        "zigbee",
+        "zwave"
+      ]
     },
     "inspired_shades": {
       "name": "Inspired Shades",
@@ -3285,7 +3325,9 @@
     },
     "jasco": {
       "name": "Jasco",
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "jellyfin": {
       "name": "Jellyfin",
@@ -3570,7 +3612,9 @@
     },
     "level": {
       "name": "Level",
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "leviton": {
       "name": "Leviton",
@@ -3582,7 +3626,9 @@
           "name": "Leviton Decora Wi-Fi"
         }
       },
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "levoit": {
       "name": "Levoit",
@@ -4268,7 +4314,9 @@
           "name": "Motionblinds Bluetooth"
         }
       },
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "motioneye": {
       "name": "motionEye",
@@ -4494,12 +4542,6 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
-    "nexia": {
-      "name": "Nexia/American Standard/Trane",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "cloud_polling"
-    },
     "nexity": {
       "name": "Nexity Eug\u00e9nie",
       "integration_type": "virtual",
@@ -4671,7 +4713,9 @@
           "name": "Nuki Bridge"
         }
       },
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "numato": {
       "name": "Numato USB GPIO Expander",
@@ -6096,7 +6140,9 @@
           "name": "Shelly"
         }
       },
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "shodan": {
       "name": "Shodan",
@@ -6652,7 +6698,9 @@
           "name": "SwitchBot Cloud"
         }
       },
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "switcher_kis": {
       "name": "Switcher",
@@ -6928,7 +6976,10 @@
     },
     "third_reality": {
       "name": "Third Reality",
-      "iot_standards": ["matter", "zigbee"]
+      "iot_standards": [
+        "matter",
+        "zigbee"
+      ]
     },
     "thomson": {
       "name": "Thomson",
@@ -7065,7 +7116,9 @@
           "name": "Tapo"
         }
       },
-      "iot_standards": ["matter"]
+      "iot_standards": [
+        "matter"
+      ]
     },
     "traccar": {
       "name": "Traccar",
@@ -7116,6 +7169,23 @@
           "config_flow": true,
           "iot_class": "cloud_polling",
           "name": "Trafikverket Weather Station"
+        }
+      }
+    },
+    "trane": {
+      "name": "Trane",
+      "integrations": {
+        "nexia": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Nexia/American Standard/Trane"
+        },
+        "trane": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_push",
+          "name": "Trane Local"
         }
       }
     },
@@ -7202,7 +7272,9 @@
         "ultraloq": {
           "integration_type": "virtual",
           "config_flow": false,
-          "iot_standards": ["zwave"],
+          "iot_standards": [
+            "zwave"
+          ],
           "name": "Ultraloq"
         }
       }
@@ -7984,7 +8056,9 @@
     },
     "zooz": {
       "name": "Zooz",
-      "iot_standards": ["zwave"]
+      "iot_standards": [
+        "zwave"
+      ]
     },
     "zwave_js": {
       "name": "Z-Wave",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -303,23 +303,6 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
-    "american_standard": {
-      "name": "American Standard",
-      "integrations": {
-        "nexia": {
-          "integration_type": "hub",
-          "config_flow": true,
-          "iot_class": "cloud_polling",
-          "name": "Nexia/American Standard/Trane"
-        },
-        "trane": {
-          "integration_type": "hub",
-          "config_flow": true,
-          "iot_class": "local_push",
-          "name": "Trane Local"
-        }
-      }
-    },
     "amp_motorization": {
       "name": "AMP Motorization",
       "integration_type": "virtual",
@@ -4511,6 +4494,12 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
+    "nexia": {
+      "name": "Nexia/American Standard/Trane",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "nexity": {
       "name": "Nexity Eug\u00e9nie",
       "integration_type": "virtual",
@@ -7127,23 +7116,6 @@
           "config_flow": true,
           "iot_class": "cloud_polling",
           "name": "Trafikverket Weather Station"
-        }
-      }
-    },
-    "trane": {
-      "name": "Trane",
-      "integrations": {
-        "nexia": {
-          "integration_type": "hub",
-          "config_flow": true,
-          "iot_class": "cloud_polling",
-          "name": "Nexia/American Standard/Trane"
-        },
-        "trane": {
-          "integration_type": "hub",
-          "config_flow": true,
-          "iot_class": "local_push",
-          "name": "Trane Local"
         }
       }
     },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -303,6 +303,23 @@
       "config_flow": false,
       "iot_class": "local_polling"
     },
+    "american_standard": {
+      "name": "American Standard",
+      "integrations": {
+        "nexia": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Nexia/American Standard/Trane"
+        },
+        "trane": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_push",
+          "name": "Trane Local"
+        }
+      }
+    },
     "amp_motorization": {
       "name": "AMP Motorization",
       "integration_type": "virtual",
@@ -474,10 +491,7 @@
     },
     "aqara": {
       "name": "Aqara",
-      "iot_standards": [
-        "matter",
-        "zigbee"
-      ]
+      "iot_standards": ["matter", "zigbee"]
     },
     "aquacell": {
       "name": "AquaCell",
@@ -1324,9 +1338,7 @@
           "name": "devolo Home Network"
         }
       },
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "dexcom": {
       "name": "Dexcom",
@@ -1674,9 +1686,7 @@
     },
     "eltako": {
       "name": "Eltako",
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "elv": {
       "name": "ELV PCA",
@@ -1886,9 +1896,7 @@
     },
     "eve": {
       "name": "Eve",
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "evergy": {
       "name": "Evergy",
@@ -2205,9 +2213,7 @@
     },
     "frient": {
       "name": "Frient",
-      "iot_standards": [
-        "zigbee"
-      ]
+      "iot_standards": ["zigbee"]
     },
     "fritzbox": {
       "name": "FRITZ!",
@@ -2709,9 +2715,7 @@
     },
     "heatit": {
       "name": "Heatit",
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "heatmiser": {
       "name": "Heatmiser",
@@ -2732,10 +2736,7 @@
     },
     "heiman": {
       "name": "Heiman",
-      "iot_standards": [
-        "matter",
-        "zigbee"
-      ]
+      "iot_standards": ["matter", "zigbee"]
     },
     "heiwa": {
       "name": "Heiwa",
@@ -2744,9 +2745,7 @@
     },
     "heltun": {
       "name": "HELTUN",
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "here_travel_time": {
       "name": "HERE Travel Time",
@@ -2868,9 +2867,7 @@
     },
     "homeseer": {
       "name": "HomeSeer",
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "homevolt": {
       "name": "Homevolt",
@@ -3148,10 +3145,7 @@
     },
     "inovelli": {
       "name": "Inovelli",
-      "iot_standards": [
-        "zigbee",
-        "zwave"
-      ]
+      "iot_standards": ["zigbee", "zwave"]
     },
     "inspired_shades": {
       "name": "Inspired Shades",
@@ -3308,9 +3302,7 @@
     },
     "jasco": {
       "name": "Jasco",
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "jellyfin": {
       "name": "Jellyfin",
@@ -3595,9 +3587,7 @@
     },
     "level": {
       "name": "Level",
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "leviton": {
       "name": "Leviton",
@@ -3609,9 +3599,7 @@
           "name": "Leviton Decora Wi-Fi"
         }
       },
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "levoit": {
       "name": "Levoit",
@@ -4297,9 +4285,7 @@
           "name": "Motionblinds Bluetooth"
         }
       },
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "motioneye": {
       "name": "motionEye",
@@ -4525,12 +4511,6 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
-    "nexia": {
-      "name": "Nexia/American Standard/Trane",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "cloud_polling"
-    },
     "nexity": {
       "name": "Nexity Eug\u00e9nie",
       "integration_type": "virtual",
@@ -4702,9 +4682,7 @@
           "name": "Nuki Bridge"
         }
       },
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "numato": {
       "name": "Numato USB GPIO Expander",
@@ -6129,9 +6107,7 @@
           "name": "Shelly"
         }
       },
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "shodan": {
       "name": "Shodan",
@@ -6687,9 +6663,7 @@
           "name": "SwitchBot Cloud"
         }
       },
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "switcher_kis": {
       "name": "Switcher",
@@ -6965,10 +6939,7 @@
     },
     "third_reality": {
       "name": "Third Reality",
-      "iot_standards": [
-        "matter",
-        "zigbee"
-      ]
+      "iot_standards": ["matter", "zigbee"]
     },
     "thomson": {
       "name": "Thomson",
@@ -7105,9 +7076,7 @@
           "name": "Tapo"
         }
       },
-      "iot_standards": [
-        "matter"
-      ]
+      "iot_standards": ["matter"]
     },
     "traccar": {
       "name": "Traccar",
@@ -7158,6 +7127,23 @@
           "config_flow": true,
           "iot_class": "cloud_polling",
           "name": "Trafikverket Weather Station"
+        }
+      }
+    },
+    "trane": {
+      "name": "Trane",
+      "integrations": {
+        "nexia": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Nexia/American Standard/Trane"
+        },
+        "trane": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "local_push",
+          "name": "Trane Local"
         }
       }
     },
@@ -7244,9 +7230,7 @@
         "ultraloq": {
           "integration_type": "virtual",
           "config_flow": false,
-          "iot_standards": [
-            "zwave"
-          ],
+          "iot_standards": ["zwave"],
           "name": "Ultraloq"
         }
       }
@@ -8028,9 +8012,7 @@
     },
     "zooz": {
       "name": "Zooz",
-      "iot_standards": [
-        "zwave"
-      ]
+      "iot_standards": ["zwave"]
     },
     "zwave_js": {
       "name": "Z-Wave",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2983,7 +2983,7 @@ starlink-grpc-core==1.2.3
 statsd==3.2.1
 
 # homeassistant.components.trane
-steamloop==1.1.0
+steamloop==1.2.0
 
 # homeassistant.components.steam_online
 steamodd==4.21

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2982,6 +2982,9 @@ starlink-grpc-core==1.2.3
 # homeassistant.components.statsd
 statsd==3.2.1
 
+# homeassistant.components.trane
+steamloop==1.1.0
+
 # homeassistant.components.steam_online
 steamodd==4.21
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2513,7 +2513,7 @@ starlink-grpc-core==1.2.3
 statsd==3.2.1
 
 # homeassistant.components.trane
-steamloop==1.1.0
+steamloop==1.2.0
 
 # homeassistant.components.steam_online
 steamodd==4.21

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2512,6 +2512,9 @@ starlink-grpc-core==1.2.3
 # homeassistant.components.statsd
 statsd==3.2.1
 
+# homeassistant.components.trane
+steamloop==1.1.0
+
 # homeassistant.components.steam_online
 steamodd==4.21
 

--- a/tests/components/trane/__init__.py
+++ b/tests/components/trane/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Trane Local integration."""

--- a/tests/components/trane/conftest.py
+++ b/tests/components/trane/conftest.py
@@ -1,0 +1,92 @@
+"""Fixtures for the Trane Local integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from steamloop import FanMode, HoldType, ThermostatState, Zone, ZoneMode
+
+from homeassistant.components.trane.const import CONF_SECRET_KEY, DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.100"
+MOCK_SECRET_KEY = "test_secret_key"
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Thermostat ({MOCK_HOST})",
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_SECRET_KEY: MOCK_SECRET_KEY,
+        },
+    )
+
+
+def _make_state() -> ThermostatState:
+    """Create a mock thermostat state."""
+    return ThermostatState(
+        zones={
+            "1": Zone(
+                zone_id="1",
+                name="Living Room",
+                mode=ZoneMode.AUTO,
+                indoor_temperature="72",
+                heat_setpoint="68",
+                cool_setpoint="76",
+                deadband="3",
+                hold_type=HoldType.MANUAL,
+            ),
+        },
+        supported_modes=[ZoneMode.OFF, ZoneMode.AUTO, ZoneMode.COOL, ZoneMode.HEAT],
+        fan_mode=FanMode.AUTO,
+        relative_humidity="45",
+    )
+
+
+@pytest.fixture
+def mock_connection() -> Generator[MagicMock]:
+    """Return a mocked ThermostatConnection."""
+    with (
+        patch(
+            "homeassistant.components.trane.ThermostatConnection",
+            autospec=True,
+        ) as mock_cls,
+        patch(
+            "homeassistant.components.trane.config_flow.ThermostatConnection",
+            new=mock_cls,
+        ),
+    ):
+        conn = mock_cls.return_value
+        conn.connect = AsyncMock()
+        conn.login = AsyncMock()
+        conn.pair = AsyncMock()
+        conn.disconnect = AsyncMock()
+        conn.start_background_tasks = MagicMock()
+        conn.set_temperature_setpoint = MagicMock()
+        conn.set_zone_mode = MagicMock()
+        conn.set_fan_mode = MagicMock()
+        conn.set_emergency_heat = MagicMock()
+        conn.add_event_callback = MagicMock(return_value=MagicMock())
+        conn.state = _make_state()
+        conn.secret_key = MOCK_SECRET_KEY
+        yield conn
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> MockConfigEntry:
+    """Set up the Trane Local integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/trane/conftest.py
+++ b/tests/components/trane/conftest.py
@@ -14,6 +14,7 @@ from tests.common import MockConfigEntry
 
 MOCK_HOST = "192.168.1.100"
 MOCK_SECRET_KEY = "test_secret_key"
+MOCK_ENTRY_ID = "test_entry_id"
 
 
 @pytest.fixture
@@ -21,6 +22,7 @@ def mock_config_entry() -> MockConfigEntry:
     """Return a mock config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
+        entry_id=MOCK_ENTRY_ID,
         title=f"Thermostat ({MOCK_HOST})",
         data={
             CONF_HOST: MOCK_HOST,

--- a/tests/components/trane/conftest.py
+++ b/tests/components/trane/conftest.py
@@ -80,6 +80,16 @@ def mock_connection() -> Generator[MagicMock]:
 
 
 @pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock setup entry."""
+    with patch(
+        "homeassistant.components.trane.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        yield mock_setup
+
+
+@pytest.fixture
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/trane/snapshots/test_switch.ambr
+++ b/tests/components/trane/snapshots/test_switch.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_switch_entities[switch.living_room_hold-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.living_room_hold',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Hold',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hold',
+    'platform': 'trane',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'hold',
+    'unique_id': '01KHP7YYR3RDWMBRMV46SBVEK1_1_hold',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.living_room_hold-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Living Room Hold',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.living_room_hold',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/trane/snapshots/test_switch.ambr
+++ b/tests/components/trane/snapshots/test_switch.ambr
@@ -31,7 +31,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'hold',
-    'unique_id': '01KHP7YYR3RDWMBRMV46SBVEK1_1_hold',
+    'unique_id': 'test_entry_id_1_hold',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/trane/test_config_flow.py
+++ b/tests/components/trane/test_config_flow.py
@@ -1,0 +1,102 @@
+"""Tests for the Trane Local config flow."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from steamloop import PairingError, SteamloopConnectionError
+
+from homeassistant.components.trane.const import CONF_SECRET_KEY, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_HOST, MOCK_SECRET_KEY
+
+
+async def test_full_user_flow(
+    hass: HomeAssistant,
+    mock_connection: MagicMock,
+) -> None:
+    """Test the full user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Thermostat ({MOCK_HOST})"
+    assert result["data"] == {
+        CONF_HOST: MOCK_HOST,
+        CONF_SECRET_KEY: MOCK_SECRET_KEY,
+    }
+    assert result["result"].unique_id is None
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [SteamloopConnectionError, PairingError],
+)
+async def test_connection_error(
+    hass: HomeAssistant,
+    mock_connection: MagicMock,
+    side_effect: Exception,
+) -> None:
+    """Test config flow with connection errors."""
+    mock_connection.pair.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_unknown_error(
+    hass: HomeAssistant,
+    mock_connection: MagicMock,
+) -> None:
+    """Test config flow with an unexpected exception."""
+    mock_connection.pair.side_effect = RuntimeError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_connection: MagicMock,
+    mock_config_entry,
+) -> None:
+    """Test config flow aborts when already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/trane/test_config_flow.py
+++ b/tests/components/trane/test_config_flow.py
@@ -13,6 +13,8 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import MOCK_HOST, MOCK_SECRET_KEY
 
+from tests.common import MockConfigEntry
+
 
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_user_flow(
@@ -89,7 +91,7 @@ async def test_form_errors_can_recover(
 async def test_already_configured(
     hass: HomeAssistant,
     mock_connection: MagicMock,
-    mock_config_entry: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test config flow aborts when already configured."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/trane/test_config_flow.py
+++ b/tests/components/trane/test_config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from .conftest import MOCK_HOST, MOCK_SECRET_KEY
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_full_user_flow(
     hass: HomeAssistant,
     mock_connection: MagicMock,
@@ -39,53 +40,56 @@ async def test_full_user_flow(
     assert result["result"].unique_id is None
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 @pytest.mark.parametrize(
-    "side_effect",
-    [SteamloopConnectionError, PairingError],
+    ("side_effect", "error_key"),
+    [
+        (SteamloopConnectionError, "cannot_connect"),
+        (PairingError, "cannot_connect"),
+        (RuntimeError, "unknown"),
+    ],
 )
-async def test_connection_error(
+async def test_form_errors_can_recover(
     hass: HomeAssistant,
     mock_connection: MagicMock,
     side_effect: Exception,
+    error_key: str,
 ) -> None:
-    """Test config flow with connection errors."""
+    """Test errors and recovery during config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
     mock_connection.pair.side_effect = side_effect
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_HOST: MOCK_HOST},
     )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error_key}
 
+    mock_connection.pair.side_effect = None
 
-async def test_unknown_error(
-    hass: HomeAssistant,
-    mock_connection: MagicMock,
-) -> None:
-    """Test config flow with an unexpected exception."""
-    mock_connection.pair.side_effect = RuntimeError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_HOST: MOCK_HOST},
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"Thermostat ({MOCK_HOST})"
+    assert result["data"] == {
+        CONF_HOST: MOCK_HOST,
+        CONF_SECRET_KEY: MOCK_SECRET_KEY,
+    }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_already_configured(
     hass: HomeAssistant,
     mock_connection: MagicMock,
-    mock_config_entry,
+    mock_config_entry: MagicMock,
 ) -> None:
     """Test config flow aborts when already configured."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/trane/test_init.py
+++ b/tests/components/trane/test_init.py
@@ -1,0 +1,69 @@
+"""Tests for the Trane Local integration setup."""
+
+from unittest.mock import MagicMock
+
+from steamloop import AuthenticationError, SteamloopConnectionError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test loading and unloading the integration."""
+    entry = init_integration
+    assert entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_connection_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test setup retries on connection error."""
+    mock_connection.connect.side_effect = SteamloopConnectionError
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_auth_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test setup fails on authentication error."""
+    mock_connection.login.side_effect = AuthenticationError
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_timeout_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test setup retries on timeout."""
+    mock_connection.connect.side_effect = TimeoutError
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/trane/test_switch.py
+++ b/tests/components/trane/test_switch.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
 from steamloop import HoldType
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -13,8 +15,20 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switch_entities(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Snapshot all switch entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
 
 
 async def test_hold_switch_on(

--- a/tests/components/trane/test_switch.py
+++ b/tests/components/trane/test_switch.py
@@ -1,0 +1,81 @@
+"""Tests for the Trane Local switch platform."""
+
+from unittest.mock import MagicMock
+
+from steamloop import HoldType
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_hold_switch_on(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test hold switch reports on when in permanent hold."""
+    state = hass.states.get("switch.living_room_hold")
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_hold_switch_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test hold switch reports off when following schedule."""
+    mock_connection.state.zones["1"].hold_type = HoldType.SCHEDULE
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.living_room_hold")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_turn_on(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test turning on the hold switch."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.living_room_hold"},
+        blocking=True,
+    )
+
+    mock_connection.set_temperature_setpoint.assert_called_once_with(
+        "1", hold_type=HoldType.MANUAL
+    )
+
+
+async def test_turn_off(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_connection: MagicMock,
+) -> None:
+    """Test turning off the hold switch."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.living_room_hold"},
+        blocking=True,
+    )
+
+    mock_connection.set_temperature_setpoint.assert_called_once_with(
+        "1", hold_type=HoldType.SCHEDULE
+    )

--- a/tests/components/trane/test_switch.py
+++ b/tests/components/trane/test_switch.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
-    STATE_ON,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -29,17 +28,6 @@ async def test_switch_entities(
 ) -> None:
     """Snapshot all switch entities."""
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
-
-
-async def test_hold_switch_on(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_connection: MagicMock,
-) -> None:
-    """Test hold switch reports on when in permanent hold."""
-    state = hass.states.get("switch.living_room_hold")
-    assert state is not None
-    assert state.state == STATE_ON
 
 
 async def test_hold_switch_off(
@@ -59,37 +47,28 @@ async def test_hold_switch_off(
     assert state.state == STATE_OFF
 
 
-async def test_turn_on(
+@pytest.mark.parametrize(
+    ("service", "expected_hold_type"),
+    [
+        (SERVICE_TURN_ON, HoldType.MANUAL),
+        (SERVICE_TURN_OFF, HoldType.SCHEDULE),
+    ],
+)
+async def test_hold_switch_service(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_connection: MagicMock,
+    service: str,
+    expected_hold_type: HoldType,
 ) -> None:
-    """Test turning on the hold switch."""
+    """Test turning on and off the hold switch."""
     await hass.services.async_call(
         SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
+        service,
         {ATTR_ENTITY_ID: "switch.living_room_hold"},
         blocking=True,
     )
 
     mock_connection.set_temperature_setpoint.assert_called_once_with(
-        "1", hold_type=HoldType.MANUAL
-    )
-
-
-async def test_turn_off(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_connection: MagicMock,
-) -> None:
-    """Test turning off the hold switch."""
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "switch.living_room_hold"},
-        blocking=True,
-    )
-
-    mock_connection.set_temperature_setpoint.assert_called_once_with(
-        "1", hold_type=HoldType.SCHEDULE
+        "1", hold_type=expected_hold_type
     )


### PR DESCRIPTION
## Breaking change

N/A - New integration.

## Proposed change

Add new `trane` integration for local control of Trane/American Standard thermostats via the `steamloop` library (mTLS over TCP).

This initial PR intentionally ships with only the switch platform (hold switch per zone) to keep the review surface as small as possible for a new integration. The hold switch is not very useful on its own, but it establishes the integration scaffolding, connection handling, and local push architecture. The climate platform will follow immediately in a subsequent PR once this lands.

Architecture: pure local push using event callbacks over a persistent TCP connection (no polling).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Library: https://github.com/hvaclibs/steamloop

- This PR fixes or closes issue:
- This PR is related to issue: https://community.home-assistant.io/t/5-000-bounty-to-make-nexia-local-integration/389042/20
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43593
- Link to brands pull request: https://github.com/home-assistant/brands/pull/9685
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr