### PR TITLE
Minor type fixes

### DIFF
--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -21,7 +21,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util.enum import try_parse_enum
 
 from . import BSBLanConfigEntry, BSBLanData
 from .const import ATTR_TARGET_TEMPERATURE, DOMAIN
@@ -113,7 +112,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         return target_temp.value
 
     @property
-    def _hvac_mode_value(self) -> int | str | None:
+    def _hvac_mode_value(self) -> int | None:
         """Return the raw hvac_mode value from the coordinator."""
         if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
             return None
@@ -124,16 +123,14 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         """Return hvac operation ie. heat, cool mode."""
         if (hvac_mode_value := self._hvac_mode_value) is None:
             return None
-        # BSB-Lan returns integer values: 0=off, 1=auto, 2=eco, 3=heat
-        if isinstance(hvac_mode_value, int):
-            return BSBLAN_TO_HA_HVAC_MODE.get(hvac_mode_value)
-        return try_parse_enum(HVACMode, hvac_mode_value)
+        return BSBLAN_TO_HA_HVAC_MODE.get(hvac_mode_value)
 
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac action."""
-        action = self.coordinator.data.state.hvac_action
-        if not action or not isinstance(action.value, int):
+        if (action := self.coordinator.data.state.hvac_action) is None:
+            return None
+        if action.value is None:
             return None
         category = get_hvac_action_category(action.value)
         return HVACAction(category.name.lower())

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -114,9 +114,7 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def _hvac_mode_value(self) -> int | None:
         """Return the raw hvac_mode value from the coordinator."""
-        if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
-            return None
-        return hvac_mode.value
+        return getattr(self.coordinator.data.state.hvac_mode, "value", None)
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -128,9 +126,9 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running hvac action."""
-        if (action := self.coordinator.data.state.hvac_action) is None:
-            return None
-        if action.value is None:
+        if (
+            action := self.coordinator.data.state.hvac_action
+        ) is None or action.value is None:
             return None
         category = get_hvac_action_category(action.value)
         return HVACAction(category.name.lower())

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -114,7 +114,9 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
     @property
     def _hvac_mode_value(self) -> int | None:
         """Return the raw hvac_mode value from the coordinator."""
-        return getattr(self.coordinator.data.state.hvac_mode, "value", None)
+        if (hvac_mode := self.coordinator.data.state.hvac_mode) is None:
+            return None
+        return hvac_mode.value
 
     @property
     def hvac_mode(self) -> HVACMode | None:

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -110,9 +110,9 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
     @property
     def current_operation(self) -> str | None:
         """Return current operation."""
-        if (operating_mode := self.coordinator.data.dhw.operating_mode) is None:
-            return None
-        if operating_mode.value is None:
+        if (
+            operating_mode := self.coordinator.data.dhw.operating_mode
+        ) is None or operating_mode.value is None:
             return None
         return BSBLAN_TO_HA_OPERATION_MODE.get(operating_mode.value)
 

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -112,10 +112,9 @@ class BSBLANWaterHeater(BSBLanDualCoordinatorEntity, WaterHeaterEntity):
         """Return current operation."""
         if (operating_mode := self.coordinator.data.dhw.operating_mode) is None:
             return None
-        # The operating_mode.value is an integer (0=Off, 1=On, 2=Eco)
-        if isinstance(operating_mode.value, int):
-            return BSBLAN_TO_HA_OPERATION_MODE.get(operating_mode.value)
-        return None
+        if operating_mode.value is None:
+            return None
+        return BSBLAN_TO_HA_OPERATION_MODE.get(operating_mode.value)
 
     @property
     def current_temperature(self) -> float | None:

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -248,30 +248,6 @@ async def test_climate_hvac_mode_object_none(
     assert state.attributes["preset_mode"] == PRESET_NONE
 
 
-async def test_climate_hvac_mode_string_fallback(
-    hass: HomeAssistant,
-    mock_bsblan: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test climate entity with string hvac_mode value (fallback path)."""
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
-
-    # Set hvac_mode.value to a string (non-integer fallback)
-    mock_hvac_mode = MagicMock()
-    mock_hvac_mode.value = "heat"
-    mock_bsblan.state.return_value.hvac_mode = mock_hvac_mode
-
-    freezer.tick(timedelta(minutes=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    # Should parse the string enum value
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.state == HVACMode.HEAT
-
-
 # Mapping from HA HVACMode to BSB-Lan integer values for test assertions
 HA_TO_BSBLAN_HVAC_MODE_TEST: dict[HVACMode, int] = {
     HVACMode.OFF: 0,

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -119,28 +119,19 @@ async def _async_set_hvac_action(
     return state.attributes.get("hvac_action")
 
 
-async def test_hvac_action_handles_empty_and_invalid_inputs(
+async def test_hvac_action_handles_none_inputs(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Ensure hvac_action gracefully handles None and malformed values."""
+    """Ensure hvac_action gracefully handles None values."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
     assert await _async_set_hvac_action(hass, mock_bsblan, freezer, None) is None
 
     mock_action = MagicMock()
     mock_action.value = None
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
-
-    mock_action.value = ""
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
-
-    mock_action.value = "not_an_int"
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
-
-    mock_action.value = {"unexpected": True}
     assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
 
 

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -200,30 +200,6 @@ async def test_climate_without_target_temperature_sensor(
     assert state.attributes["temperature"] is None
 
 
-async def test_climate_hvac_mode_none_value(
-    hass: HomeAssistant,
-    mock_bsblan: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test climate entity when hvac_mode value is None."""
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
-
-    # Set hvac_mode.value to None
-    mock_hvac_mode = MagicMock()
-    mock_hvac_mode.value = None
-    mock_bsblan.state.return_value.hvac_mode = mock_hvac_mode
-
-    freezer.tick(timedelta(minutes=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    # State should be unknown when hvac_mode is None
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.state == "unknown"
-
-
 async def test_climate_hvac_mode_object_none(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -299,6 +299,31 @@ async def test_water_heater_no_sensors(
     assert state.attributes.get("temperature") is None
 
 
+async def test_current_operation_non_int_value(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test current_operation returns None when operating_mode value is not an int."""
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.WATER_HEATER]
+    )
+
+    # Set operating_mode to a non-None object with a non-int value
+    mock_operating_mode = MagicMock()
+    mock_operating_mode.value = "some_string"
+    mock_bsblan.hot_water_state.return_value.operating_mode = mock_operating_mode
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("current_operation") is None
+
+
 @pytest.mark.parametrize(
     ("fixture_name", "test_description"),
     [

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -299,30 +299,6 @@ async def test_water_heater_no_sensors(
     assert state.attributes.get("temperature") is None
 
 
-async def test_current_operation_none_value(
-    hass: HomeAssistant,
-    mock_bsblan: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test current_operation returns None when operating_mode value is None."""
-    await setup_with_selected_platforms(
-        hass, mock_config_entry, [Platform.WATER_HEATER]
-    )
-
-    mock_operating_mode = MagicMock()
-    mock_operating_mode.value = None
-    mock_bsblan.hot_water_state.return_value.operating_mode = mock_operating_mode
-
-    freezer.tick(timedelta(minutes=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.attributes.get("current_operation") is None
-
-
 @pytest.mark.parametrize(
     ("fixture_name", "test_description"),
     [

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -299,20 +299,19 @@ async def test_water_heater_no_sensors(
     assert state.attributes.get("temperature") is None
 
 
-async def test_current_operation_non_int_value(
+async def test_current_operation_none_value(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test current_operation returns None when operating_mode value is not an int."""
+    """Test current_operation returns None when operating_mode value is None."""
     await setup_with_selected_platforms(
         hass, mock_config_entry, [Platform.WATER_HEATER]
     )
 
-    # Set operating_mode to a non-None object with a non-int value
     mock_operating_mode = MagicMock()
-    mock_operating_mode.value = "some_string"
+    mock_operating_mode.value = None
     mock_bsblan.hot_water_state.return_value.operating_mode = mock_operating_mode
 
     freezer.tick(timedelta(minutes=1))

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -299,6 +299,30 @@ async def test_water_heater_no_sensors(
     assert state.attributes.get("temperature") is None
 
 
+async def test_current_operation_none_value(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test current_operation returns None when operating_mode value is None."""
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.WATER_HEATER]
+    )
+
+    mock_operating_mode = MagicMock()
+    mock_operating_mode.value = None
+    mock_bsblan.hot_water_state.return_value.operating_mode = mock_operating_mode
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get("current_operation") is None
+
+
 @pytest.mark.parametrize(
     ("fixture_name", "test_description"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request refines how the BSBLan integration for climate and water heater entities handles and maps values, focusing on stricter type checks and improved handling of `None` values. The main changes remove fallback logic for string values, ensure only integer values are mapped, and update tests to reflect these behaviors.

**Code logic improvements:**

* The `hvac_mode` and `current_operation` properties in `climate.py` and `water_heater.py` now only map integer values, removing fallback handling for string values and ensuring `None` values are handled gracefully. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L116-R115) [[2]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L127-R133) [[3]](diffhunk://#diff-6eb0b83e8439699015b5813828b51fd54f884c489a8a7e3d805a7ddaadfd4badL115-R117)
* Removed the import of `try_parse_enum` and its usage, simplifying the code and eliminating unnecessary fallback parsing. [[1]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L24) [[2]](diffhunk://#diff-4af577574f99734c74d00cead526e36872b0c763b88f8d2413ca95384a6c6729L127-R133)

**Test updates:**

* Tests for climate entities no longer check for string fallback paths, and now focus on handling `None` values for `hvac_action` and `hvac_mode`. [[1]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadL122-R128) [[2]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadL137-L145) [[3]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadL260-L283)
* Added a new test for water heater entities to verify that `current_operation` returns `None` when the underlying value is `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
