### PR TITLE
Fix pytest warnings in screenlogic

### DIFF
--- a/tests/components/screenlogic/conftest.py
+++ b/tests/components/screenlogic/conftest.py
@@ -1,7 +1,7 @@
 """Setup fixtures for ScreenLogic integration tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -45,14 +45,8 @@ def mock_disconnect() -> Generator[None]:
         """Mock subscribe client."""
         return Mock()
 
-    with (
-        patch(
-            "homeassistant.components.screenlogic.ScreenLogicGateway.async_disconnect",
-            AsyncMock(),
-        ),
-        patch(
-            "homeassistant.components.screenlogic.ScreenLogicGateway.async_subscribe_client",
-            _subscribe_client,
-        ),
+    with patch(
+        "homeassistant.components.screenlogic.ScreenLogicGateway.async_subscribe_client",
+        _subscribe_client,
     ):
         yield

--- a/tests/components/screenlogic/conftest.py
+++ b/tests/components/screenlogic/conftest.py
@@ -1,5 +1,8 @@
 """Setup fixtures for ScreenLogic integration tests."""
 
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
 
 from homeassistant.components.screenlogic import DOMAIN
@@ -32,3 +35,24 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id=MOCK_ADAPTER_MAC,
         entry_id=MOCK_CONFIG_ENTRY_ID,
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_disconnect() -> Generator[None]:
+    """Mock disconnect for all tests."""
+
+    async def _subscribe_client(*args, **kwargs):
+        """Mock subscribe client."""
+        return Mock()
+
+    with (
+        patch(
+            "homeassistant.components.screenlogic.ScreenLogicGateway.async_disconnect",
+            AsyncMock(),
+        ),
+        patch(
+            "homeassistant.components.screenlogic.ScreenLogicGateway.async_subscribe_client",
+            _subscribe_client,
+        ),
+    ):
+        yield

--- a/tests/components/screenlogic/test_services.py
+++ b/tests/components/screenlogic/test_services.py
@@ -390,6 +390,7 @@ async def test_service_config_entry_not_loaded(
             async_connect=lambda *args, **kwargs: stub_async_connect(
                 DATA_MIN_ENTITY_CLEANUP, *args, **kwargs
             ),
+            async_disconnect=DEFAULT,
             is_connected=True,
             _async_connected_request=DEFAULT,
             async_set_color_lights=mock_set_color_lights,

--- a/tests/components/screenlogic/test_services.py
+++ b/tests/components/screenlogic/test_services.py
@@ -390,7 +390,6 @@ async def test_service_config_entry_not_loaded(
             async_connect=lambda *args, **kwargs: stub_async_connect(
                 DATA_MIN_ENTITY_CLEANUP, *args, **kwargs
             ),
-            async_disconnect=DEFAULT,
             is_connected=True,
             _async_connected_request=DEFAULT,
             async_set_color_lights=mock_set_color_lights,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Resolves tear-down errors when running `pytest tests/components/screenlogic`.

```
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1414, in async_remove
    await self.__async_remove_impl(force_remove)
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1427, in __async_remove_impl
    self._call_on_remove_callbacks()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/workspaces/core/homeassistant/helpers/entity.py", line 1377, in _call_on_remove_callbacks
    self._on_remove.pop()()
    ~~~~~~~~~~~~~~~~~~~~~^^
TypeError: 'NoneType' object is not callable
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
