### PR TITLE
Add diagnostics support to Splunk integration

### DIFF
--- a/homeassistant/components/splunk/diagnostics.py
+++ b/homeassistant/components/splunk/diagnostics.py
@@ -1,0 +1,25 @@
+"""Diagnostics support for Splunk."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from . import DATA_FILTER
+
+TO_REDACT = {CONF_TOKEN}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "entity_filter": hass.data[DATA_FILTER].config,
+    }

--- a/homeassistant/components/splunk/quality_scale.yaml
+++ b/homeassistant/components/splunk/quality_scale.yaml
@@ -83,10 +83,7 @@ rules:
       Integration does not create entities.
 
   # Gold
-  diagnostics:
-    status: todo
-    comment: |
-      Consider adding diagnostics support including config entry data with redacted token, connection status, event submission statistics, entity filter configuration, and recent error messages to help troubleshooting.
+  diagnostics: done
   discovery:
     status: exempt
     comment: |

--- a/tests/components/splunk/snapshots/test_diagnostics.ambr
+++ b/tests/components/splunk/snapshots/test_diagnostics.ambr
@@ -1,0 +1,26 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'entity_filter': dict({
+      'exclude_domains': list([
+      ]),
+      'exclude_entities': list([
+      ]),
+      'exclude_entity_globs': list([
+      ]),
+      'include_domains': list([
+      ]),
+      'include_entities': list([
+      ]),
+      'include_entity_globs': list([
+      ]),
+    }),
+    'entry_data': dict({
+      'host': 'localhost',
+      'port': 8088,
+      'ssl': False,
+      'token': '**REDACTED**',
+      'verify_ssl': True,
+    }),
+  })
+# ---

--- a/tests/components/splunk/test_diagnostics.py
+++ b/tests/components/splunk/test_diagnostics.py
@@ -1,0 +1,28 @@
+"""Test Splunk diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_hass_splunk: ...,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics for config entry."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+    assert result == snapshot(exclude=props("created_at", "modified_at", "entry_id"))


### PR DESCRIPTION
## Proposed change

Adds diagnostics support to the Splunk integration to help users troubleshoot connection and configuration issues. The diagnostics endpoint returns redacted config entry data (with token masked) and entity filter configuration.

- Created `diagnostics.py` with `async_get_config_entry_diagnostics`
- Added snapshot-based test in `test_diagnostics.py`
- Updated `quality_scale.yaml` to mark diagnostics as done

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR implements the diagnostics requirement for Gold-level quality scale

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr