### PR TITLE
Use opening/closing state for Z-Wave covers

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -87,8 +87,6 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
     _current_position_value: ZwaveValue | None = None
     _target_position_value: ZwaveValue | None = None
     _stop_position_value: ZwaveValue | None = None
-    _is_opening: bool = False
-    _is_closing: bool = False
 
     def _set_position_values(
         self,
@@ -148,16 +146,6 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         if not (value := self._current_position_value) or value.value is None:
             return None
         return bool(value.value == self._fully_closed_position)
-
-    @property
-    def is_opening(self) -> bool:
-        """Return if the cover is opening."""
-        return self._is_opening
-
-    @property
-    def is_closing(self) -> bool:
-        """Return if the cover is closing."""
-        return self._is_closing
 
     def _set_moving_state_from_direction(self, target_position: int) -> None:
         """Set opening/closing state based on target vs current position."""

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -147,23 +147,6 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             return None
         return bool(value.value == self._fully_closed_position)
 
-    def _set_moving_state_from_direction(self, target_position: int) -> None:
-        """Set opening/closing state based on target vs current position."""
-        current_value = self._current_position_value
-        if current_value is None or current_value.value is None:
-            return
-
-        if target_position > current_value.value:
-            self._attr_is_opening = True
-            self._attr_is_closing = False
-        elif target_position < current_value.value:
-            self._attr_is_opening = False
-            self._attr_is_closing = True
-        else:
-            return
-
-        self.async_write_ha_state()
-
     @callback
     def on_value_update(self) -> None:
         """Clear moving state when current position reaches target."""
@@ -171,11 +154,10 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             return
 
         if (
-            self._current_position_value is not None
-            and self._target_position_value is not None
-            and self._current_position_value.value is not None
-            and self._target_position_value.value is not None
-            and self._current_position_value.value == self._target_position_value.value
+            (current := self._current_position_value) is not None
+            and (target := self._target_position_value) is not None
+            and current.value is not None
+            and current.value == target.value
         ):
             self._attr_is_opening = False
             self._attr_is_closing = False
@@ -191,44 +173,55 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             return None
         return self.zwave_to_percent_position(self._current_position_value.value)
 
+    async def _async_set_position_and_update_moving_state(
+        self, target_position: int
+    ) -> None:
+        """Set the target position and update the moving state if applicable."""
+        assert self._target_position_value
+        result = await self._async_set_value(
+            self._target_position_value, target_position
+        )
+        if (
+            # If the command is unsupervised, or the device reported that it started
+            # working, we can assume the cover is moving in the desired direction.
+            result is None
+            or result.status
+            not in (SetValueStatus.WORKING, SetValueStatus.SUCCESS_UNSUPERVISED)
+            # If we don't know the current position, we don't know which direction
+            # the cover is moving, so we can't update the moving state.
+            or (current_value := self._current_position_value) is None
+            or (current := current_value.value) is None
+        ):
+            return
+
+        if target_position > current:
+            self._attr_is_opening = True
+            self._attr_is_closing = False
+        elif target_position < current:
+            self._attr_is_opening = False
+            self._attr_is_closing = True
+        else:
+            return
+
+        self.async_write_ha_state()
+
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
-        assert self._target_position_value
-        target = self.percent_to_zwave_position(kwargs[ATTR_POSITION])
-        result = await self._async_set_value(self._target_position_value, target)
-        # If the command is unsupervised, or the device reported that it started working
-        # we can assume that the cover is moving in the desired direction.
-        if result is not None and result.status in (
-            SetValueStatus.WORKING,
-            SetValueStatus.SUCCESS_UNSUPERVISED,
-        ):
-            self._set_moving_state_from_direction(target)
+        await self._async_set_position_and_update_moving_state(
+            self.percent_to_zwave_position(kwargs[ATTR_POSITION])
+        )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        assert self._target_position_value
-        target = self._fully_open_position
-        result = await self._async_set_value(self._target_position_value, target)
-        # If the command is unsupervised, or the device reported that it started working
-        # we can assume that the cover is moving in the desired direction.
-        if result is not None and result.status in (
-            SetValueStatus.WORKING,
-            SetValueStatus.SUCCESS_UNSUPERVISED,
-        ):
-            self._set_moving_state_from_direction(target)
+        await self._async_set_position_and_update_moving_state(
+            self._fully_open_position
+        )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        assert self._target_position_value
-        target = self._fully_closed_position
-        result = await self._async_set_value(self._target_position_value, target)
-        # If the command is unsupervised, or the device reported that it started working
-        # we can assume that the cover is moving in the desired direction.
-        if result is not None and result.status in (
-            SetValueStatus.WORKING,
-            SetValueStatus.SUCCESS_UNSUPERVISED,
-        ):
-            self._set_moving_state_from_direction(target)
+        await self._async_set_position_and_update_moving_state(
+            self._fully_closed_position
+        )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -229,7 +229,10 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         # Stop the cover, will stop regardless of the actual direction of travel.
         result = await self._async_set_value(self._stop_position_value, False)
         # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
-        if result is not None and result.status in SET_VALUE_SUCCESS:
+        if result is not None and result.status in (
+            SetValueStatus.SUCCESS,
+            SetValueStatus.SUCCESS_UNSUPERVISED,
+        ):
             self._attr_is_opening = False
             self._attr_is_closing = False
             self.async_write_ha_state()
@@ -494,8 +497,11 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         result = await self._async_set_value(self._up_value, False)
-        # StartLevelChange: SUCCESS means the device has stopped moving
-        if result is not None and result.status in SET_VALUE_SUCCESS:
+        # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
+        if result is not None and result.status in (
+            SetValueStatus.SUCCESS,
+            SetValueStatus.SUCCESS_UNSUPERVISED,
+        ):
             self._attr_is_opening = False
             self._attr_is_closing = False
             self.async_write_ha_state()

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -166,11 +166,11 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             return
 
         if target_position > current_value.value:
-            self._is_opening = True
-            self._is_closing = False
+            self._attr_is_opening = True
+            self._attr_is_closing = False
         elif target_position < current_value.value:
-            self._is_opening = False
-            self._is_closing = True
+            self._attr_is_opening = False
+            self._attr_is_closing = True
         else:
             return
 
@@ -179,7 +179,7 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
     @callback
     def on_value_update(self) -> None:
         """Clear moving state when current position reaches target."""
-        if not self._is_opening and not self._is_closing:
+        if not self._attr_is_opening and not self._attr_is_closing:
             return
 
         if (
@@ -189,8 +189,8 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             and self._target_position_value.value is not None
             and self._current_position_value.value == self._target_position_value.value
         ):
-            self._is_opening = False
-            self._is_closing = False
+            self._attr_is_opening = False
+            self._attr_is_closing = False
 
     @property
     def current_cover_position(self) -> int | None:
@@ -249,8 +249,8 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         result = await self._async_set_value(self._stop_position_value, False)
         # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
         if result is not None and result.status in SET_VALUE_SUCCESS:
-            self._is_opening = False
-            self._is_closing = False
+            self._attr_is_opening = False
+            self._attr_is_closing = False
             self.async_write_ha_state()
 
 
@@ -497,8 +497,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
         result = await self._async_set_value(self._up_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
         if result is not None and result.status in SET_VALUE_SUCCESS:
-            self._is_opening = True
-            self._is_closing = False
+            self._attr_is_opening = True
+            self._attr_is_closing = False
             self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
@@ -506,8 +506,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
         result = await self._async_set_value(self._down_value, True)
         # StartLevelChange: SUCCESS means the device started moving in the desired direction
         if result is not None and result.status in SET_VALUE_SUCCESS:
-            self._is_opening = False
-            self._is_closing = True
+            self._attr_is_opening = False
+            self._attr_is_closing = True
             self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
@@ -515,8 +515,8 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
         result = await self._async_set_value(self._up_value, False)
         # StartLevelChange: SUCCESS means the device has stopped moving
         if result is not None and result.status in SET_VALUE_SUCCESS:
-            self._is_opening = False
-            self._is_closing = False
+            self._attr_is_opening = False
+            self._attr_is_closing = False
             self.async_write_ha_state()
 
 

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -6,8 +6,10 @@ from typing import Any, cast
 
 from zwave_js_server.const import (
     CURRENT_VALUE_PROPERTY,
+    SET_VALUE_SUCCESS,
     TARGET_STATE_PROPERTY,
     TARGET_VALUE_PROPERTY,
+    SetValueStatus,
 )
 from zwave_js_server.const.command_class.barrier_operator import BarrierState
 from zwave_js_server.const.command_class.multilevel_switch import (
@@ -85,6 +87,8 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
     _current_position_value: ZwaveValue | None = None
     _target_position_value: ZwaveValue | None = None
     _stop_position_value: ZwaveValue | None = None
+    _is_opening: bool = False
+    _is_closing: bool = False
 
     def _set_position_values(
         self,
@@ -146,6 +150,49 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         return bool(value.value == self._fully_closed_position)
 
     @property
+    def is_opening(self) -> bool:
+        """Return if the cover is opening."""
+        return self._is_opening
+
+    @property
+    def is_closing(self) -> bool:
+        """Return if the cover is closing."""
+        return self._is_closing
+
+    def _set_moving_state_from_direction(self, target_position: int) -> None:
+        """Set opening/closing state based on target vs current position."""
+        current_value = self._current_position_value
+        if current_value is None or current_value.value is None:
+            return
+
+        if target_position > current_value.value:
+            self._is_opening = True
+            self._is_closing = False
+        elif target_position < current_value.value:
+            self._is_opening = False
+            self._is_closing = True
+        else:
+            return
+
+        self.async_write_ha_state()
+
+    @callback
+    def on_value_update(self) -> None:
+        """Clear moving state when current position reaches target."""
+        if not self._is_opening and not self._is_closing:
+            return
+
+        if (
+            self._current_position_value is not None
+            and self._target_position_value is not None
+            and self._current_position_value.value is not None
+            and self._target_position_value.value is not None
+            and self._current_position_value.value == self._target_position_value.value
+        ):
+            self._is_opening = False
+            self._is_closing = False
+
+    @property
     def current_cover_position(self) -> int | None:
         """Return the current position of cover where 0 means closed and 100 is fully open."""
         if (
@@ -159,30 +206,52 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         assert self._target_position_value
-        await self._async_set_value(
-            self._target_position_value,
-            self.percent_to_zwave_position(kwargs[ATTR_POSITION]),
-        )
+        target = self.percent_to_zwave_position(kwargs[ATTR_POSITION])
+        result = await self._async_set_value(self._target_position_value, target)
+        # If the command is unsupervised, or the device reported that it started working
+        # we can assume that the cover is moving in the desired direction.
+        if result is not None and result.status in (
+            SetValueStatus.WORKING,
+            SetValueStatus.SUCCESS_UNSUPERVISED,
+        ):
+            self._set_moving_state_from_direction(target)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         assert self._target_position_value
-        await self._async_set_value(
-            self._target_position_value, self._fully_open_position
-        )
+        target = self._fully_open_position
+        result = await self._async_set_value(self._target_position_value, target)
+        # If the command is unsupervised, or the device reported that it started working
+        # we can assume that the cover is moving in the desired direction.
+        if result is not None and result.status in (
+            SetValueStatus.WORKING,
+            SetValueStatus.SUCCESS_UNSUPERVISED,
+        ):
+            self._set_moving_state_from_direction(target)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         assert self._target_position_value
-        await self._async_set_value(
-            self._target_position_value, self._fully_closed_position
-        )
+        target = self._fully_closed_position
+        result = await self._async_set_value(self._target_position_value, target)
+        # If the command is unsupervised, or the device reported that it started working
+        # we can assume that the cover is moving in the desired direction.
+        if result is not None and result.status in (
+            SetValueStatus.WORKING,
+            SetValueStatus.SUCCESS_UNSUPERVISED,
+        ):
+            self._set_moving_state_from_direction(target)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop cover."""
         assert self._stop_position_value
         # Stop the cover, will stop regardless of the actual direction of travel.
-        await self._async_set_value(self._stop_position_value, False)
+        result = await self._async_set_value(self._stop_position_value, False)
+        # When stopping is successful (or unsupervised), we can assume the cover has stopped moving.
+        if result is not None and result.status in SET_VALUE_SUCCESS:
+            self._is_opening = False
+            self._is_closing = False
+            self.async_write_ha_state()
 
 
 class CoverTiltMixin(ZWaveBaseEntity, CoverEntity):
@@ -425,15 +494,30 @@ class ZWaveWindowCovering(CoverPositionMixin, CoverTiltMixin):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._async_set_value(self._up_value, True)
+        result = await self._async_set_value(self._up_value, True)
+        # StartLevelChange: SUCCESS means the device started moving in the desired direction
+        if result is not None and result.status in SET_VALUE_SUCCESS:
+            self._is_opening = True
+            self._is_closing = False
+            self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._async_set_value(self._down_value, True)
+        result = await self._async_set_value(self._down_value, True)
+        # StartLevelChange: SUCCESS means the device started moving in the desired direction
+        if result is not None and result.status in SET_VALUE_SUCCESS:
+            self._is_opening = False
+            self._is_closing = True
+            self.async_write_ha_state()
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._async_set_value(self._up_value, False)
+        result = await self._async_set_value(self._up_value, False)
+        # StartLevelChange: SUCCESS means the device has stopped moving
+        if result is not None and result.status in SET_VALUE_SUCCESS:
+            self._is_opening = False
+            self._is_closing = False
+            self.async_write_ha_state()
 
 
 class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -11,6 +11,7 @@ from zwave_js_server.const import (
     CURRENT_STATE_PROPERTY,
     CURRENT_VALUE_PROPERTY,
     CommandClass,
+    SetValueStatus,
 )
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
@@ -1265,7 +1266,9 @@ async def test_multilevel_switch_cover_moving_state_working(
     assert state.state == CoverState.CLOSED
 
     # Simulate Supervision WORKING response
-    client.async_send_command.return_value = {"result": {"status": 1}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.WORKING}
+    }
 
     # Open cover - should set OPENING state
     await hass.services.async_call(
@@ -1378,7 +1381,9 @@ async def test_multilevel_switch_cover_moving_state_closing(
     assert state.state == CoverState.OPEN
 
     # Simulate Supervision WORKING response
-    client.async_send_command.return_value = {"result": {"status": 1}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.WORKING}
+    }
 
     # Close cover - should set CLOSING state
     await hass.services.async_call(
@@ -1431,7 +1436,9 @@ async def test_multilevel_switch_cover_moving_state_unsupervised(
     assert state.state == CoverState.CLOSED
 
     # Simulate SUCCESS_UNSUPERVISED response
-    client.async_send_command.return_value = {"result": {"status": 254}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.SUCCESS_UNSUPERVISED}
+    }
 
     # Open cover - should set OPENING state optimistically
     await hass.services.async_call(
@@ -1457,7 +1464,9 @@ async def test_multilevel_switch_cover_moving_state_stop_clears(
     assert state.state == CoverState.CLOSED
 
     # Simulate WORKING response
-    client.async_send_command.return_value = {"result": {"status": 1}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.WORKING}
+    }
 
     # Open cover to set OPENING state
     await hass.services.async_call(
@@ -1471,7 +1480,9 @@ async def test_multilevel_switch_cover_moving_state_stop_clears(
     assert state.state == CoverState.OPENING
 
     # Reset to SUCCESS for stop command
-    client.async_send_command.return_value = {"result": {"status": 255}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.SUCCESS}
+    }
 
     # Stop cover - should clear opening state
     await hass.services.async_call(
@@ -1516,7 +1527,9 @@ async def test_multilevel_switch_cover_moving_state_set_position(
     node.receive_event(event)
 
     # Simulate WORKING response
-    client.async_send_command.return_value = {"result": {"status": 1}}
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.WORKING}
+    }
 
     # Set position to 20 (closing direction)
     await hass.services.async_call(
@@ -1578,7 +1591,7 @@ async def test_window_covering_cover_moving_state(
     )
 
     state = hass.states.get(entity_id)
-    assert state.state != CoverState.OPENING
+    assert state.state not in (CoverState.OPENING, CoverState.CLOSING)
 
     client.async_send_command.reset_mock()
 

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -1202,3 +1202,392 @@ async def test_window_covering_open_close(
     assert args["value"] is False
 
     client.async_send_command.reset_mock()
+
+
+async def test_multilevel_switch_cover_moving_state_working(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test opening state with Supervision WORKING on Multilevel Switch cover."""
+    node = chain_actuator_zws12
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # Simulate Supervision WORKING response
+    client.async_send_command.return_value = {"result": {"status": 1}}
+
+    # Open cover - should set OPENING state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+    # Simulate intermediate position update (still moving)
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 50,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+    # Simulate targetValue update (driver sets this when command is sent)
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "targetValue",
+                "newValue": 99,
+                "prevValue": 0,
+                "propertyName": "targetValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    # Simulate reaching target position
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 99,
+                "prevValue": 50,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPEN
+
+
+async def test_multilevel_switch_cover_moving_state_closing(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test closing state with Supervision WORKING on Multilevel Switch cover."""
+    node = chain_actuator_zws12
+
+    # First set position to open
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 99,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPEN
+
+    # Simulate Supervision WORKING response
+    client.async_send_command.return_value = {"result": {"status": 1}}
+
+    # Close cover - should set CLOSING state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSING
+
+
+async def test_multilevel_switch_cover_moving_state_success_no_moving(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test that SUCCESS does not set moving state on Multilevel Switch cover."""
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # Default mock already returns status 255 (SUCCESS)
+
+    # Open cover - SUCCESS means device already at target, no moving state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    # State should still be CLOSED since no value update has been received
+    # and SUCCESS means the command completed immediately
+    assert state.state == CoverState.CLOSED
+
+
+async def test_multilevel_switch_cover_moving_state_unsupervised(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test SUCCESS_UNSUPERVISED sets moving state on Multilevel Switch cover."""
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # Simulate SUCCESS_UNSUPERVISED response
+    client.async_send_command.return_value = {"result": {"status": 254}}
+
+    # Open cover - should set OPENING state optimistically
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+
+async def test_multilevel_switch_cover_moving_state_stop_clears(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test stop_cover clears moving state on Multilevel Switch cover."""
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # Simulate WORKING response
+    client.async_send_command.return_value = {"result": {"status": 1}}
+
+    # Open cover to set OPENING state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+    # Reset to SUCCESS for stop command
+    client.async_send_command.return_value = {"result": {"status": 255}}
+
+    # Stop cover - should clear opening state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    # Cover is still at position 0 (closed), so is_closed returns True
+    assert state.state == CoverState.CLOSED
+
+
+async def test_multilevel_switch_cover_moving_state_set_position(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test moving state direction with set_cover_position on Multilevel Switch cover."""
+    node = chain_actuator_zws12
+
+    # First set position to 50 (open)
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Multilevel Switch",
+                "commandClass": 38,
+                "endpoint": 0,
+                "property": "currentValue",
+                "newValue": 50,
+                "prevValue": 0,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    # Simulate WORKING response
+    client.async_send_command.return_value = {"result": {"status": 1}}
+
+    # Set position to 20 (closing direction)
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY, ATTR_POSITION: 20},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSING
+
+    # Set position to 80 (opening direction)
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY, ATTR_POSITION: 80},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+
+async def test_window_covering_cover_moving_state(
+    hass: HomeAssistant, client, window_covering_outbound_bottom, integration
+) -> None:
+    """Test moving state for Window Covering CC (StartLevelChange commands)."""
+    node = window_covering_outbound_bottom
+    entity_id = "cover.node_2_outbound_bottom"
+    state = hass.states.get(entity_id)
+    assert state
+
+    # Default mock returns SUCCESS (255). For StartLevelChange,
+    # SUCCESS means the device started moving.
+
+    # Open cover - should set OPENING state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.OPENING
+
+    client.async_send_command.reset_mock()
+
+    # Stop cover - should clear moving state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_STOP_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state != CoverState.OPENING
+
+    client.async_send_command.reset_mock()
+
+    # Close cover - should set CLOSING state
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSING
+
+    # Simulate reaching target: currentValue matches targetValue
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Window Covering",
+                "commandClass": 106,
+                "endpoint": 0,
+                "property": "targetValue",
+                "propertyKey": 13,
+                "newValue": 0,
+                "prevValue": 52,
+                "propertyName": "targetValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Window Covering",
+                "commandClass": 106,
+                "endpoint": 0,
+                "property": "currentValue",
+                "propertyKey": 13,
+                "newValue": 0,
+                "prevValue": 52,
+                "propertyName": "currentValue",
+            },
+        },
+    )
+    node.receive_event(event)
+
+    state = hass.states.get(entity_id)
+    assert state.state == CoverState.CLOSED
+
+
+async def test_multilevel_switch_cover_moving_state_none_result(
+    hass: HomeAssistant, client, chain_actuator_zws12, integration
+) -> None:
+    """Test None result (node asleep) does not set moving state on Multilevel Switch cover."""
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # Simulate None result (node asleep/command queued).
+    # When node.async_send_command returns None, async_set_value returns None.
+    client.async_send_command.return_value = None
+
+    # Open cover - should NOT set OPENING state since result is None
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -1,6 +1,10 @@
 """Test the Z-Wave JS cover platform."""
 
+from __future__ import annotations
+
 import logging
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from zwave_js_server.const import (
@@ -42,6 +46,8 @@ from homeassistant.core import HomeAssistant
 
 from .common import replace_value_of_zwave_value
 
+from tests.common import MockConfigEntry
+
 WINDOW_COVER_ENTITY = "cover.zws_12"
 GDC_COVER_ENTITY = "cover.aeon_labs_garage_door_controller_gen5"
 BLIND_COVER_ENTITY = "cover.window_blind_controller"
@@ -60,7 +66,10 @@ def platforms() -> list[str]:
 
 
 async def test_window_cover(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test the cover entity."""
     node = chain_actuator_zws12
@@ -243,7 +252,10 @@ async def test_window_cover(
 
 
 async def test_fibaro_fgr222_shutter_cover(
-    hass: HomeAssistant, client, fibaro_fgr222_shutter, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    fibaro_fgr222_shutter: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test tilt function of the Fibaro Shutter devices."""
     state = hass.states.get(FIBARO_FGR_222_SHUTTER_COVER_ENTITY)
@@ -344,7 +356,10 @@ async def test_fibaro_fgr222_shutter_cover(
 
 
 async def test_fibaro_fgr223_shutter_cover(
-    hass: HomeAssistant, client, fibaro_fgr223_shutter, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    fibaro_fgr223_shutter: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test tilt function of the Fibaro Shutter devices."""
     state = hass.states.get(FIBARO_FGR_223_SHUTTER_COVER_ENTITY)
@@ -438,7 +453,10 @@ async def test_fibaro_fgr223_shutter_cover(
 
 
 async def test_shelly_wave_shutter_cover_with_tilt(
-    hass: HomeAssistant, client, qubino_shutter_firmware_14_2_0, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    qubino_shutter_firmware_14_2_0: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test tilt function of the Shelly Wave Shutter with firmware 14.2.0.
 
@@ -537,7 +555,10 @@ async def test_shelly_wave_shutter_cover_with_tilt(
 
 
 async def test_aeotec_nano_shutter_cover(
-    hass: HomeAssistant, client, aeotec_nano_shutter, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    aeotec_nano_shutter: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test movement of an Aeotec Nano Shutter cover entity. Useful to make sure the stop command logic is handled properly."""
     node = aeotec_nano_shutter
@@ -655,7 +676,10 @@ async def test_aeotec_nano_shutter_cover(
 
 
 async def test_blind_cover(
-    hass: HomeAssistant, client, iblinds_v2, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    iblinds_v2: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test a blind cover entity."""
     state = hass.states.get(BLIND_COVER_ENTITY)
@@ -665,7 +689,10 @@ async def test_blind_cover(
 
 
 async def test_shutter_cover(
-    hass: HomeAssistant, client, qubino_shutter, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    qubino_shutter: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test a shutter cover entity."""
     state = hass.states.get(SHUTTER_COVER_ENTITY)
@@ -675,7 +702,10 @@ async def test_shutter_cover(
 
 
 async def test_motor_barrier_cover(
-    hass: HomeAssistant, client, gdc_zw062, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    gdc_zw062: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test the cover entity."""
     node = gdc_zw062
@@ -853,7 +883,10 @@ async def test_motor_barrier_cover(
 
 
 async def test_motor_barrier_cover_no_primary_value(
-    hass: HomeAssistant, client, gdc_zw062_state, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    gdc_zw062_state: dict[str, Any],
+    integration: MockConfigEntry,
 ) -> None:
     """Test the cover entity where primary value value is None."""
     node_state = replace_value_of_zwave_value(
@@ -879,7 +912,10 @@ async def test_motor_barrier_cover_no_primary_value(
 
 
 async def test_fibaro_fgr222_shutter_cover_no_tilt(
-    hass: HomeAssistant, client, fibaro_fgr222_shutter_state, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    fibaro_fgr222_shutter_state: dict[str, Any],
+    integration: MockConfigEntry,
 ) -> None:
     """Test tilt function of the Fibaro Shutter devices with tilt value is None."""
     node_state = replace_value_of_zwave_value(
@@ -909,7 +945,10 @@ async def test_fibaro_fgr222_shutter_cover_no_tilt(
 
 
 async def test_fibaro_fgr223_shutter_cover_no_tilt(
-    hass: HomeAssistant, client, fibaro_fgr223_shutter_state, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    fibaro_fgr223_shutter_state: dict[str, Any],
+    integration: MockConfigEntry,
 ) -> None:
     """Test absence of tilt function for Fibaro Shutter roller blind.
 
@@ -938,7 +977,10 @@ async def test_fibaro_fgr223_shutter_cover_no_tilt(
 
 
 async def test_iblinds_v3_cover(
-    hass: HomeAssistant, client, iblinds_v3, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    iblinds_v3: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test iBlinds v3 cover which uses Window Covering CC."""
     entity_id = "cover.blind_west_bed_1_horizontal_slats_angle"
@@ -1042,7 +1084,10 @@ async def test_iblinds_v3_cover(
 
 
 async def test_nice_ibt4zwave_cover(
-    hass: HomeAssistant, client, nice_ibt4zwave, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    nice_ibt4zwave: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test Nice IBT4ZWAVE cover."""
     entity_id = "cover.portail"
@@ -1102,7 +1147,10 @@ async def test_nice_ibt4zwave_cover(
 
 
 async def test_window_covering_open_close(
-    hass: HomeAssistant, client, window_covering_outbound_bottom, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    window_covering_outbound_bottom: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test Window Covering device open and close commands.
 
@@ -1205,7 +1253,10 @@ async def test_window_covering_open_close(
 
 
 async def test_multilevel_switch_cover_moving_state_working(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test opening state with Supervision WORKING on Multilevel Switch cover."""
     node = chain_actuator_zws12
@@ -1295,7 +1346,10 @@ async def test_multilevel_switch_cover_moving_state_working(
 
 
 async def test_multilevel_switch_cover_moving_state_closing(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test closing state with Supervision WORKING on Multilevel Switch cover."""
     node = chain_actuator_zws12
@@ -1339,7 +1393,10 @@ async def test_multilevel_switch_cover_moving_state_closing(
 
 
 async def test_multilevel_switch_cover_moving_state_success_no_moving(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test that SUCCESS does not set moving state on Multilevel Switch cover."""
     state = hass.states.get(WINDOW_COVER_ENTITY)
@@ -1363,7 +1420,10 @@ async def test_multilevel_switch_cover_moving_state_success_no_moving(
 
 
 async def test_multilevel_switch_cover_moving_state_unsupervised(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test SUCCESS_UNSUPERVISED sets moving state on Multilevel Switch cover."""
     state = hass.states.get(WINDOW_COVER_ENTITY)
@@ -1386,7 +1446,10 @@ async def test_multilevel_switch_cover_moving_state_unsupervised(
 
 
 async def test_multilevel_switch_cover_moving_state_stop_clears(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test stop_cover clears moving state on Multilevel Switch cover."""
     state = hass.states.get(WINDOW_COVER_ENTITY)
@@ -1424,7 +1487,10 @@ async def test_multilevel_switch_cover_moving_state_stop_clears(
 
 
 async def test_multilevel_switch_cover_moving_state_set_position(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test moving state direction with set_cover_position on Multilevel Switch cover."""
     node = chain_actuator_zws12
@@ -1476,7 +1542,10 @@ async def test_multilevel_switch_cover_moving_state_set_position(
 
 
 async def test_window_covering_cover_moving_state(
-    hass: HomeAssistant, client, window_covering_outbound_bottom, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    window_covering_outbound_bottom: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test moving state for Window Covering CC (StartLevelChange commands)."""
     node = window_covering_outbound_bottom
@@ -1570,7 +1639,10 @@ async def test_window_covering_cover_moving_state(
 
 
 async def test_multilevel_switch_cover_moving_state_none_result(
-    hass: HomeAssistant, client, chain_actuator_zws12, integration
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12: Node,
+    integration: MockConfigEntry,
 ) -> None:
     """Test None result (node asleep) does not set moving state on Multilevel Switch cover."""
     state = hass.states.get(WINDOW_COVER_ENTITY)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, none of the Z-Wave cover implementations make use of the opening/closing states. This PR adds this functionality in the following cases:
- A position based cover has started moving to a position
- Any cover has stopped moving
- A non-position based cover has started opening/closing

To determine if this is the case, we look at the set_value result:
- WORKING for going to position means the cover has started moving
- SUCCESS for opening/closing/stopping means the cover has accepted the command
- SUCCESS_UNSUPERVISED for both means we can assume the cover has started moving or stopped

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/163163
closes https://github.com/home-assistant/core/pull/163164
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
