### PR TITLE
Redact Thread dataset and format them as readable dicts in log messages

### DIFF
--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -6,6 +6,7 @@ from asyncio import Event, Task, wait
 import dataclasses
 from datetime import datetime
 import logging
+from pprint import pformat
 from typing import Any, cast
 
 from propcache.api import cached_property
@@ -28,6 +29,26 @@ STORAGE_VERSION_MINOR = 4
 SAVE_DELAY = 10
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _format_dataset(
+    dataset: dict[MeshcopTLVType | int, tlv_parser.MeshcopTLVItem],
+) -> dict[str, str]:
+    """Format a parsed Thread dataset for logging.
+
+    Returns a human-readable dict with enum field names as keys, redacting
+    NETWORKKEY and PSKC to avoid logging sensitive network credentials.
+    """
+    result = {}
+    for key, value in dataset.items():
+        name = key.name if isinstance(key, MeshcopTLVType) else str(key)
+        if key is MeshcopTLVType.NETWORKKEY:
+            result[name] = "REDACTED_KEY"
+        elif key is MeshcopTLVType.PSKC:
+            result[name] = "REDACTED_PSKC"
+        else:
+            result[name] = str(value)
+    return result
 
 
 class DatasetPreferredError(HomeAssistantError):
@@ -116,7 +137,8 @@ class DatasetStoreStore(Store):
                         or MeshcopTLVType.ACTIVETIMESTAMP not in entry.dataset
                     ):
                         _LOGGER.warning(
-                            "Dropped invalid Thread dataset '%s'", entry.tlv
+                            "Dropped invalid Thread dataset:\n%s",
+                            pformat(_format_dataset(entry.dataset)),
                         )
                         if entry.id == preferred_dataset:
                             preferred_dataset = None
@@ -125,12 +147,14 @@ class DatasetStoreStore(Store):
                     if entry.extended_pan_id in datasets:
                         if datasets[entry.extended_pan_id].id == preferred_dataset:
                             _LOGGER.warning(
-                                (
-                                    "Dropped duplicated Thread dataset '%s' "
-                                    "(duplicate of preferred dataset '%s')"
+                                "Dropped duplicated Thread dataset"
+                                " (duplicate of preferred dataset):\n%s\nkept:\n%s",
+                                pformat(_format_dataset(entry.dataset)),
+                                pformat(
+                                    _format_dataset(
+                                        datasets[entry.extended_pan_id].dataset
+                                    )
                                 ),
-                                entry.tlv,
-                                datasets[entry.extended_pan_id].tlv,
                             )
                             continue
                         new_timestamp = cast(
@@ -148,21 +172,21 @@ class DatasetStoreStore(Store):
                             new_timestamp.ticks,
                         ):
                             _LOGGER.warning(
-                                (
-                                    "Dropped duplicated Thread dataset '%s' "
-                                    "(duplicate of '%s')"
+                                "Dropped duplicated Thread dataset:\n%s\nkept:\n%s",
+                                pformat(_format_dataset(entry.dataset)),
+                                pformat(
+                                    _format_dataset(
+                                        datasets[entry.extended_pan_id].dataset
+                                    )
                                 ),
-                                entry.tlv,
-                                datasets[entry.extended_pan_id].tlv,
                             )
                             continue
                         _LOGGER.warning(
-                            (
-                                "Dropped duplicated Thread dataset '%s' "
-                                "(duplicate of '%s')"
+                            "Dropped duplicated Thread dataset:\n%s\nkept:\n%s",
+                            pformat(
+                                _format_dataset(datasets[entry.extended_pan_id].dataset)
                             ),
-                            datasets[entry.extended_pan_id].tlv,
-                            entry.tlv,
+                            pformat(_format_dataset(entry.dataset)),
                         )
                     datasets[entry.extended_pan_id] = entry
                 data = {
@@ -261,22 +285,19 @@ class DatasetStore:
                 new_timestamp.ticks,
             ):
                 _LOGGER.warning(
-                    (
-                        "Got dataset with same extended PAN ID and same or older active"
-                        " timestamp, old dataset: '%s', new dataset: '%s'"
-                    ),
-                    entry.tlv,
-                    tlv,
+                    "Got dataset with same extended PAN ID and same or older"
+                    " active timestamp\nold:\n%s\nnew:\n%s",
+                    pformat(_format_dataset(entry.dataset)),
+                    pformat(_format_dataset(dataset)),
                 )
                 return
-            _LOGGER.debug(
-                (
-                    "Updating dataset with same extended PAN ID and newer active "
-                    "timestamp, old dataset: '%s', new dataset: '%s'"
-                ),
-                entry.tlv,
-                tlv,
-            )
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "Updating dataset with same extended PAN ID and newer"
+                    " active timestamp\nold:\n%s\nnew:\n%s",
+                    pformat(_format_dataset(entry.dataset)),
+                    pformat(_format_dataset(dataset)),
+                )
             self.datasets[entry.id] = dataclasses.replace(
                 self.datasets[entry.id], tlv=tlv
             )

--- a/homeassistant/components/thread/dataset_store.py
+++ b/homeassistant/components/thread/dataset_store.py
@@ -15,6 +15,7 @@ from python_otbr_api.tlv_parser import MeshcopTLVType
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.redact import REDACTED
 from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util, ulid as ulid_util
@@ -42,10 +43,8 @@ def _format_dataset(
     result = {}
     for key, value in dataset.items():
         name = key.name if isinstance(key, MeshcopTLVType) else str(key)
-        if key is MeshcopTLVType.NETWORKKEY:
-            result[name] = "REDACTED_KEY"
-        elif key is MeshcopTLVType.PSKC:
-            result[name] = "REDACTED_PSKC"
+        if key in (MeshcopTLVType.NETWORKKEY, MeshcopTLVType.PSKC):
+            result[name] = REDACTED
         else:
             result[name] = str(value)
     return result

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -394,11 +394,8 @@ async def test_migrate_drop_bad_datasets(
     assert list(store.datasets.values())[0].tlv == DATASET_1
     assert store.preferred_dataset == "id1"
 
-    assert f"Dropped invalid Thread dataset '{DATASET_1_NO_EXTPANID}'" in caplog.text
-    assert (
-        f"Dropped invalid Thread dataset '{DATASET_1_NO_ACTIVETIMESTAMP}'"
-        in caplog.text
-    )
+    assert caplog.text.count("Dropped invalid Thread dataset") == 2
+    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
 
 
 async def test_migrate_drop_bad_datasets_preferred(
@@ -463,10 +460,8 @@ async def test_migrate_drop_duplicate_datasets(
     assert list(store.datasets.values())[0].tlv == DATASET_1_LARGER_TIMESTAMP
     assert store.preferred_dataset is None
 
-    assert (
-        f"Dropped duplicated Thread dataset '{DATASET_1}' "
-        f"(duplicate of '{DATASET_1_LARGER_TIMESTAMP}')"
-    ) in caplog.text
+    assert "Dropped duplicated Thread dataset" in caplog.text
+    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
 
 
 async def test_migrate_drop_duplicate_datasets_2(
@@ -500,10 +495,8 @@ async def test_migrate_drop_duplicate_datasets_2(
     assert list(store.datasets.values())[0].tlv == DATASET_1_LARGER_TIMESTAMP
     assert store.preferred_dataset is None
 
-    assert (
-        f"Dropped duplicated Thread dataset '{DATASET_1}' "
-        f"(duplicate of '{DATASET_1_LARGER_TIMESTAMP}')"
-    ) in caplog.text
+    assert "Dropped duplicated Thread dataset" in caplog.text
+    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
 
 
 async def test_migrate_drop_duplicate_datasets_preferred(
@@ -537,10 +530,9 @@ async def test_migrate_drop_duplicate_datasets_preferred(
     assert list(store.datasets.values())[0].tlv == DATASET_1
     assert store.preferred_dataset == "id1"
 
-    assert (
-        f"Dropped duplicated Thread dataset '{DATASET_1_LARGER_TIMESTAMP}' "
-        f"(duplicate of preferred dataset '{DATASET_1}')"
-    ) in caplog.text
+    assert "Dropped duplicated Thread dataset" in caplog.text
+    assert "duplicate of preferred dataset" in caplog.text
+    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
 
 
 async def test_migrate_set_default_border_agent_id(

--- a/tests/components/thread/test_dataset_store.py
+++ b/tests/components/thread/test_dataset_store.py
@@ -395,7 +395,7 @@ async def test_migrate_drop_bad_datasets(
     assert store.preferred_dataset == "id1"
 
     assert caplog.text.count("Dropped invalid Thread dataset") == 2
-    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
+    assert "'NETWORKKEY': '**REDACTED**'" in caplog.text
 
 
 async def test_migrate_drop_bad_datasets_preferred(
@@ -461,7 +461,7 @@ async def test_migrate_drop_duplicate_datasets(
     assert store.preferred_dataset is None
 
     assert "Dropped duplicated Thread dataset" in caplog.text
-    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
+    assert "'NETWORKKEY': '**REDACTED**'" in caplog.text
 
 
 async def test_migrate_drop_duplicate_datasets_2(
@@ -496,7 +496,7 @@ async def test_migrate_drop_duplicate_datasets_2(
     assert store.preferred_dataset is None
 
     assert "Dropped duplicated Thread dataset" in caplog.text
-    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
+    assert "'NETWORKKEY': '**REDACTED**'" in caplog.text
 
 
 async def test_migrate_drop_duplicate_datasets_preferred(
@@ -532,7 +532,7 @@ async def test_migrate_drop_duplicate_datasets_preferred(
 
     assert "Dropped duplicated Thread dataset" in caplog.text
     assert "duplicate of preferred dataset" in caplog.text
-    assert "'NETWORKKEY': 'REDACTED_KEY'" in caplog.text
+    assert "'NETWORKKEY': '**REDACTED**'" in caplog.text
 
 
 async def test_migrate_set_default_border_agent_id(


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of logging raw TLV hex strings, introduce `_format_dataset()` which converts a pre-parsed dataset dict to a human-readable dict[str, str] using enum field names as keys. `NETWORKKEY` and `PSKC` are substituted with `REDACTED_KEY`/`REDACTED_PSKC` placeholders.

Log messages that compare two datasets now use `pformat()` with `\n` separators so the fields align and the diff is immediately visible. The debug-level call is guarded with `isEnabledFor()` to avoid `pformat` overhead when debug logging is disabled.

I've considered simply redacting the TLV, but since that involves parsing anyways, I might as well print the fields. The comparison is done using the fields as well.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
