### PR TITLE
Add DeviceInfo to Google Translate

### DIFF
--- a/homeassistant/components/google_translate/strings.json
+++ b/homeassistant/components/google_translate/strings.json
@@ -11,5 +11,10 @@
         }
       }
     }
+  },
+  "device": {
+    "google_translate": {
+      "name": "Google Translate {lang} {tld}"
+    }
   }
 }

--- a/homeassistant/components/google_translate/tts.py
+++ b/homeassistant/components/google_translate/tts.py
@@ -19,6 +19,7 @@ from homeassistant.components.tts import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -26,6 +27,7 @@ from .const import (
     CONF_TLD,
     DEFAULT_LANG,
     DEFAULT_TLD,
+    DOMAIN,
     MAP_LANG_TLD,
     SUPPORT_LANGUAGES,
     SUPPORT_TLD,
@@ -66,6 +68,9 @@ async def async_setup_entry(
 class GoogleTTSEntity(TextToSpeechEntity):
     """The Google speech API entity."""
 
+    _attr_supported_languages = SUPPORT_LANGUAGES
+    _attr_supported_options = SUPPORT_OPTIONS
+
     def __init__(self, config_entry: ConfigEntry, lang: str, tld: str) -> None:
         """Init Google TTS service."""
         if lang in MAP_LANG_TLD:
@@ -77,20 +82,15 @@ class GoogleTTSEntity(TextToSpeechEntity):
         self._attr_name = f"Google Translate {self._lang} {self._tld}"
         self._attr_unique_id = config_entry.entry_id
 
-    @property
-    def default_language(self) -> str:
-        """Return the default language."""
-        return self._lang
-
-    @property
-    def supported_languages(self) -> list[str]:
-        """Return list of supported languages."""
-        return SUPPORT_LANGUAGES
-
-    @property
-    def supported_options(self) -> list[str]:
-        """Return a list of supported options."""
-        return SUPPORT_OPTIONS
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            manufacturer="Google",
+            model="Google Translate TTS",
+            translation_key="google_translate",
+            translation_placeholders={"lang": self._lang, "tld": self._tld},
+        )
+        self._attr_default_language = self._lang
 
     def get_tts_audio(
         self, message: str, language: str, options: dict[str, Any] | None = None

--- a/tests/components/google_translate/snapshots/test_tts.ambr
+++ b/tests/components/google_translate/snapshots/test_tts.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_platform[tts.google_translate_en_com-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'tts',
+    'entity_category': None,
+    'entity_id': 'tts.google_translate_en_com',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Google Translate en com',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Google Translate en com',
+    'platform': 'google_translate',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '123456789',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform[tts.google_translate_en_com-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Google Translate en com',
+    }),
+    'context': <ANY>,
+    'entity_id': 'tts.google_translate_en_com',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -10,16 +10,19 @@ from unittest.mock import MagicMock, patch
 
 from gtts import gTTSError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import tts
 from homeassistant.components.google_translate.const import CONF_TLD, DOMAIN
 from homeassistant.components.media_player import ATTR_MEDIA_CONTENT_ID
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.core_config import async_process_ha_core_config
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.tts.common import retrieve_media
 from tests.typing import ClientSessionGenerator
 
@@ -86,6 +89,26 @@ async def mock_config_entry_setup(hass: HomeAssistant, config: dict[str, Any]) -
     config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+
+async def test_platform(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test setup of the tts platform."""
+    default_config = {tts.CONF_LANG: "en", CONF_TLD: "com"}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=default_config, entry_id="123456789"
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds DeviceInfo to the Google Translate entity and changes some properties to short-hand attributes.

I tried to set the name in the device info and `_attr_name = None` in the entity, so the entity_id doesn't change,  but it seems, media_source does not support this and will fail if `engine_instance.name` is None. So entity name translations are currently not supported for tts.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
