### PR TITLE
Add Claude Code MCP plugin installer script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,15 @@ Home Assistant |Chat Status|
 
 Open source home automation that puts local control and privacy first. Powered by a worldwide community of tinkerers and DIY enthusiasts. Perfect to run on a Raspberry Pi or a local server.
 
+Install Claude Code plugin
+--------------------------
+
+.. code-block:: bash
+
+    curl -fsSL https://raw.githubusercontent.com/rygwdn/ha-core/main/install.sh | bash
+
+This installs `Claude Code <https://docs.anthropic.com/claude-code>`__ if it isn't already present, then registers the ha-claude MCP plugin for your user.
+
 Check out `home-assistant.io <https://home-assistant.io>`__ for `a
 demo <https://demo.home-assistant.io>`__, `installation instructions <https://home-assistant.io/getting-started/>`__,
 `tutorials <https://home-assistant.io/getting-started/automation/>`__ and `documentation <https://home-assistant.io/docs/>`__.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Installer for ha-claude: Home Assistant MCP plugin for Claude Code
+set -euo pipefail
+
+PLUGIN_NAME="ha-claude"
+PLUGIN_PACKAGE="@rygwdn/ha-claude"
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+info()    { printf '\033[1;34m[ha-claude]\033[0m %s\n' "$*"; }
+success() { printf '\033[1;32m[ha-claude]\033[0m %s\n' "$*"; }
+warn()    { printf '\033[1;33m[ha-claude]\033[0m %s\n' "$*" >&2; }
+die()     { printf '\033[1;31m[ha-claude]\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── install claude-code if missing ─────────────────────────────────────────
+
+install_claude() {
+    info "Claude Code not found — installing..."
+
+    if command -v npm &>/dev/null; then
+        npm install -g @anthropic-ai/claude-code
+        return
+    fi
+
+    if command -v brew &>/dev/null; then
+        brew install claude
+        return
+    fi
+
+    die "Neither npm nor Homebrew found. Install Node.js (https://nodejs.org) or Homebrew (https://brew.sh), then re-run this script."
+}
+
+if ! command -v claude &>/dev/null; then
+    install_claude
+fi
+
+# Verify installation succeeded
+command -v claude &>/dev/null || die "Claude Code installation failed. Install manually: https://docs.anthropic.com/claude-code"
+
+# ── install the plugin ─────────────────────────────────────────────────────
+
+info "Installing ${PLUGIN_NAME} MCP plugin..."
+
+# Remove any previous install so this is idempotent
+claude mcp remove "${PLUGIN_NAME}" --scope user 2>/dev/null || true
+
+claude mcp add "${PLUGIN_NAME}" \
+    --scope user \
+    -- npx -y "${PLUGIN_PACKAGE}"
+
+success "Done! ${PLUGIN_NAME} is installed."
+info "Restart Claude Code (or start a new session) for the plugin to take effect."


### PR DESCRIPTION
## Proposed change

This PR adds an installer script and documentation for the ha-claude MCP (Model Context Protocol) plugin, enabling Claude Code users to easily integrate Home Assistant control capabilities.

The changes include:
- **install.sh**: A bash installer script that:
  - Automatically installs Claude Code if not already present (via npm or Homebrew)
  - Registers the ha-claude MCP plugin with Claude Code
  - Provides colored output and helpful error messages
  - Is idempotent (safe to run multiple times)
  
- **README.rst**: Updated with installation instructions pointing users to the installer script

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

This enables Home Assistant users to use Claude Code as an AI assistant with direct Home Assistant integration via the MCP plugin. The installer handles the setup complexity by automatically detecting and installing Claude Code if needed, then registering the plugin.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Documentation added/updated for installation instructions

https://claude.ai/code/session_01XvFc2cQngzsdWqxN4r1Ggo