### PR TITLE
NRGkick integration: add reauth config flow

### DIFF
--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -198,8 +198,8 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             if info := await self._async_validate_credentials(
                 self._pending_host,
                 errors,
-                username=user_input.get(CONF_USERNAME),
-                password=user_input.get(CONF_PASSWORD),
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
             ):
                 await self.async_set_unique_id(info["serial"], raise_on_progress=False)
                 self._abort_if_unique_id_configured()
@@ -207,8 +207,8 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
                     title=info["title"],
                     data={
                         CONF_HOST: self._pending_host,
-                        CONF_USERNAME: user_input.get(CONF_USERNAME),
-                        CONF_PASSWORD: user_input.get(CONF_PASSWORD),
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
                     },
                 )
 
@@ -238,17 +238,14 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             if info := await self._async_validate_credentials(
                 reauth_entry.data[CONF_HOST],
                 errors,
-                username=user_input.get(CONF_USERNAME),
-                password=user_input.get(CONF_PASSWORD),
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
             ):
                 await self.async_set_unique_id(info["serial"], raise_on_progress=False)
                 self._abort_if_unique_id_mismatch()
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data_updates={
-                        CONF_USERNAME: user_input.get(CONF_USERNAME),
-                        CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-                    },
+                    data_updates=user_input,
                 )
 
         return self.async_show_form(
@@ -284,8 +281,9 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
         # Store discovery info for the confirmation step.
         self._discovered_host = discovery_info.host
         # Fallback: device_name -> model_type -> "NRGkick".
-        self._discovered_name = device_name or model_type or "NRGkick"
-        self.context["title_placeholders"] = {"name": self._discovered_name}
+        discovered_name = device_name or model_type or "NRGkick"
+        self._discovered_name = discovered_name
+        self.context["title_placeholders"] = {"name": discovered_name}
 
         # If JSON API is disabled, guide the user through enabling it.
         if json_api_enabled != "1":

--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -253,7 +253,10 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=STEP_AUTH_DATA_SCHEMA,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_AUTH_DATA_SCHEMA,
+                self._get_reauth_entry().data,
+            ),
             errors=errors,
         )
 

--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -119,6 +120,31 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_name: str | None = None
         self._pending_host: str | None = None
 
+    async def _async_validate_credentials(
+        self,
+        host: str,
+        errors: dict[str, str],
+        username: str | None = None,
+        password: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Validate credentials and populate errors dict on failure."""
+        try:
+            return await validate_input(
+                self.hass, host, username=username, password=password
+            )
+        except NRGkickApiClientApiDisabledError:
+            errors["base"] = "json_api_disabled"
+        except NRGkickApiClientAuthenticationError:
+            errors["base"] = "invalid_auth"
+        except NRGkickApiClientInvalidResponseError:
+            errors["base"] = "invalid_response"
+        except NRGkickApiClientCommunicationError:
+            errors["base"] = "cannot_connect"
+        except NRGkickApiClientError:
+            _LOGGER.exception("Unexpected error")
+            errors["base"] = "unknown"
+        return None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -169,36 +195,20 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             assert self._pending_host is not None
 
         if user_input is not None:
-            username = user_input.get(CONF_USERNAME)
-            password = user_input.get(CONF_PASSWORD)
-
-            try:
-                info = await validate_input(
-                    self.hass,
-                    self._pending_host,
-                    username=username,
-                    password=password,
-                )
-            except NRGkickApiClientApiDisabledError:
-                errors["base"] = "json_api_disabled"
-            except NRGkickApiClientAuthenticationError:
-                errors["base"] = "invalid_auth"
-            except NRGkickApiClientInvalidResponseError:
-                errors["base"] = "invalid_response"
-            except NRGkickApiClientCommunicationError:
-                errors["base"] = "cannot_connect"
-            except NRGkickApiClientError:
-                _LOGGER.exception("Unexpected error")
-                errors["base"] = "unknown"
-            else:
+            if info := await self._async_validate_credentials(
+                self._pending_host,
+                errors,
+                username=user_input.get(CONF_USERNAME),
+                password=user_input.get(CONF_PASSWORD),
+            ):
                 await self.async_set_unique_id(info["serial"], raise_on_progress=False)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=info["title"],
                     data={
                         CONF_HOST: self._pending_host,
-                        CONF_USERNAME: username,
-                        CONF_PASSWORD: password,
+                        CONF_USERNAME: user_input.get(CONF_USERNAME),
+                        CONF_PASSWORD: user_input.get(CONF_PASSWORD),
                     },
                 )
 
@@ -209,6 +219,42 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "device_ip": self._pending_host,
             },
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle initiation of reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            reauth_entry = self._get_reauth_entry()
+            if info := await self._async_validate_credentials(
+                reauth_entry.data[CONF_HOST],
+                errors,
+                username=user_input.get(CONF_USERNAME),
+                password=user_input.get(CONF_PASSWORD),
+            ):
+                await self.async_set_unique_id(info["serial"], raise_on_progress=False)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={
+                        CONF_USERNAME: user_input.get(CONF_USERNAME),
+                        CONF_PASSWORD: user_input.get(CONF_PASSWORD),
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_AUTH_DATA_SCHEMA,
+            errors=errors,
         )
 
     async def async_step_zeroconf(

--- a/homeassistant/components/nrgkick/coordinator.py
+++ b/homeassistant/components/nrgkick/coordinator.py
@@ -18,7 +18,7 @@ from nrgkick_api import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -65,7 +65,7 @@ class NRGkickDataUpdateCoordinator(DataUpdateCoordinator[NRGkickData]):
             control = await self.api.get_control()
             values = await self.api.get_values(raw=True)
         except NRGkickAuthenticationError as error:
-            raise ConfigEntryError(
+            raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="authentication_error",
             ) from error

--- a/homeassistant/components/nrgkick/quality_scale.yaml
+++ b/homeassistant/components/nrgkick/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/nrgkick/strings.json
+++ b/homeassistant/components/nrgkick/strings.json
@@ -4,7 +4,9 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "json_api_disabled": "JSON API is disabled on the device. Enable it in the NRGkick mobile app under Extended \u2192 Local API \u2192 API Variants.",
-      "no_serial_number": "Device does not provide a serial number"
+      "no_serial_number": "Device does not provide a serial number",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unique_id_mismatch": "The device does not match the previous device"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -15,6 +17,17 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::nrgkick::config::step::user_auth::data_description::password%]",
+          "username": "[%key:component::nrgkick::config::step::user_auth::data_description::username%]"
+        },
+        "description": "Reauthenticate with your NRGkick device.\n\nGet your username and password in the NRGkick mobile app:\n1. Open the NRGkick mobile app \u2192 Extended \u2192 Local API\n2. Under Authentication (JSON), check or set your username and password"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds reauth config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
