### PR TITLE
Fix touchline_sl zone availability when alarm state is set

### DIFF
--- a/homeassistant/components/touchline_sl/entity.py
+++ b/homeassistant/components/touchline_sl/entity.py
@@ -35,4 +35,8 @@ class TouchlineSLZoneEntity(CoordinatorEntity[TouchlineSLModuleCoordinator]):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return super().available and self.zone_id in self.coordinator.data.zones
+        return (
+            super().available
+            and self.zone_id in self.coordinator.data.zones
+            and self.zone.alarm is None
+        )

--- a/tests/components/touchline_sl/conftest.py
+++ b/tests/components/touchline_sl/conftest.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from typing import NamedTuple
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -17,6 +17,39 @@ class FakeModule(NamedTuple):
 
     name: str
     id: str
+
+
+def make_mock_zone(
+    zone_id: int = 1, name: str = "Zone 1", alarm: str | None = None
+) -> MagicMock:
+    """Return a mock Zone with configurable alarm state."""
+    zone = MagicMock()
+    zone.id = zone_id
+    zone.name = name
+    zone.temperature = 21.5
+    zone.target_temperature = 22.0
+    zone.humidity = 45
+    zone.mode = "constantTemp"
+    zone.algorithm = "heating"
+    zone.relay_on = False
+    zone.alarm = alarm
+    zone.schedule = None
+    zone.enabled = True
+    zone.signal_strength = 100
+    zone.battery_level = None
+    return zone
+
+
+def make_mock_module(zones: list) -> MagicMock:
+    """Return a mock module with the given zones."""
+    module = MagicMock()
+    module.id = "deadbeef"
+    module.name = "Foobar"
+    module.type = "SL"
+    module.version = "1.0"
+    module.zones = AsyncMock(return_value=zones)
+    module.schedules = AsyncMock(return_value=[])
+    return module
 
 
 @pytest.fixture
@@ -44,6 +77,18 @@ def mock_touchlinesl_client() -> Generator[AsyncMock]:
         client = mock_client.return_value
         client.user_id.return_value = 12345
         client.modules.return_value = [FakeModule(name="Foobar", id="deadbeef")]
+        yield client
+
+
+@pytest.fixture
+def mock_touchlinesl_full_client() -> Generator[MagicMock]:
+    """Mock a pytouchlinesl client with full module/zone support."""
+    with patch(
+        "homeassistant.components.touchline_sl.TouchlineSL",
+        autospec=True,
+    ) as mock_client:
+        client = mock_client.return_value
+        client.user_id = AsyncMock(return_value=12345)
         yield client
 
 

--- a/tests/components/touchline_sl/conftest.py
+++ b/tests/components/touchline_sl/conftest.py
@@ -81,18 +81,6 @@ def mock_touchlinesl_client() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_touchlinesl_full_client() -> Generator[MagicMock]:
-    """Mock a pytouchlinesl client with full module/zone support."""
-    with patch(
-        "homeassistant.components.touchline_sl.TouchlineSL",
-        autospec=True,
-    ) as mock_client:
-        client = mock_client.return_value
-        client.user_id = AsyncMock(return_value=12345)
-        yield client
-
-
-@pytest.fixture
 def mock_config_entry() -> MockConfigEntry:
     """Mock a config entry."""
     return MockConfigEntry(

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -1,7 +1,6 @@
 """Tests for the Roth Touchline SL climate platform."""
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -10,54 +9,9 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
+from .conftest import make_mock_module, make_mock_zone
+
 ENTITY_ID = "climate.zone_1"
-
-
-def make_mock_zone(
-    zone_id: int = 1, name: str = "Zone 1", alarm: str | None = None
-) -> MagicMock:
-    """Return a mock Zone with configurable alarm state."""
-    zone = MagicMock()
-    zone.id = zone_id
-    zone.name = name
-    zone.temperature = 21.5
-    zone.target_temperature = 22.0
-    zone.humidity = 45
-    zone.mode = "constantTemp"
-    zone.algorithm = "heating"
-    zone.relay_on = False
-    zone.alarm = alarm
-    zone.schedule = None
-    zone.enabled = True
-    zone.signal_strength = 100
-    zone.battery_level = None
-    return zone
-
-
-def make_mock_module(zones: list) -> MagicMock:
-    """Return a mock module with the given zones."""
-    module = MagicMock()
-    module.id = "deadbeef"
-    module.name = "Foobar"
-    module.type = "SL"
-    module.version = "1.0"
-    module.zones = AsyncMock(return_value=zones)
-    module.schedules = AsyncMock(return_value=[])
-    return module
-
-
-@pytest.fixture
-def mock_touchlinesl_full_client(
-    mock_config_entry: MockConfigEntry,
-) -> Generator[MagicMock]:
-    """Mock a pytouchlinesl client with full module/zone support."""
-    with patch(
-        "homeassistant.components.touchline_sl.TouchlineSL",
-        autospec=True,
-    ) as mock_client:
-        client = mock_client.return_value
-        client.user_id = AsyncMock(return_value=12345)
-        yield client
 
 
 async def test_climate_zone_available(
@@ -79,32 +33,15 @@ async def test_climate_zone_available(
     assert state.state != STATE_UNAVAILABLE
 
 
-async def test_climate_zone_unavailable_on_no_communication(
+@pytest.mark.parametrize("alarm", ["no_communication", "sensor_damaged"])
+async def test_climate_zone_unavailable_on_alarm(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_touchlinesl_full_client: MagicMock,
+    alarm: str,
 ) -> None:
-    """Test that the climate entity is unavailable when zone reports noCommunication."""
-    zone = make_mock_zone(alarm="no_communication")
-    module = make_mock_module([zone])
-    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
-
-
-async def test_climate_zone_unavailable_on_sensor_damaged(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_touchlinesl_full_client: MagicMock,
-) -> None:
-    """Test that the climate entity is unavailable when zone reports sensorDamaged."""
-    zone = make_mock_zone(alarm="sensor_damaged")
+    """Test that the climate entity is unavailable when zone reports an alarm state."""
+    zone = make_mock_zone(alarm=alarm)
     module = make_mock_module([zone])
     mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
 

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -8,9 +8,9 @@ from homeassistant.components.climate import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
-
 from .conftest import make_mock_module, make_mock_zone
+
+from tests.common import MockConfigEntry
 
 ENTITY_ID = "climate.zone_1"
 

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -1,0 +1,114 @@
+"""Tests for the Roth Touchline SL climate platform."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.touchline_sl.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "climate.zone_1"
+
+
+def make_mock_zone(zone_id: int = 1, name: str = "Zone 1", alarm: str | None = None) -> MagicMock:
+    """Return a mock Zone with configurable alarm state."""
+    zone = MagicMock()
+    zone.id = zone_id
+    zone.name = name
+    zone.temperature = 21.5
+    zone.target_temperature = 22.0
+    zone.humidity = 45
+    zone.mode = "constantTemp"
+    zone.algorithm = "heating"
+    zone.relay_on = False
+    zone.alarm = alarm
+    zone.schedule = None
+    zone.enabled = True
+    zone.signal_strength = 100
+    zone.battery_level = None
+    return zone
+
+
+def make_mock_module(zones: list) -> MagicMock:
+    """Return a mock module with the given zones."""
+    module = MagicMock()
+    module.id = "deadbeef"
+    module.name = "Foobar"
+    module.type = "SL"
+    module.version = "1.0"
+    module.zones = AsyncMock(return_value=zones)
+    module.schedules = AsyncMock(return_value=[])
+    return module
+
+
+@pytest.fixture
+def mock_touchlinesl_full_client(mock_config_entry: MockConfigEntry) -> Generator[MagicMock]:
+    """Mock a pytouchlinesl client with full module/zone support."""
+    with patch(
+        "homeassistant.components.touchline_sl.TouchlineSL",
+        autospec=True,
+    ) as mock_client:
+        client = mock_client.return_value
+        client.user_id = AsyncMock(return_value=12345)
+        yield client
+
+
+async def test_climate_zone_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_touchlinesl_full_client: MagicMock,
+) -> None:
+    """Test that the climate entity is available when zone has no alarm."""
+    zone = make_mock_zone(alarm=None)
+    module = make_mock_module([zone])
+    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+async def test_climate_zone_unavailable_on_no_communication(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_touchlinesl_full_client: MagicMock,
+) -> None:
+    """Test that the climate entity is unavailable when zone reports noCommunication."""
+    zone = make_mock_zone(alarm="no_communication")
+    module = make_mock_module([zone])
+    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_climate_zone_unavailable_on_sensor_damaged(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_touchlinesl_full_client: MagicMock,
+) -> None:
+    """Test that the climate entity is unavailable when zone reports sensorDamaged."""
+    zone = make_mock_zone(alarm="sensor_damaged")
+    module = make_mock_module([zone])
+    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from homeassistant.components.climate import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
@@ -17,12 +18,12 @@ ENTITY_ID = "climate.zone_1"
 async def test_climate_zone_available(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_touchlinesl_full_client: MagicMock,
+    mock_touchlinesl_client: MagicMock,
 ) -> None:
     """Test that the climate entity is available when zone has no alarm."""
     zone = make_mock_zone(alarm=None)
     module = make_mock_module([zone])
-    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
+    mock_touchlinesl_client.modules = AsyncMock(return_value=[module])
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -30,20 +31,20 @@ async def test_climate_zone_available(
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.state != STATE_UNAVAILABLE
+    assert state.state == HVACMode.HEAT
 
 
 @pytest.mark.parametrize("alarm", ["no_communication", "sensor_damaged"])
 async def test_climate_zone_unavailable_on_alarm(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_touchlinesl_full_client: MagicMock,
+    mock_touchlinesl_client: MagicMock,
     alarm: str,
 ) -> None:
     """Test that the climate entity is unavailable when zone reports an alarm state."""
     zone = make_mock_zone(alarm=alarm)
     module = make_mock_module([zone])
-    mock_touchlinesl_full_client.modules = AsyncMock(return_value=[module])
+    mock_touchlinesl_client.modules = AsyncMock(return_value=[module])
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/touchline_sl/test_climate.py
+++ b/tests/components/touchline_sl/test_climate.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from homeassistant.components.touchline_sl.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
@@ -14,7 +13,9 @@ from tests.common import MockConfigEntry
 ENTITY_ID = "climate.zone_1"
 
 
-def make_mock_zone(zone_id: int = 1, name: str = "Zone 1", alarm: str | None = None) -> MagicMock:
+def make_mock_zone(
+    zone_id: int = 1, name: str = "Zone 1", alarm: str | None = None
+) -> MagicMock:
     """Return a mock Zone with configurable alarm state."""
     zone = MagicMock()
     zone.id = zone_id
@@ -46,7 +47,9 @@ def make_mock_module(zones: list) -> MagicMock:
 
 
 @pytest.fixture
-def mock_touchlinesl_full_client(mock_config_entry: MockConfigEntry) -> Generator[MagicMock]:
+def mock_touchlinesl_full_client(
+    mock_config_entry: MockConfigEntry,
+) -> Generator[MagicMock]:
     """Mock a pytouchlinesl client with full module/zone support."""
     with patch(
         "homeassistant.components.touchline_sl.TouchlineSL",


### PR DESCRIPTION
When a Touchline SL zone reports noCommunication or sensorDamaged, the underlying pytouchlinesl library exposes this via Zone.alarm. However, the HA integration ignored this alarm state and continued to report the entity as available, showing stale temperature data.

This fix marks the entity as unavailable when zone.alarm is not None, which covers both 'no_communication' and 'sensor_damaged' alarm states.

Fixes a real-world scenario where a zone controller loses contact with the room thermostat (e.g. low battery or interference) — the Roth app correctly shows 'No Communication', but HA showed stale data instead.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
When a Touchline SL zone loses contact with its thermostat, the Roth
controller reports the zone as `noCommunication` or `sensorDamaged`.
The `pytouchlinesl` library exposes this via `Zone.alarm`, but the
integration ignored it — marking the entity as available and showing
stale temperature data.

This PR makes the entity unavailable when `zone.alarm is not None`,
which correctly reflects both alarm states to the user.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163339

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
