### PR TITLE
Add reconfiguration flow to Splunk integration

### DIFF
--- a/homeassistant/components/splunk/config_flow.py
+++ b/homeassistant/components/splunk/config_flow.py
@@ -85,6 +85,40 @@ class SplunkConfigFlow(ConfigFlow, domain=DOMAIN):
             data=import_config,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the Splunk integration."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            errors = await self._async_validate_input(user_input)
+
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates=user_input,
+                    title=f"{user_input[CONF_HOST]}:{user_input[CONF_PORT]}",
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(CONF_TOKEN): str,
+                        vol.Required(CONF_HOST): str,
+                        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                        vol.Optional(CONF_SSL, default=False): bool,
+                        vol.Optional(CONF_VERIFY_SSL, default=True): bool,
+                        vol.Optional(CONF_NAME): str,
+                    }
+                ),
+                self._get_reconfigure_entry().data,
+            ),
+            errors=errors,
+        )
+
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:

--- a/homeassistant/components/splunk/quality_scale.yaml
+++ b/homeassistant/components/splunk/quality_scale.yaml
@@ -119,11 +119,7 @@ rules:
     status: exempt
     comment: |
       Integration does not create entities.
-  reconfiguration-flow:
-    status: todo
-    comment: |
-      Consider adding reconfiguration flow to allow users to update host, port, entity filter, and SSL settings without deleting and re-adding the config entry.
-
+  reconfiguration-flow: done
   # Platinum
   async-dependency:
     status: todo

--- a/homeassistant/components/splunk/strings.json
+++ b/homeassistant/components/splunk/strings.json
@@ -6,6 +6,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_config": "The YAML configuration is invalid and cannot be imported. Please check your configuration.yaml file.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
@@ -25,6 +26,25 @@
         },
         "description": "The Splunk token is no longer valid. Please enter a new HTTP Event Collector token.",
         "title": "Reauthenticate Splunk"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "name": "[%key:common::config_flow::data::name%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "token": "HTTP Event Collector token",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "host": "[%key:component::splunk::config::step::user::data_description::host%]",
+          "name": "[%key:component::splunk::config::step::user::data_description::name%]",
+          "port": "[%key:component::splunk::config::step::user::data_description::port%]",
+          "ssl": "[%key:component::splunk::config::step::user::data_description::ssl%]",
+          "token": "[%key:component::splunk::config::step::user::data_description::token%]",
+          "verify_ssl": "[%key:component::splunk::config::step::user::data_description::verify_ssl%]"
+        },
+        "description": "Update your Splunk HTTP Event Collector connection settings."
       },
       "user": {
         "data": {


### PR DESCRIPTION
## Proposed change
Adds a reconfiguration flow to the Splunk integration, allowing users to update host, port, token, SSL settings, and name without deleting and re-adding the config entry. The reconfiguration flow reuses existing validation logic and properly updates the entry before reloading.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr