### PR TITLE
Improve error handling in Uptime Kuma

### DIFF
--- a/homeassistant/components/uptime_kuma/config_flow.py
+++ b/homeassistant/components/uptime_kuma/config_flow.py
@@ -10,6 +10,7 @@ from pythonkuma import (
     UptimeKuma,
     UptimeKumaAuthenticationException,
     UptimeKumaException,
+    UptimeKumaParseException,
 )
 import voluptuous as vol
 from yarl import URL
@@ -60,8 +61,11 @@ async def validate_connection(
         await uptime_kuma.metrics()
     except UptimeKumaAuthenticationException:
         errors["base"] = "invalid_auth"
+    except UptimeKumaParseException:
+        errors["base"] = "invalid_data"
     except UptimeKumaException:
         errors["base"] = "cannot_connect"
+
     except Exception:
         _LOGGER.exception("Unexpected exception")
         errors["base"] = "unknown"

--- a/homeassistant/components/uptime_kuma/config_flow.py
+++ b/homeassistant/components/uptime_kuma/config_flow.py
@@ -65,7 +65,6 @@ async def validate_connection(
         errors["base"] = "invalid_data"
     except UptimeKumaException:
         errors["base"] = "cannot_connect"
-
     except Exception:
         _LOGGER.exception("Unexpected exception")
         errors["base"] = "unknown"

--- a/homeassistant/components/uptime_kuma/coordinator.py
+++ b/homeassistant/components/uptime_kuma/coordinator.py
@@ -11,6 +11,7 @@ from pythonkuma import (
     UptimeKumaAuthenticationException,
     UptimeKumaException,
     UptimeKumaMonitor,
+    UptimeKumaParseException,
     UptimeKumaVersion,
 )
 from pythonkuma.update import LatestRelease, UpdateChecker
@@ -68,7 +69,14 @@ class UptimeKumaDataUpdateCoordinator(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed_exception",
             ) from e
+        except UptimeKumaParseException as e:
+            _LOGGER.debug("Full exception", exc_info=True)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="parsing_failed_exception",
+            ) from e
         except UptimeKumaException as e:
+            _LOGGER.debug("Full exception", exc_info=True)
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="request_failed_exception",

--- a/homeassistant/components/uptime_kuma/strings.json
+++ b/homeassistant/components/uptime_kuma/strings.json
@@ -8,6 +8,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_data": "Invalid data received, check the URL",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
@@ -157,6 +158,9 @@
   "exceptions": {
     "auth_failed_exception": {
       "message": "Authentication with Uptime Kuma failed. Please check that your API key is correct and still valid"
+    },
+    "parsing_failed_exception": {
+      "message": "Invalid data received. Please verify that the Uptime Kuma URL is correct"
     },
     "request_failed_exception": {
       "message": "Connection to Uptime Kuma failed"

--- a/tests/components/uptime_kuma/test_config_flow.py
+++ b/tests/components/uptime_kuma/test_config_flow.py
@@ -157,6 +157,7 @@ async def test_flow_reauth(
     [
         (UptimeKumaConnectionException, "cannot_connect"),
         (UptimeKumaAuthenticationException, "invalid_auth"),
+        (UptimeKumaParseException, "invalid_data"),
         (ValueError, "unknown"),
     ],
 )
@@ -235,6 +236,7 @@ async def test_flow_reconfigure(
     [
         (UptimeKumaConnectionException, "cannot_connect"),
         (UptimeKumaAuthenticationException, "invalid_auth"),
+        (UptimeKumaParseException, "invalid_data"),
         (ValueError, "unknown"),
     ],
 )
@@ -387,6 +389,7 @@ async def test_hassio_addon_discovery_already_configured(
     [
         (UptimeKumaConnectionException, "cannot_connect"),
         (UptimeKumaAuthenticationException, "invalid_auth"),
+        (UptimeKumaParseException, "invalid_data"),
         (ValueError, "unknown"),
     ],
 )

--- a/tests/components/uptime_kuma/test_config_flow.py
+++ b/tests/components/uptime_kuma/test_config_flow.py
@@ -3,7 +3,11 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from pythonkuma import UptimeKumaAuthenticationException, UptimeKumaConnectionException
+from pythonkuma import (
+    UptimeKumaAuthenticationException,
+    UptimeKumaConnectionException,
+    UptimeKumaParseException,
+)
 
 from homeassistant.components.uptime_kuma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_HASSIO, SOURCE_IGNORE, SOURCE_USER
@@ -49,6 +53,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     [
         (UptimeKumaConnectionException, "cannot_connect"),
         (UptimeKumaAuthenticationException, "invalid_auth"),
+        (UptimeKumaParseException, "invalid_data"),
         (ValueError, "unknown"),
     ],
 )

--- a/tests/components/uptime_kuma/test_init.py
+++ b/tests/components/uptime_kuma/test_init.py
@@ -3,7 +3,11 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from pythonkuma import UptimeKumaAuthenticationException, UptimeKumaException
+from pythonkuma import (
+    UptimeKumaAuthenticationException,
+    UptimeKumaException,
+    UptimeKumaParseException,
+)
 
 from homeassistant.components.uptime_kuma.const import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
@@ -37,6 +41,7 @@ async def test_entry_setup_unload(
     [
         (UptimeKumaAuthenticationException, ConfigEntryState.SETUP_ERROR),
         (UptimeKumaException, ConfigEntryState.SETUP_RETRY),
+        (UptimeKumaParseException, ConfigEntryState.SETUP_RETRY),
     ],
 )
 async def test_config_entry_not_ready(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Catches a new exception for parsing errors, which usually happen when the `/metrics` endpoint URL is not entered correctly or displays an error page with invalid contents, like HTML. Also adds additional debug logging.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
