### PR TITLE
Mark runtime-data quality as exempt in Splunk

### DIFF
--- a/homeassistant/components/splunk/quality_scale.yaml
+++ b/homeassistant/components/splunk/quality_scale.yaml
@@ -48,9 +48,11 @@ rules:
   integration-owner: done
   reauthentication-flow: done
   runtime-data:
-    status: todo
+    status: exempt
     comment: |
-      Replace hass.data[DATA_FILTER] storage with entry.runtime_data. Create typed ConfigEntry in const.py as 'type SplunkConfigEntry = ConfigEntry[EntityFilter]', update async_setup_entry signature to use SplunkConfigEntry, replace hass.data[DATA_FILTER] assignments with entry.runtime_data, and update all references including line 236 in __init__.py.
+      Integration has no per-entry runtime state to store. The only data in
+      hass.data is a YAML entity filter bridged from async_setup to
+      async_setup_entry; no platforms or other code accesses it afterward.
   test-before-configure: done
   test-before-setup: done
   test-coverage: done


### PR DESCRIPTION
## Proposed change

Mark the `runtime-data` quality scale rule as exempt for the Splunk integration. The integration has no per-entry runtime state to store — the only data in `hass.data` is a YAML entity filter bridged from `async_setup` to `async_setup_entry`, with no platforms or other code accessing it afterward.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr