### PR TITLE
Improve Plugwise set_hvac_mode() logic

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -201,11 +201,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
 
         if self.coordinator.api.cooling_present:
             if "regulation_modes" in self._gateway_data:
-                selected = self._gateway_data.get("select_regulation_mode")
-                if selected == HVACAction.COOLING.value:
-                    hvac_modes.append(HVACMode.COOL)
-                if selected == HVACAction.HEATING.value:
+                if "heating" in self._gateway_data["regulation_modes"]:
                     hvac_modes.append(HVACMode.HEAT)
+                if "cooling" in self._gateway_data["regulation_modes"]:
+                    hvac_modes.append(HVACMode.COOL)
             else:
                 hvac_modes.append(HVACMode.HEAT_COOL)
         else:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -253,47 +253,63 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
 
         await self.coordinator.api.set_temperature(self._location, data)
 
+    def _regulation_mode_for_hvac(self, hvac_mode: HVACMode) -> str | None:
+        """Return the API regulation value for a manual HVAC mode, or None."""
+        if hvac_mode == HVACMode.HEAT:
+            return HVACAction.HEATING.value
+        if hvac_mode == HVACMode.COOL:
+            return HVACAction.COOLING.value
+        return None
+
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
-        """Set the hvac mode."""
+        """Set the HVAC mode (off, heat, cool, heat_cool, or auto/schedule)."""
         if hvac_mode == self.hvac_mode:
             return
 
         api = self.coordinator.api
         current_schedule = self.device.get("select_schedule")
 
-        # OFF is always a direct switch
+        # OFF: single API call
         if hvac_mode == HVACMode.OFF:
             await api.set_regulation_mode(hvac_mode.value)
             return
 
-        # No schedule selected & switching to manual mode
+        # Manual mode (heat/cool/heat_cool) without a schedule: set regulation only
         if (
             current_schedule is None
             and hvac_mode != HVACMode.AUTO
-            and self._previous_action_mode
+            and (
+                regulation := self._regulation_mode_for_hvac(hvac_mode)
+                or self._previous_action_mode
+            )
         ):
-            await api.set_regulation_mode(self._previous_action_mode)
+            await api.set_regulation_mode(regulation)
             return
 
+        # Switch to manual mode: ensure regulation and turn off schedule if needed
         if hvac_mode in {HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL}:
-            if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
-                await api.set_regulation_mode(self._previous_action_mode)
+            regulation = self._regulation_mode_for_hvac(hvac_mode) or (
+                self._previous_action_mode if self.hvac_mode == HVACMode.OFF else None
+            )
+            if regulation:
+                await api.set_regulation_mode(regulation)
 
-                if current_schedule is not None and current_schedule != "off":
-                    await api.set_schedule_state(
-                        self._location, STATE_OFF, current_schedule
-                    )
-
+            if self.hvac_mode == HVACMode.OFF and current_schedule not in (
+                None,
+                "off",
+            ):
+                await api.set_schedule_state(
+                    self._location, STATE_OFF, current_schedule
+                )
             elif self.hvac_mode == HVACMode.AUTO and current_schedule is not None:
                 await api.set_schedule_state(
                     self._location, STATE_OFF, current_schedule
                 )
 
-        if hvac_mode != HVACMode.AUTO:
             return
 
-        # ---- AUTO mode handling ----
+        # AUTO: restore schedule and regulation
         desired_schedule = current_schedule
         if desired_schedule and desired_schedule != "off":
             self._last_active_schedule = desired_schedule
@@ -309,7 +325,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         if self._previous_action_mode:
             if self.hvac_mode == HVACMode.OFF:
                 await api.set_regulation_mode(self._previous_action_mode)
-
             await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -87,8 +87,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key = DOMAIN
 
-    __last_active_schedule: str | None = None
-    __previous_action_mode: str | None = HVACAction.HEATING.value
+    _last_active_schedule: str | None = None
+    _previous_action_mode: str | None = HVACAction.HEATING.value
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -98,8 +98,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             plugwise_extra_data = PlugwiseClimateExtraStoredData.from_dict(
                 extra_data.as_dict()
             )
-            self.__last_active_schedule = plugwise_extra_data.last_active_schedule
-            self.__previous_action_mode = (
+            self._last_active_schedule = plugwise_extra_data.last_active_schedule
+            self._previous_action_mode = (
                 plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
             )
 
@@ -151,8 +151,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     def extra_restore_state_data(self) -> PlugwiseClimateExtraStoredData:
         """Return text specific state data to be restored."""
         return PlugwiseClimateExtraStoredData(
-            last_active_schedule=self.__last_active_schedule,
-            previous_action_mode=self.__previous_action_mode,
+            last_active_schedule=self._last_active_schedule,
+            previous_action_mode=self._previous_action_mode,
         )
 
     @property
@@ -216,14 +216,14 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
         # Keep track of the previous hvac_action mode.
-        # When no cooling available, __previous_action_mode is always heating
+        # When no cooling available, _previous_action_mode is always heating
         if (
             "regulation_modes" in self._gateway_data
             and HVACAction.COOLING.value in self._gateway_data["regulation_modes"]
         ):
             mode = self._gateway_data["select_regulation_mode"]
             if mode in (HVACAction.COOLING.value, HVACAction.HEATING.value):
-                self.__previous_action_mode = mode
+                self._previous_action_mode = mode
 
         if (action := self.device.get("control_state")) is not None:
             return HVACAction(action)
@@ -279,7 +279,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             and hvac_mode != HVACMode.AUTO
             and (
                 regulation := self._regulation_mode_for_hvac(hvac_mode)
-                or self.__previous_action_mode
+                or self._previous_action_mode
             )
         ):
             await api.set_regulation_mode(regulation)
@@ -288,7 +288,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         # Manual mode: ensure regulation and turn off schedule when needed
         if hvac_mode in (HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL):
             regulation = self._regulation_mode_for_hvac(hvac_mode) or (
-                self.__previous_action_mode
+                self._previous_action_mode
                 if self.hvac_mode in (HVACMode.HEAT_COOL, HVACMode.OFF)
                 else None
             )
@@ -306,9 +306,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         # AUTO: restore schedule and regulation
         desired_schedule = current_schedule
         if desired_schedule and desired_schedule != "off":
-            self.__last_active_schedule = desired_schedule
+            self._last_active_schedule = desired_schedule
         elif desired_schedule == "off":
-            desired_schedule = self.__last_active_schedule
+            desired_schedule = self._last_active_schedule
 
         if not desired_schedule:
             raise HomeAssistantError(
@@ -316,9 +316,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 translation_key=ERROR_NO_SCHEDULE,
             )
 
-        if self.__previous_action_mode:
+        if self._previous_action_mode:
             if self.hvac_mode == HVACMode.OFF:
-                await api.set_regulation_mode(self.__previous_action_mode)
+                await api.set_regulation_mode(self._previous_action_mode)
             await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -269,7 +269,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
 
         if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL:
             if self.hvac_mode == HVACMode.OFF:
-                if current_schedule is None or current_schedule == "off":
+                if current_schedule == "off":
                     await self.coordinator.api.set_regulation_mode(hvac_mode.value)
                 else:
                     await self.coordinator.api.set_regulation_mode(hvac_mode.value)

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -88,7 +88,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     _attr_translation_key = DOMAIN
 
     __last_active_schedule: str | None = None
-    __previous_action_mode: str = HVACAction.HEATING.value
+    __previous_action_mode: str | None = HVACAction.HEATING.value
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -99,9 +99,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 extra_data.as_dict()
             )
             self.__last_active_schedule = plugwise_extra_data.last_active_schedule
-            self.__previous_action_mode = (
-                plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
-            )
+            self.__previous_action_mode = plugwise_extra_data.previous_action_mode
 
     def __init__(
         self,
@@ -317,9 +315,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 translation_key=ERROR_NO_SCHEDULE,
             )
 
-        if self.hvac_mode == HVACMode.OFF:
-            await api.set_regulation_mode(self.__previous_action_mode)
-        await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
+        if self.__previous_action_mode:
+            if self.hvac_mode == HVACMode.OFF:
+                await api.set_regulation_mode(self.__previous_action_mode)
+            await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
@@ -286,6 +287,13 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 self._last_active_schedule = desired_schedule
             elif desired_schedule == "off":
                 desired_schedule = self._last_active_schedule
+
+            if not desired_schedule:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key=ERROR_NO_SCHEDULE,
+                )
+
             if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
                 await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
                 await self.coordinator.api.set_schedule_state(self._location, STATE_ON, desired_schedule)

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -263,16 +263,16 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             return
 
         current_schedule = self.device.get("select_schedule")
-        if current_schedule is None and hvac_mode != HVACMode.AUTO:
-            await self.coordinator.api.set_regulation_mode(hvac_mode.value)
+        if current_schedule is None and hvac_mode != HVACMode.AUTO and self._previous_action_mode:
+            await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
             return
 
         if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL or hvac_mode == HVACMode.HEAT_COOL:
             if self.hvac_mode == HVACMode.OFF:
-                if current_schedule == "off":
-                    await self.coordinator.api.set_regulation_mode(hvac_mode.value)
-                else:
-                    await self.coordinator.api.set_regulation_mode(hvac_mode.value)
+                if current_schedule == "off" and self._previous_action_mode:
+                    await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
+                elif self._previous_action_mode:
+                    await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
                     await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)
             if self.hvac_mode == HVACMode.AUTO:
                 await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -259,46 +259,60 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         if hvac_mode == self.hvac_mode:
             return
 
-        if hvac_mode == HVACMode.OFF:
-            await self.coordinator.api.set_regulation_mode(hvac_mode.value)
-            return
-
+        api = self.coordinator.api
         current_schedule = self.device.get("select_schedule")
-        if current_schedule is None and hvac_mode != HVACMode.AUTO and self._previous_action_mode:
-            await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
+
+        # OFF is always a direct switch
+        if hvac_mode == HVACMode.OFF:
+            await api.set_regulation_mode(hvac_mode.value)
             return
 
-        if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL or hvac_mode == HVACMode.HEAT_COOL:
-            if self.hvac_mode == HVACMode.OFF:
-                if current_schedule == "off" and self._previous_action_mode:
-                    await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
-                elif self._previous_action_mode:
-                    await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
-                    await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)
-            if self.hvac_mode == HVACMode.AUTO:
-                await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)
+        # No schedule selected & switching to manual mode
+        if (
+            current_schedule is None
+            and hvac_mode != HVACMode.AUTO
+            and self._previous_action_mode
+        ):
+            await api.set_regulation_mode(self._previous_action_mode)
+            return
 
-        if hvac_mode == HVACMode.AUTO:
-            # current_schedule is not None and hvac_mode != HVACMode.AUTO
-            # current_schedule is None and hvac_mode == HVACMode.AUTO
-            desired_schedule = current_schedule
-            # Collect the active schedule or set the last active schedule
-            if desired_schedule and desired_schedule != "off":
-                self._last_active_schedule = desired_schedule
-            elif desired_schedule == "off":
-                desired_schedule = self._last_active_schedule
+        if hvac_mode in {HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL}:
+            if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
+                await api.set_regulation_mode(self._previous_action_mode)
 
-            if not desired_schedule:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key=ERROR_NO_SCHEDULE,
+                if current_schedule != "off":
+                    await api.set_schedule_state(
+                        self._location, STATE_OFF, current_schedule
+                    )
+
+            elif self.hvac_mode == HVACMode.AUTO:
+                await api.set_schedule_state(
+                    self._location, STATE_OFF, current_schedule
                 )
 
-            if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
-                await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
-                await self.coordinator.api.set_schedule_state(self._location, STATE_ON, desired_schedule)
-            elif self._previous_action_mode:
-                await self.coordinator.api.set_schedule_state(self._location, STATE_ON, desired_schedule)
+        if hvac_mode != HVACMode.AUTO:
+            return
+
+        # ---- AUTO mode handling ----
+        desired_schedule = current_schedule
+        if desired_schedule and desired_schedule != "off":
+            self._last_active_schedule = desired_schedule
+        elif desired_schedule == "off":
+            desired_schedule = self._last_active_schedule
+
+        if not desired_schedule:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key=ERROR_NO_SCHEDULE,
+            )
+
+        if self._previous_action_mode:
+            if self.hvac_mode == HVACMode.OFF:
+                await api.set_regulation_mode(self._previous_action_mode)
+
+            await api.set_schedule_state(
+                self._location, STATE_ON, desired_schedule
+            )
 
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -267,7 +267,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             await self.coordinator.api.set_regulation_mode(hvac_mode.value)
             return
 
-        if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL:
+        if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL or hvac_mode == HVACMode.HEAT_COOL:
             if self.hvac_mode == HVACMode.OFF:
                 if current_schedule == "off":
                     await self.coordinator.api.set_regulation_mode(hvac_mode.value)

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -38,10 +38,7 @@ class PlugwiseClimateExtraStoredData(ExtraStoredData):
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of the text data."""
-        return {
-            "last_active_schedule": self.last_active_schedule,
-            "previous_action_mode": self.previous_action_mode,
-        }
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, restored: dict[str, Any]) -> PlugwiseClimateExtraStoredData:
@@ -90,8 +87,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_translation_key = DOMAIN
 
-    _last_active_schedule: str | None = None
-    _previous_action_mode: str | None = HVACAction.HEATING.value
+    __last_active_schedule: str | None = None
+    __previous_action_mode: str = HVACAction.HEATING.value
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -101,8 +98,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             plugwise_extra_data = PlugwiseClimateExtraStoredData.from_dict(
                 extra_data.as_dict()
             )
-            self._last_active_schedule = plugwise_extra_data.last_active_schedule
-            self._previous_action_mode = plugwise_extra_data.previous_action_mode
+            self.__last_active_schedule = plugwise_extra_data.last_active_schedule
+            self.__previous_action_mode = (
+                plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
+            )
 
     def __init__(
         self,
@@ -152,8 +151,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     def extra_restore_state_data(self) -> PlugwiseClimateExtraStoredData:
         """Return text specific state data to be restored."""
         return PlugwiseClimateExtraStoredData(
-            last_active_schedule=self._last_active_schedule,
-            previous_action_mode=self._previous_action_mode,
+            last_active_schedule=self.__last_active_schedule,
+            previous_action_mode=self.__previous_action_mode,
         )
 
     @property
@@ -218,14 +217,14 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
     def hvac_action(self) -> HVACAction:
         """Return the current running hvac operation if supported."""
         # Keep track of the previous hvac_action mode.
-        # When no cooling available, _previous_action_mode is always heating
+        # When no cooling available, __previous_action_mode is always heating
         if (
             "regulation_modes" in self._gateway_data
             and HVACAction.COOLING.value in self._gateway_data["regulation_modes"]
         ):
             mode = self._gateway_data["select_regulation_mode"]
             if mode in (HVACAction.COOLING.value, HVACAction.HEATING.value):
-                self._previous_action_mode = mode
+                self.__previous_action_mode = mode
 
         if (action := self.device.get("control_state")) is not None:
             return HVACAction(action)
@@ -281,40 +280,36 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             and hvac_mode != HVACMode.AUTO
             and (
                 regulation := self._regulation_mode_for_hvac(hvac_mode)
-                or self._previous_action_mode
+                or self.__previous_action_mode
             )
         ):
             await api.set_regulation_mode(regulation)
             return
 
-        # Switch to manual mode: ensure regulation and turn off schedule if needed
-        if hvac_mode in {HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL}:
+        # Manual mode: ensure regulation and turn off schedule when needed
+        if hvac_mode in (HVACMode.HEAT, HVACMode.COOL, HVACMode.HEAT_COOL):
             regulation = self._regulation_mode_for_hvac(hvac_mode) or (
-                self._previous_action_mode if self.hvac_mode == HVACMode.OFF else None
+                self.__previous_action_mode
+                if self.hvac_mode in (HVACMode.HEAT_COOL, HVACMode.OFF)
+                else None
             )
             if regulation:
                 await api.set_regulation_mode(regulation)
 
-            if self.hvac_mode == HVACMode.OFF and current_schedule not in (
-                None,
-                "off",
-            ):
+            if (
+                self.hvac_mode == HVACMode.OFF and current_schedule not in (None, "off")
+            ) or (self.hvac_mode == HVACMode.AUTO and current_schedule is not None):
                 await api.set_schedule_state(
                     self._location, STATE_OFF, current_schedule
                 )
-            elif self.hvac_mode == HVACMode.AUTO and current_schedule is not None:
-                await api.set_schedule_state(
-                    self._location, STATE_OFF, current_schedule
-                )
-
             return
 
         # AUTO: restore schedule and regulation
         desired_schedule = current_schedule
         if desired_schedule and desired_schedule != "off":
-            self._last_active_schedule = desired_schedule
+            self.__last_active_schedule = desired_schedule
         elif desired_schedule == "off":
-            desired_schedule = self._last_active_schedule
+            desired_schedule = self.__last_active_schedule
 
         if not desired_schedule:
             raise HomeAssistantError(
@@ -322,10 +317,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 translation_key=ERROR_NO_SCHEDULE,
             )
 
-        if self._previous_action_mode:
-            if self.hvac_mode == HVACMode.OFF:
-                await api.set_regulation_mode(self._previous_action_mode)
-            await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
+        if self.hvac_mode == HVACMode.OFF:
+            await api.set_regulation_mode(self.__previous_action_mode)
+        await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -310,9 +310,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             if self.hvac_mode == HVACMode.OFF:
                 await api.set_regulation_mode(self._previous_action_mode)
 
-            await api.set_schedule_state(
-                self._location, STATE_ON, desired_schedule
-            )
+            await api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -16,7 +16,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
@@ -261,32 +260,37 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
 
         if hvac_mode == HVACMode.OFF:
             await self.coordinator.api.set_regulation_mode(hvac_mode.value)
-        else:
-            current = self.device.get("select_schedule")
-            desired = current
+            return
 
-            # Capture the last valid schedule
-            if desired and desired != "off":
-                self._last_active_schedule = desired
-            elif desired == "off":
-                desired = self._last_active_schedule
+        current_schedule = self.device.get("select_schedule")
+        if current_schedule is None and hvac_mode != HVACMode.AUTO:
+            await self.coordinator.api.set_regulation_mode(hvac_mode.value)
+            return
 
-            # Enabling HVACMode.AUTO requires a previously set schedule for saving and restoring
-            if hvac_mode == HVACMode.AUTO and not desired:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key=ERROR_NO_SCHEDULE,
-                )
+        if hvac_mode == HVACMode.HEAT or hvac_mode == HVACMode.COOL:
+            if self.hvac_mode == HVACMode.OFF:
+                if current_schedule is None or current_schedule == "off":
+                    await self.coordinator.api.set_regulation_mode(hvac_mode.value)
+                else:
+                    await self.coordinator.api.set_regulation_mode(hvac_mode.value)
+                    await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)
+            if self.hvac_mode == HVACMode.AUTO:
+                await self.coordinator.api.set_schedule_state(self._location, STATE_OFF, current_schedule)
 
-            await self.coordinator.api.set_schedule_state(
-                self._location,
-                STATE_ON if hvac_mode == HVACMode.AUTO else STATE_OFF,
-                desired,
-            )
+        if hvac_mode == HVACMode.AUTO:
+            # current_schedule is not None and hvac_mode != HVACMode.AUTO
+            # current_schedule is None and hvac_mode == HVACMode.AUTO
+            desired_schedule = current_schedule
+            # Collect the active schedule or set the last active schedule
+            if desired_schedule and desired_schedule != "off":
+                self._last_active_schedule = desired_schedule
+            elif desired_schedule == "off":
+                desired_schedule = self._last_active_schedule
             if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
-                await self.coordinator.api.set_regulation_mode(
-                    self._previous_action_mode
-                )
+                await self.coordinator.api.set_regulation_mode(self._previous_action_mode)
+                await self.coordinator.api.set_schedule_state(self._location, STATE_ON, desired_schedule)
+            elif self._previous_action_mode:
+                await self.coordinator.api.set_schedule_state(self._location, STATE_ON, desired_schedule)
 
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -280,12 +280,12 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             if self.hvac_mode == HVACMode.OFF and self._previous_action_mode:
                 await api.set_regulation_mode(self._previous_action_mode)
 
-                if current_schedule != "off":
+                if current_schedule is not None and current_schedule != "off":
                     await api.set_schedule_state(
                         self._location, STATE_OFF, current_schedule
                     )
 
-            elif self.hvac_mode == HVACMode.AUTO:
+            elif self.hvac_mode == HVACMode.AUTO and current_schedule is not None:
                 await api.set_schedule_state(
                     self._location, STATE_OFF, current_schedule
                 )

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -99,7 +99,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
                 extra_data.as_dict()
             )
             self.__last_active_schedule = plugwise_extra_data.last_active_schedule
-            self.__previous_action_mode = plugwise_extra_data.previous_action_mode
+            self.__previous_action_mode = (
+                plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
+            )
 
     def __init__(
         self,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -332,7 +332,7 @@ async def test_adam_climate_off_mode_change(
         },
         blocking=True,
     )
-    assert mock_smile_adam_jip.set_schedule_state.call_count == 1
+    assert mock_smile_adam_jip.set_schedule_state.call_count == 0
     assert mock_smile_adam_jip.set_regulation_mode.call_count == 1
     mock_smile_adam_jip.set_regulation_mode.assert_called_with("heating")
 
@@ -348,7 +348,7 @@ async def test_adam_climate_off_mode_change(
         },
         blocking=True,
     )
-    assert mock_smile_adam_jip.set_schedule_state.call_count == 1
+    assert mock_smile_adam_jip.set_schedule_state.call_count == 0
     assert mock_smile_adam_jip.set_regulation_mode.call_count == 2
     mock_smile_adam_jip.set_regulation_mode.assert_called_with("off")
 
@@ -364,7 +364,7 @@ async def test_adam_climate_off_mode_change(
         },
         blocking=True,
     )
-    assert mock_smile_adam_jip.set_schedule_state.call_count == 1
+    assert mock_smile_adam_jip.set_schedule_state.call_count == 0
     assert mock_smile_adam_jip.set_regulation_mode.call_count == 2
 
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -268,6 +268,7 @@ async def test_adam_3_climate_entity_attributes(
     assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.OFF,
         HVACMode.AUTO,
+        HVACMode.HEAT,
         HVACMode.COOL,
     ]
     data = mock_smile_adam_heat_cool.async_update.return_value
@@ -289,6 +290,7 @@ async def test_adam_3_climate_entity_attributes(
             HVACMode.OFF,
             HVACMode.AUTO,
             HVACMode.HEAT,
+            HVACMode.COOL,
         ]
 
     data = mock_smile_adam_heat_cool.async_update.return_value
@@ -309,6 +311,7 @@ async def test_adam_3_climate_entity_attributes(
         assert state.attributes[ATTR_HVAC_MODES] == [
             HVACMode.OFF,
             HVACMode.AUTO,
+            HVACMode.HEAT,
             HVACMode.COOL,
         ]
 
@@ -329,6 +332,7 @@ async def test_adam_3_climate_entity_attributes(
         assert state.attributes[ATTR_HVAC_MODES] == [
             HVACMode.OFF,
             HVACMode.AUTO,
+            HVACMode.HEAT,
             HVACMode.COOL,
         ]
         # Test setting regulation_mode to cooling, from off

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -210,9 +210,10 @@ async def test_adam_restore_state_climate(
             {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.HEAT},
             blocking=True,
         )
-        mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
+        assert mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
             "heating",
         )
+        assert mock_smile_adam_heat_cool.set_regulation_mode.call_count == 1
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "heat"
@@ -224,7 +225,7 @@ async def test_adam_restore_state_climate(
         assert (state := hass.states.get("climate.bathroom"))
         assert state.state == "heat"
 
-        # Verify restoration is used when setting a schedule
+        # Verify restoration is used when setting the schedule, schedule == "off"
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -232,9 +233,10 @@ async def test_adam_restore_state_climate(
             blocking=True,
         )
         # Verify set_schedule_state was called with the restored schedule
-        mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
+        assert mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
             "f871b8c4d63549319221e294e4f88074", STATE_ON, "Badkamer"
         )
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 1
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "heat"
@@ -247,17 +249,14 @@ async def test_adam_restore_state_climate(
         assert (state := hass.states.get("climate.bathroom"))
         assert state.state == "heat"
 
-        # Verify the __last_active_schedule is used
+        # Verify the active schedule is used
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
             {ATTR_ENTITY_ID: "climate.bathroom", ATTR_HVAC_MODE: HVACMode.AUTO},
             blocking=True,
         )
-        # Verify set_schedule_state was called
-        mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
-            "f871b8c4d63549319221e294e4f88074", STATE_ON, "Badkamer"
-        )
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -210,7 +210,6 @@ async def test_adam_restore_state_climate(
             {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.HEAT},
             blocking=True,
         )
-        # Verify set_schedule_state was called with the restored schedule
         mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
             "heating",
         )
@@ -312,6 +311,37 @@ async def test_adam_3_climate_entity_attributes(
             HVACMode.AUTO,
             HVACMode.COOL,
         ]
+
+    data = mock_smile_adam_heat_cool.async_update.return_value
+    data["da224107914542988a88561b4452b0f6"]["select_regulation_mode"] = "off"
+    data["f2bf9048bef64cc5b6d5110154e33c81"]["climate_mode"] = "off"
+    data["f2bf9048bef64cc5b6d5110154e33c81"]["control_state"] = HVACAction.OFF
+    data["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["cooling_state"] = True
+    data["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["heating_state"] = False
+    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert (state := hass.states.get("climate.living_room"))
+        assert state.state == "off"
+        assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+        assert state.attributes[ATTR_HVAC_MODES] == [
+            HVACMode.OFF,
+            HVACMode.AUTO,
+            HVACMode.COOL,
+        ]
+        # Test setting regulation_mode to cooling, from off
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.COOL},
+            blocking=True,
+        )
+        # Verify set_regulation_mode was called with the user-selected HVACMode
+        mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
+            "cooling",
+        )
 
 
 async def test_adam_climate_off_mode_change(

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -257,10 +257,34 @@ async def test_adam_2_climate_snapshot(
 async def test_adam_3_climate_entity_attributes(
     hass: HomeAssistant,
     mock_smile_adam_heat_cool: MagicMock,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test creation of adam climate device environment."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State("climate.living_room", "heat"),
+                PlugwiseClimateExtraStoredData(
+                    last_active_schedule="Weekschema",
+                    previous_action_mode="heating",
+                ).as_dict(),
+            ),
+            (
+                State("climate.bathroom", "heat"),
+                PlugwiseClimateExtraStoredData(
+                    last_active_schedule="Badkamer",
+                    previous_action_mode="heating",
+                ).as_dict(),
+            ),
+        ],
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
     state = hass.states.get("climate.living_room")
     assert state
     assert state.state == HVACMode.COOL
@@ -347,6 +371,42 @@ async def test_adam_3_climate_entity_attributes(
             "cooling",
         )
 
+    data = mock_smile_adam_heat_cool.async_update.return_value
+    data["da224107914542988a88561b4452b0f6"]["select_regulation_mode"] = "off"
+    data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "off"
+    data["f871b8c4d63549319221e294e4f88074"]["control_state"] = HVACAction.OFF
+    data["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["cooling_state"] = True
+    data["056ee145a816487eaa69243c3280f8bf"]["binary_sensors"]["heating_state"] = False
+    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert (state := hass.states.get("climate.bathroom"))
+        assert state.state == "off"
+        assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+        assert state.attributes[ATTR_HVAC_MODES] == [
+            HVACMode.OFF,
+            HVACMode.AUTO,
+            HVACMode.HEAT,
+            HVACMode.COOL,
+        ]
+        # Test setting to AUTO, from OFF
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.bathroom", ATTR_HVAC_MODE: HVACMode.AUTO},
+            blocking=True,
+        )
+        # Verify set_regulation_mode was called with the user-selected HVACMode
+        mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
+            "cooling",
+        )
+        mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
+            "f871b8c4d63549319221e294e4f88074",
+            STATE_ON,
+            "Badkamer",
+        )
 
 async def test_adam_climate_off_mode_change(
     hass: HomeAssistant,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -210,7 +210,7 @@ async def test_adam_restore_state_climate(
             {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.HEAT},
             blocking=True,
         )
-        assert mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
+        mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
             "heating",
         )
         assert mock_smile_adam_heat_cool.set_regulation_mode.call_count == 1
@@ -233,7 +233,7 @@ async def test_adam_restore_state_climate(
             blocking=True,
         )
         # Verify set_schedule_state was called with the restored schedule
-        assert mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
+        mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
             "f871b8c4d63549319221e294e4f88074", STATE_ON, "Badkamer"
         )
         assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 1

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -380,7 +380,7 @@ async def test_adam_3_climate_entity_attributes(
             HVACMode.HEAT,
             HVACMode.COOL,
         ]
-        # Test setting regulation_mode to cooling, from off
+        # Test setting regulation_mode to cooling, from off, ignoring the restored previous_action_mode
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -423,6 +423,7 @@ async def test_adam_3_climate_entity_attributes(
         mock_smile_adam_heat_cool.set_regulation_mode.assert_called_with(
             "cooling",
         )
+        # And set_schedule_state was called with the restored last_active_schedule
         mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
             "f871b8c4d63549319221e294e4f88074",
             STATE_ON,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -236,6 +236,28 @@ async def test_adam_restore_state_climate(
             "f871b8c4d63549319221e294e4f88074", STATE_ON, "Badkamer"
         )
 
+    data = mock_smile_adam_heat_cool.async_update.return_value
+    data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "heat"
+    data["f871b8c4d63549319221e294e4f88074"]["select_schedule"] = "Badkamer"
+    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert (state := hass.states.get("climate.bathroom"))
+        assert state.state == "heat"
+
+        # Verify the __last_active_schedule is used
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.bathroom", ATTR_HVAC_MODE: HVACMode.AUTO},
+            blocking=True,
+        )
+        # Verify set_schedule_state was called
+        mock_smile_adam_heat_cool.set_schedule_state.assert_called_with(
+            "f871b8c4d63549319221e294e4f88074", STATE_ON, "Badkamer"
+        )
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -258,6 +258,7 @@ async def test_adam_restore_state_climate(
         )
         assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
 
+
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
@@ -429,6 +430,7 @@ async def test_adam_3_climate_entity_attributes(
             STATE_ON,
             "Badkamer",
         )
+
 
 async def test_adam_climate_off_mode_change(
     hass: HomeAssistant,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -170,7 +170,7 @@ async def test_adam_restore_state_climate(
                 State("climate.bathroom", "heat"),
                 PlugwiseClimateExtraStoredData(
                     last_active_schedule="Badkamer",
-                    previous_action_mode=None,
+                    previous_action_mode="heating",
                 ).as_dict(),
             ),
         ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement a fix for Issue #163452
Next to fixing this issue, other `set_hvac_mode` related functionality has been added like switching from `HEAT` to `OFF` and then to `COOL`. It did not make sense to me to only fix the reported missing functionality and not fix the other missing `set_hvac_mode` functionality.
Also, tests have been added to cover the functionality updates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163452
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
