### PR TITLE
Add support for clean_area to Roborock V1 vacuums

### DIFF
--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -478,6 +478,9 @@
     "mqtt_unauthorized": {
       "message": "Roborock MQTT servers rejected the connection due to rate limiting or invalid credentials. You may either attempt to reauthenticate or wait and reload the integration."
     },
+    "multiple_maps_in_clean": {
+      "message": "All segments must belong to the same map. Got segments from maps: {map_flags}"
+    },
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },
@@ -486,6 +489,9 @@
     },
     "position_not_found": {
       "message": "Robot position not found"
+    },
+    "segment_id_parse_error": {
+      "message": "Invalid segment ID format: {segment_id}"
     },
     "update_data_fail": {
       "message": "Failed to update data"

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -484,6 +484,9 @@
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },
+    "no_segment_ids": {
+      "message": "No segment IDs provided for cleaning"
+    },
     "no_user_agreement": {
       "message": "You have not valid user agreement. Open your Roborock app and accept the agreement."
     },

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -484,9 +484,6 @@
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },
-    "no_segment_ids": {
-      "message": "No segment IDs provided for cleaning"
-    },
     "no_user_agreement": {
       "message": "You have not valid user agreement. Open your Roborock app and accept the agreement."
     },

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -8,12 +8,13 @@ from roborock.exceptions import RoborockException
 from roborock.roborock_typing import RoborockCommand
 
 from homeassistant.components.vacuum import (
+    Segment,
     StateVacuumEntity,
     VacuumActivity,
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant, ServiceResponse
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
@@ -101,6 +102,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         | VacuumEntityFeature.CLEAN_SPOT
         | VacuumEntityFeature.STATE
         | VacuumEntityFeature.START
+        | VacuumEntityFeature.CLEAN_AREA
     )
     _attr_translation_key = DOMAIN
     _attr_name = None
@@ -116,6 +118,8 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             coordinator.duid_slug,
             coordinator,
         )
+        self._home_trait = coordinator.properties_api.home
+        self._maps_trait = coordinator.properties_api.maps
 
     @property
     def fan_speed_list(self) -> list[str]:
@@ -176,6 +180,69 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
     async def async_set_vacuum_goto_position(self, x: int, y: int) -> None:
         """Send vacuum to a specific target point."""
         await self.send(RoborockCommand.APP_GOTO_TARGET, [x, y])
+
+    async def async_get_segments(self) -> list[Segment]:
+        """Get the segments that can be cleaned."""
+        home_map_info = self._home_trait.home_map_info
+        if not home_map_info:
+            return []
+        return [
+            Segment(
+                id=f"{map_flag}:{room.segment_id}",
+                name=room.name,
+                group=map_info.name,
+            )
+            for map_flag, map_info in home_map_info.items()
+            for room in map_info.rooms
+        ]
+
+    async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
+        """Clean the specified segments."""
+        parsed: list[tuple[int, int]] = []
+        for seg_id in segment_ids:
+            # Segment id is mapflag:segment_id
+            parts = seg_id.split(":")
+            if len(parts) != 2:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="segment_id_parse_error",
+                    translation_placeholders={"segment_id": seg_id},
+                )
+            try:
+                # We need to make sure both parts are ints.
+                parsed.append((int(parts[0]), int(parts[1])))
+            except ValueError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="segment_id_parse_error",
+                    translation_placeholders={"segment_id": seg_id},
+                ) from err
+
+        # Because segment_ids can overlap for each map,
+        # we need to make sure that only one map is passed in.
+        unique_map_flags = {map_flag for map_flag, _ in parsed}
+        if len(unique_map_flags) > 1:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="multiple_maps_in_clean",
+                translation_placeholders={"map_flags": str(unique_map_flags)},
+            )
+        target_map_flag = next(iter(unique_map_flags))
+        if self._maps_trait.current_map != target_map_flag:
+            # If the user is attempting to clean a area on a map that is not selected, we should try to change.
+            try:
+                await self._maps_trait.set_current_map(target_map_flag)
+            except RoborockException as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="map_failure",
+                ) from err
+
+        # We can now confirm all segments are on our current map, so clean them all.
+        await self.send(
+            RoborockCommand.APP_SEGMENT_CLEAN,
+            [{"segments": [seg_id for _, seg_id in parsed]}],
+        )
 
     async def async_send_command(
         self,

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -240,7 +240,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             try:
                 await self._maps_trait.set_current_map(target_map_flag)
             except RoborockException as err:
-                raise HomeAssistantError(
+                raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="command_failed",
                     translation_placeholders={"command": "load_multi_map"},

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -229,7 +229,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             )
         target_map_flag = next(iter(unique_map_flags))
         if self._maps_trait.current_map != target_map_flag:
-            # If the user is attempting to clean a area on a map that is not selected, we should try to change.
+            # If the user is attempting to clean an area on a map that is not selected, we should try to change.
             try:
                 await self._maps_trait.set_current_map(target_map_flag)
             except RoborockException as err:

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -200,11 +200,6 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean the specified segments."""
         parsed: list[tuple[int, int]] = []
-        if len(segment_ids) == 0:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="no_segment_ids",
-            )
         for seg_id in segment_ids:
             # Segment id is mapflag:segment_id
             parts = seg_id.split(":")

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -1,5 +1,6 @@
 """Support for Roborock vacuum class."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -17,7 +18,7 @@ from homeassistant.core import HomeAssistant, ServiceResponse
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, MAP_SLEEP
 from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
     RoborockConfigEntry,
@@ -199,11 +200,16 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
     async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
         """Clean the specified segments."""
         parsed: list[tuple[int, int]] = []
+        if len(segment_ids) == 0:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="no_segment_ids",
+            )
         for seg_id in segment_ids:
             # Segment id is mapflag:segment_id
             parts = seg_id.split(":")
             if len(parts) != 2:
-                raise HomeAssistantError(
+                raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="segment_id_parse_error",
                     translation_placeholders={"segment_id": seg_id},
@@ -212,7 +218,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
                 # We need to make sure both parts are ints.
                 parsed.append((int(parts[0]), int(parts[1])))
             except ValueError as err:
-                raise HomeAssistantError(
+                raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="segment_id_parse_error",
                     translation_placeholders={"segment_id": seg_id},
@@ -239,6 +245,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
                     translation_key="command_failed",
                     translation_placeholders={"command": "load_multi_map"},
                 ) from err
+            await asyncio.sleep(MAP_SLEEP)
 
         # We can now confirm all segments are on our current map, so clean them all.
         await self.send(

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -222,10 +222,11 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         # we need to make sure that only one map is passed in.
         unique_map_flags = {map_flag for map_flag, _ in parsed}
         if len(unique_map_flags) > 1:
+            map_flags_str = ", ".join(str(flag) for flag in sorted(unique_map_flags))
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="multiple_maps_in_clean",
-                translation_placeholders={"map_flags": str(unique_map_flags)},
+                translation_placeholders={"map_flags": map_flags_str},
             )
         target_map_flag = next(iter(unique_map_flags))
         if self._maps_trait.current_map != target_map_flag:
@@ -235,7 +236,8 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             except RoborockException as err:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
-                    translation_key="map_failure",
+                    translation_key="command_failed",
+                    translation_placeholders={"command": "load_multi_map"},
                 ) from err
 
         # We can now confirm all segments are on our current map, so clean them all.

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -17,6 +17,7 @@ from homeassistant.components.roborock.services import (
 )
 from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
+    SERVICE_CLEAN_AREA,
     SERVICE_CLEAN_SPOT,
     SERVICE_LOCATE,
     SERVICE_PAUSE,
@@ -28,7 +29,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -36,6 +37,7 @@ from .conftest import FakeDevice, set_trait_attributes
 from .mock_data import STATUS
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 ENTITY_ID = "vacuum.roborock_s7_maxv"
 DEVICE_ID = "abc123"
@@ -279,6 +281,165 @@ async def test_get_current_position_no_robot_position(
             {ATTR_ENTITY_ID: ENTITY_ID},
             blocking=True,
             return_response=True,
+        )
+
+
+async def test_get_segments(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that async_get_segments returns segments from both maps."""
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": ENTITY_ID}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "segments": [
+            {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+            {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+            {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+            {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+            {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+            {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+        ]
+    }
+
+
+async def test_get_segments_no_map(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that async_get_segments returns empty list when no map data."""
+    fake_vacuum.v1_properties.home.home_map_info = {}
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": ENTITY_ID}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {"segments": []}
+
+
+async def test_clean_segments(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+    vacuum_command: Mock,
+) -> None:
+    """Test that clean_area service sends the correct segment clean command."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["1:16", "1:17"]},
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        SERVICE_CLEAN_AREA,
+        {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+        blocking=True,
+    )
+
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_count == 0
+    assert vacuum_command.send.call_count == 1
+    assert vacuum_command.send.call_args == call(
+        RoborockCommand.APP_SEGMENT_CLEAN,
+        params=[{"segments": [16, 17]}],
+    )
+
+
+async def test_clean_segments_different_map(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+    vacuum_command: Mock,
+) -> None:
+    """Test that clean_area service switches maps when needed."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {
+                "area_1": ["0:16", "0:17"],
+                "area_2": ["0:18"],
+                "area_3": ["1:16"],
+            },
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        SERVICE_CLEAN_AREA,
+        {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+        blocking=True,
+    )
+
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_count == 1
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_args == call(0)
+    assert vacuum_command.send.call_count == 1
+    assert vacuum_command.send.call_args == call(
+        RoborockCommand.APP_SEGMENT_CLEAN,
+        params=[{"segments": [16, 17]}],
+    )
+
+
+async def test_clean_segments_multiple_maps_error(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area service raises error when segments from multiple maps."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["0:16", "1:17"]},
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="All segments must belong to the same map",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
         )
 
 

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -443,6 +443,91 @@ async def test_clean_segments_multiple_maps_error(
         )
 
 
+async def test_clean_segments_malformed_id_wrong_parts(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area raises ServiceValidationError for a segment ID missing the colon separator."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Invalid segment ID format: 16",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
+async def test_clean_segments_malformed_id_non_integer(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area raises ServiceValidationError for a segment ID with non-integer parts."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["abc:16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Invalid segment ID format: abc:16",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
+async def test_clean_segments_map_switch_fails(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that clean_area raises ServiceValidationError when switching to the target map fails."""
+    fake_vacuum.v1_properties.maps.set_current_map.side_effect = RoborockException()
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            # Map flag 0 (Upstairs) differs from current map flag 1 (Downstairs),
+            # so a map switch will be attempted and will fail.
+            "area_mapping": {"area_1": ["0:16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Error while calling load_multi_map",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
 # Tests for RoborockQ7Vacuum
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for clean area for V1 Roborock vacuums - Newer devices such as the Q7/Q10 do not yet support this in HA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
