### PR TITLE
Require strict-typing for internal integrations

### DIFF
--- a/script/hassfest/model.py
+++ b/script/hassfest/model.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import IntEnum
+from functools import lru_cache
 import json
 import pathlib
+import re
 from typing import Any, Literal
 
 
@@ -255,3 +257,22 @@ class ScaledQualityScaleTiers(IntEnum):
     SILVER = 2
     GOLD = 3
     PLATINUM = 4
+
+
+_STRICT_TYPING_FILE = pathlib.Path(".strict-typing")
+_COMPONENT_REGEX = r"homeassistant\.components\.([^.]+).*"
+
+
+@lru_cache
+def get_strict_typing_components(strict_typing_file: pathlib.Path) -> set[str]:
+    """Get set of domains that have strict typing enabled."""
+    if not strict_typing_file.is_file():
+        return set()
+
+    return set(
+        {
+            match.group(1)
+            for line in strict_typing_file.read_text(encoding="utf-8").splitlines()
+            if (match := re.match(_COMPONENT_REGEX, line)) is not None
+        }
+    )

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -11,7 +11,12 @@ from homeassistant.const import Platform
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.yaml import load_yaml_dict
 
-from .model import Config, Integration, ScaledQualityScaleTiers
+from .model import (
+    Config,
+    Integration,
+    ScaledQualityScaleTiers,
+    get_strict_typing_components,
+)
 from .quality_scale_validation import (
     RuleValidationProtocol,
     action_setup,
@@ -2323,5 +2328,20 @@ def validate_iqs_file(config: Config, integration: Integration) -> None:
 
 def validate(integrations: dict[str, Integration], config: Config) -> None:
     """Handle YAML files inside integrations."""
+    strict_typing_file = config.root / ".strict-typing"
+    strict_typing_components = get_strict_typing_components(strict_typing_file)
+
     for integration in integrations.values():
+        if not integration.core:
+            continue
+
+        # Check if internal integrations have strict typing
+        if integration.quality_scale == "internal":
+            if integration.domain not in strict_typing_components:
+                integration.add_error(
+                    "quality_scale",
+                    f"Integration '{integration.domain}' has quality_scale 'internal' "
+                    "but is not in .strict-typing. Internal integrations must have strict typing enabled.",
+                )
+
         validate_iqs_file(config, integration)

--- a/script/hassfest/quality_scale_validation/strict_typing.py
+++ b/script/hassfest/quality_scale_validation/strict_typing.py
@@ -3,26 +3,12 @@
 https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/strict-typing/
 """
 
-from functools import lru_cache
 from importlib import metadata
 from pathlib import Path
-import re
 
-from script.hassfest.model import Config, Integration
+from script.hassfest.model import Config, Integration, get_strict_typing_components
 
 _STRICT_TYPING_FILE = Path(".strict-typing")
-_COMPONENT_REGEX = r"homeassistant.components.([^.]+).*"
-
-
-@lru_cache
-def _strict_typing_components(strict_typing_file: Path) -> set[str]:
-    return set(
-        {
-            match.group(1)
-            for line in strict_typing_file.read_text(encoding="utf-8").splitlines()
-            if (match := re.match(_COMPONENT_REGEX, line)) is not None
-        }
-    )
 
 
 def _check_requirements_are_typed(integration: Integration) -> list[str]:
@@ -58,7 +44,7 @@ def validate(
     """Validate that the integration has strict typing enabled."""
     strict_typing_file = config.root / _STRICT_TYPING_FILE
 
-    if integration.domain not in _strict_typing_components(strict_typing_file):
+    if integration.domain not in get_strict_typing_components(strict_typing_file):
         return [
             "Integration does not have strict typing enabled "
             "(is missing from .strict-typing)"


### PR DESCRIPTION
Add validation to hassfest that requires all integrations with quality_scale: internal in manifest.json to be present in .strict-typing file. This ensures internal integrations maintain high code quality standards.

Internal components (`quality_scale: internal`) are:
- **Widely depended upon** - other integrations use them as helpers and patterns
- **Reference implementations** - new contributors copy their structure
- **Stable by design** - breaking changes affect the entire ecosystem

So it's worth making sure they meet good code standards.

Currently 19 integrations fail this validation and will need to be updated with strict typing to pass CI, This PR won't be merged until all issues are fixed, but I've set it up to track progress.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [] The code change is tested and works locally.
- [] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
