### PR TITLE
Add exception translations for Splunk setup errors

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -179,24 +179,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     except ClientConnectionError as err:
         raise ConfigEntryNotReady(
-            f"Connection error connecting to Splunk at {host}:{port}: {err}"
+            translation_domain=DOMAIN,
+            translation_key="connection_error",
+            translation_placeholders={
+                "host": host,
+                "port": str(port),
+                "error": str(err),
+            },
         ) from err
     except TimeoutError as err:
         raise ConfigEntryNotReady(
-            f"Timeout connecting to Splunk at {host}:{port}"
+            translation_domain=DOMAIN,
+            translation_key="timeout_connect",
+            translation_placeholders={"host": host, "port": str(port)},
         ) from err
     except Exception as err:
         _LOGGER.exception("Unexpected error setting up Splunk")
         raise ConfigEntryNotReady(
-            f"Unexpected error connecting to Splunk: {err}"
+            translation_domain=DOMAIN,
+            translation_key="unexpected_error",
+            translation_placeholders={
+                "host": host,
+                "port": str(port),
+                "error": str(err),
+            },
         ) from err
 
     if not connectivity_ok:
         raise ConfigEntryNotReady(
-            f"Unable to connect to Splunk instance at {host}:{port}"
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"host": host, "port": str(port)},
         )
     if not token_ok:
-        raise ConfigEntryAuthFailed("Invalid Splunk token - please reauthenticate")
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN, translation_key="invalid_auth"
+        )
 
     # Send startup event
     payload: dict[str, Any] = {

--- a/homeassistant/components/splunk/quality_scale.yaml
+++ b/homeassistant/components/splunk/quality_scale.yaml
@@ -111,10 +111,7 @@ rules:
     status: exempt
     comment: |
       Integration does not create entities.
-  exception-translations:
-    status: todo
-    comment: |
-      Consider adding exception translations for user-facing errors beyond the current strings.json error section to provide more detailed translated error messages.
+  exception-translations: done
   icon-translations:
     status: exempt
     comment: |

--- a/homeassistant/components/splunk/strings.json
+++ b/homeassistant/components/splunk/strings.json
@@ -48,6 +48,23 @@
       }
     }
   },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Unable to connect to Splunk at {host}:{port}."
+    },
+    "connection_error": {
+      "message": "Unable to connect to Splunk at {host}:{port}: {error}."
+    },
+    "invalid_auth": {
+      "message": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "timeout_connect": {
+      "message": "Connection to Splunk at {host}:{port} timed out."
+    },
+    "unexpected_error": {
+      "message": "Unexpected error while connecting to Splunk at {host}:{port}: {error}."
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_cannot_connect": {
       "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release.\n\nWhile importing your configuration, a connection error occurred. Please correct your YAML configuration and restart Home Assistant, or remove the connection settings from your `{domain}:` configuration and configure the integration via the UI.\n\nNote: Entity filtering via YAML (`filter:`) will continue to work.",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds translated exception messages for Splunk config entry setup failures, so user-facing setup errors use `strings.json` exception keys instead of hardcoded English strings. Updates setup error handling to raise `ConfigEntryNotReady` and `ConfigEntryAuthFailed` with `translation_domain`, `translation_key`, and placeholders where relevant. Extends Splunk setup tests to validate translation keys recorded on config-entry setup failure states. Marks the Splunk quality-scale `exception-translations` item as complete.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
