### PR TITLE
Bump python-bsblan version to 4.2.1

### DIFF
--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==4.2.0"],
+  "requirements": ["python-bsblan==4.2.1"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -81,31 +81,29 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         self._attr_available = True
 
         # Set temperature limits based on device capabilities from slow coordinator
+        dhw_config = (
+            data.slow_coordinator.data.dhw_config
+            if data.slow_coordinator.data
+            else None
+        )
+
         # For min_temp: Use reduced_setpoint from config data (slow polling)
         if (
-            data.slow_coordinator.data
-            and data.slow_coordinator.data.dhw_config is not None
-            and data.slow_coordinator.data.dhw_config.reduced_setpoint is not None
-            and hasattr(data.slow_coordinator.data.dhw_config.reduced_setpoint, "value")
+            dhw_config is not None
+            and dhw_config.reduced_setpoint is not None
+            and dhw_config.reduced_setpoint.value is not None
         ):
-            self._attr_min_temp = float(
-                data.slow_coordinator.data.dhw_config.reduced_setpoint.value
-            )
+            self._attr_min_temp = dhw_config.reduced_setpoint.value
         else:
             self._attr_min_temp = 10.0  # Default minimum
 
         # For max_temp: Use nominal_setpoint_max from config data (slow polling)
         if (
-            data.slow_coordinator.data
-            and data.slow_coordinator.data.dhw_config is not None
-            and data.slow_coordinator.data.dhw_config.nominal_setpoint_max is not None
-            and hasattr(
-                data.slow_coordinator.data.dhw_config.nominal_setpoint_max, "value"
-            )
+            dhw_config is not None
+            and dhw_config.nominal_setpoint_max is not None
+            and dhw_config.nominal_setpoint_max.value is not None
         ):
-            self._attr_max_temp = float(
-                data.slow_coordinator.data.dhw_config.nominal_setpoint_max.value
-            )
+            self._attr_max_temp = dhw_config.nominal_setpoint_max.value
         else:
             self._attr_max_temp = 65.0  # Default maximum
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2524,7 +2524,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==4.2.0
+python-bsblan==4.2.1
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2147,7 +2147,7 @@ python-MotionMount==2.3.0
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==4.2.0
+python-bsblan==4.2.1
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -47,8 +47,8 @@ def mock_dhw_config_missing_attributes(mock_bsblan: AsyncMock) -> None:
 
 
 @pytest.fixture
-def mock_dhw_config_missing_value_attribute(mock_bsblan: AsyncMock) -> None:
-    """Mock config with objects where value is None."""
+def mock_dhw_config_none_values(mock_bsblan: AsyncMock) -> None:
+    """Mock config with temperature setpoint objects where value is None."""
     mock_config = MagicMock()
     mock_reduced_setpoint = MagicMock()
     mock_reduced_setpoint.value = None
@@ -308,8 +308,8 @@ async def test_water_heater_no_sensors(
             "DHW config with missing temperature attributes",
         ),
         (
-            "mock_dhw_config_missing_value_attribute",
-            "DHW config with objects missing value attribute",
+            "mock_dhw_config_none_values",
+            "DHW config with None temperature values",
         ),
     ],
 )

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -48,10 +48,12 @@ def mock_dhw_config_missing_attributes(mock_bsblan: AsyncMock) -> None:
 
 @pytest.fixture
 def mock_dhw_config_missing_value_attribute(mock_bsblan: AsyncMock) -> None:
-    """Mock config with objects that don't have 'value' attribute."""
+    """Mock config with objects where value is None."""
     mock_config = MagicMock()
-    mock_reduced_setpoint = MagicMock(spec=[])  # Empty spec means no attributes
-    mock_nominal_setpoint_max = MagicMock(spec=[])  # Empty spec means no attributes
+    mock_reduced_setpoint = MagicMock()
+    mock_reduced_setpoint.value = None
+    mock_nominal_setpoint_max = MagicMock()
+    mock_nominal_setpoint_max.value = None
     mock_config.reduced_setpoint = mock_reduced_setpoint
     mock_config.nominal_setpoint_max = mock_nominal_setpoint_max
     mock_bsblan.hot_water_config.return_value = mock_config


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/liudger/python-bsblan/releases/tag/v4.2.1
for better type handling

This pull request updates the `bsblan` integration to use the latest `python-bsblan` library and simplifies the handling of temperature limits in the water heater component. The most important changes are grouped below:

Dependency Update:

* Updated `python-bsblan` requirement from version 4.2.0 to 4.2.1 in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt` to ensure compatibility with the latest upstream improvements. [[1]](diffhunk://#diff-fbd49835c369530338a67413a9b235d801f9a0affb21aa1a4645440499c5fef6L10-R10) [[2]](diffhunk://#diff-ae66cd41e5a8644fe0cdd7b9a2f0fee97b5deabe5f3793da15b73fa6353d2128L2527-R2527) [[3]](diffhunk://#diff-f946654c97927cbf41d54a07e10b9f92e95e9a43c0a7e2455d30acc696f08019L2150-R2150)

Water Heater Component Improvements:

* Refactored temperature limit logic in `water_heater.py` to use a local `dhw_config` variable and check for `.value` being `None` instead of using `hasattr`, making the code clearer and more robust. Now, min and max temperature attributes are directly set from `dhw_config` values if available, otherwise defaults are used.

Test Adjustments:

* Updated the test fixture `mock_dhw_config_missing_value_attribute` in `test_water_heater.py` to mock config objects with `.value = None` instead of missing the attribute, aligning tests with the new logic in the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
