### PR TITLE
Adds curfew functionality to Sure Petcare flaps

### DIFF
--- a/homeassistant/components/surepetcare/__init__.py
+++ b/homeassistant/components/surepetcare/__init__.py
@@ -19,8 +19,11 @@ from .const import (
     ATTR_FLAP_ID,
     ATTR_LOCATION,
     ATTR_LOCK_STATE,
+    ATTR_LOCK_TIME,
     ATTR_PET_NAME,
+    ATTR_UNLOCK_TIME,
     DOMAIN,
+    SERVICE_SET_CURFEW,
     SERVICE_SET_LOCK_STATE,
     SERVICE_SET_PET_LOCATION,
 )
@@ -86,6 +89,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         SERVICE_SET_PET_LOCATION,
         coordinator.handle_set_pet_location,
         schema=set_pet_location_schema,
+    )
+
+    curfew_service_schema = vol.Schema(
+        {
+            vol.Required(ATTR_FLAP_ID): vol.All(
+                cv.positive_int, vol.In(coordinator.data.keys())
+            ),
+            vol.Required(ATTR_LOCK_TIME): cv.time,
+            vol.Required(ATTR_UNLOCK_TIME): cv.time,
+        }
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_CURFEW,
+        coordinator.handle_set_curfew,
+        schema=curfew_service_schema,
     )
 
     return True

--- a/homeassistant/components/surepetcare/binary_sensor.py
+++ b/homeassistant/components/surepetcare/binary_sensor.py
@@ -42,7 +42,11 @@ async def async_setup_entry(
             EntityType.FELAQUA,
         ]:
             entities.append(DeviceConnectivity(surepy_entity.id, coordinator))
-        elif surepy_entity.type == EntityType.PET:
+        # curfew added for flaps
+        if surepy_entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+            entities.append(CurfewEnabled(surepy_entity.id, coordinator))
+
+        if surepy_entity.type == EntityType.PET:
             entities.append(Pet(surepy_entity.id, coordinator))
         elif surepy_entity.type == EntityType.HUB:
             entities.append(Hub(surepy_entity.id, coordinator))
@@ -145,3 +149,34 @@ class DeviceConnectivity(SurePetcareBinarySensor):
             hub_rssi = state.get("signal", {}).get("hub_rssi")
             if hub_rssi is not None:
                 self._attr_extra_state_attributes["hub_rssi"] = f"{hub_rssi:.2f}"
+
+
+class CurfewEnabled(SurePetcareBinarySensor):
+    """Sure Petcare Curfew Enabled."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:clock-check-outline"
+
+    def __init__(
+        self,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
+    ) -> None:
+        """Initialize a Sure Petcare Curfew Enabled sensor."""
+        super().__init__(surepetcare_id, coordinator)
+        self._attr_name = f"{self._device_name} Curfew Enabled"
+        self._attr_unique_id = f"{self._device_id}-curfew-enabled"
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the state."""
+        status = surepy_entity.raw_data()["status"]
+        mode = status.get("locking", {}).get("mode", {})
+
+        enabled = True
+        # If mode is 0 then curfew is disabled
+        if mode == 0:
+            enabled = False
+
+        # Check if curfew is enabled (has an 'enabled' field)
+        self._attr_is_on = enabled

--- a/homeassistant/components/surepetcare/const.py
+++ b/homeassistant/components/surepetcare/const.py
@@ -21,3 +21,8 @@ ATTR_FLAP_ID = "flap_id"
 ATTR_LOCATION = "location"
 ATTR_LOCK_STATE = "lock_state"
 ATTR_PET_NAME = "pet_name"
+
+# curfew
+SERVICE_SET_CURFEW = "set_curfew"
+ATTR_LOCK_TIME = "lock_time"
+ATTR_UNLOCK_TIME = "unlock_time"

--- a/homeassistant/components/surepetcare/coordinator.py
+++ b/homeassistant/components/surepetcare/coordinator.py
@@ -20,7 +20,9 @@ from .const import (
     ATTR_FLAP_ID,
     ATTR_LOCATION,
     ATTR_LOCK_STATE,
+    ATTR_LOCK_TIME,
     ATTR_PET_NAME,
+    ATTR_UNLOCK_TIME,
     DOMAIN,
     SURE_API_TIMEOUT,
 )
@@ -88,4 +90,16 @@ class SurePetcareDataCoordinator(DataUpdateCoordinator[dict[int, SurepyEntity]])
         location = call.data[ATTR_LOCATION]
         device_id = self.get_pets()[pet_name]
         await self.surepy.sac.set_pet_location(device_id, Location[location.upper()])
+        await self.async_request_refresh()
+
+    async def handle_set_curfew(self, call: ServiceCall) -> None:
+        """Call when setting curfew times."""
+        flap_id = call.data[ATTR_FLAP_ID]
+        lock_time = call.data[ATTR_LOCK_TIME]
+        unlock_time = call.data[ATTR_UNLOCK_TIME]
+        await self.surepy.sac.set_curfew(
+            flap_id,
+            lock_time=lock_time,
+            unlock_time=unlock_time,
+        )
         await self.async_request_refresh()

--- a/homeassistant/components/surepetcare/icons.json
+++ b/homeassistant/components/surepetcare/icons.json
@@ -1,5 +1,8 @@
 {
   "services": {
+    "set_curfew": {
+      "service": "mdi:clock-outline"
+    },
     "set_lock_state": {
       "service": "mdi:lock"
     },

--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -39,6 +39,11 @@ async def async_setup_entry(
         ]:
             entities.append(SureBattery(surepy_entity.id, coordinator))
 
+        # Add curfew time sensors for flaps that support locking
+        if surepy_entity.type in [EntityType.CAT_FLAP, EntityType.PET_FLAP]:
+            entities.append(CurfewTime(surepy_entity.id, coordinator, "lock"))
+            entities.append(CurfewTime(surepy_entity.id, coordinator, "unlock"))
+
         if surepy_entity.type == EntityType.FELAQUA:
             entities.append(Felaqua(surepy_entity.id, coordinator))
 
@@ -108,3 +113,33 @@ class Felaqua(SurePetcareEntity, SensorEntity):
         """Update the state."""
         surepy_entity = cast(SurepyFelaqua, surepy_entity)
         self._attr_native_value = surepy_entity.water_remaining
+
+
+class CurfewTime(SurePetcareEntity, SensorEntity):
+    """A sensor implementation for Sure Petcare curfew times."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:clock-outline"
+
+    def __init__(
+        self,
+        surepetcare_id: int,
+        coordinator: SurePetcareDataCoordinator,
+        time_type: str,
+    ) -> None:
+        """Initialize a Sure Petcare curfew time sensor."""
+        self._time_type = time_type
+        super().__init__(surepetcare_id, coordinator)
+
+        self._attr_name = f"{self._device_name} Curfew {time_type.capitalize()} Time"
+        self._attr_unique_id = f"{self._device_id}-curfew-{time_type}-time"
+
+    @callback
+    def _update_attr(self, surepy_entity: SurepyEntity) -> None:
+        """Update the state."""
+        status = surepy_entity.raw_data()["status"]
+        curfew = status.get("locking", {}).get("curfew", {})
+
+        # Get the appropriate time based on sensor type
+        time_value = curfew.get(f"{self._time_type}_time")
+        self._attr_native_value = time_value

--- a/homeassistant/components/surepetcare/services.yaml
+++ b/homeassistant/components/surepetcare/services.yaml
@@ -30,3 +30,21 @@ set_pet_location:
           options:
             - "Inside"
             - "Outside"
+
+set_curfew:
+  fields:
+    flap_id:
+      required: true
+      example: "123456"
+      selector:
+        text:
+    lock_time:
+      required: true
+      example: "22:00:00"
+      selector:
+        time:
+    unlock_time:
+      required: true
+      example: "07:00:00"
+      selector:
+        time:

--- a/homeassistant/components/surepetcare/strings.json
+++ b/homeassistant/components/surepetcare/strings.json
@@ -26,6 +26,24 @@
     }
   },
   "services": {
+    "set_curfew": {
+      "description": "Sets curfew times for a flap.",
+      "fields": {
+        "flap_id": {
+          "description": "Flap ID to configure curfew for.",
+          "name": "Flap ID"
+        },
+        "lock_time": {
+          "description": "Time to lock the flap.",
+          "name": "Lock time"
+        },
+        "unlock_time": {
+          "description": "Time to unlock the flap.",
+          "name": "Unlock time"
+        }
+      },
+      "name": "Set curfew"
+    },
     "set_lock_state": {
       "description": "Sets lock state.",
       "fields": {

--- a/tests/components/surepetcare/__init__.py
+++ b/tests/components/surepetcare/__init__.py
@@ -51,7 +51,13 @@ MOCK_CAT_FLAP = {
     "parent": {"product_id": 1, "id": HUB_ID},
     "status": {
         "battery": 6.4,
-        "locking": {"mode": 0},
+        "locking": {
+            "mode": 4,
+            "curfew": {
+                "lock_time": "22:00",
+                "unlock_time": "07:00",
+            },
+        },
         "learn_mode": 0,
         "signal": {"device_rssi": 65, "hub_rssi": 64},
         "online": True,
@@ -66,7 +72,30 @@ MOCK_PET_FLAP = {
     "parent": {"product_id": 1, "id": HUB_ID},
     "status": {
         "battery": 6.4,
-        "locking": {"mode": 0},
+        "locking": {
+            "mode": 4,
+            "curfew": {
+                "lock_time": "20:00",
+                "unlock_time": "08:00",
+            },
+        },
+        "learn_mode": 0,
+        "signal": {"device_rssi": 70, "hub_rssi": 65},
+        "online": True,
+    },
+}
+
+MOCK_PET_FLAP_NO_CURFEW = {
+    "id": 18976,
+    "product_id": 3,
+    "household_id": HOUSEHOLD_ID,
+    "name": "Pet Flap - No Curfew",
+    "parent": {"product_id": 1, "id": HUB_ID},
+    "status": {
+        "battery": 6.4,
+        "locking": {
+            "mode": 0,
+        },
         "learn_mode": 0,
         "signal": {"device_rssi": 70, "hub_rssi": 65},
         "online": True,
@@ -82,6 +111,13 @@ MOCK_PET = {
 }
 
 MOCK_API_DATA = {
-    "devices": [MOCK_HUB, MOCK_CAT_FLAP, MOCK_PET_FLAP, MOCK_FEEDER, MOCK_FELAQUA],
+    "devices": [
+        MOCK_HUB,
+        MOCK_CAT_FLAP,
+        MOCK_PET_FLAP,
+        MOCK_FEEDER,
+        MOCK_FELAQUA,
+        MOCK_PET_FLAP_NO_CURFEW,
+    ],
     "pets": [MOCK_PET],
 }

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -13,6 +13,9 @@ EXPECTED_ENTITY_IDS = {
     "binary_sensor.feeder_connectivity": f"{HOUSEHOLD_ID}-12345-connectivity",
     "binary_sensor.pet": f"{HOUSEHOLD_ID}-24680",
     "binary_sensor.hub": f"{HOUSEHOLD_ID}-{HUB_ID}",
+    "binary_sensor.pet_flap_curfew_enabled": f"{HOUSEHOLD_ID}-13576-curfew-enabled",
+    "binary_sensor.cat_flap_curfew_enabled": f"{HOUSEHOLD_ID}-13579-curfew-enabled",
+    "binary_sensor.pet_flap_no_curfew_curfew_enabled": f"{HOUSEHOLD_ID}-18976-curfew-enabled",
 }
 
 
@@ -29,6 +32,35 @@ async def test_binary_sensors(
         assert entity_id in state_entity_ids
         state = hass.states.get(entity_id)
         assert state
-        assert state.state == "on"
+        if "no_curfew" in entity_id:
+            # The pet flap without curfew should have curfew disabled
+            assert state.state == "off"
+        else:
+            assert state.state == "on"
         entity = entity_registry.async_get(entity_id)
         assert entity.unique_id == unique_id
+
+
+async def test_curfew_enabled_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test curfew enabled binary sensors."""
+    # Test cat flap curfew enabled sensor
+    cat_flap_curfew = hass.states.get("binary_sensor.cat_flap_curfew_enabled")
+    assert cat_flap_curfew is not None
+    assert cat_flap_curfew.state == "on"
+
+    # Test pet flap curfew enabled sensor
+    pet_flap_curfew = hass.states.get("binary_sensor.pet_flap_curfew_enabled")
+    assert pet_flap_curfew is not None
+    assert pet_flap_curfew.state == "on"
+
+    # Test pet flap without curfew sensor is disabled
+    pet_flap_no_curfew = hass.states.get(
+        "binary_sensor.pet_flap_no_curfew_curfew_enabled"
+    )
+    assert pet_flap_no_curfew is not None
+    assert pet_flap_no_curfew.state == "off"

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -12,6 +12,12 @@ EXPECTED_ENTITY_IDS = {
     "sensor.cat_flap_battery_level": f"{HOUSEHOLD_ID}-13579-battery",
     "sensor.feeder_battery_level": f"{HOUSEHOLD_ID}-12345-battery",
     "sensor.felaqua_battery_level": f"{HOUSEHOLD_ID}-{MOCK_FELAQUA['id']}-battery",
+    "sensor.pet_flap_curfew_lock_time": f"{HOUSEHOLD_ID}-13576-curfew-lock-time",
+    "sensor.pet_flap_curfew_unlock_time": f"{HOUSEHOLD_ID}-13576-curfew-unlock-time",
+    "sensor.cat_flap_curfew_lock_time": f"{HOUSEHOLD_ID}-13579-curfew-lock-time",
+    "sensor.cat_flap_curfew_unlock_time": f"{HOUSEHOLD_ID}-13579-curfew-unlock-time",
+    "sensor.pet_flap_no_curfew_curfew_lock_time": f"{HOUSEHOLD_ID}-18976-curfew-lock-time",
+    "sensor.pet_flap_no_curfew_curfew_unlock_time": f"{HOUSEHOLD_ID}-18976-curfew-unlock-time",
 }
 
 
@@ -28,6 +34,49 @@ async def test_sensors(
         assert entity_id in state_entity_ids
         state = hass.states.get(entity_id)
         assert state
-        assert state.state == "100"
         entity = entity_registry.async_get(entity_id)
         assert entity.unique_id == unique_id
+
+    # Test battery sensors have correct state
+    assert hass.states.get("sensor.pet_flap_battery_level").state == "100"
+    assert hass.states.get("sensor.cat_flap_battery_level").state == "100"
+    assert hass.states.get("sensor.feeder_battery_level").state == "100"
+
+    # Test curfew time sensors have correct states
+    assert hass.states.get("sensor.pet_flap_curfew_lock_time").state == "20:00"
+    assert hass.states.get("sensor.pet_flap_curfew_unlock_time").state == "08:00"
+    assert hass.states.get("sensor.cat_flap_curfew_lock_time").state == "22:00"
+    assert hass.states.get("sensor.cat_flap_curfew_unlock_time").state == "07:00"
+
+
+async def test_curfew_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    surepetcare,
+    mock_config_entry_setup: MockConfigEntry,
+) -> None:
+    """Test curfew time sensors."""
+    # Verify pet flap has correct curfew times
+    pet_flap_lock = hass.states.get("sensor.pet_flap_curfew_lock_time")
+    assert pet_flap_lock is not None
+    assert pet_flap_lock.state == "20:00"
+
+    pet_flap_unlock = hass.states.get("sensor.pet_flap_curfew_unlock_time")
+    assert pet_flap_unlock is not None
+    assert pet_flap_unlock.state == "08:00"
+
+    # Verify cat flap has correct curfew times
+    cat_flap_lock = hass.states.get("sensor.cat_flap_curfew_lock_time")
+    assert cat_flap_lock is not None
+    assert cat_flap_lock.state == "22:00"
+
+    cat_flap_unlock = hass.states.get("sensor.cat_flap_curfew_unlock_time")
+    assert cat_flap_unlock is not None
+    assert cat_flap_unlock.state == "07:00"
+
+    # Verify pet flap without curfew has correct states
+    pet_flap_no_curfew_lock = hass.states.get(
+        "sensor.pet_flap_no_curfew_curfew_lock_time"
+    )
+    assert pet_flap_no_curfew_lock is not None
+    assert pet_flap_no_curfew_lock.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the ability to set curfew times for Sure Petcare cat and pet flaps, allowing users to define lock and unlock times.

This feature introduces a new action for setting the curfew, along with corresponding sensors and binary sensors to reflect the curfew status and times.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The current surepy curfew function doesn't work so a dependency update would be needed once [this](https://github.com/benleb/surepy/pull/239) PR is merged however the rest of the features do work.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
