### PR TITLE
Fix ESPHome pipeline select translation placeholder

### DIFF
--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -102,7 +102,7 @@
     },
     "select": {
       "pipeline": {
-        "name": "[%key:component::assist_pipeline::entity::select::pipeline::name%]",
+        "name": "Assistant{index}",
         "state": {
           "preferred": "[%key:component::assist_pipeline::entity::select::pipeline::state::preferred%]"
         }


### PR DESCRIPTION
## Proposed change

Fixes the translation validation error reported in #152245.

The `pipeline` select entity in the ESPHome integration used a `%key:` cross-reference to `assist_pipeline` for its name:

```json
"name": "[%key:component::assist_pipeline::entity::select::pipeline::name%]"
```

This entity declares `translation_placeholders={"index": ...}` so multiple satellites can be named "Assistant", "Assistant 2", etc. However, the `assist_pipeline` translations in some locales (e.g. French) omit `{index}`, causing hassfest validation to fail with:

```
Validation of translation placeholders for localized (fr) string
component.esphome.entity.select.pipeline.name failed: (set() != {'index'})
```

The fix replaces the cross-reference with a direct string `"Assistant{index}"`, matching the existing pattern already used by the `wake_word` entity in the same file (`"Wake word{index}"`). This ensures every locale's translation is validated to include `{index}`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

- Fixes #152245
- No Python changes — strings.json only
- No new tests needed; existing `test_pipeline_selector` and `test_secondary_pipeline_selector` tests cover the entity setup; translation validation is enforced by hassfest CI