### PR TITLE
Add fan platform for Prana Integration

### DIFF
--- a/homeassistant/components/prana/__init__.py
+++ b/homeassistant/components/prana/__init__.py
@@ -14,13 +14,12 @@ from .coordinator import PranaConfigEntry, PranaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Keep platforms sorted alphabetically to satisfy lint rule
-PLATFORMS = [Platform.SWITCH]
+PLATFORMS = [Platform.FAN, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PranaConfigEntry) -> bool:
     """Set up Prana from a config entry."""
-
+    _LOGGER.info("Setting up Prana integration")
     coordinator = PranaCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator

--- a/homeassistant/components/prana/__init__.py
+++ b/homeassistant/components/prana/__init__.py
@@ -19,7 +19,6 @@ PLATFORMS = [Platform.FAN, Platform.SWITCH]
 
 async def async_setup_entry(hass: HomeAssistant, entry: PranaConfigEntry) -> bool:
     """Set up Prana from a config entry."""
-    _LOGGER.info("Setting up Prana integration")
     coordinator = PranaCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -108,17 +108,8 @@ class PranaFan(PranaBaseEntity, FanEntity):
         if percentage == 0:
             await self.async_turn_off()
             return
-        speed_value = (
-            math.ceil(
-                percentage_to_ranged_value(
-                    self.entity_description.speed_range(self.coordinator),
-                    percentage,
-                )
-            )
-            * 10
-        )
         await self.coordinator.api_client.set_speed(
-            speed_value, self.entity_description.key
+            self.__get_speed_value(), self.entity_description.key
         )
         await self.coordinator.async_refresh()
 
@@ -141,7 +132,8 @@ class PranaFan(PranaBaseEntity, FanEntity):
             await self.async_set_percentage(percentage)
         if preset_mode is not None:
             await self.async_set_preset_mode(preset_mode)
-        await self.coordinator.async_refresh()
+        if percentage is None and preset_mode is None:
+            await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
@@ -154,6 +146,16 @@ class PranaFan(PranaBaseEntity, FanEntity):
         """Set the preset mode (e.g., night or boost)."""
         await self.coordinator.api_client.set_switch(preset_mode, True)
         await self.coordinator.async_refresh()
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        speed_value = self.__get_speed_value()
+        if speed_value == 1:
+            return "night"
+        if speed_value == self.entity_description.value_fn(self.coordinator).max_speed:
+            return "boost"
+        return None
 
     @property
     def available(self) -> bool:
@@ -169,3 +171,17 @@ class PranaFan(PranaBaseEntity, FanEntity):
         ):
             return self.coordinator.last_update_success
         return False
+
+    def __get_speed_value(self) -> int:
+        """Helper to get the current speed value from coordinator data."""
+        if self.percentage is None:
+            return 0
+        return (
+            math.ceil(
+                percentage_to_ranged_value(
+                    self.entity_description.speed_range(self.coordinator),
+                    self.percentage,
+                )
+            )
+            * 10
+        )

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -173,7 +173,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode (e.g., night or boost)."""
-        await self.coordinator.api_client.set_switch(preset_mode, value=True)
+        await self.coordinator.api_client.set_switch(preset_mode, True)
         await self.coordinator.async_refresh()
 
     @property

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -105,10 +105,14 @@ class PranaFan(PranaBaseEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set fan speed (0-100%) by converting to device-specific speed steps."""
+        if percentage == 0:
+            await self.async_turn_off()
+            return
         speed_value = (
             math.ceil(
                 percentage_to_ranged_value(
-                    self.entity_description.speed_range(self.coordinator), percentage
+                    self.entity_description.speed_range(self.coordinator),
+                    percentage,
                 )
             )
             * 10

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -1,10 +1,10 @@
 """Fan platform for Prana integration."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 import math
 from typing import Any
 
-from aioesphomeapi import dataclass
 from prana_local_api_client.models.prana_state import FanState
 
 from homeassistant.components.fan import (

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -46,20 +46,28 @@ ENTITIES: tuple[PranaEntityDescription, ...] = (
     PranaFanEntityDescription(
         key=PranaFanType.SUPPLY,
         translation_key="supply",
-        value_fn=lambda coord: coord.data.supply,
-        speed_range=lambda coord: (1, coord.data.supply.max_speed),
+        value_fn=lambda coord: (
+            coord.data.supply if not coord.data.bound else coord.data.bounded
+        ),
+        speed_range=lambda coord: (
+            1,
+            coord.data.supply.max_speed
+            if not coord.data.bound
+            else coord.data.bounded.max_speed,
+        ),
     ),
     PranaFanEntityDescription(
         key=PranaFanType.EXTRACT,
         translation_key="extract",
-        value_fn=lambda coord: coord.data.extract,
-        speed_range=lambda coord: (1, coord.data.extract.max_speed),
-    ),
-    PranaFanEntityDescription(
-        key=PranaFanType.BOUNDED,
-        translation_key="bounded",
-        value_fn=lambda coord: coord.data.bounded,
-        speed_range=lambda coord: (1, coord.data.bounded.max_speed),
+        value_fn=lambda coord: (
+            coord.data.extract if not coord.data.bound else coord.data.bounded
+        ),
+        speed_range=lambda coord: (
+            1,
+            coord.data.extract.max_speed
+            if not coord.data.bound
+            else coord.data.bounded.max_speed,
+        ),
     ),
 )
 
@@ -89,6 +97,15 @@ class PranaFan(PranaBaseEntity, FanEntity):
     )
 
     @property
+    def _api_target_key(self) -> str:
+        """Return the correct target key for API commands based on bounded state."""
+        # If the device is in bound mode, both supply and extract fans control the same bounded fan speeds.
+        if self.coordinator.data.bound:
+            return PranaFanType.BOUNDED
+        # Otherwise, return the specific fan type (supply or extract) for API commands.
+        return self.entity_description.key
+
+    @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(
@@ -116,7 +133,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
                 )
             )
             * 10,
-            self.entity_description.key,
+            self._api_target_key,
         )
         await self.coordinator.async_refresh()
 
@@ -132,9 +149,11 @@ class PranaFan(PranaBaseEntity, FanEntity):
         **kwargs: Any,
     ) -> None:
         """Turn the fan on and optionally set speed or preset mode."""
-        await self.coordinator.api_client.set_speed_is_on(
-            True, self.entity_description.key
-        )
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        await self.coordinator.api_client.set_speed_is_on(True, self._api_target_key)
         if percentage is not None:
             await self.async_set_percentage(percentage)
         if preset_mode is not None:
@@ -144,9 +163,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the fan off."""
-        await self.coordinator.api_client.set_speed_is_on(
-            False, self.entity_description.key
-        )
+        await self.coordinator.api_client.set_speed_is_on(False, self._api_target_key)
         await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -162,18 +179,3 @@ class PranaFan(PranaBaseEntity, FanEntity):
         if self.coordinator.data.boost:
             return "boost"
         return None
-
-    @property
-    def available(self) -> bool:
-        """Return entity availability based on coordinator success and device state."""
-        # Make bounded fan available only when device is in bound mode since it doesn't function otherwise
-        if (
-            self.coordinator.data.bound
-            and self.entity_description.key == PranaFanType.BOUNDED
-        ) or (
-            not self.coordinator.data.bound
-            and self.entity_description.key
-            in [PranaFanType.SUPPLY, PranaFanType.EXTRACT]
-        ):
-            return super().available
-        return False

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -1,0 +1,163 @@
+"""Fan platform for Prana integration."""
+
+from collections.abc import Callable
+import math
+from typing import Any
+
+from aioesphomeapi import dataclass
+from prana_local_api_client.models.prana_state import FanState
+
+from homeassistant.components.fan import (
+    FanEntity,
+    FanEntityDescription,
+    FanEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+from homeassistant.util.scaling import int_states_in_range
+
+from . import PranaConfigEntry
+from .entity import PranaBaseEntity, PranaCoordinator, PranaEntityDescription, StrEnum
+
+PARALLEL_UPDATES = 1
+
+
+class PranaFanType(StrEnum):
+    """Enumerates Prana fan types exposed by the device API."""
+
+    SUPPLY = "supply"
+    EXTRACT = "extract"
+    BOUNDED = "bounded"
+
+
+@dataclass(frozen=True, kw_only=True)
+class PranaFanEntityDescription(FanEntityDescription, PranaEntityDescription):
+    """Description of a Prana fan entity."""
+
+    value_fn: Callable[[PranaCoordinator], FanState]
+    speed_range: Callable[[PranaCoordinator], tuple[int, int]]
+
+
+ENTITIES: tuple[PranaEntityDescription, ...] = (
+    PranaFanEntityDescription(
+        key=PranaFanType.SUPPLY,
+        translation_key="supply",
+        value_fn=lambda coord: coord.data.supply,
+        speed_range=lambda coord: (1, coord.data.supply.max_speed),
+    ),
+    PranaFanEntityDescription(
+        key=PranaFanType.EXTRACT,
+        translation_key="extract",
+        value_fn=lambda coord: coord.data.extract,
+        speed_range=lambda coord: (1, coord.data.extract.max_speed),
+    ),
+    PranaFanEntityDescription(
+        key=PranaFanType.BOUNDED,
+        translation_key="bounded",
+        value_fn=lambda coord: coord.data.bounded,
+        speed_range=lambda coord: (1, coord.data.bounded.max_speed),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PranaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Prana fan entities from a config entry."""
+    async_add_entities(
+        PranaFan(entry.runtime_data, entity_description)
+        for entity_description in ENTITIES
+    )
+
+
+class PranaFan(PranaBaseEntity, FanEntity):
+    """Representation of a Prana fan entity."""
+
+    entity_description: PranaFanEntityDescription
+    _attr_preset_modes = ["night", "boost"]
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.PRESET_MODE
+    )
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(
+            self.entity_description.speed_range(self.coordinator)
+        )
+
+    @property
+    def percentage(self) -> int:
+        """Return the current fan speed percentage."""
+        current_speed = self.entity_description.value_fn(self.coordinator).speed
+        return ranged_value_to_percentage(
+            self.entity_description.speed_range(self.coordinator), current_speed
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set fan speed (0-100%) by converting to device-specific speed steps."""
+        speed_value = (
+            math.ceil(
+                percentage_to_ranged_value(
+                    self.entity_description.speed_range(self.coordinator), percentage
+                )
+            )
+            * 10
+        )
+        await self.coordinator.api_client.set_speed(
+            speed_value, self.entity_description.key
+        )
+        await self.coordinator.async_refresh()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the fan is on."""
+        return self.entity_description.value_fn(self.coordinator).is_on
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn the fan on."""
+        await self.coordinator.api_client.set_speed_is_on(
+            True, self.entity_description.key
+        )
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        await self.coordinator.api_client.set_speed_is_on(
+            False, self.entity_description.key
+        )
+        await self.coordinator.async_refresh()
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the preset mode (e.g., night or boost)."""
+        await self.coordinator.api_client.set_switch(preset_mode, True)
+        await self.coordinator.async_refresh()
+
+    @property
+    def available(self) -> bool:
+        """Return entity availability based on coordinator success and device state."""
+        # Make bounded fan available only when device is in bound mode since it doesn't function otherwise
+        if (
+            self.coordinator.data.bound
+            and self.entity_description.key == PranaFanType.BOUNDED
+        ) or (
+            not self.coordinator.data.bound
+            and self.entity_description.key
+            in [PranaFanType.SUPPLY, PranaFanType.EXTRACT]
+        ):
+            return self.coordinator.last_update_success
+        return False

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -109,7 +109,14 @@ class PranaFan(PranaBaseEntity, FanEntity):
             await self.async_turn_off()
             return
         await self.coordinator.api_client.set_speed(
-            self.__get_speed_value(), self.entity_description.key
+            math.ceil(
+                percentage_to_ranged_value(
+                    self.entity_description.speed_range(self.coordinator),
+                    percentage,
+                )
+            )
+            * 10,
+            self.entity_description.key,
         )
         await self.coordinator.async_refresh()
 
@@ -144,16 +151,15 @@ class PranaFan(PranaBaseEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode (e.g., night or boost)."""
-        await self.coordinator.api_client.set_switch(preset_mode, True)
+        await self.coordinator.api_client.set_switch(preset_mode, value=True)
         await self.coordinator.async_refresh()
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
-        speed_value = self.__get_speed_value()
-        if speed_value == 1:
+        if self.coordinator.data.night:
             return "night"
-        if speed_value == self.entity_description.value_fn(self.coordinator).max_speed:
+        if self.coordinator.data.boost:
             return "boost"
         return None
 
@@ -169,19 +175,5 @@ class PranaFan(PranaBaseEntity, FanEntity):
             and self.entity_description.key
             in [PranaFanType.SUPPLY, PranaFanType.EXTRACT]
         ):
-            return self.coordinator.last_update_success
+            return super().available
         return False
-
-    def __get_speed_value(self) -> int:
-        """Helper to get the current speed value from coordinator data."""
-        if self.percentage is None:
-            return 0
-        return (
-            math.ceil(
-                percentage_to_ranged_value(
-                    self.entity_description.speed_range(self.coordinator),
-                    self.percentage,
-                )
-            )
-            * 10
-        )

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -25,6 +25,11 @@ from .entity import PranaBaseEntity, PranaCoordinator, PranaEntityDescription, S
 
 PARALLEL_UPDATES = 1
 
+# The Prana device API expects fan speed values in scaled units (tenths of a speed step)
+# rather than the raw step value used internally by this integration. This factor is
+# applied when sending speeds to the API to match its expected units.
+PRANA_SPEED_MULTIPLIER = 10
+
 
 class PranaFanType(StrEnum):
     """Enumerates Prana fan types exposed by the device API."""
@@ -132,7 +137,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
                     percentage,
                 )
             )
-            * 10,
+            * PRANA_SPEED_MULTIPLIER,
             self._api_target_key,
         )
         await self.coordinator.async_refresh()

--- a/homeassistant/components/prana/fan.py
+++ b/homeassistant/components/prana/fan.py
@@ -96,7 +96,7 @@ class PranaFan(PranaBaseEntity, FanEntity):
         )
 
     @property
-    def percentage(self) -> int:
+    def percentage(self) -> int | None:
         """Return the current fan speed percentage."""
         current_speed = self.entity_description.value_fn(self.coordinator).speed
         return ranged_value_to_percentage(
@@ -129,10 +129,14 @@ class PranaFan(PranaBaseEntity, FanEntity):
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Turn the fan on."""
+        """Turn the fan on and optionally set speed or preset mode."""
         await self.coordinator.api_client.set_speed_is_on(
             True, self.entity_description.key
         )
+        if percentage is not None:
+            await self.async_set_percentage(percentage)
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/prana/icons.json
+++ b/homeassistant/components/prana/icons.json
@@ -1,9 +1,6 @@
 {
   "entity": {
     "fan": {
-      "bounded": {
-        "default": "mdi:arrow-expand-horizontal"
-      },
       "extract": {
         "default": "mdi:arrow-expand-right"
       },

--- a/homeassistant/components/prana/icons.json
+++ b/homeassistant/components/prana/icons.json
@@ -1,5 +1,16 @@
 {
   "entity": {
+    "fan": {
+      "bounded": {
+        "default": "mdi:arrow-expand-horizontal"
+      },
+      "extract": {
+        "default": "mdi:arrow-expand-right"
+      },
+      "supply": {
+        "default": "mdi:arrow-expand-left"
+      }
+    },
     "switch": {
       "auto": {
         "default": "mdi:fan-auto"

--- a/homeassistant/components/prana/strings.json
+++ b/homeassistant/components/prana/strings.json
@@ -27,7 +27,7 @@
   "entity": {
     "fan": {
       "bounded": {
-        "name": "Bounded Air Flows",
+        "name": "Bounded Air Flow",
         "state_attributes": {
           "preset_mode": {
             "state": {

--- a/homeassistant/components/prana/strings.json
+++ b/homeassistant/components/prana/strings.json
@@ -27,7 +27,7 @@
   "entity": {
     "fan": {
       "extract": {
-        "name": "Extract Fan",
+        "name": "Extract fan",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -38,7 +38,7 @@
         }
       },
       "supply": {
-        "name": "Supply Fan",
+        "name": "Supply fan",
         "state_attributes": {
           "preset_mode": {
             "state": {

--- a/homeassistant/components/prana/strings.json
+++ b/homeassistant/components/prana/strings.json
@@ -26,17 +26,6 @@
   },
   "entity": {
     "fan": {
-      "bounded": {
-        "name": "Bounded Air Flow",
-        "state_attributes": {
-          "preset_mode": {
-            "state": {
-              "boost": "Boost",
-              "night": "Night"
-            }
-          }
-        }
-      },
       "extract": {
         "name": "Extract Air Flow",
         "state_attributes": {
@@ -53,8 +42,8 @@
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "boost": "Boost",
-              "night": "Night"
+              "boost": "[%key:component::prana::entity::fan::extract::state_attributes::preset_mode::state::boost%]",
+              "night": "[%key:component::prana::entity::fan::extract::state_attributes::preset_mode::state::night%]"
             }
           }
         }

--- a/homeassistant/components/prana/strings.json
+++ b/homeassistant/components/prana/strings.json
@@ -27,7 +27,7 @@
   "entity": {
     "fan": {
       "extract": {
-        "name": "Extract Air Flow",
+        "name": "Extract Fan",
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -38,7 +38,7 @@
         }
       },
       "supply": {
-        "name": "Supply Air Flow",
+        "name": "Supply Fan",
         "state_attributes": {
           "preset_mode": {
             "state": {

--- a/homeassistant/components/prana/strings.json
+++ b/homeassistant/components/prana/strings.json
@@ -25,6 +25,41 @@
     }
   },
   "entity": {
+    "fan": {
+      "bounded": {
+        "name": "Bounded Air Flows",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "boost": "Boost",
+              "night": "Night"
+            }
+          }
+        }
+      },
+      "extract": {
+        "name": "Extract Air Flow",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "boost": "Boost",
+              "night": "Night"
+            }
+          }
+        }
+      },
+      "supply": {
+        "name": "Supply Air Flow",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "boost": "Boost",
+              "night": "Night"
+            }
+          }
+        }
+      }
+    },
     "switch": {
       "auto": {
         "name": "Auto"

--- a/tests/components/prana/conftest.py
+++ b/tests/components/prana/conftest.py
@@ -4,6 +4,8 @@ from collections.abc import Generator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from prana_local_api_client.models.prana_device_info import PranaDeviceInfo
+from prana_local_api_client.models.prana_state import PranaState
 import pytest
 
 from homeassistant.components.prana.const import DOMAIN
@@ -44,8 +46,8 @@ def mock_prana_api() -> Generator[AsyncMock]:
         device_info_data = load_json_object_fixture("device_info.json", DOMAIN)
         state_data = load_json_object_fixture("state.json", DOMAIN)
 
-        device_info_obj = SimpleNamespace(**device_info_data)
-        state_obj = SimpleNamespace(**state_data)
+        device_info_obj = PranaDeviceInfo.from_dict(device_info_data)
+        state_obj = PranaState.from_dict(state_data)
 
         mock_api_class.return_value.get_device_info = AsyncMock(
             return_value=device_info_obj

--- a/tests/components/prana/fixtures/device_info.json
+++ b/tests/components/prana/fixtures/device_info.json
@@ -2,6 +2,6 @@
   "manufactureId": "ECC9FFE0E574",
   "isValid": true,
   "fwVersion": 46,
-  "pranaModel": "PRANA RECUPERATOR 150",
+  "pranaModel": "PRANA RECUPERATOR 200",
   "label": "PRANA RECUPERATOR"
 }

--- a/tests/components/prana/fixtures/state.json
+++ b/tests/components/prana/fixtures/state.json
@@ -21,5 +21,7 @@
   "winter": false,
   "inside_temperature": 217,
   "humidity": 56,
-  "brightness": 6
+  "brightness": 6,
+  "night": false,
+  "boost": false
 }

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -1,66 +1,4 @@
 # serializer version: 1
-# name: test_fans[fan.prana_recuperator_bounded_air_flow-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'preset_modes': list([
-        'night',
-        'boost',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'fan',
-    'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_bounded_air_flow',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Bounded Air Flow',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Bounded Air Flow',
-    'platform': 'prana',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': <FanEntityFeature: 57>,
-    'translation_key': 'bounded',
-    'unique_id': 'ECC9FFE0E574_bounded',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_fans[fan.prana_recuperator_bounded_air_flow-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Bounded Air Flow',
-      'percentage': 10,
-      'percentage_step': 10.0,
-      'preset_mode': None,
-      'preset_modes': list([
-        'night',
-        'boost',
-      ]),
-      'supported_features': <FanEntityFeature: 57>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_bounded_air_flow',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
 # name: test_fans[fan.prana_recuperator_extract_air_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -106,6 +44,9 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'PRANA RECUPERATOR Extract Air Flow',
+      'percentage': 10,
+      'percentage_step': 10.0,
+      'preset_mode': None,
       'preset_modes': list([
         'night',
         'boost',
@@ -117,7 +58,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unavailable',
+    'state': 'on',
   })
 # ---
 # name: test_fans[fan.prana_recuperator_supply_air_flow-entry]
@@ -165,6 +106,9 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'PRANA RECUPERATOR Supply Air Flow',
+      'percentage': 10,
+      'percentage_step': 10.0,
+      'preset_mode': None,
       'preset_modes': list([
         'night',
         'boost',
@@ -176,6 +120,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unavailable',
+    'state': 'on',
   })
 # ---

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_fans[fan.prana_recuperator_bounded-entry]
+# name: test_fans[fan.prana_recuperator_bounded_air_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -17,7 +17,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_bounded',
+    'entity_id': 'fan.prana_recuperator_bounded_air_flow',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -25,12 +25,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Bounded',
+    'object_id_base': 'Bounded Air Flow',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Bounded',
+    'original_name': 'Bounded Air Flow',
     'platform': 'prana',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -40,10 +40,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan.prana_recuperator_bounded-state]
+# name: test_fans[fan.prana_recuperator_bounded_air_flow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Bounded',
+      'friendly_name': 'PRANA RECUPERATOR Bounded Air Flow',
       'percentage': 10,
       'percentage_step': 10.0,
       'preset_mode': None,
@@ -54,14 +54,14 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_bounded',
+    'entity_id': 'fan.prana_recuperator_bounded_air_flow',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_fans[fan.prana_recuperator_extract-entry]
+# name: test_fans[fan.prana_recuperator_extract_air_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -79,7 +79,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_extract',
+    'entity_id': 'fan.prana_recuperator_extract_air_flow',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -87,12 +87,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Extract',
+    'object_id_base': 'Extract Air Flow',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Extract',
+    'original_name': 'Extract Air Flow',
     'platform': 'prana',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -102,10 +102,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan.prana_recuperator_extract-state]
+# name: test_fans[fan.prana_recuperator_extract_air_flow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Extract',
+      'friendly_name': 'PRANA RECUPERATOR Extract Air Flow',
       'preset_modes': list([
         'night',
         'boost',
@@ -113,14 +113,14 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_extract',
+    'entity_id': 'fan.prana_recuperator_extract_air_flow',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_fans[fan.prana_recuperator_supply-entry]
+# name: test_fans[fan.prana_recuperator_supply_air_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -138,7 +138,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_supply',
+    'entity_id': 'fan.prana_recuperator_supply_air_flow',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -146,12 +146,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Supply',
+    'object_id_base': 'Supply Air Flow',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Supply',
+    'original_name': 'Supply Air Flow',
     'platform': 'prana',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -161,10 +161,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan.prana_recuperator_supply-state]
+# name: test_fans[fan.prana_recuperator_supply_air_flow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Supply',
+      'friendly_name': 'PRANA RECUPERATOR Supply Air Flow',
       'preset_modes': list([
         'night',
         'boost',
@@ -172,7 +172,7 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_supply',
+    'entity_id': 'fan.prana_recuperator_supply_air_flow',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_fans[fan.prana_recuperator_extract_air_flow-entry]
+# name: test_fans[fan.prana_recuperator_extract_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -17,7 +17,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_extract_air_flow',
+    'entity_id': 'fan.prana_recuperator_extract_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -25,12 +25,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Extract Air Flow',
+    'object_id_base': 'Extract fan',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Extract Air Flow',
+    'original_name': 'Extract fan',
     'platform': 'prana',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -40,10 +40,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan.prana_recuperator_extract_air_flow-state]
+# name: test_fans[fan.prana_recuperator_extract_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Extract Air Flow',
+      'friendly_name': 'PRANA RECUPERATOR Extract fan',
       'percentage': 10,
       'percentage_step': 10.0,
       'preset_mode': None,
@@ -54,14 +54,14 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_extract_air_flow',
+    'entity_id': 'fan.prana_recuperator_extract_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_fans[fan.prana_recuperator_supply_air_flow-entry]
+# name: test_fans[fan.prana_recuperator_supply_fan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -79,7 +79,7 @@
     'disabled_by': None,
     'domain': 'fan',
     'entity_category': None,
-    'entity_id': 'fan.prana_recuperator_supply_air_flow',
+    'entity_id': 'fan.prana_recuperator_supply_fan',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -87,12 +87,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Supply Air Flow',
+    'object_id_base': 'Supply fan',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Supply Air Flow',
+    'original_name': 'Supply fan',
     'platform': 'prana',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -102,10 +102,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_fans[fan.prana_recuperator_supply_air_flow-state]
+# name: test_fans[fan.prana_recuperator_supply_fan-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'PRANA RECUPERATOR Supply Air Flow',
+      'friendly_name': 'PRANA RECUPERATOR Supply fan',
       'percentage': 10,
       'percentage_step': 10.0,
       'preset_mode': None,
@@ -116,7 +116,7 @@
       'supported_features': <FanEntityFeature: 57>,
     }),
     'context': <ANY>,
-    'entity_id': 'fan.prana_recuperator_supply_air_flow',
+    'entity_id': 'fan.prana_recuperator_supply_fan',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -1,0 +1,181 @@
+# serializer version: 1
+# name: test_fans[fan.prana_recuperator_bounded-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.prana_recuperator_bounded',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Bounded',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bounded',
+    'platform': 'prana',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 57>,
+    'translation_key': 'bounded',
+    'unique_id': 'ECC9FFE0E574_bounded',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fans[fan.prana_recuperator_bounded-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PRANA RECUPERATOR Bounded',
+      'percentage': 10,
+      'percentage_step': 10.0,
+      'preset_mode': None,
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+      'supported_features': <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.prana_recuperator_bounded',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_fans[fan.prana_recuperator_extract-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.prana_recuperator_extract',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Extract',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Extract',
+    'platform': 'prana',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 57>,
+    'translation_key': 'extract',
+    'unique_id': 'ECC9FFE0E574_extract',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fans[fan.prana_recuperator_extract-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PRANA RECUPERATOR Extract',
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+      'supported_features': <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.prana_recuperator_extract',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_fans[fan.prana_recuperator_supply-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.prana_recuperator_supply',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Supply',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Supply',
+    'platform': 'prana',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 57>,
+    'translation_key': 'supply',
+    'unique_id': 'ECC9FFE0E574_supply',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_fans[fan.prana_recuperator_supply-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'PRANA RECUPERATOR Supply',
+      'preset_modes': list([
+        'night',
+        'boost',
+      ]),
+      'supported_features': <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.prana_recuperator_supply',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -46,7 +46,7 @@
       'friendly_name': 'PRANA RECUPERATOR Bounded Air Flow',
       'percentage': 10,
       'percentage_step': 10.0,
-      'preset_mode': 'boost',
+      'preset_mode': None,
       'preset_modes': list([
         'night',
         'boost',

--- a/tests/components/prana/snapshots/test_fan.ambr
+++ b/tests/components/prana/snapshots/test_fan.ambr
@@ -46,7 +46,7 @@
       'friendly_name': 'PRANA RECUPERATOR Bounded Air Flow',
       'percentage': 10,
       'percentage_step': 10.0,
-      'preset_mode': None,
+      'preset_mode': 'boost',
       'preset_modes': list([
         'night',
         'boost',

--- a/tests/components/prana/snapshots/test_init.ambr
+++ b/tests/components/prana/snapshots/test_init.ambr
@@ -20,7 +20,7 @@
     'labels': set({
     }),
     'manufacturer': 'Prana',
-    'model': 'PRANA RECUPERATOR 150',
+    'model': 'PRANA RECUPERATOR 200',
     'model_id': None,
     'name': 'PRANA RECUPERATOR',
     'name_by_user': None,

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -2,7 +2,7 @@
 
 import math
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -36,7 +36,7 @@ FAN_TEST_CASES = [
 
 async def _async_setup_fan_entity(
     hass: HomeAssistant,
-    mock_prana_api: MagicMock,
+    mock_prana_api: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     type_key: str,
@@ -63,7 +63,7 @@ async def test_fans(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    mock_prana_api: MagicMock,
+    mock_prana_api: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the Prana fans snapshot."""
@@ -79,7 +79,7 @@ async def test_fans(
 )
 async def test_fans_turn_on_off(
     hass: HomeAssistant,
-    mock_prana_api: MagicMock,
+    mock_prana_api: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     type_key: str,
@@ -126,7 +126,7 @@ async def test_fans_turn_on_off(
 )
 async def test_fans_set_percentage(
     hass: HomeAssistant,
-    mock_prana_api: MagicMock,
+    mock_prana_api: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     type_key: str,

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -59,14 +59,15 @@ async def test_fans_actions(
 
     await async_init_integration(hass, mock_config_entry)
 
+    # Resolve the entity ID dynamically using the unique ID
     unique_id = f"{mock_config_entry.unique_id}_{type_key}"
-
     entity_entry = entity_registry.async_get_entity_id(FAN_DOMAIN, "prana", unique_id)
 
     assert entity_entry, f"Entity with unique_id {unique_id} not found in registry"
     target = entity_entry
 
     # --- Test Turn OFF ---
+    # Force state to ON so HA allows turning off
     hass.states.async_set(target, "on")
 
     await hass.services.async_call(
@@ -80,7 +81,7 @@ async def test_fans_actions(
     mock_prana_api.reset_mock()
 
     # --- Test Turn ON ---
-
+    # Force state to OFF so HA allows turning on
     hass.states.async_set(target, "off")
 
     await hass.services.async_call(
@@ -91,7 +92,9 @@ async def test_fans_actions(
     )
     mock_prana_api.set_speed_is_on.assert_called_with(True, type_key)
 
-    # --- Test Set Percentage (Speed) ---
+    mock_prana_api.reset_mock()
+
+    # --- Test Set Percentage (Speed 50%) ---
     hass.states.async_set(target, "on")
 
     await hass.services.async_call(
@@ -103,6 +106,22 @@ async def test_fans_actions(
 
     mock_prana_api.set_speed.assert_called()
     assert mock_prana_api.set_speed.call_args[0][1] == type_key
+
+    mock_prana_api.reset_mock()
+
+    # --- Test Set Percentage 0% (Should Turn OFF) ---
+    # Ensure it is ON before we test turning it off via percentage
+    hass.states.async_set(target, "on")
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 0},
+        blocking=True,
+    )
+
+    # Verify that setting 0% called the turn_off API method, not set_speed
+    mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
 
     # --- Test Preset Mode ---
     await hass.services.async_call(

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -1,5 +1,6 @@
 """Integration-style tests for Prana fans."""
 
+import math
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -15,9 +16,11 @@ from homeassistant.components.fan import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.components.prana.fan import PRANA_SPEED_MULTIPLIER
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.percentage import percentage_to_ranged_value
 
 from . import async_init_integration
 
@@ -149,8 +152,10 @@ async def test_fans_set_percentage(
         {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 50},
         blocking=True,
     )
-    speed_range = fan_mock_state.speed_range
-    expected_speed = round(speed_range.min + (speed_range.max - speed_range.min) * 0.5)
+    expected_speed = (
+        math.ceil(percentage_to_ranged_value((1, fan_mock_state.max_speed), 50))
+        * PRANA_SPEED_MULTIPLIER
+    )
     mock_prana_api.set_speed.assert_called_once_with(
         expected_speed,
         expected_api_key,

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -200,4 +200,4 @@ async def test_fans_set_preset_mode(
         {ATTR_ENTITY_ID: target, ATTR_PRESET_MODE: "night"},
         blocking=True,
     )
-    mock_prana_api.set_switch.assert_called_with("night", value=True)
+    mock_prana_api.set_switch.assert_called_with("night", True)

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -149,8 +149,12 @@ async def test_fans_set_percentage(
         {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 50},
         blocking=True,
     )
-    mock_prana_api.set_speed.assert_called()
-    assert mock_prana_api.set_speed.call_args[0][1] == expected_api_key
+    speed_range = fan_mock_state.speed_range
+    expected_speed = round(speed_range.min + (speed_range.max - speed_range.min) * 0.5)
+    mock_prana_api.set_speed.assert_called_once_with(
+        expected_speed,
+        expected_api_key,
+    )
     mock_prana_api.reset_mock()
 
     await hass.services.async_call(

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -31,9 +31,6 @@ async def test_fans(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the Prana fans snapshot."""
-    # The default mock state has bound=False.
-    # Therefore, 'supply' and 'extract' fans will be available, while 'bounded' will be unavailable.
-    # This expected availability state is captured by the snapshot.
     with patch("homeassistant.components.prana.PLATFORMS", [Platform.FAN]):
         await async_init_integration(hass, mock_config_entry)
 
@@ -41,11 +38,11 @@ async def test_fans(
 
 
 @pytest.mark.parametrize(
-    ("type_key", "entity_suffix", "is_bound_mode"),
+    ("type_key", "is_bound_mode"),
     [
-        ("supply", "_supply", False),
-        ("extract", "_extract", False),
-        ("bounded", "_bounded", True),
+        ("supply", False),
+        ("extract", False),
+        ("bounded", True),
     ],
 )
 async def test_fans_actions(
@@ -54,21 +51,20 @@ async def test_fans_actions(
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     type_key: str,
-    entity_suffix: str,
     is_bound_mode: bool,
 ) -> None:
     """Test turning fans on/off, setting speed and presets."""
-
-    # Set the bound mode in the mock, as this determines entity availability.
+    # Set the mock API state for the fan type being tested
     mock_prana_api.get_state.return_value.bound = is_bound_mode
 
     await async_init_integration(hass, mock_config_entry)
 
-    entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-    assert entries
-    target = f"fan.prana_recuperator{entity_suffix}"
+    unique_id = f"{mock_config_entry.unique_id}_{type_key}"
+
+    entity_entry = entity_registry.async_get_entity_id(FAN_DOMAIN, "prana", unique_id)
+
+    assert entity_entry, f"Entity with unique_id {unique_id} not found in registry"
+    target = entity_entry
 
     # --- Test Turn OFF ---
     hass.states.async_set(target, "on")
@@ -81,10 +77,10 @@ async def test_fans_actions(
     )
     mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
 
-    # Reset the mock to clear previous call history.
     mock_prana_api.reset_mock()
 
     # --- Test Turn ON ---
+
     hass.states.async_set(target, "off")
 
     await hass.services.async_call(

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -1,0 +1,123 @@
+"""Integration-style tests for Prana fans."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import async_init_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_fans(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_prana_api: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Prana fans snapshot."""
+    # The default mock state has bound=False.
+    # Therefore, 'supply' and 'extract' fans will be available, while 'bounded' will be unavailable.
+    # This expected availability state is captured by the snapshot.
+    with patch("homeassistant.components.prana.PLATFORMS", [Platform.FAN]):
+        await async_init_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("type_key", "entity_suffix", "is_bound_mode"),
+    [
+        ("supply", "_supply", False),
+        ("extract", "_extract", False),
+        ("bounded", "_bounded", True),
+    ],
+)
+async def test_fans_actions(
+    hass: HomeAssistant,
+    mock_prana_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    type_key: str,
+    entity_suffix: str,
+    is_bound_mode: bool,
+) -> None:
+    """Test turning fans on/off, setting speed and presets."""
+
+    # Set the bound mode in the mock state.
+    # This determines entity availability: 'bounded' is only available when bound=True.
+    mock_prana_api.get_state.return_value.bound = is_bound_mode
+
+    # Ensure the fan is initially ON in the mock.
+    # Home Assistant optimizes service calls and will not send a 'turn_off' command
+    # if it believes the entity is already off.
+    getattr(mock_prana_api.get_state.return_value, type_key).is_on = True
+
+    await async_init_integration(hass, mock_config_entry)
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert entries
+    target = f"fan.prana_recuperator{entity_suffix}"
+
+    # --- Test Turn OFF ---
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: target},
+        blocking=True,
+    )
+    mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
+
+    # Reset the mock to clear the previous call history.
+    mock_prana_api.reset_mock()
+
+    # --- Test Turn ON ---
+    # Update the mock state to OFF.
+    # Home Assistant requires the entity to be off to process a 'turn_on' command.
+    getattr(mock_prana_api.get_state.return_value, type_key).is_on = False
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: target},
+        blocking=True,
+    )
+    mock_prana_api.set_speed_is_on.assert_called_with(True, type_key)
+
+    # --- Test Set Percentage (Speed) ---
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 50},
+        blocking=True,
+    )
+
+    # Verify the API was called and the correct type key (e.g., 'supply') was passed.
+    mock_prana_api.set_speed.assert_called()
+    assert mock_prana_api.set_speed.call_args[0][1] == type_key
+
+    # --- Test Preset Mode ---
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {ATTR_ENTITY_ID: target, ATTR_PRESET_MODE: "night"},
+        blocking=True,
+    )
+    mock_prana_api.set_switch.assert_called_with("night", True)

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -1,5 +1,6 @@
 """Integration-style tests for Prana fans."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +23,38 @@ from . import async_init_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+FAN_TEST_CASES = [
+    ("supply", False, "supply"),
+    ("extract", False, "extract"),
+    ("supply", True, "bounded"),
+    ("extract", True, "bounded"),
+]
+
+
+async def _async_setup_fan_entity(
+    hass: HomeAssistant,
+    mock_prana_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    type_key: str,
+    is_bound_mode: bool,
+) -> tuple[str, Any]:
+    """Set up a Prana fan entity for service tests."""
+    mock_prana_api.get_state.return_value.bound = is_bound_mode
+    fan_mock_state = getattr(
+        mock_prana_api.get_state.return_value,
+        "bounded" if is_bound_mode else type_key,
+    )
+
+    await async_init_integration(hass, mock_config_entry)
+
+    unique_id = f"{mock_config_entry.unique_id}_{type_key}"
+    target = entity_registry.async_get_entity_id(FAN_DOMAIN, "prana", unique_id)
+
+    assert target, f"Entity with unique_id {unique_id} not found"
+
+    return target, fan_mock_state
+
 
 async def test_fans(
     hass: HomeAssistant,
@@ -38,37 +71,30 @@ async def test_fans(
 
 
 @pytest.mark.parametrize(
-    ("type_key", "is_bound_mode"),
-    [
-        ("supply", False),
-        ("extract", False),
-        ("bounded", True),
-    ],
+    ("type_key", "is_bound_mode", "expected_api_key"),
+    FAN_TEST_CASES,
 )
-async def test_fans_actions(
+async def test_fans_turn_on_off(
     hass: HomeAssistant,
     mock_prana_api: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     type_key: str,
     is_bound_mode: bool,
+    expected_api_key: str,
 ) -> None:
-    """Test turning fans on/off, setting speed and presets."""
-    # Set the mock API state for the fan type being tested
-    mock_prana_api.get_state.return_value.bound = is_bound_mode
+    """Test turning Prana fans on and off."""
+    target, fan_mock_state = await _async_setup_fan_entity(
+        hass,
+        mock_prana_api,
+        mock_config_entry,
+        entity_registry,
+        type_key,
+        is_bound_mode,
+    )
 
-    await async_init_integration(hass, mock_config_entry)
-
-    # Resolve the entity ID dynamically using the unique ID
-    unique_id = f"{mock_config_entry.unique_id}_{type_key}"
-    entity_entry = entity_registry.async_get_entity_id(FAN_DOMAIN, "prana", unique_id)
-
-    assert entity_entry, f"Entity with unique_id {unique_id} not found in registry"
-    target = entity_entry
-
-    # --- Test Turn OFF ---
-    # Force state to ON so HA allows turning off
-    hass.states.async_set(target, "on")
+    fan_mock_state.is_on = True
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -76,13 +102,11 @@ async def test_fans_actions(
         {ATTR_ENTITY_ID: target},
         blocking=True,
     )
-    mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
-
+    mock_prana_api.set_speed_is_on.assert_called_with(False, expected_api_key)
     mock_prana_api.reset_mock()
 
-    # --- Test Turn ON ---
-    # Force state to OFF so HA allows turning on
-    hass.states.async_set(target, "off")
+    fan_mock_state.is_on = False
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -90,12 +114,34 @@ async def test_fans_actions(
         {ATTR_ENTITY_ID: target},
         blocking=True,
     )
-    mock_prana_api.set_speed_is_on.assert_called_with(True, type_key)
+    mock_prana_api.set_speed_is_on.assert_called_with(True, expected_api_key)
 
-    mock_prana_api.reset_mock()
 
-    # --- Test Set Percentage (Speed 50%) ---
-    hass.states.async_set(target, "on")
+@pytest.mark.parametrize(
+    ("type_key", "is_bound_mode", "expected_api_key"),
+    FAN_TEST_CASES,
+)
+async def test_fans_set_percentage(
+    hass: HomeAssistant,
+    mock_prana_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    type_key: str,
+    is_bound_mode: bool,
+    expected_api_key: str,
+) -> None:
+    """Test setting the Prana fan percentage."""
+    target, fan_mock_state = await _async_setup_fan_entity(
+        hass,
+        mock_prana_api,
+        mock_config_entry,
+        entity_registry,
+        type_key,
+        is_bound_mode,
+    )
+
+    fan_mock_state.is_on = True
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -103,15 +149,9 @@ async def test_fans_actions(
         {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 50},
         blocking=True,
     )
-
     mock_prana_api.set_speed.assert_called()
-    assert mock_prana_api.set_speed.call_args[0][1] == type_key
-
+    assert mock_prana_api.set_speed.call_args[0][1] == expected_api_key
     mock_prana_api.reset_mock()
-
-    # --- Test Set Percentage 0% (Should Turn OFF) ---
-    # Ensure it is ON before we test turning it off via percentage
-    hass.states.async_set(target, "on")
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -119,15 +159,36 @@ async def test_fans_actions(
         {ATTR_ENTITY_ID: target, ATTR_PERCENTAGE: 0},
         blocking=True,
     )
+    mock_prana_api.set_speed_is_on.assert_called_with(False, expected_api_key)
 
-    # Verify that setting 0% called the turn_off API method, not set_speed
-    mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
 
-    # --- Test Preset Mode ---
+@pytest.mark.parametrize(
+    ("type_key", "is_bound_mode", "expected_api_key"),
+    FAN_TEST_CASES,
+)
+async def test_fans_set_preset_mode(
+    hass: HomeAssistant,
+    mock_prana_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    type_key: str,
+    is_bound_mode: bool,
+    expected_api_key: str,
+) -> None:
+    """Test setting the Prana fan preset mode."""
+    target, _ = await _async_setup_fan_entity(
+        hass,
+        mock_prana_api,
+        mock_config_entry,
+        entity_registry,
+        type_key,
+        is_bound_mode,
+    )
+
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PRESET_MODE,
         {ATTR_ENTITY_ID: target, ATTR_PRESET_MODE: "night"},
         blocking=True,
     )
-    mock_prana_api.set_switch.assert_called_with("night", True)
+    mock_prana_api.set_switch.assert_called_with("night", value=True)

--- a/tests/components/prana/test_fan.py
+++ b/tests/components/prana/test_fan.py
@@ -59,14 +59,8 @@ async def test_fans_actions(
 ) -> None:
     """Test turning fans on/off, setting speed and presets."""
 
-    # Set the bound mode in the mock state.
-    # This determines entity availability: 'bounded' is only available when bound=True.
+    # Set the bound mode in the mock, as this determines entity availability.
     mock_prana_api.get_state.return_value.bound = is_bound_mode
-
-    # Ensure the fan is initially ON in the mock.
-    # Home Assistant optimizes service calls and will not send a 'turn_off' command
-    # if it believes the entity is already off.
-    getattr(mock_prana_api.get_state.return_value, type_key).is_on = True
 
     await async_init_integration(hass, mock_config_entry)
 
@@ -77,6 +71,8 @@ async def test_fans_actions(
     target = f"fan.prana_recuperator{entity_suffix}"
 
     # --- Test Turn OFF ---
+    hass.states.async_set(target, "on")
+
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_TURN_OFF,
@@ -85,13 +81,11 @@ async def test_fans_actions(
     )
     mock_prana_api.set_speed_is_on.assert_called_with(False, type_key)
 
-    # Reset the mock to clear the previous call history.
+    # Reset the mock to clear previous call history.
     mock_prana_api.reset_mock()
 
     # --- Test Turn ON ---
-    # Update the mock state to OFF.
-    # Home Assistant requires the entity to be off to process a 'turn_on' command.
-    getattr(mock_prana_api.get_state.return_value, type_key).is_on = False
+    hass.states.async_set(target, "off")
 
     await hass.services.async_call(
         FAN_DOMAIN,
@@ -102,6 +96,8 @@ async def test_fans_actions(
     mock_prana_api.set_speed_is_on.assert_called_with(True, type_key)
 
     # --- Test Set Percentage (Speed) ---
+    hass.states.async_set(target, "on")
+
     await hass.services.async_call(
         FAN_DOMAIN,
         SERVICE_SET_PERCENTAGE,
@@ -109,7 +105,6 @@ async def test_fans_actions(
         blocking=True,
     )
 
-    # Verify the API was called and the correct type key (e.g., 'supply') was passed.
     mock_prana_api.set_speed.assert_called()
     assert mock_prana_api.set_speed.call_args[0][1] == type_key
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
Add new Fan platform for an integration
This PR introduces the Fan platform for the Prana integration, allowing control over airflow speeds like supply, extract and both
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43611
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
