### PR TITLE
Set last_reported timestamp for Satel Integra entities

### DIFF
--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -102,11 +102,8 @@ class SatelIntegraAlarmPanel(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        state = self._read_alarm_state()
-
-        if state != self._attr_alarm_state:
-            self._attr_alarm_state = state
-            self.async_write_ha_state()
+        self._attr_alarm_state = self._read_alarm_state()
+        self.async_write_ha_state()
 
     def _read_alarm_state(self) -> AlarmControlPanelState | None:
         """Read current status of the alarm and translate it into HA status."""

--- a/homeassistant/components/satel_integra/binary_sensor.py
+++ b/homeassistant/components/satel_integra/binary_sensor.py
@@ -103,10 +103,8 @@ class SatelIntegraBinarySensor[_CoordinatorT: SatelIntegraBaseCoordinator](
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        new_state = self._get_state_from_coordinator()
-        if new_state != self._attr_is_on:
-            self._attr_is_on = new_state
-            self.async_write_ha_state()
+        self._attr_is_on = self._get_state_from_coordinator()
+        self.async_write_ha_state()
 
     def _get_state_from_coordinator(self) -> bool | None:
         """Method to get binary sensor state from coordinator data."""

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -74,10 +74,8 @@ class SatelIntegraSwitch(
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        new_state = self._get_state_from_coordinator()
-        if new_state != self._attr_is_on:
-            self._attr_is_on = new_state
-            self.async_write_ha_state()
+        self._attr_is_on = self._get_state_from_coordinator()
+        self.async_write_ha_state()
 
     def _get_state_from_coordinator(self) -> bool | None:
         """Method to get switch state from coordinator data."""

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from satel_integra.satel_integra import AlarmState
 from syrupy.assertion import SnapshotAssertion
@@ -26,7 +27,12 @@ from homeassistant.helpers.entity_registry import EntityRegistry
 
 from . import MOCK_CODE, MOCK_ENTRY_ID, get_monitor_callbacks, setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_fire_time_changed,
+    snapshot_platform,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -163,3 +169,29 @@ async def test_alarm_control_panel_disarming(
     mock_satel.disarm.assert_awaited_once_with(MOCK_CODE, [1])
 
     mock_satel.clear_alarm.assert_awaited_once_with(MOCK_CODE, [1])
+
+
+async def test_alarm_panel_last_reported(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensors only update last_reported if same state is reported."""
+    events = async_capture_events(hass, "state_changed")
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    first_reported = hass.states.get("alarm_control_panel.home").last_reported
+    assert first_reported is not None
+    # Initial state change event
+    assert len(events) == 1
+
+    freezer.tick(1)
+    async_fire_time_changed(hass)
+
+    # Run callbacks with same payload
+    alarm_panel_update_method, _, _ = get_monitor_callbacks(mock_satel)
+    alarm_panel_update_method()
+
+    assert first_reported != hass.states.get("alarm_control_panel.home").last_reported
+    assert len(events) == 1  # last_reported shall not fire state_changed

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -177,7 +177,7 @@ async def test_alarm_panel_last_reported(
     mock_config_entry_with_subentries: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test binary sensors only update last_reported if same state is reported."""
+    """Test alarm panels update last_reported if same state is reported."""
     events = async_capture_events(hass, "state_changed")
     await setup_integration(hass, mock_config_entry_with_subentries)
 

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -131,7 +131,7 @@ async def test_binary_sensor_last_reported(
     mock_config_entry_with_subentries: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test binary sensors only update last_reported if same state is reported."""
+    """Test binary sensors update last_reported if same state is reported."""
     events = async_capture_events(hass, "state_changed")
     await setup_integration(hass, mock_config_entry_with_subentries)
 

--- a/tests/components/satel_integra/test_binary_sensor.py
+++ b/tests/components/satel_integra/test_binary_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -15,7 +16,12 @@ from homeassistant.helpers.entity_registry import EntityRegistry
 
 from . import get_monitor_callbacks, setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_fire_time_changed,
+    snapshot_platform,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -117,3 +123,30 @@ async def test_binary_sensor_callback(
     zone_update_method({"zones": {2: 1}})
     assert hass.states.get("binary_sensor.zone").state == STATE_UNKNOWN
     assert hass.states.get("binary_sensor.output").state == STATE_UNKNOWN
+
+
+async def test_binary_sensor_last_reported(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensors only update last_reported if same state is reported."""
+    events = async_capture_events(hass, "state_changed")
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    first_reported = hass.states.get("binary_sensor.zone").last_reported
+    assert first_reported is not None
+    # Initial 2 state change events for both zone and output
+    assert len(events) == 2
+
+    freezer.tick(1)
+    async_fire_time_changed(hass)
+
+    # Run callbacks with same payload
+    _, zone_update_method, output_update_method = get_monitor_callbacks(mock_satel)
+    output_update_method({"outputs": {1: 0}})
+    zone_update_method({"zones": {1: 0}})
+
+    assert first_reported != hass.states.get("binary_sensor.zone").last_reported
+    assert len(events) == 2  # last_reported shall not fire state_changed

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -158,7 +158,7 @@ async def test_switch_last_reported(
     mock_config_entry_with_subentries: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test binary sensors only update last_reported if same state is reported."""
+    """Test switches update last_reported if same state is reported."""
     events = async_capture_events(hass, "state_changed")
     await setup_integration(hass, mock_config_entry_with_subentries)
 

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -25,7 +26,12 @@ from homeassistant.helpers.entity_registry import EntityRegistry
 
 from . import MOCK_CODE, MOCK_ENTRY_ID, get_monitor_callbacks, setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_fire_time_changed,
+    snapshot_platform,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -144,3 +150,29 @@ async def test_switch_change_state(
 
     assert hass.states.get("switch.switchable_output").state == STATE_OFF
     mock_satel.set_output.assert_awaited_once_with(MOCK_CODE, 1, False)
+
+
+async def test_switch_last_reported(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test binary sensors only update last_reported if same state is reported."""
+    events = async_capture_events(hass, "state_changed")
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    first_reported = hass.states.get("switch.switchable_output").last_reported
+    assert first_reported is not None
+    # Initial state change event
+    assert len(events) == 1
+
+    freezer.tick(1)
+    async_fire_time_changed(hass)
+
+    # Run callbacks with same payload
+    _, _, output_update_method = get_monitor_callbacks(mock_satel)
+    output_update_method({"outputs": {1: 0}})
+
+    assert first_reported != hass.states.get("switch.switchable_output").last_reported
+    assert len(events) == 1  # last_reported shall not fire state_changed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In https://github.com/home-assistant/core/pull/158533 a coordinator pattern was added to the Satel Integra integration. Data reporting is now split in 3 coordinators, depending on the source data type (partitions, zones, outputs), with each coordinator reporting the entire list of source data.

In this PR I have removed the internal check on state change (this was leftover from YAML configuration). This allows Home Assistant to record the `last_reported` timestamp on the entities, whenever the entity's own coordinator report it's data, even if the state didn't change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
