### PR TITLE
Update BSB-LAN strings, error handling, and code cleanup

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -1,4 +1,4 @@
-"""The BSB-Lan integration."""
+"""The BSB-LAN integration."""
 
 import asyncio
 import dataclasses
@@ -56,13 +56,13 @@ class BSBLanData:
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the BSB-Lan integration."""
+    """Set up the BSB-LAN integration."""
     async_setup_services(hass)
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bool:
-    """Set up BSB-Lan from a config entry."""
+    """Set up BSB-LAN from a config entry."""
 
     # create config using BSBLANConfig
     config = BSBLANConfig(

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -69,7 +69,6 @@ async def async_setup_entry(
 class BSBLANClimate(BSBLanEntity, ClimateEntity):
     """Defines a BSBLAN climate device."""
 
-    _attr_has_entity_name = True
     _attr_name = None
     # Determine preset modes
     _attr_supported_features = (

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -39,15 +39,15 @@ PRESET_MODES = [
     PRESET_NONE,
 ]
 
-# Mapping from Home Assistant HVACMode to BSB-Lan integer values
-# BSB-Lan uses: 0=off, 1=auto, 2=eco/reduced, 3=heat/comfort
+# Mapping from Home Assistant HVACMode to BSB-LAN integer values
+# BSB-LAN uses: 0=off, 1=auto, 2=eco/reduced, 3=heat/comfort
 HA_TO_BSBLAN_HVAC_MODE: Final[dict[HVACMode, int]] = {
     HVACMode.OFF: 0,
     HVACMode.AUTO: 1,
     HVACMode.HEAT: 3,
 }
 
-# Mapping from BSB-Lan integer values to Home Assistant HVACMode
+# Mapping from BSB-LAN integer values to Home Assistant HVACMode
 BSBLAN_TO_HA_HVAC_MODE: Final[dict[int, HVACMode]] = {
     0: HVACMode.OFF,
     1: HVACMode.AUTO,
@@ -137,7 +137,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
-        # BSB-Lan mode 2 is eco/reduced mode
+        # BSB-LAN mode 2 is eco/reduced mode
         if self._hvac_mode_value == 2:
             return PRESET_ECO
         return PRESET_NONE
@@ -162,7 +162,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         if ATTR_HVAC_MODE in kwargs:
             data[ATTR_HVAC_MODE] = HA_TO_BSBLAN_HVAC_MODE[kwargs[ATTR_HVAC_MODE]]
         if ATTR_PRESET_MODE in kwargs:
-            # eco preset uses BSB-Lan mode 2, none preset uses mode 1 (auto)
+            # eco preset uses BSB-LAN mode 2, none preset uses mode 1 (auto)
             if kwargs[ATTR_PRESET_MODE] == PRESET_ECO:
                 data[ATTR_HVAC_MODE] = 2
             elif kwargs[ATTR_PRESET_MODE] == PRESET_NONE:

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for BSB-Lan integration."""
+"""Config flow for BSB-LAN integration."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/bsblan/const.py
+++ b/homeassistant/components/bsblan/const.py
@@ -1,4 +1,4 @@
-"""Constants for the BSB-Lan integration."""
+"""Constants for the BSB-LAN integration."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -110,12 +110,15 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
 
         except BSBLANAuthError as err:
             raise ConfigEntryAuthFailed(
-                "Authentication failed for BSB-Lan device"
+                translation_domain=DOMAIN,
+                translation_key="coordinator_auth_error",
             ) from err
         except BSBLANConnectionError as err:
             host = self.config_entry.data[CONF_HOST]
             raise UpdateFailed(
-                f"Error while establishing connection with BSB-Lan device at {host}"
+                translation_domain=DOMAIN,
+                translation_key="coordinator_connection_error",
+                translation_placeholders={"host": host},
             ) from err
 
         return BSBLanFastData(

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -1,4 +1,4 @@
-"""DataUpdateCoordinator for the BSB-Lan integration."""
+"""DataUpdateCoordinator for the BSB-LAN integration."""
 
 from __future__ import annotations
 
@@ -57,7 +57,7 @@ class BSBLanSlowData:
 
 
 class BSBLanCoordinator[T](DataUpdateCoordinator[T]):
-    """Base BSB-Lan coordinator."""
+    """Base BSB-LAN coordinator."""
 
     config_entry: BSBLanConfigEntry
 
@@ -69,7 +69,7 @@ class BSBLanCoordinator[T](DataUpdateCoordinator[T]):
         name: str,
         update_interval: timedelta,
     ) -> None:
-        """Initialize the BSB-Lan coordinator."""
+        """Initialize the BSB-LAN coordinator."""
         super().__init__(
             hass,
             logger=LOGGER,
@@ -81,7 +81,7 @@ class BSBLanCoordinator[T](DataUpdateCoordinator[T]):
 
 
 class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
-    """The BSB-Lan fast update coordinator for frequently changing data."""
+    """The BSB-LAN fast update coordinator for frequently changing data."""
 
     def __init__(
         self,
@@ -89,7 +89,7 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
         config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
-        """Initialize the BSB-Lan fast coordinator."""
+        """Initialize the BSB-LAN fast coordinator."""
         super().__init__(
             hass,
             config_entry,
@@ -99,7 +99,7 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
         )
 
     async def _async_update_data(self) -> BSBLanFastData:
-        """Fetch fast-changing data from the BSB-Lan device."""
+        """Fetch fast-changing data from the BSB-LAN device."""
         try:
             # Client is already initialized in async_setup_entry
             # Use include filtering to only fetch parameters we actually use
@@ -129,7 +129,7 @@ class BSBLanFastCoordinator(BSBLanCoordinator[BSBLanFastData]):
 
 
 class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
-    """The BSB-Lan slow update coordinator for infrequently changing data."""
+    """The BSB-LAN slow update coordinator for infrequently changing data."""
 
     def __init__(
         self,
@@ -137,7 +137,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         config_entry: BSBLanConfigEntry,
         client: BSBLAN,
     ) -> None:
-        """Initialize the BSB-Lan slow coordinator."""
+        """Initialize the BSB-LAN slow coordinator."""
         super().__init__(
             hass,
             config_entry,
@@ -147,7 +147,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         )
 
     async def _async_update_data(self) -> BSBLanSlowData:
-        """Fetch slow-changing data from the BSB-Lan device."""
+        """Fetch slow-changing data from the BSB-LAN device."""
         try:
             # Client is already initialized in async_setup_entry
             # Use include filtering to only fetch parameters we actually use

--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -34,6 +34,11 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
                 if data.info.device_identification
                 else None
             ),
+            model_id=(
+                f"{data.info.controller_family.value}_{data.info.controller_variant.value}"
+                if data.info.controller_family and data.info.controller_variant
+                else None
+            ),
             sw_version=data.device.version,
             configuration_url=f"http://{host}",
         )

--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -32,11 +32,15 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
             model=(
                 data.info.device_identification.value
                 if data.info.device_identification
+                and data.info.device_identification.value
                 else None
             ),
             model_id=(
                 f"{data.info.controller_family.value}_{data.info.controller_variant.value}"
-                if data.info.controller_family and data.info.controller_variant
+                if data.info.controller_family
+                and data.info.controller_variant
+                and data.info.controller_family.value
+                and data.info.controller_variant.value
                 else None
             ),
             sw_version=data.device.version,

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "bsblan",
-  "name": "BSB-Lan",
+  "name": "BSB-LAN",
   "codeowners": ["@liudger"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bsblan",

--- a/homeassistant/components/bsblan/sensor.py
+++ b/homeassistant/components/bsblan/sensor.py
@@ -1,4 +1,4 @@
-"""Support for BSB-Lan sensors."""
+"""Support for BSB-LAN sensors."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ PARALLEL_UPDATES = 1
 
 @dataclass(frozen=True, kw_only=True)
 class BSBLanSensorEntityDescription(SensorEntityDescription):
-    """Describes BSB-Lan sensor entity."""
+    """Describes BSB-LAN sensor entity."""
 
     value_fn: Callable[[BSBLanFastData], StateType]
     exists_fn: Callable[[BSBLanFastData], bool] = lambda data: True
@@ -66,7 +66,7 @@ async def async_setup_entry(
     entry: BSBLanConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up BSB-Lan sensor based on a config entry."""
+    """Set up BSB-LAN sensor based on a config entry."""
     data = entry.runtime_data
 
     # Only create sensors for available data points
@@ -81,7 +81,7 @@ async def async_setup_entry(
 
 
 class BSBLanSensor(BSBLanEntity, SensorEntity):
-    """Defines a BSB-Lan sensor."""
+    """Defines a BSB-LAN sensor."""
 
     entity_description: BSBLanSensorEntityDescription
 
@@ -90,7 +90,7 @@ class BSBLanSensor(BSBLanEntity, SensorEntity):
         data: BSBLanData,
         description: BSBLanSensorEntityDescription,
     ) -> None:
-        """Initialize BSB-Lan sensor."""
+        """Initialize BSB-LAN sensor."""
         super().__init__(data.fast_coordinator, data)
         self.entity_description = description
         self._attr_unique_id = f"{data.device.MAC}-{description.key}"

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -1,4 +1,4 @@
-"""Support for BSB-Lan services."""
+"""Support for BSB-LAN services."""
 
 from __future__ import annotations
 
@@ -192,7 +192,7 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     )
 
     try:
-        # Call the BSB-Lan API to set the schedule
+        # Call the BSB-LAN API to set the schedule
         await client.set_hot_water_schedule(dhw_schedule)
     except BSBLANError as err:
         raise HomeAssistantError(
@@ -275,7 +275,7 @@ SYNC_TIME_SCHEMA = vol.Schema(
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Register the BSB-Lan services."""
+    """Register the BSB-LAN services."""
     hass.services.async_register(
         DOMAIN,
         SERVICE_SET_HOT_WATER_SCHEDULE,

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -73,6 +73,12 @@
     "config_entry_not_loaded": {
       "message": "The device `{device_name}` is not currently loaded or available"
     },
+    "coordinator_auth_error": {
+      "message": "Authentication failed for BSB-Lan device"
+    },
+    "coordinator_connection_error": {
+      "message": "Error while establishing connection with BSB-Lan device at {host}"
+    },
     "end_time_before_start_time": {
       "message": "End time ({end_time}) must be after start time ({start_time})"
     },
@@ -87,9 +93,6 @@
     },
     "set_operation_mode_error": {
       "message": "An error occurred while setting the operation mode"
-    },
-    "set_preset_mode_error": {
-      "message": "Can't set preset mode to {preset_mode} when HVAC mode is not set to auto"
     },
     "set_schedule_failed": {
       "message": "Failed to set hot water schedule: {error}"

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -22,8 +22,8 @@
           "password": "[%key:component::bsblan::config::step::user::data_description::password%]",
           "username": "[%key:component::bsblan::config::step::user::data_description::username%]"
         },
-        "description": "A BSB-Lan device was discovered at {host}. Please provide credentials if required.",
-        "title": "BSB-Lan device discovered"
+        "description": "A BSB-LAN device was discovered at {host}. Please provide credentials if required.",
+        "title": "BSB-LAN device discovered"
       },
       "reauth_confirm": {
         "data": {
@@ -36,7 +36,7 @@
           "password": "[%key:component::bsblan::config::step::user::data_description::password%]",
           "username": "[%key:component::bsblan::config::step::user::data_description::username%]"
         },
-        "description": "The BSB-Lan integration needs to re-authenticate with {name}",
+        "description": "The BSB-LAN integration needs to re-authenticate with {name}",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "user": {
@@ -48,14 +48,14 @@
           "username": "[%key:common::config_flow::data::username%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of your BSB-Lan device.",
-          "passkey": "The passkey for your BSB-Lan device.",
-          "password": "The password for your BSB-Lan device.",
-          "port": "The port number of your BSB-Lan device.",
-          "username": "The username for your BSB-Lan device."
+          "host": "The hostname or IP address of your BSB-LAN device.",
+          "passkey": "The passkey for your BSB-LAN device.",
+          "password": "The password for your BSB-LAN device.",
+          "port": "The port number of your BSB-LAN device.",
+          "username": "The username for your BSB-LAN device."
         },
-        "description": "Set up your BSB-Lan device to integrate with Home Assistant.",
-        "title": "Connect to the BSB-Lan device"
+        "description": "Set up your BSB-LAN device to integrate with Home Assistant.",
+        "title": "Connect to the BSB-LAN device"
       }
     }
   },
@@ -74,10 +74,10 @@
       "message": "The device `{device_name}` is not currently loaded or available"
     },
     "coordinator_auth_error": {
-      "message": "Authentication failed for BSB-Lan device"
+      "message": "Authentication failed for BSB-LAN device"
     },
     "coordinator_connection_error": {
-      "message": "Error while establishing connection with BSB-Lan device at {host}"
+      "message": "Error while establishing connection with BSB-LAN device at {host}"
     },
     "end_time_before_start_time": {
       "message": "End time ({end_time}) must be after start time ({start_time})"
@@ -89,7 +89,7 @@
       "message": "No configuration entry found for device: {device_id}"
     },
     "set_data_error": {
-      "message": "An error occurred while sending the data to the BSB-Lan device"
+      "message": "An error occurred while sending the data to the BSB-LAN device"
     },
     "set_operation_mode_error": {
       "message": "An error occurred while setting the operation mode"
@@ -104,7 +104,7 @@
       "message": "Authentication failed while retrieving static device data"
     },
     "setup_connection_error": {
-      "message": "Failed to retrieve static device data from BSB-Lan device at {host}"
+      "message": "Failed to retrieve static device data from BSB-LAN device at {host}"
     },
     "setup_general_error": {
       "message": "An unknown error occurred while retrieving static device data"
@@ -153,7 +153,7 @@
       "name": "Set hot water schedule"
     },
     "sync_time": {
-      "description": "Synchronize Home Assistant time to the BSB-Lan device. Only updates if device time differs from Home Assistant time.",
+      "description": "Synchronize Home Assistant time to the BSB-LAN device. Only updates if device time differs from Home Assistant time.",
       "fields": {
         "device_id": {
           "description": "The BSB-LAN device to sync time for.",

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -63,6 +63,7 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
     """Defines a BSBLAN water heater entity."""
 
     _attr_name = None
+    _attr_operation_list = list(HA_TO_BSBLAN_OPERATION_MODE.keys())
     _attr_supported_features = (
         WaterHeaterEntityFeature.TARGET_TEMPERATURE
         | WaterHeaterEntityFeature.OPERATION_MODE
@@ -73,7 +74,6 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         """Initialize BSBLAN water heater."""
         super().__init__(data.fast_coordinator, data.slow_coordinator, data)
         self._attr_unique_id = format_mac(data.device.MAC)
-        self._attr_operation_list = list(HA_TO_BSBLAN_OPERATION_MODE.keys())
 
         # Set temperature unit
         self._attr_temperature_unit = data.fast_coordinator.client.get_temperature_unit

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -905,7 +905,7 @@
       "iot_class": "local_polling"
     },
     "bsblan": {
-      "name": "BSB-Lan",
+      "name": "BSB-LAN",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_polling"

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -1,4 +1,4 @@
-"""Tests for the BSB-Lan climate platform."""
+"""Tests for the BSB-LAN climate platform."""
 
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
@@ -69,7 +69,7 @@ async def test_climate_entity_properties(
     state = hass.states.get(ENTITY_ID)
     assert state.attributes["temperature"] == 23.5
 
-    # Test hvac_mode - BSB-Lan returns integer: 1=auto
+    # Test hvac_mode - BSB-LAN returns integer: 1=auto
     mock_hvac_mode = MagicMock()
     mock_hvac_mode.value = 1  # auto mode
     mock_bsblan.state.return_value.hvac_mode = mock_hvac_mode
@@ -81,7 +81,7 @@ async def test_climate_entity_properties(
     state = hass.states.get(ENTITY_ID)
     assert state.state == HVACMode.AUTO
 
-    # Test preset_mode - BSB-Lan mode 2 is eco/reduced
+    # Test preset_mode - BSB-LAN mode 2 is eco/reduced
     mock_hvac_mode.value = 2  # eco mode
 
     freezer.tick(timedelta(minutes=1))
@@ -278,7 +278,7 @@ async def test_async_set_preset_mode_success(
     """Test setting preset mode via service call."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
-    # patch hvac_mode with integer value (BSB-Lan returns integers)
+    # patch hvac_mode with integer value (BSB-LAN returns integers)
     mock_hvac_mode = MagicMock()
     mock_hvac_mode.value = hvac_mode_int
     mock_bsblan.state.return_value.hvac_mode = mock_hvac_mode

--- a/tests/components/bsblan/test_sensor.py
+++ b/tests/components/bsblan/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for the BSB-Lan sensor platform."""
+"""Tests for the BSB-LAN sensor platform."""
 
 from unittest.mock import AsyncMock
 

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -1,4 +1,4 @@
-"""Tests for the BSB-Lan water heater platform."""
+"""Tests for the BSB-LAN water heater platform."""
 
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request makes several improvements and fixes to the BSB-LAN integration, focusing on error handling, translation support, and code cleanup for climate and water heater entities. The main changes include improved error message translation, streamlined HVAC mode handling, and enhanced device information.

**Error handling and translation improvements:**

* Updated error handling in `coordinator.py` to use translation keys and placeholders for authentication and connection errors, and added corresponding entries to `strings.json` for better localization support. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL108-R116) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R76-R81)
* Removed an unused translation string for preset mode errors in `strings.json`.

**Device and entity improvements:**

* Added a `model_id` field to device info in `entity.py`, combining controller family and variant for better device identification.
* Set the `_attr_operation_list` attribute at the class level in `water_heater.py` for consistency and code clarity, and removed redundant initialization in the constructor. [[1]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badR66) [[2]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badL76)

**Climate entity cleanup:**

* Simplified HVAC mode parsing in `climate.py` by removing the use of `try_parse_enum` and handling all values as integers. Also removed the unused `_attr_has_entity_name` attribute. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L24) [[2]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L73) [[3]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L127-R125)

**Fix BSB-LAN casing through whole integration**

**Removed redundant test**


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
