### PR TITLE
Add Powerfox Local integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -417,6 +417,7 @@ homeassistant.components.plugwise.*
 homeassistant.components.pooldose.*
 homeassistant.components.portainer.*
 homeassistant.components.powerfox.*
+homeassistant.components.powerfox_local.*
 homeassistant.components.powerwall.*
 homeassistant.components.private_ble_device.*
 homeassistant.components.prometheus.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1279,6 +1279,8 @@ build.json @home-assistant/supervisor
 /tests/components/portainer/ @erwindouna
 /homeassistant/components/powerfox/ @klaasnicolaas
 /tests/components/powerfox/ @klaasnicolaas
+/homeassistant/components/powerfox_local/ @klaasnicolaas
+/tests/components/powerfox_local/ @klaasnicolaas
 /homeassistant/components/powerwall/ @bdraco @jrester @daniel-simpson
 /tests/components/powerwall/ @bdraco @jrester @daniel-simpson
 /homeassistant/components/prana/ @prana-dev-official

--- a/homeassistant/brands/powerfox.json
+++ b/homeassistant/brands/powerfox.json
@@ -1,0 +1,5 @@
+{
+  "domain": "powerfox",
+  "name": "Powerfox",
+  "integrations": ["powerfox", "powerfox_local"]
+}

--- a/homeassistant/components/powerfox_local/__init__.py
+++ b/homeassistant/components/powerfox_local/__init__.py
@@ -1,0 +1,30 @@
+"""The Powerfox Local integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import PowerfoxLocalConfigEntry, PowerfoxLocalDataUpdateCoordinator
+
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: PowerfoxLocalConfigEntry
+) -> bool:
+    """Set up Powerfox Local from a config entry."""
+    coordinator = PowerfoxLocalDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: PowerfoxLocalConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -27,6 +27,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _host: str
     _api_key: str
+    _device_id: str
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -37,6 +38,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self._host = user_input[CONF_HOST]
             self._api_key = user_input[CONF_API_KEY]
+            self._device_id = self._api_key
 
             try:
                 await self._async_validate_connection()
@@ -58,7 +60,8 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         self._host = discovery_info.host
-        self._api_key = discovery_info.properties.get("id", "")
+        self._device_id = discovery_info.properties["id"]
+        self._api_key = self._device_id
 
         try:
             await self._async_validate_connection()
@@ -98,5 +101,5 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         await client.value()
 
-        await self.async_set_unique_id(self._api_key)
+        await self.async_set_unique_id(self._device_id)
         self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})

--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -1,0 +1,102 @@
+"""Config flow for Powerfox Local integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError, PowerfoxLocal
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_API_KEY): str,
+    }
+)
+
+
+class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Powerfox Local."""
+
+    _host: str
+    _api_key: str
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the user step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._host = user_input[CONF_HOST]
+            self._api_key = user_input[CONF_API_KEY]
+
+            try:
+                await self._async_validate_connection()
+            except PowerfoxAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except PowerfoxConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self._async_create_entry()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        self._host = discovery_info.host
+        self._api_key = discovery_info.properties.get("id", "")
+
+        try:
+            await self._async_validate_connection()
+        except PowerfoxAuthenticationError, PowerfoxConnectionError:
+            return self.async_abort(reason="cannot_connect")
+
+        self.context["title_placeholders"] = {"name": f"Poweropti ({self._host})"}
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={"host": self._host},
+        )
+
+    async def async_step_zeroconf_confirm(
+        self, _: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a confirmation flow for zeroconf discovery."""
+        return self._async_create_entry()
+
+    def _async_create_entry(self) -> ConfigFlowResult:
+        """Create a config entry."""
+        return self.async_create_entry(
+            title=f"Poweropti ({self._host})",
+            data={
+                CONF_HOST: self._host,
+                CONF_API_KEY: self._api_key,
+            },
+        )
+
+    async def _async_validate_connection(self) -> None:
+        """Validate the connection and set unique ID."""
+        client = PowerfoxLocal(
+            host=self._host,
+            api_key=self._api_key,
+            session=async_get_clientsession(self.hass),
+        )
+        await client.value()
+
+        await self.async_set_unique_id(self._api_key)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: self._host})

--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -68,7 +68,9 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         except PowerfoxAuthenticationError, PowerfoxConnectionError:
             return self.async_abort(reason="cannot_connect")
 
-        self.context["title_placeholders"] = {"name": f"Poweropti ({self._host})"}
+        self.context["title_placeholders"] = {
+            "name": f"Poweropti ({self._device_id[-5:]})"
+        }
 
         self._set_confirm_only()
         return self.async_show_form(
@@ -85,7 +87,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     def _async_create_entry(self) -> ConfigFlowResult:
         """Create a config entry."""
         return self.async_create_entry(
-            title=f"Poweropti ({self._host})",
+            title=f"Poweropti ({self._device_id[-5:]})",
             data={
                 CONF_HOST: self._host,
                 CONF_API_KEY: self._api_key,

--- a/homeassistant/components/powerfox_local/const.py
+++ b/homeassistant/components/powerfox_local/const.py
@@ -1,0 +1,11 @@
+"""Constants for the Powerfox Local integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Final
+
+DOMAIN: Final = "powerfox_local"
+LOGGER = logging.getLogger(__package__)
+SCAN_INTERVAL = timedelta(seconds=5)

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -1,0 +1,54 @@
+"""Coordinator for Powerfox Local integration."""
+
+from __future__ import annotations
+
+from powerfox import (
+    LocalResponse,
+    PowerfoxAuthenticationError,
+    PowerfoxConnectionError,
+    PowerfoxLocal,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER, SCAN_INTERVAL
+
+type PowerfoxLocalConfigEntry = ConfigEntry[PowerfoxLocalDataUpdateCoordinator]
+
+
+class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
+    """Class to manage fetching Powerfox local data."""
+
+    config_entry: PowerfoxLocalConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, entry: PowerfoxLocalConfigEntry
+    ) -> None:
+        """Initialize the coordinator."""
+        self.client = PowerfoxLocal(
+            host=entry.data[CONF_HOST],
+            api_key=entry.data[CONF_API_KEY],
+            session=async_get_clientsession(hass),
+        )
+        self.device_id: str = entry.data[CONF_API_KEY]
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}_{entry.data[CONF_HOST]}",
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> LocalResponse:
+        """Fetch data from the local poweropti."""
+        try:
+            return await self.client.value()
+        except PowerfoxAuthenticationError as err:
+            raise ConfigEntryAuthFailed(err) from err
+        except PowerfoxConnectionError as err:
+            raise UpdateFailed(err) from err

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-from powerfox import (
-    LocalResponse,
-    PowerfoxAuthenticationError,
-    PowerfoxConnectionError,
-    PowerfoxLocal,
-)
+from powerfox import LocalResponse, PowerfoxConnectionError, PowerfoxLocal
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -26,9 +20,7 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
 
     config_entry: PowerfoxLocalConfigEntry
 
-    def __init__(
-        self, hass: HomeAssistant, entry: PowerfoxLocalConfigEntry
-    ) -> None:
+    def __init__(self, hass: HomeAssistant, entry: PowerfoxLocalConfigEntry) -> None:
         """Initialize the coordinator."""
         self.client = PowerfoxLocal(
             host=entry.data[CONF_HOST],
@@ -48,7 +40,5 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
         """Fetch data from the local poweropti."""
         try:
             return await self.client.value()
-        except PowerfoxAuthenticationError as err:
-            raise ConfigEntryAuthFailed(err) from err
         except PowerfoxConnectionError as err:
             raise UpdateFailed(err) from err

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -41,4 +41,8 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
         try:
             return await self.client.value()
         except PowerfoxConnectionError as err:
-            raise UpdateFailed(err) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -27,6 +27,7 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
             api_key=entry.data[CONF_API_KEY],
             session=async_get_clientsession(hass),
         )
+        self.device_id: str = entry.data[CONF_API_KEY]
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -27,7 +27,6 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
             api_key=entry.data[CONF_API_KEY],
             session=async_get_clientsession(hass),
         )
-        self.device_id: str = entry.data[CONF_API_KEY]
         super().__init__(
             hass,
             LOGGER,

--- a/homeassistant/components/powerfox_local/entity.py
+++ b/homeassistant/components/powerfox_local/entity.py
@@ -24,6 +24,6 @@ class PowerfoxLocalEntity(CoordinatorEntity[PowerfoxLocalDataUpdateCoordinator])
             identifiers={(DOMAIN, coordinator.device_id)},
             manufacturer="Powerfox",
             model="Poweropti",
-            name="Poweropti",
+            name=coordinator.config_entry.title,
             serial_number=coordinator.device_id,
         )

--- a/homeassistant/components/powerfox_local/entity.py
+++ b/homeassistant/components/powerfox_local/entity.py
@@ -1,0 +1,29 @@
+"""Base entity for Powerfox Local."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import PowerfoxLocalDataUpdateCoordinator
+
+
+class PowerfoxLocalEntity(CoordinatorEntity[PowerfoxLocalDataUpdateCoordinator]):
+    """Base entity for Powerfox Local."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: PowerfoxLocalDataUpdateCoordinator,
+    ) -> None:
+        """Initialize Powerfox Local entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.device_id)},
+            manufacturer="Powerfox",
+            model="Poweropti",
+            name="Poweropti",
+            serial_number=coordinator.device_id,
+        )

--- a/homeassistant/components/powerfox_local/entity.py
+++ b/homeassistant/components/powerfox_local/entity.py
@@ -24,6 +24,5 @@ class PowerfoxLocalEntity(CoordinatorEntity[PowerfoxLocalDataUpdateCoordinator])
             identifiers={(DOMAIN, coordinator.device_id)},
             manufacturer="Powerfox",
             model="Poweropti",
-            name=coordinator.config_entry.title,
             serial_number=coordinator.device_id,
         )

--- a/homeassistant/components/powerfox_local/manifest.json
+++ b/homeassistant/components/powerfox_local/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "powerfox_local",
+  "name": "Powerfox Local",
+  "codeowners": ["@klaasnicolaas"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/powerfox_local",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "quality_scale": "bronze",
+  "requirements": ["powerfox==2.1.0"],
+  "zeroconf": [
+    {
+      "name": "powerfox*",
+      "type": "_http._tcp.local."
+    }
+  ]
+}

--- a/homeassistant/components/powerfox_local/quality_scale.yaml
+++ b/homeassistant/components/powerfox_local/quality_scale.yaml
@@ -1,0 +1,87 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities of this integration does not explicitly subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration does not have an options flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: todo
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: |
+      Each config entry represents a single device.
+  entity-category: todo
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: todo
+  icon-translations:
+    status: exempt
+    comment: |
+      There is no need for icon translations.
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      This integration doesn't have any cases where raising an issue is needed.
+  stale-devices:
+    status: exempt
+    comment: |
+      Each config entry represents a single device.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/powerfox_local/quality_scale.yaml
+++ b/homeassistant/components/powerfox_local/quality_scale.yaml
@@ -49,24 +49,27 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery-update-info: todo
+  discovery-update-info: done
   discovery: done
-  docs-data-update: todo
-  docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: |
       Each config entry represents a single device.
-  entity-category: todo
+  entity-category: done
   entity-device-class: done
-  entity-disabled-by-default: todo
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      There are no entities that should be disabled by default.
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations:
     status: exempt
     comment: |

--- a/homeassistant/components/powerfox_local/sensor.py
+++ b/homeassistant/components/powerfox_local/sensor.py
@@ -1,0 +1,112 @@
+"""Sensors for Powerfox Local integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from powerfox import LocalResponse
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import PowerfoxLocalConfigEntry, PowerfoxLocalDataUpdateCoordinator
+from .entity import PowerfoxLocalEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class PowerfoxLocalSensorEntityDescription(SensorEntityDescription):
+    """Describes Powerfox Local sensor entity."""
+
+    value_fn: Callable[[LocalResponse], float | int | None]
+
+
+SENSORS: tuple[PowerfoxLocalSensorEntityDescription, ...] = (
+    PowerfoxLocalSensorEntityDescription(
+        key="power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.power,
+    ),
+    PowerfoxLocalSensorEntityDescription(
+        key="energy_usage",
+        translation_key="energy_usage",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.energy_usage,
+    ),
+    PowerfoxLocalSensorEntityDescription(
+        key="energy_usage_high_tariff",
+        translation_key="energy_usage_high_tariff",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.energy_usage_high_tariff,
+    ),
+    PowerfoxLocalSensorEntityDescription(
+        key="energy_usage_low_tariff",
+        translation_key="energy_usage_low_tariff",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.energy_usage_low_tariff,
+    ),
+    PowerfoxLocalSensorEntityDescription(
+        key="energy_return",
+        translation_key="energy_return",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.energy_return,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PowerfoxLocalConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Powerfox Local sensors based on a config entry."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        PowerfoxLocalSensorEntity(
+            coordinator=coordinator,
+            description=description,
+        )
+        for description in SENSORS
+        if description.value_fn(coordinator.data) is not None
+    )
+
+
+class PowerfoxLocalSensorEntity(PowerfoxLocalEntity, SensorEntity):
+    """Defines a Powerfox Local sensor."""
+
+    entity_description: PowerfoxLocalSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: PowerfoxLocalDataUpdateCoordinator,
+        description: PowerfoxLocalSensorEntityDescription,
+    ) -> None:
+        """Initialize the Powerfox Local sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.device_id}_{description.key}"
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the state of the entity."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/powerfox_local/strings.json
+++ b/homeassistant/components/powerfox_local/strings.json
@@ -41,5 +41,10 @@
         "name": "Energy usage low tariff"
       }
     }
+  },
+  "exceptions": {
+    "update_failed": {
+      "message": "Error while updating the device: {error}"
+    }
   }
 }

--- a/homeassistant/components/powerfox_local/strings.json
+++ b/homeassistant/components/powerfox_local/strings.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of your Poweropti device.",
+          "api_key": "The API key (device ID) of your Poweropti device."
+        },
+        "description": "Set up your Poweropti device to poll locally."
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to set up the Poweropti device found at {host}?",
+        "title": "Discovered Poweropti"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "energy_return": {
+        "name": "Energy return"
+      },
+      "energy_usage": {
+        "name": "Energy usage"
+      },
+      "energy_usage_high_tariff": {
+        "name": "Energy usage high tariff"
+      },
+      "energy_usage_low_tariff": {
+        "name": "Energy usage low tariff"
+      }
+    }
+  }
+}

--- a/homeassistant/components/powerfox_local/strings.json
+++ b/homeassistant/components/powerfox_local/strings.json
@@ -11,12 +11,12 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "api_key": "[%key:common::config_flow::data::api_key%]"
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your Poweropti device.",
-          "api_key": "The API key (device ID) of your Poweropti device."
+          "api_key": "The API key (device ID) of your Poweropti device.",
+          "host": "The hostname or IP address of your Poweropti device."
         },
         "description": "Set up your Poweropti device to poll locally."
       },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -540,6 +540,7 @@ FLOWS = {
         "poolsense",
         "portainer",
         "powerfox",
+        "powerfox_local",
         "powerwall",
         "prana",
         "private_ble_device",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5267,9 +5267,20 @@
     },
     "powerfox": {
       "name": "Powerfox",
-      "integration_type": "hub",
-      "config_flow": true,
-      "iot_class": "cloud_polling"
+      "integrations": {
+        "powerfox": {
+          "integration_type": "hub",
+          "config_flow": true,
+          "iot_class": "cloud_polling",
+          "name": "Powerfox"
+        },
+        "powerfox_local": {
+          "integration_type": "device",
+          "config_flow": true,
+          "iot_class": "local_polling",
+          "name": "Powerfox Local"
+        }
+      }
     },
     "prana": {
       "name": "Prana",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -628,6 +628,10 @@ ZEROCONF = {
             "name": "powerfox*",
         },
         {
+            "domain": "powerfox_local",
+            "name": "powerfox*",
+        },
+        {
             "domain": "pure_energie",
             "name": "smartbridge*",
         },

--- a/mypy.ini
+++ b/mypy.ini
@@ -3926,6 +3926,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.powerfox_local.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.powerwall.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1778,6 +1778,7 @@ pmsensor==0.4
 poolsense==0.0.8
 
 # homeassistant.components.powerfox
+# homeassistant.components.powerfox_local
 powerfox==2.1.0
 
 # homeassistant.components.prana

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1533,6 +1533,7 @@ plugwise==1.11.2
 poolsense==0.0.8
 
 # homeassistant.components.powerfox
+# homeassistant.components.powerfox_local
 powerfox==2.1.0
 
 # homeassistant.components.prana

--- a/tests/components/powerfox_local/__init__.py
+++ b/tests/components/powerfox_local/__init__.py
@@ -6,6 +6,7 @@ from tests.common import MockConfigEntry
 
 MOCK_HOST = "1.1.1.1"
 MOCK_API_KEY = "9x9x1f12xx3x"
+MOCK_DEVICE_ID = MOCK_API_KEY
 
 
 async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
@@ -13,3 +14,4 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/powerfox_local/__init__.py
+++ b/tests/components/powerfox_local/__init__.py
@@ -1,0 +1,15 @@
+"""Tests for the Powerfox Local integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "1.1.1.1"
+MOCK_API_KEY = "9x9x1f12xx3x"
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Fixture for setting up the integration."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/powerfox_local/conftest.py
+++ b/tests/components/powerfox_local/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from homeassistant.components.powerfox_local.const import DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 
-from . import MOCK_API_KEY, MOCK_HOST
+from . import MOCK_API_KEY, MOCK_DEVICE_ID, MOCK_HOST
 
 from tests.common import MockConfigEntry
 
@@ -59,8 +59,8 @@ def mock_config_entry() -> MockConfigEntry:
     """Mock a Powerfox Local config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
-        title=f"Poweropti ({MOCK_HOST})",
-        unique_id=MOCK_API_KEY,
+        title=f"Poweropti ({MOCK_DEVICE_ID[-5:]})",
+        unique_id=MOCK_DEVICE_ID,
         data={
             CONF_HOST: MOCK_HOST,
             CONF_API_KEY: MOCK_API_KEY,

--- a/tests/components/powerfox_local/conftest.py
+++ b/tests/components/powerfox_local/conftest.py
@@ -1,0 +1,68 @@
+"""Common fixtures for the Powerfox Local tests."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from powerfox import LocalResponse
+import pytest
+
+from homeassistant.components.powerfox_local.const import DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_HOST
+
+from . import MOCK_API_KEY, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+def _local_response() -> LocalResponse:
+    """Return a mocked local response."""
+    return LocalResponse(
+        timestamp=datetime(2024, 11, 26, 10, 48, 51, tzinfo=UTC),
+        power=111,
+        energy_usage=1111111,
+        energy_return=111111,
+        energy_usage_high_tariff=111111,
+        energy_usage_low_tariff=111111,
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.powerfox_local.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_powerfox_local_client() -> Generator[AsyncMock]:
+    """Mock a PowerfoxLocal client."""
+    with (
+        patch(
+            "homeassistant.components.powerfox_local.coordinator.PowerfoxLocal",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.powerfox_local.config_flow.PowerfoxLocal",
+            new=mock_client,
+        ),
+    ):
+        client = mock_client.return_value
+        client.value.return_value = _local_response()
+        yield client
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock a Powerfox Local config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Poweropti ({MOCK_HOST})",
+        unique_id=MOCK_API_KEY,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_API_KEY: MOCK_API_KEY,
+        },
+    )

--- a/tests/components/powerfox_local/snapshots/test_sensor.ambr
+++ b/tests/components/powerfox_local/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_sensors[sensor.poweropti_energy_return-entry]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_return-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,7 +14,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_energy_return',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_return',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -40,23 +40,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_return-state]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_return-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti Energy return',
+      'friendly_name': 'Poweropti (1.1.1.1) Energy return',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_energy_return',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_return',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage-entry]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -71,7 +71,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_energy_usage',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -97,23 +97,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage-state]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti Energy usage',
+      'friendly_name': 'Poweropti (1.1.1.1) Energy usage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_energy_usage',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage_high_tariff-entry]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_high_tariff-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -128,7 +128,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_energy_usage_high_tariff',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_high_tariff',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -154,23 +154,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage_high_tariff-state]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_high_tariff-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti Energy usage high tariff',
+      'friendly_name': 'Poweropti (1.1.1.1) Energy usage high tariff',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_energy_usage_high_tariff',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_high_tariff',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage_low_tariff-entry]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_low_tariff-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -185,7 +185,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_energy_usage_low_tariff',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_low_tariff',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -211,23 +211,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_energy_usage_low_tariff-state]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_low_tariff-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti Energy usage low tariff',
+      'friendly_name': 'Poweropti (1.1.1.1) Energy usage low tariff',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_energy_usage_low_tariff',
+    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_low_tariff',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_power-entry]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -242,7 +242,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_power',
+    'entity_id': 'sensor.poweropti_1_1_1_1_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -268,16 +268,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_power-state]
+# name: test_all_sensors[sensor.poweropti_1_1_1_1_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Poweropti Power',
+      'friendly_name': 'Poweropti (1.1.1.1) Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_power',
+    'entity_id': 'sensor.poweropti_1_1_1_1_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/powerfox_local/snapshots/test_sensor.ambr
+++ b/tests/components/powerfox_local/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_return-entry]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_return-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -14,7 +14,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_return',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_return',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -40,23 +40,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_return-state]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_return-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti (1.1.1.1) Energy return',
+      'friendly_name': 'Poweropti (2xx3x) Energy return',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_return',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_return',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage-entry]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -71,7 +71,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -97,23 +97,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage-state]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti (1.1.1.1) Energy usage',
+      'friendly_name': 'Poweropti (2xx3x) Energy usage',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_high_tariff-entry]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage_high_tariff-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -128,7 +128,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_high_tariff',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage_high_tariff',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -154,23 +154,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_high_tariff-state]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage_high_tariff-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti (1.1.1.1) Energy usage high tariff',
+      'friendly_name': 'Poweropti (2xx3x) Energy usage high tariff',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_high_tariff',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage_high_tariff',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_low_tariff-entry]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage_low_tariff-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -185,7 +185,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_low_tariff',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage_low_tariff',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -211,23 +211,23 @@
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_energy_usage_low_tariff-state]
+# name: test_all_sensors[sensor.poweropti_2xx3x_energy_usage_low_tariff-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
-      'friendly_name': 'Poweropti (1.1.1.1) Energy usage low tariff',
+      'friendly_name': 'Poweropti (2xx3x) Energy usage low tariff',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_1_1_1_1_energy_usage_low_tariff',
+    'entity_id': 'sensor.poweropti_2xx3x_energy_usage_low_tariff',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '111111',
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_power-entry]
+# name: test_all_sensors[sensor.poweropti_2xx3x_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -242,7 +242,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.poweropti_1_1_1_1_power',
+    'entity_id': 'sensor.poweropti_2xx3x_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -268,16 +268,16 @@
     'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_all_sensors[sensor.poweropti_1_1_1_1_power-state]
+# name: test_all_sensors[sensor.poweropti_2xx3x_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
-      'friendly_name': 'Poweropti (1.1.1.1) Power',
+      'friendly_name': 'Poweropti (2xx3x) Power',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.poweropti_1_1_1_1_power',
+    'entity_id': 'sensor.poweropti_2xx3x_power',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/powerfox_local/snapshots/test_sensor.ambr
+++ b/tests/components/powerfox_local/snapshots/test_sensor.ambr
@@ -1,0 +1,286 @@
+# serializer version: 1
+# name: test_all_sensors[sensor.poweropti_energy_return-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.poweropti_energy_return',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy return',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy return',
+    'platform': 'powerfox_local',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_return',
+    'unique_id': '9x9x1f12xx3x_energy_return',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_return-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Poweropti Energy return',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.poweropti_energy_return',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '111111',
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.poweropti_energy_usage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy usage',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy usage',
+    'platform': 'powerfox_local',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_usage',
+    'unique_id': '9x9x1f12xx3x_energy_usage',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Poweropti Energy usage',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.poweropti_energy_usage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1111111',
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage_high_tariff-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.poweropti_energy_usage_high_tariff',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy usage high tariff',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy usage high tariff',
+    'platform': 'powerfox_local',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_usage_high_tariff',
+    'unique_id': '9x9x1f12xx3x_energy_usage_high_tariff',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage_high_tariff-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Poweropti Energy usage high tariff',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.poweropti_energy_usage_high_tariff',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '111111',
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage_low_tariff-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.poweropti_energy_usage_low_tariff',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy usage low tariff',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy usage low tariff',
+    'platform': 'powerfox_local',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_usage_low_tariff',
+    'unique_id': '9x9x1f12xx3x_energy_usage_low_tariff',
+    'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_energy_usage_low_tariff-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Poweropti Energy usage low tariff',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.poweropti_energy_usage_low_tariff',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '111111',
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.poweropti_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'powerfox_local',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '9x9x1f12xx3x_power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_all_sensors[sensor.poweropti_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Poweropti Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.poweropti_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '111',
+  })
+# ---

--- a/tests/components/powerfox_local/test_config_flow.py
+++ b/tests/components/powerfox_local/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from . import MOCK_API_KEY, MOCK_HOST
+from . import MOCK_API_KEY, MOCK_DEVICE_ID, MOCK_HOST
 
 from tests.common import MockConfigEntry
 
@@ -23,7 +23,7 @@ MOCK_ZEROCONF_DISCOVERY_INFO = ZeroconfServiceInfo(
     name="Powerfox",
     port=443,
     type="_http._tcp",
-    properties={"id": MOCK_API_KEY},
+    properties={"id": MOCK_DEVICE_ID},
 )
 
 
@@ -47,11 +47,12 @@ async def test_full_user_flow(
     )
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
-    assert result.get("title") == f"Poweropti ({MOCK_HOST})"
+    assert result.get("title") == f"Poweropti ({MOCK_DEVICE_ID[-5:]})"
     assert result.get("data") == {
         CONF_HOST: MOCK_HOST,
         CONF_API_KEY: MOCK_API_KEY,
     }
+    assert result["result"].unique_id == MOCK_DEVICE_ID
     assert len(mock_powerfox_local_client.value.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -77,11 +78,12 @@ async def test_zeroconf_discovery(
     )
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
-    assert result.get("title") == f"Poweropti ({MOCK_HOST})"
+    assert result.get("title") == f"Poweropti ({MOCK_DEVICE_ID[-5:]})"
     assert result.get("data") == {
         CONF_HOST: MOCK_HOST,
         CONF_API_KEY: MOCK_API_KEY,
     }
+    assert result["result"].unique_id == MOCK_DEVICE_ID
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/powerfox_local/test_config_flow.py
+++ b/tests/components/powerfox_local/test_config_flow.py
@@ -85,28 +85,20 @@ async def test_zeroconf_discovery(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_zeroconf_cannot_connect(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        PowerfoxConnectionError,
+        PowerfoxAuthenticationError,
+    ],
+)
+async def test_zeroconf_discovery_errors(
     hass: HomeAssistant,
     mock_powerfox_local_client: AsyncMock,
+    exception: Exception,
 ) -> None:
-    """Test zeroconf discovery aborts when device cannot be reached."""
-    mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=MOCK_ZEROCONF_DISCOVERY_INFO,
-    )
-
-    assert result.get("type") is FlowResultType.ABORT
-    assert result.get("reason") == "cannot_connect"
-
-
-async def test_zeroconf_auth_error(
-    hass: HomeAssistant,
-    mock_powerfox_local_client: AsyncMock,
-) -> None:
-    """Test zeroconf discovery aborts on auth error (no local support)."""
-    mock_powerfox_local_client.value.side_effect = PowerfoxAuthenticationError
+    """Test zeroconf discovery aborts on connection/auth errors."""
+    mock_powerfox_local_client.value.side_effect = exception
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_ZEROCONF},

--- a/tests/components/powerfox_local/test_config_flow.py
+++ b/tests/components/powerfox_local/test_config_flow.py
@@ -1,0 +1,192 @@
+"""Test the Powerfox Local config flow."""
+
+from unittest.mock import AsyncMock
+
+from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
+import pytest
+
+from homeassistant.components.powerfox_local.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from . import MOCK_API_KEY, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+MOCK_ZEROCONF_DISCOVERY_INFO = ZeroconfServiceInfo(
+    ip_address=MOCK_HOST,
+    ip_addresses=[MOCK_HOST],
+    hostname="powerfox.local",
+    name="Powerfox",
+    port=443,
+    type="_http._tcp",
+    properties={"id": MOCK_API_KEY},
+)
+
+
+async def test_full_user_flow(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the full user configuration flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "user"
+    assert not result.get("errors")
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST, CONF_API_KEY: MOCK_API_KEY},
+    )
+
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == f"Poweropti ({MOCK_HOST})"
+    assert result.get("data") == {
+        CONF_HOST: MOCK_HOST,
+        CONF_API_KEY: MOCK_API_KEY,
+    }
+    assert len(mock_powerfox_local_client.value.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_discovery(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test zeroconf discovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=MOCK_ZEROCONF_DISCOVERY_INFO,
+    )
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == f"Poweropti ({MOCK_HOST})"
+    assert result.get("data") == {
+        CONF_HOST: MOCK_HOST,
+        CONF_API_KEY: MOCK_API_KEY,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_cannot_connect(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+) -> None:
+    """Test zeroconf discovery aborts when device cannot be reached."""
+    mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=MOCK_ZEROCONF_DISCOVERY_INFO,
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "cannot_connect"
+
+
+async def test_zeroconf_auth_error(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+) -> None:
+    """Test zeroconf discovery aborts on auth error (no local support)."""
+    mock_powerfox_local_client.value.side_effect = PowerfoxAuthenticationError
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=MOCK_ZEROCONF_DISCOVERY_INFO,
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "cannot_connect"
+
+
+async def test_zeroconf_already_configured(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test zeroconf discovery aborts when already configured."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=MOCK_ZEROCONF_DISCOVERY_INFO,
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+
+
+async def test_duplicate_entry(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test abort when setting up duplicate entry."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result.get("type") is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST, CONF_API_KEY: MOCK_API_KEY},
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (PowerfoxConnectionError, "cannot_connect"),
+        (PowerfoxAuthenticationError, "invalid_auth"),
+    ],
+)
+async def test_user_flow_exceptions(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test exceptions during user config flow."""
+    mock_powerfox_local_client.value.side_effect = exception
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST, CONF_API_KEY: MOCK_API_KEY},
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("errors") == {"base": error}
+
+    # Recover from error
+    mock_powerfox_local_client.value.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: MOCK_HOST, CONF_API_KEY: MOCK_API_KEY},
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY

--- a/tests/components/powerfox_local/test_init.py
+++ b/tests/components/powerfox_local/test_init.py
@@ -1,0 +1,59 @@
+"""Test the Powerfox Local init module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_load_unload_entry(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test load and unload entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_config_entry_not_ready(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test config entry not ready on connection error."""
+    mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_auth_error(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test auth error triggers reauth."""
+    mock_powerfox_local_client.value.side_effect = PowerfoxAuthenticationError
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/powerfox_local/test_init.py
+++ b/tests/components/powerfox_local/test_init.py
@@ -24,7 +24,7 @@ async def test_load_unload_entry(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    await hass.config_entries.async_remove(mock_config_entry.entry_id)
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/powerfox_local/test_init.py
+++ b/tests/components/powerfox_local/test_init.py
@@ -43,17 +43,3 @@ async def test_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_setup_entry_auth_error(
-    hass: HomeAssistant,
-    mock_powerfox_local_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test auth error triggers reauth."""
-    mock_powerfox_local_client.value.side_effect = PowerfoxAuthenticationError
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/powerfox_local/test_init.py
+++ b/tests/components/powerfox_local/test_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
+from powerfox import PowerfoxConnectionError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/powerfox_local/test_sensor.py
+++ b/tests/components/powerfox_local/test_sensor.py
@@ -1,0 +1,55 @@
+"""Test the sensors provided by the Powerfox Local integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from powerfox import PowerfoxConnectionError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_sensors(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Powerfox Local sensors."""
+    with patch("homeassistant.components.powerfox_local.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_update_failed(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test entities become unavailable after failed update."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert hass.states.get("sensor.poweropti_energy_usage").state is not None
+
+    mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
+    freezer.tick(timedelta(seconds=15))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.poweropti_energy_usage").state == STATE_UNAVAILABLE

--- a/tests/components/powerfox_local/test_sensor.py
+++ b/tests/components/powerfox_local/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import setup_integration
+from . import MOCK_DEVICE_ID, setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -42,17 +42,15 @@ async def test_update_failed(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test entities become unavailable after failed update."""
+    entity_id = f"sensor.poweropti_{MOCK_DEVICE_ID[-5:]}_energy_usage"
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    assert hass.states.get("sensor.poweropti_1_1_1_1_energy_usage").state is not None
+    assert hass.states.get(entity_id).state is not None
 
     mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
     freezer.tick(timedelta(seconds=15))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.poweropti_1_1_1_1_energy_usage").state
-        == STATE_UNAVAILABLE
-    )
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/powerfox_local/test_sensor.py
+++ b/tests/components/powerfox_local/test_sensor.py
@@ -45,11 +45,14 @@ async def test_update_failed(
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    assert hass.states.get("sensor.poweropti_energy_usage").state is not None
+    assert hass.states.get("sensor.poweropti_1_1_1_1_energy_usage").state is not None
 
     mock_powerfox_local_client.value.side_effect = PowerfoxConnectionError
     freezer.tick(timedelta(seconds=15))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.poweropti_energy_usage").state == STATE_UNAVAILABLE
+    assert (
+        hass.states.get("sensor.poweropti_1_1_1_1_energy_usage").state
+        == STATE_UNAVAILABLE
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a separate, second Powerfox integration, aimed at enabling local reading of PowerOpti devices. The existing Powerfox integration only connects to the Powerfox cloud API. It also brings both integrations directly under Brand, so the user can choose.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43597
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
