### PR TITLE
Add missing data_description for reauth_confirm token in Splunk

### DIFF
--- a/homeassistant/components/splunk/quality_scale.yaml
+++ b/homeassistant/components/splunk/quality_scale.yaml
@@ -12,10 +12,7 @@ rules:
   common-modules: done
   config-entry-unloading: done
   config-flow-test-coverage: done
-  config-flow:
-    status: todo
-    comment: |
-      Missing `data_description` for `token` in `config.step.reauth_confirm` in strings.json. Tests fail with: "Translation not found for splunk: config.step.reauth_confirm.data_description.token".
+  config-flow: done
   dependency-transparency:
     status: todo
     comment: |

--- a/homeassistant/components/splunk/strings.json
+++ b/homeassistant/components/splunk/strings.json
@@ -20,6 +20,9 @@
         "data": {
           "token": "HTTP Event Collector token"
         },
+        "data_description": {
+          "token": "The HEC token configured in your Splunk instance"
+        },
         "description": "The Splunk token is no longer valid. Please enter a new HTTP Event Collector token.",
         "title": "Reauthenticate Splunk"
       },


### PR DESCRIPTION
## Proposed change

Add missing `data_description` for the `token` field in the `reauth_confirm` step of the Splunk integration's config flow. This fixes a translation-not-found error that occurs when the reauthentication flow is triggered. The description text matches what is already used in the `user` step for the same field.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes quality scale config-flow check
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr