### PR TITLE
Allow support of Graph QL 4.0 / Bump pytibber 0.36.0

### DIFF
--- a/homeassistant/components/tibber/manifest.json
+++ b/homeassistant/components/tibber/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tibber",
   "iot_class": "cloud_polling",
   "loggers": ["tibber"],
-  "requirements": ["pyTibber==0.35.0"]
+  "requirements": ["pyTibber==0.36.0"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -223,6 +223,9 @@ num2words==0.5.14
 # This ensures all use the same version
 pymodbus==3.11.2
 
+# gql 4.x is incompatible with aioaseko==1.0.0 used by aseko_pool_live
+# Keep gql < 4.0.0 until aioaseko supports gql 4 or the integration changes
+gql<4.0.0
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -223,9 +223,6 @@ num2words==0.5.14
 # This ensures all use the same version
 pymodbus==3.11.2
 
-# gql 4.x is incompatible with aioaseko==1.0.0 used by aseko_pool_live
-# Keep gql < 4.0.0 until aioaseko supports gql 4 or the integration changes
-#gql<4.0.0
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -225,7 +225,7 @@ pymodbus==3.11.2
 
 # gql 4.x is incompatible with aioaseko==1.0.0 used by aseko_pool_live
 # Keep gql < 4.0.0 until aioaseko supports gql 4 or the integration changes
-gql<4.0.0
+#gql<4.0.0
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -223,9 +223,6 @@ num2words==0.5.14
 # This ensures all use the same version
 pymodbus==3.11.2
 
-# Some packages don't support gql 4.0.0 yet
-gql<4.0.0
-
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1900,7 +1900,7 @@ pyRFXtrx==0.31.1
 pySDCP==1
 
 # homeassistant.components.tibber
-pyTibber==0.35.0
+pyTibber==0.36.0
 
 # homeassistant.components.dlink
 pyW215==0.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1637,7 +1637,7 @@ pyHomee==1.3.8
 pyRFXtrx==0.31.1
 
 # homeassistant.components.tibber
-pyTibber==0.35.0
+pyTibber==0.36.0
 
 # homeassistant.components.dlink
 pyW215==0.8.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -212,9 +212,6 @@ num2words==0.5.14
 # This ensures all use the same version
 pymodbus==3.11.2
 
-# Some packages don't support gql 4.0.0 yet
-gql<4.0.0
-
 # Pin pytest-rerunfailures to prevent accidental breaks
 pytest-rerunfailures==16.0.1
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


I'm proposing to update `pytibber` to `0.36.0` in order to remove the remaining GQL < 4.0 dependency in Home Assistant. All other 3 libs that use gql already supported 4.0

## Changeling of PyTibber
https://github.com/Danielhiversen/pyTibber/compare/0.35.0...0.36.0



### Table of integrations using GQL

| Version of Lib supporting GQL4 | Library                          | Integration                                      | Integration Owner                  | Library Maintainer | Issue opened with Backing Lib                                      |
|--------------------------------|----------------------------------|--------------------------------------------------|------------------------------------|--------------------|--------------------------------------------------------------------|
| ✅️                        | [aioaseko](https://github.com/milanmeu/aioaseko)                  | [aseko_pool_live](https://www.home-assistant.io/integrations/aseko_pool_live/) | milanmeu                           | @milanmeu           |      https://github.com/milanmeu/aioaseko/issues/15                                                              |
| ✅️ (2025.9.0)                        | [pydrawise](https://github.com/dknowles2/pydrawise)               | [hydrawise](https://www.home-assistant.io/integrations/hydrawise/)             | dknowles2, thomaskistler, ptcryan  | @dknowles2          |          https://github.com/dknowles2/pydrawise/issues/431 |                                                          |
| ✅️  0.36.0                        | [pyTibber](https://github.com/Danielhiversen/pyTibber)            | [tibber](https://www.home-assistant.io/integrations/tibber/)                   | Danielhiversen| @Danielhiversen | https://github.com/Danielhiversen/pyTibber/issues/392              |
| ✅️  (0.7.0)                        | [typedmonarchmoney](https://pypi.org/project/typedmonarchmoney)   | [monarch_money](https://www.home-assistant.io/integrations/monarch_money/)     | @jeeftor  | @jeeftor @bradleyseanf |       https://github.com/bradleyseanf/monarchmoneycommunity/issues/13 , https://github.com/jeeftor/monarchmoney-typed/issues/112                                                             |


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
