### PR TITLE
Bump librehardwaremonitor-api to version 1.10.1

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/manifest.json
+++ b/homeassistant/components/libre_hardware_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["librehardwaremonitor-api==1.9.1"]
+  "requirements": ["librehardwaremonitor-api==1.10.1"]
 }

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from librehardwaremonitor_api.model import LibreHardwareMonitorSensorData
@@ -16,8 +15,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LibreHardwareMonitorConfigEntry, LibreHardwareMonitorCoordinator
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -33,19 +30,8 @@ async def async_setup_entry(
     """Set up the LibreHardwareMonitor platform."""
     lhm_coordinator = config_entry.runtime_data
 
-    is_deprecated_lhm_version = lhm_coordinator.data.is_deprecated_version
-    if is_deprecated_lhm_version:
-        _LOGGER.warning(
-            "Your version of Libre Hardware Monitor is deprecated. Please update to v0.9.5 or above for full support"
-        )
-
     async_add_entities(
-        LibreHardwareMonitorSensor(
-            lhm_coordinator,
-            config_entry.entry_id,
-            sensor_data,
-            is_deprecated_lhm_version,
-        )
+        LibreHardwareMonitorSensor(lhm_coordinator, config_entry.entry_id, sensor_data)
         for sensor_data in lhm_coordinator.data.sensor_data.values()
     )
 
@@ -63,14 +49,13 @@ class LibreHardwareMonitorSensor(
         coordinator: LibreHardwareMonitorCoordinator,
         entry_id: str,
         sensor_data: LibreHardwareMonitorSensorData,
-        is_deprecated_lhm_version: bool,
     ) -> None:
         """Initialize an LibreHardwareMonitor sensor."""
         super().__init__(coordinator)
 
         self._attr_name: str = sensor_data.name
 
-        self._set_state(is_deprecated_lhm_version, sensor_data)
+        self._set_state(coordinator.data.is_deprecated_version, sensor_data)
         self._attr_unique_id: str = f"{entry_id}_{sensor_data.sensor_id}"
 
         self._sensor_id: str = sensor_data.sensor_id

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from librehardwaremonitor_api.model import LibreHardwareMonitorSensorData
+from librehardwaremonitor_api.sensor_type import SensorType
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import HomeAssistant, callback
@@ -14,6 +16,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import LibreHardwareMonitorConfigEntry, LibreHardwareMonitorCoordinator
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -29,8 +33,19 @@ async def async_setup_entry(
     """Set up the LibreHardwareMonitor platform."""
     lhm_coordinator = config_entry.runtime_data
 
+    is_deprecated_lhm_version = lhm_coordinator.data.is_deprecated_version
+    if is_deprecated_lhm_version:
+        _LOGGER.warning(
+            "Your version of Libre Hardware Monitor is deprecated. Please update to v0.9.5 or above for full support"
+        )
+
     async_add_entities(
-        LibreHardwareMonitorSensor(lhm_coordinator, config_entry.entry_id, sensor_data)
+        LibreHardwareMonitorSensor(
+            lhm_coordinator,
+            config_entry.entry_id,
+            sensor_data,
+            is_deprecated_lhm_version,
+        )
         for sensor_data in lhm_coordinator.data.sensor_data.values()
     )
 
@@ -48,17 +63,14 @@ class LibreHardwareMonitorSensor(
         coordinator: LibreHardwareMonitorCoordinator,
         entry_id: str,
         sensor_data: LibreHardwareMonitorSensorData,
+        is_deprecated_lhm_version: bool,
     ) -> None:
         """Initialize an LibreHardwareMonitor sensor."""
         super().__init__(coordinator)
 
         self._attr_name: str = sensor_data.name
-        self._attr_native_value: str | None = sensor_data.value
-        self._attr_extra_state_attributes: dict[str, Any] = {
-            STATE_MIN_VALUE: sensor_data.min,
-            STATE_MAX_VALUE: sensor_data.max,
-        }
-        self._attr_native_unit_of_measurement = sensor_data.unit
+
+        self._set_state(is_deprecated_lhm_version, sensor_data)
         self._attr_unique_id: str = f"{entry_id}_{sensor_data.sensor_id}"
 
         self._sensor_id: str = sensor_data.sensor_id
@@ -70,15 +82,36 @@ class LibreHardwareMonitorSensor(
             model=sensor_data.device_type,
         )
 
+    def _set_state(
+        self,
+        is_deprecated_lhm_version: bool,
+        sensor_data: LibreHardwareMonitorSensorData,
+    ) -> None:
+        value = sensor_data.value
+        min_value = sensor_data.min
+        max_value = sensor_data.max
+        unit = sensor_data.unit
+
+        if not is_deprecated_lhm_version and sensor_data.type == SensorType.THROUGHPUT:
+            # Temporary fix: convert the B/s value to KB/s to not break existing entries
+            # This will be migrated properly once SensorDeviceClass is introduced
+            value = f"{(float(value) / 1024):.1f}" if value else None
+            min_value = f"{(float(min_value) / 1024):.1f}" if min_value else None
+            max_value = f"{(float(max_value) / 1024):.1f}" if max_value else None
+            unit = "KB/s"
+
+        self._attr_native_value: str | None = value
+        self._attr_extra_state_attributes: dict[str, Any] = {
+            STATE_MIN_VALUE: min_value,
+            STATE_MAX_VALUE: max_value,
+        }
+        self._attr_native_unit_of_measurement = unit
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if sensor_data := self.coordinator.data.sensor_data.get(self._sensor_id):
-            self._attr_native_value = sensor_data.value
-            self._attr_extra_state_attributes = {
-                STATE_MIN_VALUE: sensor_data.min,
-                STATE_MAX_VALUE: sensor_data.max,
-            }
+            self._set_state(self.coordinator.data.is_deprecated_version, sensor_data)
         else:
             self._attr_native_value = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1416,7 +1416,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.9.1
+librehardwaremonitor-api==1.10.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1250,7 +1250,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.9.1
+librehardwaremonitor-api==1.10.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -130,26 +130,38 @@ async def test_sensor_invalid_auth_during_startup(
     assert all(state.state == STATE_UNAVAILABLE for state in unavailable_states)
 
 
+@pytest.mark.parametrize(
+    ("entity_id", "sensor_id", "new_value", "state_value"),
+    [
+        (
+            "gaming_pc_amd_ryzen_7_7800x3d_package_temperature",
+            "amdcpu-0-temperature-3",
+            "42.1",
+            "42.1",
+        ),
+        (
+            "gaming_pc_nvidia_geforce_rtx_4080_super_gpu_pcie_tx_throughput",
+            "gpu-nvidia-0-throughput-1",
+            "792150000.0",
+            "773584.0",
+        ),
+    ],
+)
 async def test_sensors_are_updated(
     hass: HomeAssistant,
     mock_lhm_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    entity_id: str,
+    sensor_id: str,
+    new_value: str,
+    state_value: str,
 ) -> None:
     """Test sensors are updated with properly formatted values."""
     await init_integration(hass, mock_config_entry)
 
-    entity_id = "sensor.gaming_pc_amd_ryzen_7_7800x3d_package_temperature"
-    state = hass.states.get(entity_id)
-
-    assert state
-    assert state.state != STATE_UNAVAILABLE
-    assert state.state == "52.8"
-
     updated_data = dict(mock_lhm_client.get_data.return_value.sensor_data)
-    updated_data["amdcpu-0-temperature-3"] = replace(
-        updated_data["amdcpu-0-temperature-3"], value="42.1"
-    )
+    updated_data[sensor_id] = replace(updated_data[sensor_id], value=new_value)
     mock_lhm_client.get_data.return_value = replace(
         mock_lhm_client.get_data.return_value,
         sensor_data=MappingProxyType(updated_data),
@@ -159,11 +171,11 @@ async def test_sensors_are_updated(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity_id)
+    state = hass.states.get(f"sensor.{entity_id}")
 
     assert state
     assert state.state != STATE_UNAVAILABLE
-    assert state.state == "42.1"
+    assert state.state == state_value
 
 
 async def test_sensor_state_is_unknown_when_no_sensor_data_is_provided(
@@ -263,6 +275,7 @@ async def _mock_orphaned_device(
                 if not sensor_id.startswith(removed_device)
             }
         ),
+        is_deprecated_version=False,
     )
 
     return device_registry.async_get_or_create(
@@ -287,6 +300,7 @@ async def test_integration_does_not_log_new_devices_on_first_refresh(
             }
         ),
         sensor_data=mock_lhm_client.get_data.return_value.sensor_data,
+        is_deprecated_version=False,
     )
 
     with caplog.at_level(logging.WARNING):

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -131,7 +131,7 @@ async def test_sensor_invalid_auth_during_startup(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "sensor_id", "new_value", "state_value"),
+    ("object_id", "sensor_id", "new_value", "state_value"),
     [
         (
             "gaming_pc_amd_ryzen_7_7800x3d_package_temperature",
@@ -152,7 +152,7 @@ async def test_sensors_are_updated(
     mock_lhm_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
-    entity_id: str,
+    object_id: str,
     sensor_id: str,
     new_value: str,
     state_value: str,
@@ -171,7 +171,7 @@ async def test_sensors_are_updated(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(f"sensor.{entity_id}")
+    state = hass.states.get(f"sensor.{object_id}")
 
     assert state
     assert state.state != STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `librehardwaremonitor-api` dependency to v1.10.1

This removes the custom unit conversion to `KB/s` (it was not a good idea to start with, we live and we learn).
In order to not break existing entries, this conversion is temporarily moved to the integration. It will be removed in an upcoming PR when introducing sensor device classes.
Unfortunately it is an ugly trade-off that needs to be made at the moment.

It also adds an `is_deprecated_version` flag based on the version of Libre Hardware Monitor that is running, as in more recent versions there were major API improvements and support for those older API versions will be dropped from the integration eventually. ~There is now a warning about this.~ This is not just a matter of developer convenience, but versions of LHM < 0.9.5 use an old WinRing0 driver that has security vulnerabilities which have been fixed by migrating to a new underlying driver (PawnIO). More context about this can be found [here](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/984).

Diff: https://github.com/Sab44/librehardwaremonitor-api/compare/v1.9.1...v1.10.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
