### PR TITLE
Roborock: Add map rotation option to ImageEntity

### DIFF
--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -47,6 +47,9 @@ from .const import (
     DOMAIN,
     DRAWABLES,
     REGION_OPTIONS,
+    CONF_MAP_ROTATION,           # <<< NEU
+    MAP_ROTATION_OPTIONS,        # <<< NEU
+    DEFAULT_MAP_ROTATION,        # <<< NEU
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -243,7 +246,10 @@ class RoborockOptionsFlowHandler(OptionsFlowWithReload):
     ) -> ConfigFlowResult:
         """Manage the map object drawable options."""
         if user_input is not None:
-            self.options[CONF_SHOW_BACKGROUND] = user_input.pop(CONF_SHOW_BACKGROUND)
+            self.options[CONF_SHOW_BACKGROUND] = user_input.pop(CONF_SHOW_BACKGROUND) 
+            # Rotation speichern (als int)
+            rotation = int(user_input.pop(CONF_MAP_ROTATION))
+            self.options[CONF_MAP_ROTATION] = rotation
             self.options.setdefault(DRAWABLES, {}).update(user_input)
             return self.async_create_entry(title="", data=self.options)
         data_schema = {}
@@ -262,6 +268,21 @@ class RoborockOptionsFlowHandler(OptionsFlowWithReload):
                 default=self.config_entry.options.get(CONF_SHOW_BACKGROUND, False),
             )
         ] = bool
+        data_schema[
+            vol.Required(
+                CONF_MAP_ROTATION,
+                default=str(
+                    self.config_entry.options.get(
+                        CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
+                    )
+                ),
+            )
+        ] = SelectSelector(
+            SelectSelectorConfig(
+                options=[str(v) for v in MAP_ROTATION_OPTIONS],
+                mode=SelectSelectorMode.DROPDOWN,
+            )
+        )
         return self.async_show_form(
             step_id=DRAWABLES,
             data_schema=vol.Schema(data_schema),

--- a/homeassistant/components/roborock/config_flow.py
+++ b/homeassistant/components/roborock/config_flow.py
@@ -47,9 +47,9 @@ from .const import (
     DOMAIN,
     DRAWABLES,
     REGION_OPTIONS,
-    CONF_MAP_ROTATION,           # <<< NEU
-    MAP_ROTATION_OPTIONS,        # <<< NEU
-    DEFAULT_MAP_ROTATION,        # <<< NEU
+    CONF_MAP_ROTATION,
+    MAP_ROTATION_OPTIONS,
+    DEFAULT_MAP_ROTATION,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -246,8 +246,7 @@ class RoborockOptionsFlowHandler(OptionsFlowWithReload):
     ) -> ConfigFlowResult:
         """Manage the map object drawable options."""
         if user_input is not None:
-            self.options[CONF_SHOW_BACKGROUND] = user_input.pop(CONF_SHOW_BACKGROUND) 
-            # Rotation speichern (als int)
+            self.options[CONF_SHOW_BACKGROUND] = user_input.pop(CONF_SHOW_BACKGROUND)
             rotation = int(user_input.pop(CONF_MAP_ROTATION))
             self.options[CONF_MAP_ROTATION] = rotation
             self.options.setdefault(DRAWABLES, {}).update(user_input)

--- a/homeassistant/components/roborock/const.py
+++ b/homeassistant/components/roborock/const.py
@@ -16,6 +16,11 @@ REGION_OPTIONS = ["auto", "us", "eu", "ru", "cn"]
 # Option Flow steps
 DRAWABLES = "drawables"
 
+# Map options
+CONF_MAP_ROTATION = "map_rotation"
+MAP_ROTATION_OPTIONS = (0, 90, 180, 270)
+DEFAULT_MAP_ROTATION = 0
+
 DEFAULT_DRAWABLES = {
     Drawable.CHARGER: True,
     Drawable.CLEANED_AREA: False,

--- a/homeassistant/components/roborock/const.py
+++ b/homeassistant/components/roborock/const.py
@@ -13,6 +13,7 @@ CONF_USER_DATA = "user_data"
 CONF_SHOW_BACKGROUND = "show_background"
 CONF_REGION = "region"
 REGION_OPTIONS = ["auto", "us", "eu", "ru", "cn"]
+# Option Flow steps
 DRAWABLES = "drawables"
 CONF_MAP_ROTATION = "map_rotation"
 MAP_ROTATION_OPTIONS = (0, 90, 180, 270)
@@ -49,6 +50,7 @@ PLATFORMS = [
     Platform.VACUUM,
 ]
 
+# This can be lowered in the future if we do not receive rate limiting issues.
 IMAGE_CACHE_INTERVAL = timedelta(seconds=30)
 
 MAP_SLEEP = 3

--- a/homeassistant/components/roborock/const.py
+++ b/homeassistant/components/roborock/const.py
@@ -13,10 +13,7 @@ CONF_USER_DATA = "user_data"
 CONF_SHOW_BACKGROUND = "show_background"
 CONF_REGION = "region"
 REGION_OPTIONS = ["auto", "us", "eu", "ru", "cn"]
-# Option Flow steps
 DRAWABLES = "drawables"
-
-# Map options
 CONF_MAP_ROTATION = "map_rotation"
 MAP_ROTATION_OPTIONS = (0, 90, 180, 270)
 DEFAULT_MAP_ROTATION = 0
@@ -52,7 +49,6 @@ PLATFORMS = [
     Platform.VACUUM,
 ]
 
-# This can be lowered in the future if we do not receive rate limiting issues.
 IMAGE_CACHE_INTERVAL = timedelta(seconds=30)
 
 MAP_SLEEP = 3

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -65,6 +65,9 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
     ) -> None:
         """Initialize a Roborock map."""
         map_name = map_name or f"Map {map_flag}"
+        # Note: Map names are not a valid unique id since they can be changed
+        # in the roborock app. This should be migrated to use map flag for
+        # the unique id.
         unique_id = f"{coordinator.duid_slug}_map_{map_name}"
         RoborockCoordinatedEntityV1.__init__(self, unique_id, coordinator)
         ImageEntity.__init__(self, coordinator.hass)
@@ -105,7 +108,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             self._attr_image_last_updated = self.coordinator.last_home_update
 
         super()._handle_coordinator_update()
-    
+
     async def async_image(self) -> bytes | None:
         """Get the cached image."""
         if (map_content := self._map_content) is None:

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -117,6 +117,15 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
 
         super()._handle_coordinator_update()
 
+    def _rotate_image(self, raw: bytes, rotation: int) -> bytes:
+        """Rotate image in executor thread."""
+        img = Image.open(io.BytesIO(raw))
+        img = img.rotate(rotation, expand=True)
+
+        out = io.BytesIO()
+        img.save(out, format="PNG")
+        return out.getvalue()
+    
     async def async_image(self) -> bytes | None:
         """Return the map image."""
         if (map_content := self._map_content) is None:
@@ -148,7 +157,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         if rotation == 0:
             return raw
 
-        # Return cached rotated image if available
+        # Cache check
         if (
             self._rotated_cache is not None
             and self._rotated_cache_rotation == rotation
@@ -156,23 +165,20 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             return self._rotated_cache
 
         try:
-            img = Image.open(io.BytesIO(raw))
-            img = img.rotate(rotation, expand=True)
+            rotated = await self.hass.async_add_executor_job(
+                self._rotate_image, raw, rotation
+            )
 
-            out = io.BytesIO()
-            img.save(out, format="PNG")
-
-            self._rotated_cache = out.getvalue()
+            self._rotated_cache = rotated
             self._rotated_cache_rotation = rotation
 
-            return self._rotated_cache
+            return rotated
 
         except (OSError, UnidentifiedImageError) as err:
             _LOGGER.debug(
                 "Failed to rotate Roborock map image: %s. Returning original image.",
                 err,
             )
-            # Do not cache failed rotation
             self._rotated_cache = None
             self._rotated_cache_rotation = None
             return raw

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -17,7 +17,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
+from .const import (
+    CONF_MAP_ROTATION,
+    DEFAULT_MAP_ROTATION,
+    MAP_ROTATION_OPTIONS,
+)
 from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
 from .entity import RoborockCoordinatedEntityV1
 
@@ -119,11 +123,29 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             raise HomeAssistantError("Map flag not found in coordinator maps")
 
         raw = map_content.image_content
-        rotation = int(
-            self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION)
+
+        raw_rotation = self.config_entry.options.get(
+            CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
         )
 
-        if rotation % 360 == 0:
+        try:
+            rotation = int(raw_rotation)
+        except (TypeError, ValueError):
+            _LOGGER.debug(
+                "Invalid map rotation value %s, falling back to 0",
+                raw_rotation,
+            )
+            rotation = 0
+
+        if rotation not in MAP_ROTATION_OPTIONS:
+            _LOGGER.debug(
+                "Unsupported map rotation %s, allowed values: %s. Falling back to 0.",
+                rotation,
+                MAP_ROTATION_OPTIONS,
+            )
+            rotation = 0
+
+        if rotation == 0:
             return raw
 
         # Return cached rotated image if available

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import io
 import logging
 
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from roborock.devices.traits.v1.home import HomeTrait
 from roborock.devices.traits.v1.map_content import MapContent
 
@@ -126,15 +126,31 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         if rotation % 360 == 0:
             return raw
 
-        if self._rotated_cache is not None and self._rotated_cache_rotation == rotation:
+        # Return cached rotated image if available
+        if (
+            self._rotated_cache is not None
+            and self._rotated_cache_rotation == rotation
+        ):
             return self._rotated_cache
 
-        img = Image.open(io.BytesIO(raw))
-        img = img.rotate(rotation, expand=True)
+        try:
+            img = Image.open(io.BytesIO(raw))
+            img = img.rotate(rotation, expand=True)
 
-        out = io.BytesIO()
-        img.save(out, format="PNG")
+            out = io.BytesIO()
+            img.save(out, format="PNG")
 
-        self._rotated_cache = out.getvalue()
-        self._rotated_cache_rotation = rotation
-        return self._rotated_cache
+            self._rotated_cache = out.getvalue()
+            self._rotated_cache_rotation = rotation
+
+            return self._rotated_cache
+
+        except (OSError, UnidentifiedImageError) as err:
+            _LOGGER.debug(
+                "Failed to rotate Roborock map image: %s. Returning original image.",
+                err,
+            )
+            # Do not cache failed rotation
+            self._rotated_cache = None
+            self._rotated_cache_rotation = None
+            return raw

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -1,11 +1,12 @@
 """Support for Roborock image."""
 
+from __future__ import annotations
+
 from datetime import datetime
+import io
 import logging
 
-import io
 from PIL import Image
-
 from roborock.devices.traits.v1.home import HomeTrait
 from roborock.devices.traits.v1.map_content import MapContent
 
@@ -16,9 +17,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
 from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
 from .entity import RoborockCoordinatedEntityV1
-from .const import CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,9 +66,6 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
     ) -> None:
         """Initialize a Roborock map."""
         map_name = map_name or f"Map {map_flag}"
-        # Note: Map names are not a valid unique id since they can be changed
-        # in the roborock app. This should be migrated to use map flag for
-        # the unique id.
         unique_id = f"{coordinator.duid_slug}_map_{map_name}"
         RoborockCoordinatedEntityV1.__init__(self, unique_id, coordinator)
         ImageEntity.__init__(self, coordinator.hass)
@@ -76,8 +74,11 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         self._home_trait = home_trait
         self.map_flag = map_flag
         self.cached_map: bytes | None = None
+
+        # Rotated image cache (invalidated when map content changes)
         self._rotated_cache: bytes | None = None
-        self._rotated_cache_key: tuple[int, int] | None = None
+        self._rotated_cache_rotation: int | None = None
+
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_added_to_hass(self) -> None:
@@ -103,26 +104,29 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             return
         if self.cached_map != map_content.image_content:
             self.cached_map = map_content.image_content
+
+            # Invalidate rotated cache on new map content
             self._rotated_cache = None
-            self._rotated_cache_key = None
+            self._rotated_cache_rotation = None
+
             self._attr_image_last_updated = self.coordinator.last_home_update
 
         super()._handle_coordinator_update()
 
     async def async_image(self) -> bytes | None:
-        """Get the cached image."""
+        """Return the map image."""
         if (map_content := self._map_content) is None:
             raise HomeAssistantError("Map flag not found in coordinator maps")
 
         raw = map_content.image_content
-        rotation = int(self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION))
+        rotation = int(
+            self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION)
+        )
 
         if rotation % 360 == 0:
             return raw
 
-        cache_key = (rotation, hash(raw))
-
-        if self._rotated_cache is not None and self._rotated_cache_key == cache_key:
+        if self._rotated_cache is not None and self._rotated_cache_rotation == rotation:
             return self._rotated_cache
 
         img = Image.open(io.BytesIO(raw))
@@ -132,5 +136,5 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         img.save(out, format="PNG")
 
         self._rotated_cache = out.getvalue()
-        self._rotated_cache_key = cache_key
+        self._rotated_cache_rotation = rotation
         return self._rotated_cache

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -3,6 +3,9 @@
 from datetime import datetime
 import logging
 
+import io
+from PIL import Image
+
 from roborock.devices.traits.v1.home import HomeTrait
 from roborock.devices.traits.v1.map_content import MapContent
 
@@ -15,6 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import RoborockConfigEntry, RoborockDataUpdateCoordinator
 from .entity import RoborockCoordinatedEntityV1
+from .const import CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +76,8 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         self._home_trait = home_trait
         self.map_flag = map_flag
         self.cached_map: bytes | None = None
+        self._rotated_cache: bytes | None = None
+        self._rotated_cache_key: tuple[int, int] | None = None
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_added_to_hass(self) -> None:
@@ -97,12 +103,37 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             return
         if self.cached_map != map_content.image_content:
             self.cached_map = map_content.image_content
+            self._rotated_cache = None
+            self._rotated_cache_key = None
             self._attr_image_last_updated = self.coordinator.last_home_update
 
         super()._handle_coordinator_update()
-
+    
     async def async_image(self) -> bytes | None:
         """Get the cached image."""
         if (map_content := self._map_content) is None:
             raise HomeAssistantError("Map flag not found in coordinator maps")
-        return map_content.image_content
+
+        raw = map_content.image_content
+        rotation = int(self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION))
+
+        # Keine Rotation nötig
+        if rotation % 360 == 0:
+            return raw
+
+        cache_key = (rotation, hash(raw))
+
+         # Cache verwenden
+        if self._rotated_cache is not None and self._rotated_cache_key == cache_key:
+            return self._rotated_cache
+
+        #  Rotieren
+        img = Image.open(io.BytesIO(raw))
+        img = img.rotate(rotation, expand=True)
+
+        out = io.BytesIO()
+        img.save(out, format="PNG")
+
+        self._rotated_cache = out.getvalue()
+        self._rotated_cache_key = cache_key
+        return self._rotated_cache

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -65,9 +65,6 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
     ) -> None:
         """Initialize a Roborock map."""
         map_name = map_name or f"Map {map_flag}"
-        # Note: Map names are not a valid unique id since they can be changed
-        # in the roborock app. This should be migrated to use map flag for
-        # the unique id.
         unique_id = f"{coordinator.duid_slug}_map_{map_name}"
         RoborockCoordinatedEntityV1.__init__(self, unique_id, coordinator)
         ImageEntity.__init__(self, coordinator.hass)
@@ -117,17 +114,14 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         raw = map_content.image_content
         rotation = int(self.config_entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION))
 
-        # Keine Rotation nötig
         if rotation % 360 == 0:
             return raw
 
         cache_key = (rotation, hash(raw))
 
-         # Cache verwenden
         if self._rotated_cache is not None and self._rotated_cache_key == cache_key:
             return self._rotated_cache
 
-        #  Rotieren
         img = Image.open(io.BytesIO(raw))
         img = img.rotate(rotation, expand=True)
 

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -70,6 +70,8 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
     ) -> None:
         """Initialize a Roborock map."""
         map_name = map_name or f"Map {map_flag}"
+        # Map names are not a valid unique id since they can be changed in the Roborock app.
+        # This should be migrated to use map flag for the unique id.
         unique_id = f"{coordinator.duid_slug}_map_{map_name}"
         RoborockCoordinatedEntityV1.__init__(self, unique_id, coordinator)
         ImageEntity.__init__(self, coordinator.hass)
@@ -125,6 +127,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         out = io.BytesIO()
         img.save(out, format="PNG")
         return out.getvalue()
+    
     async def async_image(self) -> bytes | None:
         """Return the map image."""
         if (map_content := self._map_content) is None:

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -125,7 +125,6 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         out = io.BytesIO()
         img.save(out, format="PNG")
         return out.getvalue()
-    
     async def async_image(self) -> bytes | None:
         """Return the map image."""
         if (map_content := self._map_content) is None:

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -182,3 +182,4 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             self._rotated_cache = None
             self._rotated_cache_rotation = None
             return raw
+        

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -143,23 +143,24 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
             rotation = int(raw_rotation)
         except (TypeError, ValueError):
             _LOGGER.debug(
-                "Invalid map rotation value %s, falling back to 0",
+                "Invalid map rotation value %s, falling back to %s",
                 raw_rotation,
+                DEFAULT_MAP_ROTATION,
             )
-            rotation = 0
+            rotation = DEFAULT_MAP_ROTATION
 
         if rotation not in MAP_ROTATION_OPTIONS:
             _LOGGER.debug(
-                "Unsupported map rotation %s, allowed values: %s. Falling back to 0.",
+                "Unsupported map rotation %s, allowed values: %s, falling back to %s",
                 rotation,
                 MAP_ROTATION_OPTIONS,
+                DEFAULT_MAP_ROTATION,
             )
-            rotation = 0
+            rotation = DEFAULT_MAP_ROTATION
 
-        if rotation == 0:
+        if rotation == DEFAULT_MAP_ROTATION:
             return raw
-
-        # Cache check
+        
         if (
             self._rotated_cache is not None
             and self._rotated_cache_rotation == rotation
@@ -178,7 +179,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
 
         except (OSError, UnidentifiedImageError) as err:
             _LOGGER.debug(
-                "Failed to rotate Roborock map image: %s. Returning original image.",
+                "Failed to rotate Roborock map image: %s, returning original image",
                 err,
             )
             self._rotated_cache = None

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -522,7 +522,7 @@
           "show_background": "Show background",
           "vacuum_position": "Vacuum position",
           "virtual_walls": "Virtual walls",
-          "zones": "Zones"
+          "zones": "Zones",
           "map_rotation": "Map rotation"
         },
         "data_description": {

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -543,7 +543,8 @@
           "show_background": "Add a background to the map.",
           "vacuum_position": "Show the vacuum position on the map.",
           "virtual_walls": "Show virtual walls on the map.",
-          "zones": "Show zones on the map."
+          "zones": "Show zones on the map.",
+          "map_rotation": "Rotate the floor plan image to match your Home Assistant layout orientation."
         },
         "description": "Specify which features to draw on the map."
       }

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -523,6 +523,7 @@
           "vacuum_position": "Vacuum position",
           "virtual_walls": "Virtual walls",
           "zones": "Zones"
+          "map_rotation": "Map rotation"
         },
         "data_description": {
           "charger": "Show the charger on the map.",

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant import config_entries
 from homeassistant.components.roborock.const import (
     CONF_BASE_URL,
     CONF_ENTRY_CODE,
+    CONF_MAP_ROTATION,
     CONF_REGION,
     DOMAIN,
     DRAWABLES,
@@ -224,17 +225,27 @@ async def test_options_flow_drawables(
 
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == DRAWABLES
+
+        # Ensure the rotation option is part of the schema
+        assert CONF_MAP_ROTATION in result["data_schema"].schema
+
         with patch(
             "homeassistant.components.roborock.async_setup_entry", return_value=True
         ) as mock_setup:
             result = await hass.config_entries.options.async_configure(
                 result["flow_id"],
-                user_input={Drawable.PREDICTED_PATH: True},
+                user_input={
+                    Drawable.PREDICTED_PATH: True,
+                    # SelectSelector typically returns strings; config_flow casts to int
+                    CONF_MAP_ROTATION: "90",
+                },
             )
             await hass.async_block_till_done()
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert mock_roborock_entry.options[DRAWABLES][Drawable.PREDICTED_PATH] is True
+        assert mock_roborock_entry.options[CONF_MAP_ROTATION] == 90
+        assert isinstance(mock_roborock_entry.options[CONF_MAP_ROTATION], int)
         assert len(mock_setup.mock_calls) == 1
 
 
@@ -348,9 +359,7 @@ async def test_discovery_not_setup(
     hass: HomeAssistant,
 ) -> None:
     """Handle the config flow and make sure it succeeds."""
-    with (
-        patch("homeassistant.components.roborock.async_setup_entry", return_value=True),
-    ):
+    with patch("homeassistant.components.roborock.async_setup_entry", return_value=True):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_DHCP},
@@ -428,7 +437,6 @@ async def test_config_flow_with_region(
             mock_client.request_code_v4 = AsyncMock(return_value=None)
             mock_client.code_login_v4 = AsyncMock(return_value=USER_DATA)
 
-            # base_url is awaited in config_flow, so it needs to be an awaitable
             future_base_url = asyncio.Future()
             future_base_url.set_result("https://usiot.roborock.com")
             mock_client.base_url = future_base_url
@@ -437,7 +445,6 @@ async def test_config_flow_with_region(
                 result["flow_id"], {CONF_USERNAME: USER_EMAIL, CONF_REGION: "us"}
             )
 
-            # Check that the client was initialized with the correct base_url
             mock_client_cls.assert_called_with(
                 USER_EMAIL,
                 base_url="https://usiot.roborock.com",

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -165,6 +165,67 @@ async def test_floorplan_image_rotation_cache_changes_on_rotation_change(
     # Ensure output changed (cache updated)
     assert body_180 != body_90
 
+async def test_floorplan_image_rotation_invalid_value_falls_back_to_raw(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test invalid rotation value falls back to raw image."""
+    setup_entry.options = {CONF_MAP_ROTATION: "invalid"}
+
+    assert fake_vacuum.v1_properties
+    assert fake_vacuum.v1_properties.map_content
+    fake_vacuum.v1_properties.map_content.image_content = _png_bytes(10, 20)
+
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+
+    body = await resp.read()
+    img = Image.open(io.BytesIO(body))
+    assert img.size == (10, 20)
+
+async def test_floorplan_image_rotation_out_of_range_falls_back_to_raw(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test unsupported rotation value falls back to raw image."""
+    setup_entry.options = {CONF_MAP_ROTATION: 45}
+
+    assert fake_vacuum.v1_properties
+    assert fake_vacuum.v1_properties.map_content
+    fake_vacuum.v1_properties.map_content.image_content = _png_bytes(10, 20)
+
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+
+    body = await resp.read()
+    img = Image.open(io.BytesIO(body))
+    assert img.size == (10, 20)
+
+async def test_floorplan_image_rotation_corrupt_image_returns_original_bytes(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test corrupt image data returns original bytes when rotation fails."""
+    setup_entry.options = {CONF_MAP_ROTATION: 90}
+
+    assert fake_vacuum.v1_properties
+    assert fake_vacuum.v1_properties.map_content
+    fake_vacuum.v1_properties.map_content.image_content = b"not-a-valid-png"
+
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+
+    body = await resp.read()
+    assert body == b"not-a-valid-png"
 
 async def test_fail_updating_image(
     hass: HomeAssistant,

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -185,7 +185,6 @@ async def test_floorplan_image_rotation_invalid_value_falls_back_to_raw(
     body = await resp.read()
     img = Image.open(io.BytesIO(body))
     assert img.size == (10, 20)
-
 async def test_floorplan_image_rotation_out_of_range_falls_back_to_raw(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -1,18 +1,42 @@
+"""Test Roborock Image platform."""
+
 from __future__ import annotations
 
+import copy
 import io
-from datetime import datetime
-from types import SimpleNamespace
-from unittest.mock import MagicMock
+from datetime import timedelta
+from http import HTTPStatus
+import logging
+from unittest.mock import patch
 
-from PIL import Image
 import pytest
+from PIL import Image
+from roborock import MultiMapsList, RoborockException
+from roborock.data import RoborockStateCode
+from roborock.devices.traits.v1.map_content import MapContent
 
+from homeassistant.components.roborock.const import (
+    CONF_MAP_ROTATION,
+    V1_LOCAL_NOT_CLEANING_INTERVAL,
+)
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
 
-from homeassistant.components.roborock.const import CONF_MAP_ROTATION
-from homeassistant.components.roborock.image import RoborockMap
+from .conftest import FakeDevice, make_home_trait
+from .mock_data import (
+    HOME_DATA,
+    MAP_DATA,
+    MULTI_MAP_LIST,
+    MULTI_MAP_LIST_NO_MAP_NAMES,
+    ROOM_MAPPING,
+    STATUS,
+)
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import ClientSessionGenerator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _png_bytes(width: int, height: int) -> bytes:
@@ -22,116 +46,140 @@ def _png_bytes(width: int, height: int) -> bytes:
     return buf.getvalue()
 
 
-def _coordinator(hass: HomeAssistant):
-    """Minimal coordinator-like object for RoborockCoordinatedEntityV1."""
-    coord = SimpleNamespace()
-    coord.hass = hass
-    coord.duid_slug = "test_duid"
-    coord.last_home_update = datetime.utcnow()
-
-    # CoordinatorEntity expects async_add_listener to exist
-    coord.async_add_listener = lambda _cb: (lambda: None)
-
-    return coord
+@pytest.fixture
+def platforms() -> list[Platform]:
+    """Fixture to set platforms used in the test."""
+    return [Platform.IMAGE]
 
 
-@pytest.mark.asyncio
-async def test_roborock_map_rotation_90(hass: HomeAssistant) -> None:
-    raw = _png_bytes(10, 20)
+async def test_floorplan_image(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test floor plan map image is correctly set up."""
+    assert len(hass.states.async_all("image")) == 4
 
-    config_entry = MagicMock()
-    config_entry.options = {CONF_MAP_ROTATION: 90}
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
-    home_trait = MagicMock()
-    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw)}
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+    body = await resp.read()
+    assert body is not None
+    assert body == b"\x89PNG-001"
 
-    entity = RoborockMap(
-        config_entry=config_entry,
-        coordinator=_coordinator(hass),
-        home_trait=home_trait,
-        map_flag=1,
-        map_name="Test Map",
+    now = dt_util.utcnow() + timedelta(minutes=61)
+
+    for fake_vacuum in fake_devices:
+        if fake_vacuum.v1_properties is None:
+            continue
+        fake_vacuum.v1_properties.status.in_cleaning = 1
+        fake_vacuum.v1_properties.map_content.image_content = b"\x89PNG-002"
+
+    with patch(
+        "homeassistant.components.roborock.coordinator.dt_util.utcnow",
+        return_value=now,
+    ):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+        assert resp.status == HTTPStatus.OK
+
+
+async def test_floorplan_image_rotation(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test map rotation option rotates the served image."""
+    setup_entry.options = {CONF_MAP_ROTATION: 90}
+
+    assert fake_vacuum.v1_properties
+    fake_vacuum.v1_properties.map_content.image_content = _png_bytes(10, 20)
+
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+
+    body = await resp.read()
+    rotated = Image.open(io.BytesIO(body))
+    assert rotated.size == (20, 10)
+
+
+async def test_fail_updating_image(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that we handle failing getting the image after it has already been setup."""
+    client = await hass_client()
+
+    previous_state = hass.states.get("image.roborock_s7_maxv_upstairs").state
+
+    fake_vacuum.v1_properties.home.refresh.side_effect = RoborockException
+    fake_vacuum.v1_properties.status.in_cleaning = 1
+
+    now = dt_util.utcnow() + timedelta(seconds=91)
+    with patch(
+        "homeassistant.components.roborock.coordinator.dt_util.utcnow",
+        return_value=now,
+    ):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+
+    assert resp.ok
+    assert previous_state == hass.states.get("image.roborock_s7_maxv_upstairs").state
+
+
+@pytest.mark.parametrize(
+    ("multi_maps_list", "expected_entity_ids"),
+    [
+        (
+            MULTI_MAP_LIST,
+            {
+                "image.roborock_s7_2_downstairs",
+                "image.roborock_s7_2_upstairs",
+                "image.roborock_s7_maxv_downstairs",
+                "image.roborock_s7_maxv_upstairs",
+            },
+        ),
+        (
+            MULTI_MAP_LIST_NO_MAP_NAMES,
+            {
+                "image.roborock_s7_2_downstairs",
+                "image.roborock_s7_2_upstairs",
+                "image.roborock_s7_maxv_map_0",
+                "image.roborock_s7_maxv_map_1",
+            },
+        ),
+    ],
+)
+async def test_image_entity_naming(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_roborock_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+    multi_maps_list: MultiMapsList,
+    expected_entity_ids: set[str],
+) -> None:
+    """Test entity naming when no map name is set."""
+    fake_vacuum.v1_properties.home = make_home_trait(
+        map_info=multi_maps_list.map_info or [],
+        current_map=STATUS.current_map,
+        room_mapping=ROOM_MAPPING,
+        rooms=HOME_DATA.rooms,
     )
 
-    rotated = await entity.async_image()
-    assert rotated is not None
-    assert rotated != raw
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
 
-    img = Image.open(io.BytesIO(rotated))
-    assert img.size == (20, 10)
-
-
-@pytest.mark.asyncio
-async def test_roborock_map_rotation_0_returns_raw(hass: HomeAssistant) -> None:
-    raw = _png_bytes(12, 34)
-
-    config_entry = MagicMock()
-    config_entry.options = {CONF_MAP_ROTATION: 0}
-
-    home_trait = MagicMock()
-    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw)}
-
-    entity = RoborockMap(
-        config_entry=config_entry,
-        coordinator=_coordinator(hass),
-        home_trait=home_trait,
-        map_flag=1,
-        map_name="Test Map",
-    )
-
-    out = await entity.async_image()
-    assert out == raw
-
-
-@pytest.mark.asyncio
-async def test_roborock_map_cache_invalidation_on_map_change(hass: HomeAssistant) -> None:
-    raw1 = _png_bytes(10, 20)
-    raw2 = _png_bytes(30, 40)
-
-    config_entry = MagicMock()
-    config_entry.options = {CONF_MAP_ROTATION: 90}
-
-    home_trait = MagicMock()
-    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw1)}
-
-    coord = _coordinator(hass)
-
-    entity = RoborockMap(
-        config_entry=config_entry,
-        coordinator=coord,
-        home_trait=home_trait,
-        map_flag=1,
-        map_name="Test Map",
-    )
-
-    rotated1 = await entity.async_image()
-    img1 = Image.open(io.BytesIO(rotated1))
-    assert img1.size == (20, 10)
-
-    # Update map content and simulate coordinator update
-    home_trait.home_map_content[1].image_content = raw2
-    entity._handle_coordinator_update()
-
-    rotated2 = await entity.async_image()
-    img2 = Image.open(io.BytesIO(rotated2))
-    assert img2.size == (40, 30)
-
-
-@pytest.mark.asyncio
-async def test_roborock_map_missing_flag_raises(hass: HomeAssistant) -> None:
-    config_entry = MagicMock()
-    config_entry.options = {CONF_MAP_ROTATION: 90}
-
-    home_trait = MagicMock()
-    home_trait.home_map_content = {}  # no map_flag present
-
-    entity = RoborockMap(
-        config_entry=config_entry,
-        coordinator=_coordinator(hass),
-        home_trait=home_trait,
-        map_flag=1,
-        map_name="Test Map",
-    )
-
-    with pytest.raises(HomeAssistantError):
-        await entity.async_image()
+    assert {
+        state.entity_id for state in hass.states.async_all("image")
+    } == expected_entity_ids

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -164,7 +164,6 @@ async def test_floorplan_image_rotation_cache_changes_on_rotation_change(
 
     # Ensure output changed (cache updated)
     assert body_180 != body_90
-
 async def test_floorplan_image_rotation_invalid_value_falls_back_to_raw(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -86,7 +86,9 @@ async def test_floorplan_image(
         "homeassistant.components.roborock.coordinator.dt_util.utcnow",
         return_value=now,
     ):
+        # This should call parse_map twice as the both devices are in cleaning.
         async_fire_time_changed(hass, now)
+        # Refresh device in the background
         await hass.async_block_till_done()
 
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
@@ -95,7 +97,8 @@ async def test_floorplan_image(
         assert resp.status == HTTPStatus.OK
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_downstairs")
         assert resp.status == HTTPStatus.OK
-        _ = await resp.read()
+    body = await resp.read()
+    assert body is not None
 
 
 @pytest.mark.parametrize(
@@ -185,10 +188,10 @@ async def test_fail_updating_image(
         return_value=now,
     ):
         async_fire_time_changed(hass, now)
+        # Refresh device in the background
         await hass.async_block_till_done()
 
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-
     # The map should load fine from the coordinator, but it should not update the
     # last_updated timestamp.
     assert resp.ok
@@ -213,7 +216,8 @@ async def test_map_status_change(
 
     _LOGGER.debug("First image fetch complete")
 
-    # Trigger a status update which detects the state has changed and updates the map
+    # Call a second time. This interval does not directly trigger a map update, but does
+    # trigger a status update which detects the state has changed and updates the map
     now = dt_util.utcnow() + V1_LOCAL_NOT_CLEANING_INTERVAL
 
     assert fake_vacuum.v1_properties
@@ -230,14 +234,15 @@ async def test_map_status_change(
         return_value=now,
     ):
         async_fire_time_changed(hass, now)
+        # Refresh device in the background
         await hass.async_block_till_done()
 
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
 
-    assert resp.status == HTTPStatus.OK
-    body = await resp.read()
-    assert body is not None
-    assert body != old_body
+        assert resp.status == HTTPStatus.OK
+        body = await resp.read()
+        assert body is not None
+        assert body != old_body
 
 
 @pytest.mark.parametrize(

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -62,7 +62,7 @@ async def test_floorplan_image(
     assert len(hass.states.async_all("image")) == 4
 
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
-
+    # Load the image on demand
     client = await hass_client()
     resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
     assert resp.status == HTTPStatus.OK
@@ -70,12 +70,16 @@ async def test_floorplan_image(
     assert body is not None
     assert body == b"\x89PNG-001"
 
+    # Call a second time - this time forcing it to update - and save new image
     now = dt_util.utcnow() + timedelta(minutes=61)
 
+    # Update maps for all v1 devices
     for fake_vacuum in fake_devices:
         if fake_vacuum.v1_properties is None:
             continue
+        assert fake_vacuum.v1_properties
         fake_vacuum.v1_properties.status.in_cleaning = 1
+        assert fake_vacuum.v1_properties.map_content
         fake_vacuum.v1_properties.map_content.image_content = b"\x89PNG-002"
 
     with patch(
@@ -87,18 +91,35 @@ async def test_floorplan_image(
 
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
         assert resp.status == HTTPStatus.OK
+        resp = await client.get("/api/image_proxy/image.roborock_s7_2_upstairs")
+        assert resp.status == HTTPStatus.OK
+        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_downstairs")
+        assert resp.status == HTTPStatus.OK
+        _ = await resp.read()
 
 
-async def test_floorplan_image_rotation(
+@pytest.mark.parametrize(
+    ("rotation", "expected_size"),
+    [
+        (0, (10, 20)),
+        (90, (20, 10)),
+        (180, (10, 20)),
+        (270, (20, 10)),
+    ],
+)
+async def test_floorplan_image_rotation_angles(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
     hass_client: ClientSessionGenerator,
     fake_vacuum: FakeDevice,
+    rotation: int,
+    expected_size: tuple[int, int],
 ) -> None:
-    """Test map rotation option rotates the served image."""
-    setup_entry.options = {CONF_MAP_ROTATION: 90}
+    """Test map rotation option rotates the served image for all supported angles."""
+    setup_entry.options = {CONF_MAP_ROTATION: rotation}
 
     assert fake_vacuum.v1_properties
+    assert fake_vacuum.v1_properties.map_content
     fake_vacuum.v1_properties.map_content.image_content = _png_bytes(10, 20)
 
     client = await hass_client()
@@ -106,8 +127,40 @@ async def test_floorplan_image_rotation(
     assert resp.status == HTTPStatus.OK
 
     body = await resp.read()
-    rotated = Image.open(io.BytesIO(body))
-    assert rotated.size == (20, 10)
+    img = Image.open(io.BytesIO(body))
+    assert img.size == expected_size
+
+
+async def test_floorplan_image_rotation_cache_changes_on_rotation_change(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that served image updates when rotation option changes (cache behavior)."""
+    assert fake_vacuum.v1_properties
+    assert fake_vacuum.v1_properties.map_content
+    fake_vacuum.v1_properties.map_content.image_content = _png_bytes(10, 20)
+
+    client = await hass_client()
+
+    setup_entry.options = {CONF_MAP_ROTATION: 90}
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+    body_90 = await resp.read()
+    img_90 = Image.open(io.BytesIO(body_90))
+    assert img_90.size == (20, 10)
+
+    # Change rotation without changing map bytes
+    setup_entry.options = {CONF_MAP_ROTATION: 180}
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+    body_180 = await resp.read()
+    img_180 = Image.open(io.BytesIO(body_180))
+    assert img_180.size == (10, 20)
+
+    # Ensure output changed (cache updated)
+    assert body_180 != body_90
 
 
 async def test_fail_updating_image(
@@ -121,6 +174,8 @@ async def test_fail_updating_image(
 
     previous_state = hass.states.get("image.roborock_s7_maxv_upstairs").state
 
+    # Refreshing the map should fail, but we should still be able to get the existing image.
+    assert fake_vacuum.v1_properties
     fake_vacuum.v1_properties.home.refresh.side_effect = RoborockException
     fake_vacuum.v1_properties.status.in_cleaning = 1
 
@@ -134,8 +189,55 @@ async def test_fail_updating_image(
 
         resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
 
+    # The map should load fine from the coordinator, but it should not update the
+    # last_updated timestamp.
     assert resp.ok
     assert previous_state == hass.states.get("image.roborock_s7_maxv_upstairs").state
+
+
+async def test_map_status_change(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test floor plan map image is correctly updated on status change."""
+    assert len(hass.states.async_all("image")) == 4
+
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
+    client = await hass_client()
+    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+    assert resp.status == HTTPStatus.OK
+    old_body = await resp.read()
+    assert old_body == b"\x89PNG-001"
+
+    _LOGGER.debug("First image fetch complete")
+
+    # Trigger a status update which detects the state has changed and updates the map
+    now = dt_util.utcnow() + V1_LOCAL_NOT_CLEANING_INTERVAL
+
+    assert fake_vacuum.v1_properties
+    fake_vacuum.v1_properties.status.state = RoborockStateCode.returning_home
+    fake_vacuum.v1_properties.home.home_map_content = {
+        0: MapContent(
+            image_content=b"\x89PNG-003",
+            map_data=copy.deepcopy(MAP_DATA),
+        )
+    }
+
+    with patch(
+        "homeassistant.components.roborock.coordinator.dt_util.utcnow",
+        return_value=now,
+    ):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+
+        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.read()
+    assert body is not None
+    assert body != old_body
 
 
 @pytest.mark.parametrize(
@@ -155,6 +257,7 @@ async def test_fail_updating_image(
             {
                 "image.roborock_s7_2_downstairs",
                 "image.roborock_s7_2_upstairs",
+                # Expect default names based on map flags
                 "image.roborock_s7_maxv_map_0",
                 "image.roborock_s7_maxv_map_1",
             },
@@ -170,6 +273,9 @@ async def test_image_entity_naming(
     expected_entity_ids: set[str],
 ) -> None:
     """Test entity naming when no map name is set."""
+    # Override one of the vacuums multi map list response based on the
+    # test parameterization
+    assert fake_vacuum.v1_properties
     fake_vacuum.v1_properties.home = make_home_trait(
         map_info=multi_maps_list.map_info or [],
         current_map=STATUS.current_map,
@@ -177,9 +283,11 @@ async def test_image_entity_naming(
         rooms=HOME_DATA.rooms,
     )
 
+    # Setup the config entry
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     await hass.async_block_till_done()
 
+    # Verify the image entities are created with the expected names
     assert {
         state.entity_id for state in hass.states.async_all("image")
     } == expected_entity_ids

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -1,223 +1,137 @@
-"""Test Roborock Image platform."""
+from __future__ import annotations
 
-import copy
-from datetime import timedelta
-from http import HTTPStatus
-import logging
-from unittest.mock import patch
+import io
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+from PIL import Image
 import pytest
-from roborock import MultiMapsList, RoborockException
-from roborock.data import RoborockStateCode
-from roborock.devices.traits.v1.map_content import MapContent
 
-from homeassistant.components.roborock.const import V1_LOCAL_NOT_CLEANING_INTERVAL
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
+from homeassistant.exceptions import HomeAssistantError
 
-from .conftest import FakeDevice, make_home_trait
-from .mock_data import (
-    HOME_DATA,
-    MAP_DATA,
-    MULTI_MAP_LIST,
-    MULTI_MAP_LIST_NO_MAP_NAMES,
-    ROOM_MAPPING,
-    STATUS,
-)
-
-from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.typing import ClientSessionGenerator
-
-_LOGGER = logging.getLogger(__name__)
+from homeassistant.components.roborock.const import CONF_MAP_ROTATION
+from homeassistant.components.roborock.image import RoborockMap
 
 
-@pytest.fixture
-def platforms() -> list[Platform]:
-    """Fixture to set platforms used in the test."""
-    return [Platform.IMAGE]
+def _png_bytes(width: int, height: int) -> bytes:
+    img = Image.new("RGB", (width, height))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
 
 
-async def test_floorplan_image(
-    hass: HomeAssistant,
-    setup_entry: MockConfigEntry,
-    hass_client: ClientSessionGenerator,
-    fake_devices: list[FakeDevice],
-) -> None:
-    """Test floor plan map image is correctly set up."""
-    assert len(hass.states.async_all("image")) == 4
+def _coordinator(hass: HomeAssistant):
+    """Minimal coordinator-like object for RoborockCoordinatedEntityV1."""
+    coord = SimpleNamespace()
+    coord.hass = hass
+    coord.duid_slug = "test_duid"
+    coord.last_home_update = datetime.utcnow()
 
-    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
-    # Load the image on demand
-    client = await hass_client()
-    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-    assert resp.status == HTTPStatus.OK
-    body = await resp.read()
-    assert body is not None
-    assert body == b"\x89PNG-001"
+    # CoordinatorEntity expects async_add_listener to exist
+    coord.async_add_listener = lambda _cb: (lambda: None)
 
-    # Call a second time - this time forcing it to update - and save new image
-    now = dt_util.utcnow() + timedelta(minutes=61)
-
-    # Update maps for all v1 devices
-    for fake_vacuum in fake_devices:
-        if fake_vacuum.v1_properties is None:
-            continue
-        assert fake_vacuum.v1_properties
-        fake_vacuum.v1_properties.status.in_cleaning = 1
-        assert fake_vacuum.v1_properties.map_content
-        fake_vacuum.v1_properties.map_content.image_content = b"\x89PNG-002"
-
-    with (
-        patch(
-            "homeassistant.components.roborock.coordinator.dt_util.utcnow",
-            return_value=now,
-        ),
-    ):
-        # This should call parse_map twice as the both devices are in cleaning.
-        async_fire_time_changed(hass, now)
-        # Refresh device in the background
-        await hass.async_block_till_done()
-
-        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-        assert resp.status == HTTPStatus.OK
-        resp = await client.get("/api/image_proxy/image.roborock_s7_2_upstairs")
-        assert resp.status == HTTPStatus.OK
-        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_downstairs")
-    assert resp.status == HTTPStatus.OK
-    body = await resp.read()
-    assert body is not None
+    return coord
 
 
-async def test_fail_updating_image(
-    hass: HomeAssistant,
-    setup_entry: MockConfigEntry,
-    hass_client: ClientSessionGenerator,
-    fake_vacuum: FakeDevice,
-) -> None:
-    """Test that we handle failing getting the image after it has already been setup."""
-    client = await hass_client()
+@pytest.mark.asyncio
+async def test_roborock_map_rotation_90(hass: HomeAssistant) -> None:
+    raw = _png_bytes(10, 20)
 
-    previous_state = hass.states.get("image.roborock_s7_maxv_upstairs").state
+    config_entry = MagicMock()
+    config_entry.options = {CONF_MAP_ROTATION: 90}
 
-    # Refreshing the map should fail, but we should still be able to get the existing image.
-    assert fake_vacuum.v1_properties
-    fake_vacuum.v1_properties.home.refresh.side_effect = RoborockException
-    fake_vacuum.v1_properties.status.in_cleaning = 1
+    home_trait = MagicMock()
+    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw)}
 
-    now = dt_util.utcnow() + timedelta(seconds=91)
-    with (
-        patch(
-            "homeassistant.components.roborock.coordinator.dt_util.utcnow",
-            return_value=now,
-        ),
-    ):
-        async_fire_time_changed(hass, now)
-        # Refresh device in the background
-        await hass.async_block_till_done()
-
-        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-    # The map should load fine from the coordinator, but it should not update the
-    # last_updated timestamp.
-    assert resp.ok
-    assert previous_state == hass.states.get("image.roborock_s7_maxv_upstairs").state
-
-
-async def test_map_status_change(
-    hass: HomeAssistant,
-    setup_entry: MockConfigEntry,
-    hass_client: ClientSessionGenerator,
-    fake_vacuum: FakeDevice,
-) -> None:
-    """Test floor plan map image is correctly updated on status change."""
-    assert len(hass.states.async_all("image")) == 4
-
-    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
-    client = await hass_client()
-    resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-    assert resp.status == HTTPStatus.OK
-    old_body = await resp.read()
-    assert old_body == b"\x89PNG-001"
-
-    _LOGGER.debug("First image fetch complete")
-
-    # Call a second time. This interval does not directly trigger a map update, but does
-    # trigger a status update which detects the state has changed and uddates the map
-    now = dt_util.utcnow() + V1_LOCAL_NOT_CLEANING_INTERVAL
-
-    assert fake_vacuum.v1_properties
-    fake_vacuum.v1_properties.status.state = RoborockStateCode.returning_home
-    fake_vacuum.v1_properties.home.home_map_content = {
-        0: MapContent(
-            image_content=b"\x89PNG-003",
-            map_data=copy.deepcopy(MAP_DATA),
-        )
-    }
-
-    with patch(
-        "homeassistant.components.roborock.coordinator.dt_util.utcnow",
-        return_value=now,
-    ):
-        async_fire_time_changed(hass, now)
-        # Refresh device in the background
-        await hass.async_block_till_done()
-
-        resp = await client.get("/api/image_proxy/image.roborock_s7_maxv_upstairs")
-
-        assert resp.status == HTTPStatus.OK
-        body = await resp.read()
-        assert body is not None
-        assert body != old_body
-
-
-@pytest.mark.parametrize(
-    ("multi_maps_list", "expected_entity_ids"),
-    [
-        (
-            MULTI_MAP_LIST,
-            {
-                "image.roborock_s7_2_downstairs",
-                "image.roborock_s7_2_upstairs",
-                "image.roborock_s7_maxv_downstairs",
-                "image.roborock_s7_maxv_upstairs",
-            },
-        ),
-        (
-            MULTI_MAP_LIST_NO_MAP_NAMES,
-            {
-                "image.roborock_s7_2_downstairs",
-                "image.roborock_s7_2_upstairs",
-                # Expect default names based on map flags
-                "image.roborock_s7_maxv_map_0",
-                "image.roborock_s7_maxv_map_1",
-            },
-        ),
-    ],
-)
-async def test_image_entity_naming(
-    hass: HomeAssistant,
-    hass_client: ClientSessionGenerator,
-    mock_roborock_entry: MockConfigEntry,
-    fake_vacuum: FakeDevice,
-    multi_maps_list: MultiMapsList,
-    expected_entity_ids: set[str],
-) -> None:
-    """Test entity naming when no map name is set."""
-    # Override one of the vacuums multi map list response based on the
-    # test parameterization
-    assert fake_vacuum.v1_properties
-    fake_vacuum.v1_properties.home = make_home_trait(
-        map_info=multi_maps_list.map_info or [],
-        current_map=STATUS.current_map,
-        room_mapping=ROOM_MAPPING,
-        rooms=HOME_DATA.rooms,
+    entity = RoborockMap(
+        config_entry=config_entry,
+        coordinator=_coordinator(hass),
+        home_trait=home_trait,
+        map_flag=1,
+        map_name="Test Map",
     )
 
-    # Setup the config entry
-    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
-    await hass.async_block_till_done()
+    rotated = await entity.async_image()
+    assert rotated is not None
+    assert rotated != raw
 
-    # Verify the image entities are created with the expected names
-    assert {
-        state.entity_id for state in hass.states.async_all("image")
-    } == expected_entity_ids
+    img = Image.open(io.BytesIO(rotated))
+    assert img.size == (20, 10)
+
+
+@pytest.mark.asyncio
+async def test_roborock_map_rotation_0_returns_raw(hass: HomeAssistant) -> None:
+    raw = _png_bytes(12, 34)
+
+    config_entry = MagicMock()
+    config_entry.options = {CONF_MAP_ROTATION: 0}
+
+    home_trait = MagicMock()
+    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw)}
+
+    entity = RoborockMap(
+        config_entry=config_entry,
+        coordinator=_coordinator(hass),
+        home_trait=home_trait,
+        map_flag=1,
+        map_name="Test Map",
+    )
+
+    out = await entity.async_image()
+    assert out == raw
+
+
+@pytest.mark.asyncio
+async def test_roborock_map_cache_invalidation_on_map_change(hass: HomeAssistant) -> None:
+    raw1 = _png_bytes(10, 20)
+    raw2 = _png_bytes(30, 40)
+
+    config_entry = MagicMock()
+    config_entry.options = {CONF_MAP_ROTATION: 90}
+
+    home_trait = MagicMock()
+    home_trait.home_map_content = {1: SimpleNamespace(image_content=raw1)}
+
+    coord = _coordinator(hass)
+
+    entity = RoborockMap(
+        config_entry=config_entry,
+        coordinator=coord,
+        home_trait=home_trait,
+        map_flag=1,
+        map_name="Test Map",
+    )
+
+    rotated1 = await entity.async_image()
+    img1 = Image.open(io.BytesIO(rotated1))
+    assert img1.size == (20, 10)
+
+    # Update map content and simulate coordinator update
+    home_trait.home_map_content[1].image_content = raw2
+    entity._handle_coordinator_update()
+
+    rotated2 = await entity.async_image()
+    img2 = Image.open(io.BytesIO(rotated2))
+    assert img2.size == (40, 30)
+
+
+@pytest.mark.asyncio
+async def test_roborock_map_missing_flag_raises(hass: HomeAssistant) -> None:
+    config_entry = MagicMock()
+    config_entry.options = {CONF_MAP_ROTATION: 90}
+
+    home_trait = MagicMock()
+    home_trait.home_map_content = {}  # no map_flag present
+
+    entity = RoborockMap(
+        config_entry=config_entry,
+        coordinator=_coordinator(hass),
+        home_trait=home_trait,
+        map_flag=1,
+        map_name="Test Map",
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await entity.async_image()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

This PR does not introduce any breaking changes.

The default rotation value is `0°`, which preserves existing behavior.
Users must explicitly enable map rotation in the integration options.

---

## Proposed change

This PR adds an optional **map rotation setting** to the Roborock integration.

Users can now configure map rotation (0°, 90°, 180°, 270°) via the integration Options Flow.

The rotation is applied server-side in the `ImageEntity.async_image()` method.  
This ensures that:

- The map is correctly oriented in all Lovelace cards
- Interactive features such as zone cleaning remain aligned
- No frontend CSS workarounds are required
- No scaling or coordinate issues occur

The rotation is applied only when configured and uses internal caching to avoid unnecessary image processing.

---

## Type of change

- [x] New feature (which adds functionality to an existing integration)

---

## Additional information

- This PR fixes or closes issue: fixes #  
- This PR is related to issue:  
- Link to documentation pull request:  
- Link to developer documentation pull request:  
- Link to frontend pull request:  

Technical details:

- Rotation value stored in `config_entry.options`
- Implemented using Pillow with `expand=True`
- Rotated images are cached per map update
- Cache invalidates automatically when map content changes
- Default value is 0° (no behavior change)

---

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

---

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.