### PR TITLE
Add switch tests to vesync

### DIFF
--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -71,38 +71,6 @@ async def test_switch_state(
         ),
     ],
 )
-async def test_turn_on_off_display_success(
-    hass: HomeAssistant,
-    humidifier_config_entry: MockConfigEntry,
-    aioclient_mock: AiohttpClientMocker,
-    action: str,
-    command: str,
-) -> None:
-    """Test switch turn on and off command with success response."""
-
-    mock_devices_response(aioclient_mock, "Humidifier 200s")
-
-    with (
-        patch(
-            command,
-            return_value=True,
-        ) as method_mock,
-        patch(
-            "homeassistant.components.vesync.switch.VeSyncSwitchEntity.async_write_ha_state"
-        ) as update_mock,
-    ):
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            action,
-            {ATTR_ENTITY_ID: ENTITY_SWITCH_DISPLAY},
-            blocking=True,
-        )
-
-    await hass.async_block_till_done()
-    method_mock.assert_called_once()
-    update_mock.assert_called_once()
-
-
 @pytest.mark.parametrize(
     ("action", "command"),
     [

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -71,19 +71,6 @@ async def test_switch_state(
         ),
     ],
 )
-@pytest.mark.parametrize(
-    ("action", "command"),
-    [
-        (
-            SERVICE_TURN_ON,
-            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
-        ),
-        (
-            SERVICE_TURN_OFF,
-            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
-        ),
-    ],
-)
 async def test_turn_on_off_display_raises_error(
     hass: HomeAssistant,
     humidifier_config_entry: MockConfigEntry,

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -143,3 +143,110 @@ async def test_turn_on_off_display_raises_error(
 
     await hass.async_block_till_done()
     method_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("device_name", "switch_key", "action", "command"),
+    [
+        # device_status switch for outlet
+        (
+            "Outlet",
+            "device_status",
+            SERVICE_TURN_ON,
+            "pyvesync.devices.vesyncoutlet.VeSyncOutlet.turn_on",
+        ),
+        (
+            "Outlet",
+            "device_status",
+            SERVICE_TURN_OFF,
+            "pyvesync.devices.vesyncoutlet.VeSyncOutlet.turn_off",
+        ),
+        # display switch for humidifier
+        (
+            "Humidifier 200s",
+            "display",
+            SERVICE_TURN_ON,
+            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
+        ),
+        (
+            "Humidifier 200s",
+            "display",
+            SERVICE_TURN_OFF,
+            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
+        ),
+        # auto_off_config switch for humidifier
+        (
+            "Humidifier 200s",
+            "auto_off_config",
+            SERVICE_TURN_ON,
+            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_automatic_stop",
+        ),
+        (
+            "Humidifier 200s",
+            "auto_off_config",
+            SERVICE_TURN_OFF,
+            "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_automatic_stop",
+        ),
+        # drying_mode_power_off switch for humidifier with drying mode
+        (
+            "Humidifier 6000s",
+            "drying_mode_power_off",
+            SERVICE_TURN_ON,
+            "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_drying_mode",
+        ),
+        (
+            "Humidifier 6000s",
+            "drying_mode_power_off",
+            SERVICE_TURN_OFF,
+            "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_drying_mode",
+        ),
+    ],
+)
+async def test_switch_operations(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    device_name: str,
+    switch_key: str,
+    action: str,
+    command: str,
+) -> None:
+    """Test all switch operations with appropriate devices and parameters."""
+
+    # Configure the API devices call for the specific device
+    mock_devices_response(aioclient_mock, device_name)
+
+    # Setup platform
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Find the switch entity for the specific switch key
+    switch_entity_id = None
+    for entity in er.async_entries_for_config_entry(
+        er.async_get(hass), config_entry.entry_id
+    ):
+        if entity.domain == SWITCH_DOMAIN and entity.unique_id.endswith(switch_key):
+            switch_entity_id = entity.entity_id
+            break
+
+    assert switch_entity_id is not None, f"No switch entity found for key {switch_key}"
+
+    with (
+        patch(
+            command,
+            return_value=True,
+        ) as method_mock,
+        patch(
+            "homeassistant.components.vesync.switch.VeSyncSwitchEntity.async_write_ha_state"
+        ) as update_mock,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            action,
+            {ATTR_ENTITY_ID: switch_entity_id},
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    method_mock.assert_called_once()
+    update_mock.assert_called_once()

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -101,57 +101,57 @@ async def test_turn_on_off_display_raises_error(
 
 
 @pytest.mark.parametrize(
-    ("device_name", "switch_key", "action", "command"),
+    ("device_name", "entity_id", "action", "command"),
     [
         # device_status switch for outlet
         (
             "Outlet",
-            "device_status",
+            "switch.outlet",
             SERVICE_TURN_ON,
             "pyvesync.devices.vesyncoutlet.VeSyncOutlet.turn_on",
         ),
         (
             "Outlet",
-            "device_status",
+            "switch.outlet",
             SERVICE_TURN_OFF,
             "pyvesync.devices.vesyncoutlet.VeSyncOutlet.turn_off",
         ),
         # display switch for humidifier
         (
             "Humidifier 200s",
-            "display",
+            "switch.humidifier_200s_display",
             SERVICE_TURN_ON,
             "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
         ),
         (
             "Humidifier 200s",
-            "display",
+            "switch.humidifier_200s_display",
             SERVICE_TURN_OFF,
             "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_display",
         ),
         # auto_off_config switch for humidifier
         (
             "Humidifier 200s",
-            "auto_off_config",
+            "switch.humidifier_200s_auto_off",
             SERVICE_TURN_ON,
             "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_automatic_stop",
         ),
         (
             "Humidifier 200s",
-            "auto_off_config",
+            "switch.humidifier_200s_auto_off",
             SERVICE_TURN_OFF,
             "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_automatic_stop",
         ),
         # drying_mode_power_off switch for humidifier with drying mode
         (
             "Humidifier 6000s",
-            "drying_mode_power_off",
+            "switch.humidifier_6000s_enable_drying_mode_while_power_is_off",
             SERVICE_TURN_ON,
             "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_drying_mode",
         ),
         (
             "Humidifier 6000s",
-            "drying_mode_power_off",
+            "switch.humidifier_6000s_enable_drying_mode_while_power_is_off",
             SERVICE_TURN_OFF,
             "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_drying_mode",
         ),
@@ -162,7 +162,7 @@ async def test_switch_operations(
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
     device_name: str,
-    switch_key: str,
+    entity_id: str,
     action: str,
     command: str,
 ) -> None:
@@ -174,17 +174,6 @@ async def test_switch_operations(
     # Setup platform
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-
-    # Find the switch entity for the specific switch key
-    switch_entity_id = None
-    for entity in er.async_entries_for_config_entry(
-        er.async_get(hass), config_entry.entry_id
-    ):
-        if entity.domain == SWITCH_DOMAIN and entity.unique_id.endswith(switch_key):
-            switch_entity_id = entity.entity_id
-            break
-
-    assert switch_entity_id is not None, f"No switch entity found for key {switch_key}"
 
     with (
         patch(
@@ -198,7 +187,7 @@ async def test_switch_operations(
         await hass.services.async_call(
             SWITCH_DOMAIN,
             action,
-            {ATTR_ENTITY_ID: switch_entity_id},
+            {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
 

--- a/tests/components/vesync/test_switch.py
+++ b/tests/components/vesync/test_switch.py
@@ -142,6 +142,19 @@ async def test_turn_on_off_display_raises_error(
             SERVICE_TURN_OFF,
             "pyvesync.devices.vesynchumidifier.VeSyncHumid200S.toggle_automatic_stop",
         ),
+        # child_lock switch for humidifier
+        (
+            "Humidifier 6000s",
+            "switch.humidifier_6000s_child_lock",
+            SERVICE_TURN_ON,
+            "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_child_lock",
+        ),
+        (
+            "Humidifier 6000s",
+            "switch.humidifier_6000s_child_lock",
+            SERVICE_TURN_OFF,
+            "pyvesync.devices.vesynchumidifier.VeSyncSuperior6000S.toggle_child_lock",
+        ),
         # drying_mode_power_off switch for humidifier with drying mode
         (
             "Humidifier 6000s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Test all existing switches for vesync.   Error testing to be added in a future PR.   Increases test coverage to 88% for switch.py.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
