### PR TITLE
Reconfiguration flow Watts Vision + and platinium level

### DIFF
--- a/homeassistant/components/watts/config_flow.py
+++ b/homeassistant/components/watts/config_flow.py
@@ -80,7 +80,7 @@ class OAuth2FlowHandler(
         await self.async_set_unique_id(user_id)
 
         if self.source == SOURCE_REAUTH:
-            self._abort_if_unique_id_mismatch(reason="reauth_account_mismatch")
+            self._abort_if_unique_id_mismatch(reason="account_mismatch")
 
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
@@ -88,7 +88,7 @@ class OAuth2FlowHandler(
             )
 
         if self.source == SOURCE_RECONFIGURE:
-            self._abort_if_unique_id_mismatch(reason="reconfigure_account_mismatch")
+            self._abort_if_unique_id_mismatch(reason="account_mismatch")
 
             return self.async_update_reload_and_abort(
                 self._get_reconfigure_entry(),

--- a/homeassistant/components/watts/config_flow.py
+++ b/homeassistant/components/watts/config_flow.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from visionpluspython.auth import WattsVisionAuth
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlowResult,
+)
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import DOMAIN, OAUTH2_SCOPES
@@ -52,6 +56,18 @@ class OAuth2FlowHandler(
             }
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        return await self.async_step_pick_implementation(
+            user_input={
+                "implementation": self._get_reconfigure_entry().data[
+                    "auth_implementation"
+                ]
+            }
+        )
+
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> ConfigFlowResult:
         """Create an entry for the OAuth2 flow."""
 
@@ -68,6 +84,14 @@ class OAuth2FlowHandler(
 
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
+                data=data,
+            )
+
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(reason="reconfigure_account_mismatch")
+
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
                 data=data,
             )
 

--- a/homeassistant/components/watts/manifest.json
+++ b/homeassistant/components/watts/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": ["application_credentials", "cloud"],
   "documentation": "https://www.home-assistant.io/integrations/watts",
   "iot_class": "cloud_polling",
-  "quality_scale": "silver",
+  "quality_scale": "platinum",
   "requirements": ["visionpluspython==1.0.2"]
 }

--- a/homeassistant/components/watts/quality_scale.yaml
+++ b/homeassistant/components/watts/quality_scale.yaml
@@ -60,7 +60,7 @@ rules:
   icon-translations:
     status: exempt
     comment: Thermostat entities use standard HA Climate entity.
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: No actionable repair scenarios, auth issues are handled by reauthentication flow.

--- a/homeassistant/components/watts/strings.json
+++ b/homeassistant/components/watts/strings.json
@@ -14,6 +14,8 @@
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_account_mismatch": "The authenticated account does not match the account that needed re-authentication",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_account_mismatch": "The authenticated account does not match the account that needed reconfiguration",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "create_entry": {

--- a/homeassistant/components/watts/strings.json
+++ b/homeassistant/components/watts/strings.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "abort": {
+      "account_mismatch": "The authenticated account does not match the configured account",
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "authorize_url_timeout": "[%key:common::config_flow::abort::oauth2_authorize_url_timeout%]",
@@ -12,9 +13,7 @@
       "oauth_implementation_unavailable": "[%key:common::config_flow::abort::oauth2_implementation_unavailable%]",
       "oauth_timeout": "[%key:common::config_flow::abort::oauth2_timeout%]",
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
-      "reauth_account_mismatch": "The authenticated account does not match the account that needed re-authentication",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "reconfigure_account_mismatch": "The authenticated account does not match the account that needed reconfiguration",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },

--- a/tests/components/watts/test_config_flow.py
+++ b/tests/components/watts/test_config_flow.py
@@ -297,7 +297,7 @@ async def test_reauth_account_mismatch(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reauth_account_mismatch"
+    assert result["reason"] == "account_mismatch"
 
 
 @pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
@@ -390,7 +390,7 @@ async def test_reconfigure_account_mismatch(
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_account_mismatch"
+    assert result["reason"] == "account_mismatch"
 
 
 @pytest.mark.usefixtures("current_request_with_host")

--- a/tests/components/watts/test_config_flow.py
+++ b/tests/components/watts/test_config_flow.py
@@ -300,6 +300,99 @@ async def test_reauth_account_mismatch(
     assert result["reason"] == "reauth_account_mismatch"
 
 
+@pytest.mark.usefixtures("current_request_with_host", "mock_setup_entry")
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reconfiguration flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "new-refresh-token",
+            "access_token": "new-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.watts.config_flow.WattsVisionAuth.extract_user_id_from_token",
+        return_value="test-user-id",
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    mock_config_entry.data["token"].pop("expires_at")
+    assert mock_config_entry.data["token"] == {
+        "refresh_token": "new-refresh-token",
+        "access_token": "new-access-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_reconfigure_account_mismatch(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfiguration with a different account aborts."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "new-refresh-token",
+            "access_token": "new-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.watts.config_flow.WattsVisionAuth.extract_user_id_from_token",
+        return_value="different-user-id",
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_account_mismatch"
+
+
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_unique_config_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Reconfiguration flow for Watts Vision + and reach Platinium level

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
