### PR TITLE
Add room correction intensity to Cambridge Audio

### DIFF
--- a/homeassistant/components/cambridge_audio/__init__.py
+++ b/homeassistant/components/cambridge_audio/__init__.py
@@ -16,7 +16,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONNECT_TIMEOUT, DOMAIN, STREAM_MAGIC_EXCEPTIONS
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.SELECT, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.MEDIA_PLAYER,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cambridge_audio/icons.json
+++ b/homeassistant/components/cambridge_audio/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "number": {
+      "room_correction_intensity": {
+        "default": "mdi:home-sound-out"
+      }
+    },
     "select": {
       "audio_output": {
         "default": "mdi:audio-input-stereo-minijack"

--- a/homeassistant/components/cambridge_audio/number.py
+++ b/homeassistant/components/cambridge_audio/number.py
@@ -1,7 +1,7 @@
 """Support for Cambridge Audio number entities."""
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from aiostreammagic import StreamMagicClient
@@ -21,7 +21,7 @@ PARALLEL_UPDATES = 0
 class CambridgeAudioNumberEntityDescription(NumberEntityDescription):
     """Describes Cambridge Audio number entity."""
 
-    exists_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
+    exists_fn: Callable[[StreamMagicClient], bool] = lambda _: True
     value_fn: Callable[[StreamMagicClient], int]
     set_value_fn: Callable[[StreamMagicClient, int], Awaitable[None]]
 

--- a/homeassistant/components/cambridge_audio/number.py
+++ b/homeassistant/components/cambridge_audio/number.py
@@ -1,0 +1,88 @@
+"""Support for Cambridge Audio switch entities."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from aiostreammagic import StreamMagicClient
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import CambridgeAudioConfigEntry
+from .entity import CambridgeAudioEntity, command
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class CambridgeAudioNumberEntityDescription(NumberEntityDescription):
+    """Describes Cambridge Audio switch entity."""
+
+    load_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
+    value_fn: Callable[[StreamMagicClient], int]
+    set_value_fn: Callable[[StreamMagicClient, int], Awaitable[None]]
+
+
+def room_correction_intensity(client: StreamMagicClient) -> int:
+    """Check if room correction is enabled."""
+    if TYPE_CHECKING:
+        assert client.audio.tilt_eq is not None
+    return client.audio.tilt_eq.intensity
+
+
+CONTROL_ENTITIES: tuple[CambridgeAudioNumberEntityDescription, ...] = (
+    CambridgeAudioNumberEntityDescription(
+        key="room_correction_intensity",
+        translation_key="room_correction_intensity",
+        entity_category=EntityCategory.CONFIG,
+        native_min_value=-15,
+        native_max_value=15,
+        native_step=1,
+        load_fn=lambda client: client.audio.tilt_eq is not None,
+        value_fn=room_correction_intensity,
+        set_value_fn=lambda client, value: client.set_room_correction_intensity(value),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CambridgeAudioConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Cambridge Audio switch entities based on a config entry."""
+    client: StreamMagicClient = entry.runtime_data
+    async_add_entities(
+        CambridgeAudioNumber(entry.runtime_data, description)
+        for description in CONTROL_ENTITIES
+        if description.load_fn(client)
+    )
+
+
+class CambridgeAudioNumber(CambridgeAudioEntity, NumberEntity):
+    """Defines a Cambridge Audio switch entity."""
+
+    entity_description: CambridgeAudioNumberEntityDescription
+
+    def __init__(
+        self,
+        client: StreamMagicClient,
+        description: CambridgeAudioNumberEntityDescription,
+    ) -> None:
+        """Initialize Cambridge Audio switch."""
+        super().__init__(client)
+        self.entity_description = description
+        self._attr_unique_id = f"{client.info.unit_id}-{description.key}"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the state of the number."""
+        return self.entity_description.value_fn(self.client)
+
+    @command
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the selected value."""
+        await self.entity_description.set_value_fn(self.client, int(value))

--- a/homeassistant/components/cambridge_audio/number.py
+++ b/homeassistant/components/cambridge_audio/number.py
@@ -21,7 +21,7 @@ PARALLEL_UPDATES = 0
 class CambridgeAudioNumberEntityDescription(NumberEntityDescription):
     """Describes Cambridge Audio switch entity."""
 
-    load_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
+    exists_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
     value_fn: Callable[[StreamMagicClient], int]
     set_value_fn: Callable[[StreamMagicClient, int], Awaitable[None]]
 
@@ -41,7 +41,7 @@ CONTROL_ENTITIES: tuple[CambridgeAudioNumberEntityDescription, ...] = (
         native_min_value=-15,
         native_max_value=15,
         native_step=1,
-        load_fn=lambda client: client.audio.tilt_eq is not None,
+        exists_fn=lambda client: client.audio.tilt_eq is not None,
         value_fn=room_correction_intensity,
         set_value_fn=lambda client, value: client.set_room_correction_intensity(value),
     ),
@@ -54,11 +54,11 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Cambridge Audio switch entities based on a config entry."""
-    client: StreamMagicClient = entry.runtime_data
+    client = entry.runtime_data
     async_add_entities(
         CambridgeAudioNumber(entry.runtime_data, description)
         for description in CONTROL_ENTITIES
-        if description.load_fn(client)
+        if description.exists_fn(client)
     )
 
 

--- a/homeassistant/components/cambridge_audio/number.py
+++ b/homeassistant/components/cambridge_audio/number.py
@@ -27,7 +27,7 @@ class CambridgeAudioNumberEntityDescription(NumberEntityDescription):
 
 
 def room_correction_intensity(client: StreamMagicClient) -> int:
-    """Check if room correction is enabled."""
+    """Get room correction intensity."""
     if TYPE_CHECKING:
         assert client.audio.tilt_eq is not None
     return client.audio.tilt_eq.intensity

--- a/homeassistant/components/cambridge_audio/number.py
+++ b/homeassistant/components/cambridge_audio/number.py
@@ -1,4 +1,4 @@
-"""Support for Cambridge Audio switch entities."""
+"""Support for Cambridge Audio number entities."""
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -19,7 +19,7 @@ PARALLEL_UPDATES = 0
 
 @dataclass(frozen=True, kw_only=True)
 class CambridgeAudioNumberEntityDescription(NumberEntityDescription):
-    """Describes Cambridge Audio switch entity."""
+    """Describes Cambridge Audio number entity."""
 
     exists_fn: Callable[[StreamMagicClient], bool] = field(default=lambda _: True)
     value_fn: Callable[[StreamMagicClient], int]
@@ -53,7 +53,7 @@ async def async_setup_entry(
     entry: CambridgeAudioConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Cambridge Audio switch entities based on a config entry."""
+    """Set up Cambridge Audio number entities based on a config entry."""
     client = entry.runtime_data
     async_add_entities(
         CambridgeAudioNumber(entry.runtime_data, description)
@@ -63,7 +63,7 @@ async def async_setup_entry(
 
 
 class CambridgeAudioNumber(CambridgeAudioEntity, NumberEntity):
-    """Defines a Cambridge Audio switch entity."""
+    """Defines a Cambridge Audio number entity."""
 
     entity_description: CambridgeAudioNumberEntityDescription
 
@@ -72,7 +72,7 @@ class CambridgeAudioNumber(CambridgeAudioEntity, NumberEntity):
         client: StreamMagicClient,
         description: CambridgeAudioNumberEntityDescription,
     ) -> None:
-        """Initialize Cambridge Audio switch."""
+        """Initialize Cambridge Audio number entity."""
         super().__init__(client)
         self.entity_description = description
         self._attr_unique_id = f"{client.info.unit_id}-{description.key}"

--- a/homeassistant/components/cambridge_audio/strings.json
+++ b/homeassistant/components/cambridge_audio/strings.json
@@ -35,6 +35,11 @@
     }
   },
   "entity": {
+    "number": {
+      "room_correction_intensity": {
+        "name": "Room correction intensity"
+      }
+    },
     "select": {
       "audio_output": {
         "name": "Audio output"

--- a/tests/components/cambridge_audio/fixtures/get_audio.json
+++ b/tests/components/cambridge_audio/fixtures/get_audio.json
@@ -1,6 +1,6 @@
 {
   "tilt_eq": {
     "enabled": true,
-    "intensity": 100
+    "intensity": 0
   }
 }

--- a/tests/components/cambridge_audio/snapshots/test_number.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_number.ambr
@@ -54,6 +54,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '100',
+    'state': '0',
   })
 # ---

--- a/tests/components/cambridge_audio/snapshots/test_number.ambr
+++ b/tests/components/cambridge_audio/snapshots/test_number.ambr
@@ -1,0 +1,59 @@
+# serializer version: 1
+# name: test_all_entities[number.cambridge_audio_cxnv2_room_correction_intensity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 15,
+      'min': -15,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.cambridge_audio_cxnv2_room_correction_intensity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Room correction intensity',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Room correction intensity',
+    'platform': 'cambridge_audio',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'room_correction_intensity',
+    'unique_id': '0020c2d8-room_correction_intensity',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[number.cambridge_audio_cxnv2_room_correction_intensity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Cambridge Audio CXNv2 Room correction intensity',
+      'max': 15,
+      'min': -15,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.cambridge_audio_cxnv2_room_correction_intensity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---

--- a/tests/components/cambridge_audio/test_number.py
+++ b/tests/components/cambridge_audio/test_number.py
@@ -1,0 +1,55 @@
+"""Tests for the Cambridge Audio select platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_stream_magic_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch("homeassistant.components.cambridge_audio.PLATFORMS", [Platform.NUMBER]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_setting_value(
+    hass: HomeAssistant,
+    mock_stream_magic_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting value."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        service_data={ATTR_VALUE: 13},
+        target={
+            ATTR_ENTITY_ID: "number.cambridge_audio_cxnv2_room_correction_intensity"
+        },
+        blocking=True,
+    )
+
+    mock_stream_magic_client.set_room_correction_intensity.assert_called_once_with(13)

--- a/tests/components/cambridge_audio/test_number.py
+++ b/tests/components/cambridge_audio/test_number.py
@@ -1,4 +1,4 @@
-"""Tests for the Cambridge Audio select platform."""
+"""Tests for the Cambridge Audio number platform."""
 
 from unittest.mock import AsyncMock, patch
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds room correction intensity adjustment to Cambridge Audio. This results in the addition of the number entity to the integration.

The HA integration docs already has a note for room correction support so no additional doc updating is necessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43490
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
