### PR TITLE
Add projector_screen device class for cover domain

### DIFF
--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -64,6 +64,7 @@ class CoverDeviceClass(StrEnum):
     DOOR = "door"
     GARAGE = "garage"
     GATE = "gate"
+    PROJECTOR_SCREEN = "projector_screen"
     SHADE = "shade"
     SHUTTER = "shutter"
     WINDOW = "window"

--- a/homeassistant/components/cover/icons.json
+++ b/homeassistant/components/cover/icons.json
@@ -52,6 +52,14 @@
         "opening": "mdi:arrow-right"
       }
     },
+    "projector_screen": {
+      "default": "mdi:projector-screen",
+      "state": {
+        "closed": "mdi:projector-screen-off",
+        "closing": "mdi:arrow-up-box",
+        "opening": "mdi:arrow-down-box"
+      }
+    },
     "shade": {
       "default": "mdi:roller-shade",
       "state": {

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -72,6 +72,9 @@
     "gate": {
       "name": "Gate"
     },
+    "projector_screen": {
+      "name": "Projector screen"
+    },
     "shade": {
       "name": "Shade"
     },


### PR DESCRIPTION
## Proposed change

Adds a `projector_screen` device class to the cover domain. Projector screens have inverted physical behavior compared to typical covers — "open" means deploying the screen downward, while "close" means retracting it upward.

This enables integrations to properly represent projector screens with correct state icons showing directional arrows that match actual device movement (down arrow for opening/deploying, up arrow for closing/retracting).

Related architecture discussion: https://github.com/home-assistant/architecture/discussions/983
Community thread: https://community.home-assistant.io/t/open-close-direction-for-projector-screens/464292

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- Frontend PR: _to follow_
- Affected devices: XY Screens, Celexon, RFXCom AC114, and DIY setups

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented-out code in this PR
- [x] Tests have been added to verify that the new code works (frontend tests for icon logic)