### PR TITLE
Bump victron-ble-ha-parser to 0.4.10

### DIFF
--- a/homeassistant/components/victron_ble/manifest.json
+++ b/homeassistant/components/victron_ble/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["victron-ble-ha-parser==0.4.9"]
+  "requirements": ["victron-ble-ha-parser==0.4.10"]
 }

--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -44,6 +44,7 @@ AC_IN_OPTIONS = [
 ]
 
 ALARM_OPTIONS = [
+    "no_alarm",
     "low_voltage",
     "high_voltage",
     "low_soc",
@@ -336,6 +337,7 @@ SENSOR_DESCRIPTIONS = {
             "switched_off_register",
             "remote_input",
             "protection_active",
+            "load_output_disabled",
             "pay_as_you_go_out_of_credit",
             "bms",
             "engine_shutdown",

--- a/homeassistant/components/victron_ble/strings.json
+++ b/homeassistant/components/victron_ble/strings.json
@@ -63,6 +63,7 @@
           "low_v_ac_out": "AC-out undervoltage",
           "low_voltage": "Undervoltage",
           "mid_voltage": "[%key:component::victron_ble::common::midpoint_voltage%]",
+          "no_alarm": "No alarm",
           "overload": "Overload",
           "short_circuit": "Short circuit"
         }
@@ -224,6 +225,7 @@
           "analysing_input_voltage": "Analyzing input voltage",
           "bms": "Battery management system",
           "engine_shutdown": "Engine shutdown",
+          "load_output_disabled": "Load output disabled",
           "no_input_power": "No input power",
           "no_reason": "No reason",
           "pay_as_you_go_out_of_credit": "Pay-as-you-go out of credit",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3179,7 +3179,7 @@ venstarcolortouch==0.21
 viaggiatreno_ha==0.2.4
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.4.9
+victron-ble-ha-parser==0.4.10
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2670,7 +2670,7 @@ velbus-aio==2026.1.4
 venstarcolortouch==0.21
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.4.9
+victron-ble-ha-parser==0.4.10
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/tests/components/victron_ble/snapshots/test_sensor.ambr
+++ b/tests/components/victron_ble/snapshots/test_sensor.ambr
@@ -6,6 +6,7 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
+        'no_alarm',
         'low_voltage',
         'high_voltage',
         'low_soc',
@@ -58,6 +59,7 @@
       'device_class': 'enum',
       'friendly_name': 'Battery Monitor Alarm',
       'options': list([
+        'no_alarm',
         'low_voltage',
         'high_voltage',
         'low_soc',
@@ -79,7 +81,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'no_alarm',
   })
 # ---
 # name: test_sensors[battery_monitor][sensor.battery_monitor_battery-entry]
@@ -592,6 +594,7 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
+        'no_alarm',
         'low_voltage',
         'high_voltage',
         'low_soc',
@@ -644,6 +647,7 @@
       'device_class': 'enum',
       'friendly_name': 'DC Energy Meter Alarm',
       'options': list([
+        'no_alarm',
         'low_voltage',
         'high_voltage',
         'low_soc',


### PR DESCRIPTION
## Breaking change

## Proposed change

Bump victron-ble-ha-parser from 0.4.9 to 0.4.10.

The upstream `victron-ble` library (0.9.2 -> 0.9.3) switched `AlarmReason` and `OffReason` from `Flag` to `Enum`. Previously, devices could report combined bitmask values like `no_input_power|engine_shutdown`, which weren't in the allowed options list and caused a `ValueError` that killed the sensor update.

With the switch to `Enum`, each reason is now a single discrete value. This PR also adds two new enum options that come with the update:
- `no_alarm` for `AlarmReason` (value 0, previously returned as `None`)
- `load_output_disabled` for `OffReason` (new in victron-ble 0.9.3)

Library diff: https://github.com/rajlaud/victron-ble-ha-parser/compare/v0.4.9...v0.4.10

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #161717
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to requirements_all.txt.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure