### PR TITLE
Add debounce to Satel Integra alarm panel state

### DIFF
--- a/homeassistant/components/satel_integra/coordinator.py
+++ b/homeassistant/components/satel_integra/coordinator.py
@@ -9,12 +9,15 @@ from satel_integra.satel_integra import AlarmState
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .client import SatelClient
 from .const import ZONES
 
 _LOGGER = logging.getLogger(__name__)
+
+PARTITION_UPDATE_DEBOUNCE_DELAY = 0.1
 
 
 @dataclass
@@ -106,9 +109,21 @@ class SatelIntegraPartitionsCoordinator(
 
         self.data = {}
 
+        self._debouncer = Debouncer(
+            hass=self.hass,
+            logger=_LOGGER,
+            cooldown=PARTITION_UPDATE_DEBOUNCE_DELAY,
+            immediate=False,
+            function=callback(
+                lambda: self.async_set_updated_data(
+                    self.client.controller.partition_states
+                )
+            ),
+        )
+
     @callback
     def partitions_update_callback(self) -> None:
         """Update partition objects as per notification from the alarm."""
         _LOGGER.debug("Sending request to update panel state")
 
-        self.async_set_updated_data(self.client.controller.partition_states)
+        self._debouncer.async_schedule_call()

--- a/homeassistant/components/satel_integra/coordinator.py
+++ b/homeassistant/components/satel_integra/coordinator.py
@@ -17,7 +17,7 @@ from .const import ZONES
 
 _LOGGER = logging.getLogger(__name__)
 
-PARTITION_UPDATE_DEBOUNCE_DELAY = 0.1
+PARTITION_UPDATE_DEBOUNCE_DELAY = 0.15
 
 
 @dataclass

--- a/tests/components/satel_integra/__init__.py
+++ b/tests/components/satel_integra/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 MOCK_CODE = "1234"
 MOCK_CONFIG_DATA = {CONF_HOST: "192.168.0.2", CONF_PORT: DEFAULT_PORT}
@@ -79,11 +79,14 @@ MOCK_SWITCHABLE_OUTPUT_SUBENTRY = ConfigSubentry(
 )
 
 
+@pytest.mark.usefixtures("patch_debounce")
 async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry):
     """Set up the component."""
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
+
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
 

--- a/tests/components/satel_integra/conftest.py
+++ b/tests/components/satel_integra/conftest.py
@@ -32,6 +32,16 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
+def patch_debounce() -> Generator[None]:
+    """Override coordinator debounce time."""
+    with patch(
+        "homeassistant.components.satel_integra.coordinator.PARTITION_UPDATE_DEBOUNCE_DELAY",
+        0,
+    ):
+        yield
+
+
+@pytest.fixture
 def mock_satel() -> Generator[AsyncMock]:
     """Override the satel test."""
     with (

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -3,7 +3,6 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from satel_integra.satel_integra import AlarmState
 from syrupy.assertion import SnapshotAssertion
@@ -115,7 +114,54 @@ async def test_alarm_status_callback(
     mock_satel.partition_states = {source_state: [1]}
 
     alarm_panel_update_method()
+
+    # Trigger coordinator debounce
+    async_fire_time_changed(hass)
+
     assert hass.states.get("alarm_control_panel.home").state == resulting_state
+
+
+async def test_alarm_status_callback_debounce(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test that rapid partition state callbacks are debounced."""
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    assert (
+        hass.states.get("alarm_control_panel.home").state
+        == AlarmControlPanelState.DISARMED
+    )
+
+    alarm_panel_update_method, _, _ = get_monitor_callbacks(mock_satel)
+
+    # Simulate rapid state changes from the alarm panel
+    mock_satel.partition_states = {AlarmState.EXIT_COUNTDOWN_OVER_10: [1]}
+    alarm_panel_update_method()
+
+    mock_satel.partition_states = {AlarmState.EXIT_COUNTDOWN_UNDER_10: [1]}
+    alarm_panel_update_method()
+
+    mock_satel.partition_states = {AlarmState.ARMED_MODE0: [1]}
+    alarm_panel_update_method()
+
+    mock_satel.partition_states = {AlarmState.ARMED_MODE1: [1]}
+    alarm_panel_update_method()
+
+    # State should still be DISARMED because updates are debounced
+    assert (
+        hass.states.get("alarm_control_panel.home").state
+        == AlarmControlPanelState.DISARMED
+    )
+
+    # Trigger coordinator debounce
+    async_fire_time_changed(hass)
+
+    assert (
+        hass.states.get("alarm_control_panel.home").state
+        == AlarmControlPanelState.ARMED_HOME
+    )
 
 
 async def test_alarm_control_panel_arming(
@@ -175,7 +221,6 @@ async def test_alarm_panel_last_reported(
     hass: HomeAssistant,
     mock_satel: AsyncMock,
     mock_config_entry_with_subentries: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test alarm panels update last_reported if same state is reported."""
     events = async_capture_events(hass, "state_changed")
@@ -186,12 +231,12 @@ async def test_alarm_panel_last_reported(
     # Initial state change event
     assert len(events) == 1
 
-    freezer.tick(1)
-    async_fire_time_changed(hass)
-
     # Run callbacks with same payload
     alarm_panel_update_method, _, _ = get_monitor_callbacks(mock_satel)
     alarm_panel_update_method()
+
+    # Trigger coordinator debounce
+    async_fire_time_changed(hass)
 
     assert first_reported != hass.states.get("alarm_control_panel.home").last_reported
     assert len(events) == 1  # last_reported shall not fire state_changed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Satel Integra alarm panels pushes alarm states as soon as they happen. The logic on the hardware side however is that when a panel changes state, it first sends out it was 'removed' from the previous state list, then (I've seen up to ~60ms) send out an updated list of the new state. 

This causes jitter in the alarm state on the Home Assistant side:
<img width="605" height="342" alt="image" src="https://github.com/user-attachments/assets/0f8e1763-a1f1-41ad-9a5b-07a3a52c182d" />

After the debouncing:
<img width="498" height="149" alt="image" src="https://github.com/user-attachments/assets/2937d2db-07fa-41a4-bf06-0973d57ebe22" />

Partially fixes https://github.com/home-assistant/core/issues/163451
It does not fully solve the issue, as the panel still reports the arm home mode some seconds after reporting arm away, I will need more thought on how to solve that one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/163451
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
