### PR TITLE
Fix race condition and cancelled future in TTS ResultStream

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -527,6 +527,16 @@ class ResultStream:
 
         This method will leverage a disk cache to speed up generation.
         """
+        if self._result_cache.done():
+            if self._result_cache.cancelled():
+                # Client disconnected before result was set, recreate the future.
+                try:
+                    del self.__dict__["_result_cache"]
+                except KeyError:
+                    pass
+            else:
+                # Stream already set the result, skip.
+                return
         self._result_cache.set_result(
             self._manager.async_cache_message_in_memory(
                 engine=self.engine,
@@ -543,6 +553,12 @@ class ResultStream:
 
         This method can result in faster first byte when generating long responses.
         """
+        if self._result_cache.done():
+            # Previous result or cancelled future, recreate.
+            try:
+                del self.__dict__["_result_cache"]
+            except KeyError:
+                pass
         self._result_cache.set_result(
             self._manager.async_cache_message_stream_in_memory(
                 engine=self.engine,
@@ -562,7 +578,7 @@ class ResultStream:
             self.last_used = monotonic()
             return
 
-        cache = await self._result_cache
+        cache = await asyncio.shield(self._result_cache)
         async for chunk in cache.async_stream_data():
             yield chunk
 

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import AsyncGenerator, MutableMapping
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -530,10 +531,8 @@ class ResultStream:
         if self._result_cache.done():
             if self._result_cache.cancelled():
                 # Client disconnected before result was set, recreate the future.
-                try:
+                with contextlib.suppress(KeyError):
                     del self.__dict__["_result_cache"]
-                except KeyError:
-                    pass
             else:
                 # Stream already set the result, skip.
                 return
@@ -555,10 +554,8 @@ class ResultStream:
         """
         if self._result_cache.done():
             # Previous result or cancelled future, recreate.
-            try:
+            with contextlib.suppress(KeyError):
                 del self.__dict__["_result_cache"]
-            except KeyError:
-                pass
         self._result_cache.set_result(
             self._manager.async_cache_message_stream_in_memory(
                 engine=self.engine,


### PR DESCRIPTION
## Summary

Fixes two issues in `ResultStream._result_cache` future handling that cause intermittent TTS failures:

- **Race condition** (`InvalidStateError`): Both `async_set_message()` and `async_set_message_stream()` call `set_result()` on the same future when an LLM streaming response crosses `STREAM_RESPONSE_CHARS`. The second call crashes the pipeline.
- **Client cancellation** (silent TTS failure): When a client fetches `/api/tts_proxy/{token}` before the TTS result is ready and then disconnects, the handler task cancellation propagates to the future via `asyncio`. The future ends up cancelled, so the subsequent `set_result()` raises `InvalidStateError` and TTS is silently skipped.

### Changes

- `async_set_message()`: If the future is already done (stream won the race), skip. If cancelled (client disconnected), recreate the future and proceed.
- `async_set_message_stream()`: If the future is already done (previous result or cancelled), recreate it. Stream always takes priority.
- `async_stream_result()`: Wrap `await self._result_cache` with `asyncio.shield()` so client disconnections don't cancel the underlying future.

### Affected clients

- **Android Companion App / Web GUI**: Consume TTS via HTTP fetch from `/api/tts_proxy/`. Affected by both issues.
- **ESP32 voice satellites** (ESPHome VoiceAssistant API): Not affected — they use direct streaming, not HTTP fetch.

### Tested with

- Google Cloud TTS (non-streaming) — confirmed cancelled future fix
- Wyoming Piper (streaming) — confirmed race condition fix
- Home Assistant 2026.2.2, Python 3.13

Closes #162438