### PR TITLE
Add event platform to Kaleidescape integration

### DIFF
--- a/homeassistant/components/kaleidescape/__init__.py
+++ b/homeassistant/components/kaleidescape/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE, Platform.SENSOR]
+PLATFORMS = [Platform.EVENT, Platform.MEDIA_PLAYER, Platform.REMOTE, Platform.SENSOR]
 
 type KaleidescapeConfigEntry = ConfigEntry[KaleidescapeDevice]
 

--- a/homeassistant/components/kaleidescape/entity.py
+++ b/homeassistant/components/kaleidescape/entity.py
@@ -47,5 +47,9 @@ class KaleidescapeEntity(Entity):
         def _update(event: str, *args: Any) -> None:
             """Handle device state changes."""
             self.async_write_ha_state()
+            self.hass.async_create_task(self._async_handle_event(event, *args))
 
         self.async_on_remove(self._device.dispatcher.connect(_update).disconnect)
+
+    async def _async_handle_event(self, event: str, *args: Any) -> None:
+        """Abstract method to handle device events."""

--- a/homeassistant/components/kaleidescape/event.py
+++ b/homeassistant/components/kaleidescape/event.py
@@ -1,0 +1,197 @@
+"""Event platform for Kaleidescape."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import TYPE_CHECKING, Any
+
+from kaleidescape import const as kaleidescape_const
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.components.media_player import ATTR_MEDIA_VOLUME_LEVEL
+from homeassistant.const import CONF_COMMAND, CONF_PARAMS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import KaleidescapeConfigEntry
+from .entity import KaleidescapeEntity
+
+if TYPE_CHECKING:
+    from kaleidescape import Device as KaleidescapeDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+# Event type constants
+EVENT_VOLUME_QUERY = "volume_query"
+EVENT_VOLUME_SET = "volume_set"
+EVENT_VOLUME_UP = "volume_up"
+EVENT_VOLUME_DOWN = "volume_down"
+EVENT_VOLUME_MUTE = "volume_mute"
+EVENT_USER_DEFINED = "user_defined"
+
+TRIGGERED = "triggered"
+DEBOUNCE_TIME = 0.5
+
+KALEIDESCAPE_EVENTS_VOLUME_UP = (
+    kaleidescape_const.USER_DEFINED_EVENT_VOLUME_UP,
+    kaleidescape_const.USER_DEFINED_EVENT_VOLUME_UP_PRESS,
+)
+
+KALEIDESCAPE_EVENTS_VOLUME_DOWN = (
+    kaleidescape_const.USER_DEFINED_EVENT_VOLUME_DOWN,
+    kaleidescape_const.USER_DEFINED_EVENT_VOLUME_DOWN_PRESS,
+)
+
+
+@dataclass(kw_only=True, frozen=True)
+class KaleidescapeEventEntityDescription(EventEntityDescription):
+    """Describes Kaleidescape event entity."""
+
+    device_user_event_names: tuple[str, ...]
+    event_handle_fn: Callable[[KaleidescapeEventEntity, str, list[str]], None] = (
+        lambda e, c, f: e.handle_user_defined_volume_event(c, f)
+    )
+
+
+EVENT_DESCRIPTIONS = [
+    KaleidescapeEventEntityDescription(
+        key=EVENT_VOLUME_QUERY,
+        translation_key=EVENT_VOLUME_QUERY,
+        event_types=[TRIGGERED],
+        device_user_event_names=(kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY,),
+    ),
+    KaleidescapeEventEntityDescription(
+        key=EVENT_VOLUME_SET,
+        translation_key=EVENT_VOLUME_SET,
+        event_types=[TRIGGERED],
+        event_handle_fn=lambda e, c, f: e.handle_user_defined_volume_set_event(c, f),
+        device_user_event_names=(
+            kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL,
+        ),
+    ),
+    KaleidescapeEventEntityDescription(
+        key=EVENT_VOLUME_UP,
+        translation_key=EVENT_VOLUME_UP,
+        event_types=[TRIGGERED],
+        device_user_event_names=KALEIDESCAPE_EVENTS_VOLUME_UP,
+    ),
+    KaleidescapeEventEntityDescription(
+        key=EVENT_VOLUME_DOWN,
+        translation_key=EVENT_VOLUME_DOWN,
+        event_types=[TRIGGERED],
+        device_user_event_names=KALEIDESCAPE_EVENTS_VOLUME_DOWN,
+    ),
+    KaleidescapeEventEntityDescription(
+        key=EVENT_VOLUME_MUTE,
+        translation_key=EVENT_VOLUME_MUTE,
+        event_types=[TRIGGERED],
+        device_user_event_names=(kaleidescape_const.USER_DEFINED_EVENT_TOGGLE_MUTE,),
+    ),
+    KaleidescapeEventEntityDescription(
+        key=EVENT_USER_DEFINED,
+        translation_key=EVENT_USER_DEFINED,
+        event_types=[TRIGGERED],
+        event_handle_fn=lambda e, c, f: e.handle_user_defined_event(c, f),
+        device_user_event_names=(),
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: KaleidescapeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the platform from a config entry."""
+    async_add_entities(
+        [
+            KaleidescapeEventEntity(entry.runtime_data, description)
+            for description in EVENT_DESCRIPTIONS
+        ]
+    )
+
+
+class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
+    """Representation of a Kaleidescape event."""
+
+    entity_description: KaleidescapeEventEntityDescription
+
+    def __init__(
+        self,
+        device: KaleidescapeDevice,
+        entity_description: KaleidescapeEventEntityDescription,
+    ) -> None:
+        """Initialize the event entity."""
+        super().__init__(device)
+        self.entity_description: KaleidescapeEventEntityDescription = entity_description
+        self._attr_unique_id = f"{self._attr_unique_id}-{entity_description.key}"
+        self._debounce: asyncio.TimerHandle | None = None
+
+    async def _async_handle_event(self, event: str, *args: Any) -> None:
+        """Handle device events."""
+        if event != kaleidescape_const.USER_DEFINED_EVENT:
+            return
+
+        if not args or not isinstance(args[0], list) or not args[0]:
+            return
+
+        command, params = args[0][0], args[0][1:]
+
+        if (
+            command in self.entity_description.device_user_event_names
+            or self.entity_description.key == EVENT_USER_DEFINED
+        ):
+            self.entity_description.event_handle_fn(self, command, params)
+
+    @callback
+    def handle_user_defined_volume_event(self, command: str, params: list[str]) -> None:
+        """Handle volume related device events."""
+        _LOGGER.debug("Received USER_DEFINED_EVENT: %s %s", command, params)
+
+        self._trigger_event(TRIGGERED)
+
+        self.async_write_ha_state()
+
+    @callback
+    def handle_user_defined_volume_set_event(
+        self, command: str, params: list[str]
+    ) -> None:
+        """Handle volume set device events."""
+        _LOGGER.debug("Received USER_DEFINED_EVENT: %s %s", command, params)
+
+        try:
+            volume_level = int(params[0])
+        except (IndexError, ValueError, TypeError):
+            _LOGGER.warning("Invalid level for SET_VOLUME_LEVEL: %s", params)
+            return
+
+        scaled_volume_level = float(max(0, min(100, volume_level)) / 100)
+
+        if self._debounce is not None:
+            self._debounce.cancel()
+            self._debounce = None
+
+        def _trigger() -> None:
+            self._debounce = None
+            self._trigger_event(
+                TRIGGERED, {ATTR_MEDIA_VOLUME_LEVEL: scaled_volume_level}
+            )
+            self.async_write_ha_state()
+
+        self._debounce = self.hass.loop.call_later(DEBOUNCE_TIME, _trigger)
+
+    @callback
+    def handle_user_defined_event(self, command: str, params: list[str]) -> None:
+        """Handle custom user defined device events."""
+        if command in kaleidescape_const.VOLUME_EVENTS:
+            # Ignore all volume related events
+            return
+
+        _LOGGER.debug("Received USER_DEFINED_EVENT: %s %s", command, params)
+
+        self._trigger_event(TRIGGERED, {CONF_COMMAND: command, CONF_PARAMS: params})
+
+        self.async_write_ha_state()

--- a/homeassistant/components/kaleidescape/event.py
+++ b/homeassistant/components/kaleidescape/event.py
@@ -107,10 +107,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the platform from a config entry."""
     async_add_entities(
-        [
-            KaleidescapeEventEntity(entry.runtime_data, description)
-            for description in EVENT_DESCRIPTIONS
-        ]
+        KaleidescapeEventEntity(entry.runtime_data, description)
+        for description in EVENT_DESCRIPTIONS
     )
 
 
@@ -126,7 +124,7 @@ class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
     ) -> None:
         """Initialize the event entity."""
         super().__init__(device)
-        self.entity_description: KaleidescapeEventEntityDescription = entity_description
+        self.entity_description = entity_description
         self._attr_unique_id = f"{self._attr_unique_id}-{entity_description.key}"
         self._debounce: asyncio.TimerHandle | None = None
 

--- a/homeassistant/components/kaleidescape/event.py
+++ b/homeassistant/components/kaleidescape/event.py
@@ -164,7 +164,7 @@ class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
 
         try:
             volume_level = int(params[0])
-        except (IndexError, ValueError, TypeError):
+        except IndexError, ValueError, TypeError:
             _LOGGER.warning("Invalid level for SET_VOLUME_LEVEL: %s", params)
             return
 

--- a/homeassistant/components/kaleidescape/event.py
+++ b/homeassistant/components/kaleidescape/event.py
@@ -187,7 +187,7 @@ class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
     def handle_user_defined_event(self, command: str, params: list[str]) -> None:
         """Handle custom user defined device events."""
         if command in kaleidescape_const.VOLUME_EVENTS:
-            # Ignore all volume related events
+            # Ignore all volume-related events
             return
 
         _LOGGER.debug("Received USER_DEFINED_EVENT: %s %s", command, params)
@@ -195,3 +195,10 @@ class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
         self._trigger_event(TRIGGERED, {CONF_COMMAND: command, CONF_PARAMS: params})
 
         self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        if self._debounce is not None:
+            self._debounce.cancel()
+            self._debounce = None
+        await super().async_will_remove_from_hass()

--- a/homeassistant/components/kaleidescape/event.py
+++ b/homeassistant/components/kaleidescape/event.py
@@ -172,6 +172,7 @@ class KaleidescapeEventEntity(KaleidescapeEntity, EventEntity):
             self._debounce.cancel()
             self._debounce = None
 
+        @callback
         def _trigger() -> None:
             self._debounce = None
             self._trigger_event(

--- a/homeassistant/components/kaleidescape/strings.json
+++ b/homeassistant/components/kaleidescape/strings.json
@@ -25,7 +25,7 @@
   "entity": {
     "event": {
       "user_defined": {
-        "name": "User defined event",
+        "name": "User-defined event",
         "state_attributes": {
           "command": {
             "name": "Command"

--- a/homeassistant/components/kaleidescape/strings.json
+++ b/homeassistant/components/kaleidescape/strings.json
@@ -31,7 +31,7 @@
             "name": "Command"
           },
           "params": {
-            "name": "Params"
+            "name": "Parameters"
           }
         }
       },

--- a/homeassistant/components/kaleidescape/strings.json
+++ b/homeassistant/components/kaleidescape/strings.json
@@ -23,6 +23,39 @@
     }
   },
   "entity": {
+    "event": {
+      "user_defined": {
+        "name": "User defined event",
+        "state_attributes": {
+          "command": {
+            "name": "Command"
+          },
+          "params": {
+            "name": "Params"
+          }
+        }
+      },
+      "volume_down": {
+        "name": "Volume down pressed"
+      },
+      "volume_mute": {
+        "name": "Volume mute toggled"
+      },
+      "volume_query": {
+        "name": "Volume state queried"
+      },
+      "volume_set": {
+        "name": "Volume level set",
+        "state_attributes": {
+          "volume_level": {
+            "name": "Volume level"
+          }
+        }
+      },
+      "volume_up": {
+        "name": "Volume up pressed"
+      }
+    },
     "sensor": {
       "cinemascape_mask": {
         "name": "Cinemascape mask"

--- a/tests/components/kaleidescape/__init__.py
+++ b/tests/components/kaleidescape/__init__.py
@@ -1,5 +1,10 @@
 """Tests for Kaleidescape integration."""
 
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_SERIAL,
@@ -19,3 +24,21 @@ MOCK_SSDP_DISCOVERY_INFO = SsdpServiceInfo(
         ATTR_UPNP_SERIAL: MOCK_SERIAL,
     },
 )
+
+
+def find_event_update_callback(
+    connect_mock: MagicMock, event_key: str
+) -> Callable[..., None]:
+    """Find the callback registered for a specific event entity key."""
+    for call in connect_mock.call_args_list:
+        callback: Callable[..., None] = call[0][0]
+        if callback.__closure__ is None:
+            continue
+
+        for cell in callback.__closure__:
+            if getattr(cell.cell_contents, "entity_description", None) is None:
+                continue
+            if cell.cell_contents.entity_description.key == event_key:
+                return callback
+
+    pytest.fail(f"Callback for event key {event_key} not found")

--- a/tests/components/kaleidescape/conftest.py
+++ b/tests/components/kaleidescape/conftest.py
@@ -26,6 +26,7 @@ def fixture_mock_device() -> Generator[MagicMock]:
 
         device = mock.return_value
         device.dispatcher = Dispatcher()
+        device.dispatcher.connect = MagicMock(wraps=device.dispatcher.connect)
         device.host = host
         device.port = 10000
         device.serial_number = MOCK_SERIAL

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -1,0 +1,164 @@
+"""Tests for Kaleidescape media player platform."""
+
+import asyncio
+import re
+from unittest.mock import MagicMock
+
+from kaleidescape import const as kaleidescape_const
+import pytest
+
+from homeassistant.components.kaleidescape import event
+from homeassistant.components.media_player import ATTR_MEDIA_VOLUME_LEVEL
+from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_COMMAND, CONF_PARAMS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import MOCK_SERIAL
+
+ENTITY_ID = f"event.kaleidescape_device_{MOCK_SERIAL}"
+FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
+
+
+@pytest.mark.usefixtures("mock_integration")
+async def test_handle_user_defined_volume_event(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_device: MagicMock
+) -> None:
+    """Test test_handle_user_defined_volume_event callback."""
+
+    # Test initial state
+    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
+    entry = entity_registry.async_get(f"{ENTITY_ID}_volume_state_queried")
+    assert entity is not None
+    assert entity.state == "unknown"
+    assert (
+        entity.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"{FRIENDLY_NAME} Volume state queried"
+    )
+    assert entry
+    assert entry.unique_id == f"{MOCK_SERIAL}-volume_query"
+
+    # Test event handling
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT,
+        [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY],
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
+    assert entity is not None
+    assert re.match(r"^\d{4}-", entity.state)
+    last_updated = entity.state
+
+    # Test repeated event updates timestamp
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT,
+        [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY],
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
+    assert entity is not None
+    assert re.match(r"^\d{4}-", entity.state)
+    assert entity.state != last_updated
+
+
+@pytest.mark.usefixtures("mock_integration")
+async def test_handle_user_defined_volume_set_event(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test test_handle_user_defined_volume_set_event callback."""
+    monkeypatch.setattr(event, "DEBOUNCE_TIME", 0)
+
+    # Test initial state
+    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
+    entry = entity_registry.async_get(f"{ENTITY_ID}_volume_level_set")
+    assert entity is not None
+    assert entity.state == "unknown"
+    assert (
+        entity.attributes.get(ATTR_FRIENDLY_NAME) == f"{FRIENDLY_NAME} Volume level set"
+    )
+    assert entry
+    assert entry.unique_id == f"{MOCK_SERIAL}-volume_set"
+
+    # Test event handling
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT,
+        [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "42"],
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
+    assert entity is not None
+    assert re.match(r"^\d{4}-", entity.state) is not None
+    assert ATTR_MEDIA_VOLUME_LEVEL in entity.attributes
+    assert entity.attributes[ATTR_MEDIA_VOLUME_LEVEL] == 0.42
+    last_updated = entity.state
+
+    # Test with bad volume level
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT,
+        [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "bad"],
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
+    assert entity is not None
+    assert entity.state == last_updated
+
+    # Test debounce clears (for complete code coverage)
+    monkeypatch.setattr(event, "DEBOUNCE_TIME", 1.0)
+    for _ in range(2):
+        mock_device.dispatcher.send(
+            kaleidescape_const.USER_DEFINED_EVENT,
+            [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "42"],
+        )
+        await hass.async_block_till_done()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.usefixtures("mock_integration")
+async def test_handle_user_defined_event(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_device: MagicMock
+) -> None:
+    """Test test_handle_user_defined_event callback."""
+
+    # Test initial state
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entry = entity_registry.async_get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert entity.state == "unknown"
+    assert (
+        entity.attributes.get(ATTR_FRIENDLY_NAME)
+        == f"{FRIENDLY_NAME} User defined event"
+    )
+    assert entry
+    assert entry.unique_id == f"{MOCK_SERIAL}-user_defined"
+
+    # Test event handling
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT, ["custom_event", "42"]
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert re.match(r"^\d{4}-", entity.state) is not None
+    assert CONF_COMMAND in entity.attributes
+    assert entity.attributes[CONF_COMMAND] == "custom_event"
+    assert CONF_PARAMS in entity.attributes
+    assert entity.attributes[CONF_PARAMS] == ["42"]
+    last_updated = entity.state
+
+    # Test volume commands are ignored
+    mock_device.dispatcher.send(
+        kaleidescape_const.USER_DEFINED_EVENT,
+        [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_CAPABILITIES],
+    )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert entity.state == last_updated

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -1,4 +1,4 @@
-"""Tests for Kaleidescape media player platform."""
+"""Tests for Kaleidescape event platform."""
 
 import asyncio
 import re
@@ -162,3 +162,30 @@ async def test_handle_user_defined_event(
     entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
     assert entity is not None
     assert entity.state == last_updated
+
+
+@pytest.mark.usefixtures("mock_integration")
+async def test_handle_user_defined_event_empty_payload_ignored(
+    hass: HomeAssistant, mock_device: MagicMock
+) -> None:
+    """Test invalid/unsupported payloads are ignored."""
+
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert entity.state == "unknown"
+
+    mock_device.dispatcher.send("not_user_defined_event", [])
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert entity.state == "unknown"
+
+    mock_device.dispatcher.send(kaleidescape_const.USER_DEFINED_EVENT, [])
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
+
+    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    assert entity is not None
+    assert entity.state == "unknown"

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -13,50 +13,55 @@ from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_COMMAND, CONF_PARAMS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import MOCK_SERIAL
+from . import MOCK_SERIAL, find_event_update_callback
 
-ENTITY_ID = f"event.kaleidescape_device_{MOCK_SERIAL}"
 FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
 
 @pytest.mark.usefixtures("mock_integration")
 async def test_handle_user_defined_volume_event(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_device: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: MagicMock,
 ) -> None:
     """Test test_handle_user_defined_volume_event callback."""
+    update_callback = find_event_update_callback(
+        mock_device.dispatcher.connect, event.EVENT_VOLUME_QUERY
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        "event", "kaleidescape", f"{MOCK_SERIAL}-volume_query"
+    )
+    assert entity_id is not None
 
     # Test initial state
-    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
-    entry = entity_registry.async_get(f"{ENTITY_ID}_volume_state_queried")
+    entity = hass.states.get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert (
-        entity.attributes.get(ATTR_FRIENDLY_NAME)
-        == f"{FRIENDLY_NAME} Volume state queried"
-    )
+    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
     assert entry.unique_id == f"{MOCK_SERIAL}-volume_query"
 
     # Test event handling
-    mock_device.dispatcher.send(
+    update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY],
     )
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert re.match(r"^\d{4}-", entity.state)
     last_updated = entity.state
 
     # Test repeated event updates timestamp
-    mock_device.dispatcher.send(
+    update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY],
     )
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_volume_state_queried")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert re.match(r"^\d{4}-", entity.state)
     assert entity.state != last_updated
@@ -71,26 +76,31 @@ async def test_handle_user_defined_volume_set_event(
 ) -> None:
     """Test test_handle_user_defined_volume_set_event callback."""
     monkeypatch.setattr(event, "DEBOUNCE_TIME", 0)
+    update_callback = find_event_update_callback(
+        mock_device.dispatcher.connect, event.EVENT_VOLUME_SET
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        "event", "kaleidescape", f"{MOCK_SERIAL}-volume_set"
+    )
+    assert entity_id is not None
 
     # Test initial state
-    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
-    entry = entity_registry.async_get(f"{ENTITY_ID}_volume_level_set")
+    entity = hass.states.get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert (
-        entity.attributes.get(ATTR_FRIENDLY_NAME) == f"{FRIENDLY_NAME} Volume level set"
-    )
+    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
     assert entry.unique_id == f"{MOCK_SERIAL}-volume_set"
 
     # Test event handling
-    mock_device.dispatcher.send(
+    update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "42"],
     )
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert re.match(r"^\d{4}-", entity.state) is not None
     assert ATTR_MEDIA_VOLUME_LEVEL in entity.attributes
@@ -98,20 +108,20 @@ async def test_handle_user_defined_volume_set_event(
     last_updated = entity.state
 
     # Test with bad volume level
-    mock_device.dispatcher.send(
+    update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "bad"],
     )
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_volume_level_set")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.state == last_updated
 
     # Test debounce clears (for complete code coverage)
     monkeypatch.setattr(event, "DEBOUNCE_TIME", 1.0)
     for _ in range(2):
-        mock_device.dispatcher.send(
+        update_callback(
             kaleidescape_const.USER_DEFINED_EVENT,
             [kaleidescape_const.USER_DEFINED_EVENT_SET_VOLUME_LEVEL, "42"],
         )
@@ -121,29 +131,33 @@ async def test_handle_user_defined_volume_set_event(
 
 @pytest.mark.usefixtures("mock_integration")
 async def test_handle_user_defined_event(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_device: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: MagicMock,
 ) -> None:
     """Test test_handle_user_defined_event callback."""
+    update_callback = find_event_update_callback(
+        mock_device.dispatcher.connect, event.EVENT_USER_DEFINED
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        "event", "kaleidescape", f"{MOCK_SERIAL}-user_defined"
+    )
+    assert entity_id is not None
 
     # Test initial state
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
-    entry = entity_registry.async_get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert (
-        entity.attributes.get(ATTR_FRIENDLY_NAME)
-        == f"{FRIENDLY_NAME} User-defined event"
-    )
+    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
     assert entry.unique_id == f"{MOCK_SERIAL}-user_defined"
 
     # Test event handling
-    mock_device.dispatcher.send(
-        kaleidescape_const.USER_DEFINED_EVENT, ["custom_event", "42"]
-    )
+    update_callback(kaleidescape_const.USER_DEFINED_EVENT, ["custom_event", "42"])
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert re.match(r"^\d{4}-", entity.state) is not None
     assert CONF_COMMAND in entity.attributes
@@ -153,39 +167,48 @@ async def test_handle_user_defined_event(
     last_updated = entity.state
 
     # Test volume commands are ignored
-    mock_device.dispatcher.send(
+    update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_CAPABILITIES],
     )
     await hass.async_block_till_done()
     await asyncio.sleep(0)
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.state == last_updated
 
 
 @pytest.mark.usefixtures("mock_integration")
 async def test_handle_user_defined_event_empty_payload_ignored(
-    hass: HomeAssistant, mock_device: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_device: MagicMock,
 ) -> None:
     """Test invalid/unsupported payloads are ignored."""
+    update_callback = find_event_update_callback(
+        mock_device.dispatcher.connect, event.EVENT_USER_DEFINED
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        "event", "kaleidescape", f"{MOCK_SERIAL}-user_defined"
+    )
+    assert entity_id is not None
 
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
 
-    mock_device.dispatcher.send("not_user_defined_event", [])
+    update_callback("not_user_defined_event", [])
     await hass.async_block_till_done()
     await asyncio.sleep(0)
 
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
 
-    mock_device.dispatcher.send(kaleidescape_const.USER_DEFINED_EVENT, [])
+    update_callback(kaleidescape_const.USER_DEFINED_EVENT, [])
     await hass.async_block_till_done()
     await asyncio.sleep(0)
 
-    entity = hass.states.get(f"{ENTITY_ID}_user_defined_event")
+    entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -54,6 +54,7 @@ async def test_handle_user_defined_volume_event(
     last_updated = entity.state
 
     # Test repeated event updates timestamp
+    await asyncio.sleep(0.01)
     update_callback(
         kaleidescape_const.USER_DEFINED_EVENT,
         [kaleidescape_const.USER_DEFINED_EVENT_VOLUME_QUERY],

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -9,13 +9,11 @@ import pytest
 
 from homeassistant.components.kaleidescape import event
 from homeassistant.components.media_player import ATTR_MEDIA_VOLUME_LEVEL
-from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_COMMAND, CONF_PARAMS
+from homeassistant.const import CONF_COMMAND, CONF_PARAMS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import MOCK_SERIAL, find_event_update_callback
-
-FRIENDLY_NAME = f"Kaleidescape Device {MOCK_SERIAL}"
 
 
 @pytest.mark.usefixtures("mock_integration")
@@ -38,8 +36,9 @@ async def test_handle_user_defined_volume_event(
     entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
+    assert entry.has_entity_name is True
+    assert entry.translation_key == event.EVENT_VOLUME_QUERY
     assert entry.unique_id == f"{MOCK_SERIAL}-volume_query"
 
     # Test event handling
@@ -89,8 +88,9 @@ async def test_handle_user_defined_volume_set_event(
     entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
+    assert entry.has_entity_name is True
+    assert entry.translation_key == event.EVENT_VOLUME_SET
     assert entry.unique_id == f"{MOCK_SERIAL}-volume_set"
 
     # Test event handling
@@ -149,8 +149,9 @@ async def test_handle_user_defined_event(
     entry = entity_registry.async_get(entity_id)
     assert entity is not None
     assert entity.state == "unknown"
-    assert entity.attributes.get(ATTR_FRIENDLY_NAME) == FRIENDLY_NAME
     assert entry
+    assert entry.has_entity_name is True
+    assert entry.translation_key == event.EVENT_USER_DEFINED
     assert entry.unique_id == f"{MOCK_SERIAL}-user_defined"
 
     # Test event handling

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -132,7 +132,7 @@ async def test_handle_user_defined_event(
     assert entity.state == "unknown"
     assert (
         entity.attributes.get(ATTR_FRIENDLY_NAME)
-        == f"{FRIENDLY_NAME} User defined event"
+        == f"{FRIENDLY_NAME} User-defined event"
     )
     assert entry
     assert entry.unique_id == f"{MOCK_SERIAL}-user_defined"

--- a/tests/components/kaleidescape/test_event.py
+++ b/tests/components/kaleidescape/test_event.py
@@ -22,7 +22,7 @@ async def test_handle_user_defined_volume_event(
     entity_registry: er.EntityRegistry,
     mock_device: MagicMock,
 ) -> None:
-    """Test test_handle_user_defined_volume_event callback."""
+    """Verify volume query events update the event entity timestamp."""
     update_callback = find_event_update_callback(
         mock_device.dispatcher.connect, event.EVENT_VOLUME_QUERY
     )
@@ -74,7 +74,7 @@ async def test_handle_user_defined_volume_set_event(
     mock_device: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test test_handle_user_defined_volume_set_event callback."""
+    """Verify volume set events expose parsed volume level and debounce behavior."""
     monkeypatch.setattr(event, "DEBOUNCE_TIME", 0)
     update_callback = find_event_update_callback(
         mock_device.dispatcher.connect, event.EVENT_VOLUME_SET
@@ -136,7 +136,7 @@ async def test_handle_user_defined_event(
     entity_registry: er.EntityRegistry,
     mock_device: MagicMock,
 ) -> None:
-    """Test test_handle_user_defined_event callback."""
+    """Verify user-defined events expose command/params and ignore volume commands."""
     update_callback = find_event_update_callback(
         mock_device.dispatcher.connect, event.EVENT_USER_DEFINED
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

It was requested I split https://github.com/home-assistant/core/pull/158756 into multiple PRs. This one introduces a new Event platform.

Description mostly copied from the original:

Allows automations to use the volume management feature of Kaleidescape movie players, a hardware based streaming device. Some important considerations in how this feature was added to the HA integration:

The Kaleidescape hardware API just acts a gateway for volume/mute event commands. It does not hold or manage state at all.

The Kaleidescape handheld remote has volume up/down/mute buttons that on press generates events in their Control API. It's up to the integrator to do what they will with the event.

Kaleidescape also publishes a mobile app that allows users to send volume set/up/down/mute. In addition the app can receive feedback containing the current volume level (0-100), and mute state with it renders in its UI. These functions too are exposed through the device Control API, and up to the integrator to handle.

This facilitate automations by allowing the user to wire an AVR media_player (denon, sony, etc) to a Kaleidescape media_player. An automation can handle volume change requests from Kaleidescape hardware remotes and moble apps then forward them to a AVR media_player, and visa-versa; state changes to the AVR media_player can be sent back to the Kaleidescape hardware (volume_set 0-100, volume_mute true/false).

This PR implements one part of this solution.

New events to inform automations of an action:
kaleidescape.volume_up
kaleidescape.volume_down
kaleidescape.volume_mute
kaleidescape.volume_set (Kaleidescape mobile app slider moved)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43606
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
