### PR TITLE
Improve config flow tests for Anthropic

### DIFF
--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -14,7 +14,6 @@ rules:
     status: todo
     comment: |
       * Make `mock_setup_entry` a separate fixture
-      * Use the mock_config_entry fixture in `test_duplicate_entry`
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -10,10 +10,7 @@ rules:
       Integration does not poll.
   brands: done
   common-modules: done
-  config-flow-test-coverage:
-    status: todo
-    comment: |
-      * Make `mock_setup_entry` a separate fixture
+  config-flow-test-coverage: done
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -16,7 +16,6 @@ rules:
       * Make `mock_setup_entry` a separate fixture
       * Use the mock_config_entry fixture in `test_duplicate_entry`
       * `test_duplicate_entry`: Patch `homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list`
-      * Fix docstring and name for `test_form_invalid_auth` (does not only test auth)
       * In `test_form_invalid_auth`, make sure the test run until CREATE_ENTRY to test that the flow is able to recover
   config-flow: done
   dependency-transparency: done

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -16,7 +16,6 @@ rules:
       * Make `mock_setup_entry` a separate fixture
       * Use the mock_config_entry fixture in `test_duplicate_entry`
       * `test_duplicate_entry`: Patch `homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list`
-      * In `test_form_invalid_auth`, make sure the test run until CREATE_ENTRY to test that the flow is able to recover
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -13,7 +13,6 @@ rules:
   config-flow-test-coverage:
     status: todo
     comment: |
-      * Remove integration setup from the config flow init test
       * Make `mock_setup_entry` a separate fixture
       * Use the mock_config_entry fixture in `test_duplicate_entry`
       * `test_duplicate_entry`: Patch `homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list`

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -15,7 +15,6 @@ rules:
     comment: |
       * Make `mock_setup_entry` a separate fixture
       * Use the mock_config_entry fixture in `test_duplicate_entry`
-      * `test_duplicate_entry`: Patch `homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list`
   config-flow: done
   dependency-transparency: done
   docs-actions:

--- a/tests/components/anthropic/conftest.py
+++ b/tests/components/anthropic/conftest.py
@@ -166,6 +166,16 @@ async def setup_ha(hass: HomeAssistant) -> None:
 
 
 @pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock setup entry."""
+    with patch(
+        "homeassistant.components.anthropic.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        yield mock_setup
+
+
+@pytest.fixture
 def mock_create_stream() -> Generator[AsyncMock]:
     """Mock stream response."""
 

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Anthropic config flow."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 from anthropic import (
     APIConnectionError,
@@ -108,8 +108,8 @@ async def test_duplicate_entry(hass: HomeAssistant) -> None:
     assert not result["errors"]
 
     with patch(
-        "anthropic.resources.models.AsyncModels.retrieve",
-        return_value=Mock(display_name="Claude 3.5 Sonnet"),
+        "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -230,15 +230,31 @@ async def test_api_error(hass: HomeAssistant, side_effect, error) -> None:
         new_callable=AsyncMock,
         side_effect=side_effect,
     ):
-        result2 = await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 "api_key": "bla",
             },
         )
 
-    assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": error}
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    with patch(
+        "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "api_key": "blabla",
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        "api_key": "blabla",
+    }
 
 
 async def test_subentry_web_search_user_location(

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -219,8 +219,8 @@ async def test_creating_conversation_subentry_not_loaded(
         ),
     ],
 )
-async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> None:
-    """Test we handle invalid auth."""
+async def test_api_error(hass: HomeAssistant, side_effect, error) -> None:
+    """Test that we handle API errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -49,13 +49,6 @@ from tests.common import MockConfigEntry
 
 async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
-    # Pretend we already set up a config entry.
-    hass.config.components.add("anthropic")
-    MockConfigEntry(
-        domain=DOMAIN,
-        state=config_entries.ConfigEntryState.LOADED,
-    ).add_to_hass(hass)
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -208,6 +208,7 @@ async def test_creating_conversation_subentry_not_loaded(
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_api_error(hass: HomeAssistant, side_effect, error) -> None:
     """Test that we handle API errors."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -94,13 +94,8 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_duplicate_entry(hass: HomeAssistant) -> None:
+async def test_duplicate_entry(hass: HomeAssistant, mock_config_entry) -> None:
     """Test we abort on duplicate config entry."""
-    MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_API_KEY: "bla"},
-    ).add_to_hass(hass)
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -114,7 +109,7 @@ async def test_duplicate_entry(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_API_KEY: "bla",
+                CONF_API_KEY: mock_config_entry.data[CONF_API_KEY],
             },
         )
 

--- a/tests/components/anthropic/test_config_flow.py
+++ b/tests/components/anthropic/test_config_flow.py
@@ -47,7 +47,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-async def test_form(hass: HomeAssistant) -> None:
+async def test_form(hass: HomeAssistant, mock_setup_entry) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -55,15 +55,9 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] is None
 
-    with (
-        patch(
-            "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "homeassistant.components.anthropic.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
+    with patch(
+        "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -784,6 +778,7 @@ async def test_creating_ai_task_subentry_advanced(
     }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reauth(hass: HomeAssistant) -> None:
     """Test we can reauthenticate."""
     # Pretend we already set up a config entry.
@@ -799,15 +794,9 @@ async def test_reauth(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
 
-    with (
-        patch(
-            "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
-            new_callable=AsyncMock,
-        ),
-        patch(
-            "homeassistant.components.anthropic.async_setup_entry",
-            return_value=True,
-        ),
+    with patch(
+        "homeassistant.components.anthropic.config_flow.anthropic.resources.models.AsyncModels.list",
+        new_callable=AsyncMock,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -84,6 +84,7 @@ async def test_init_auth_error(
         assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_downgrade_from_v3_to_v2(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -133,18 +134,15 @@ async def test_downgrade_from_v3_to_v2(
     )
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # Verify migration was skipped and version was not updated
     assert mock_config_entry.version == 3
     assert mock_config_entry.minor_version == 0
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migration_from_v1_to_v2(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -185,12 +183,8 @@ async def test_migration_from_v1_to_v2(
     )
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     assert mock_config_entry.version == 2
     assert mock_config_entry.minor_version == 3
@@ -303,6 +297,7 @@ async def test_migration_from_v1_to_v2(
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migration_from_v1_disabled(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -383,12 +378,8 @@ async def test_migration_from_v1_disabled(
     devices = [device_1, device_2]
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -441,6 +432,7 @@ async def test_migration_from_v1_disabled(
         assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migration_from_v1_to_v2_with_multiple_keys(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -506,12 +498,8 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
     )
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
@@ -534,6 +522,7 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
         assert dev.config_entries_subentries == {entry.entry_id: {subentry.subentry_id}}
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migration_from_v1_to_v2_with_same_keys(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -599,12 +588,8 @@ async def test_migration_from_v1_to_v2_with_same_keys(
     )
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     # Should have only one entry left (consolidated)
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -637,6 +622,7 @@ async def test_migration_from_v1_to_v2_with_same_keys(
         }
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migration_from_v2_1_to_v2_2(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -724,12 +710,8 @@ async def test_migration_from_v2_1_to_v2_2(
     )
 
     # Run migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -890,6 +872,7 @@ async def test_migration_from_v2_1_to_v2_2(
         ),
     ],
 )
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_migrate_entry_to_v2_3(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -959,13 +942,9 @@ async def test_migrate_entry_to_v2_3(
     assert conversation_entity.disabled_by == entity_disabled_by
 
     # Run setup to trigger migration
-    with patch(
-        "homeassistant.components.anthropic.async_setup_entry",
-        return_value=True,
-    ):
-        result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        assert result is setup_result
-        await hass.async_block_till_done()
+    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert result is setup_result
+    await hass.async_block_till_done()
 
     # Verify migration completed
     entries = hass.config_entries.async_entries(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Address comments related to config flow test raised in https://github.com/home-assistant/core/pull/162953
Each comment is a separate commit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
