### PR TITLE
Bump python-robroock to 4.17.1

### DIFF
--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -2,8 +2,8 @@
 
 from typing import Any
 
-from roborock.data import Status
 from roborock.devices.traits.v1.command import CommandTrait
+from roborock.devices.traits.v1.status import StatusTrait
 from roborock.exceptions import RoborockException
 from roborock.roborock_typing import RoborockCommand
 
@@ -94,7 +94,7 @@ class RoborockCoordinatedEntityV1(
         self._attr_unique_id = unique_id
 
     @property
-    def _device_status(self) -> Status:
+    def _device_status(self) -> StatusTrait:
         """Return the status of the device."""
         data = self.coordinator.data
         return data.status

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==4.17.0",
+    "python-roborock==4.17.1",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==4.14.0",
+    "python-roborock==4.17.0",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/models.py
+++ b/homeassistant/components/roborock/models.py
@@ -12,8 +12,8 @@ from roborock.data import (
     HomeDataDevice,
     HomeDataProduct,
     NetworkInfo,
-    Status,
 )
+from roborock.devices.traits.v1.status import StatusTrait
 from vacuum_map_parser_base.map_data import MapData
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 class DeviceState:
     """Data about the current state of a device."""
 
-    status: Status
+    status: StatusTrait
     dnd_timer: DnDTimer
     consumable: Consumable
     clean_summary: CleanSummaryWithDetail

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -92,25 +92,31 @@ SELECT_DESCRIPTIONS: list[RoborockSelectDescription] = [
         key="water_box_mode",
         translation_key="mop_intensity",
         api_command=RoborockCommand.SET_WATER_BOX_CUSTOM_MODE,
-        value_fn=lambda api: api.status.water_box_mode_name,
+        value_fn=lambda api: api.status.water_mode_name,
         entity_category=EntityCategory.CONFIG,
         options_lambda=lambda api: (
-            api.status.water_box_mode.keys()
-            if api.status.water_box_mode is not None
+            [mode.value for mode in api.status.water_mode_options]
+            if api.status.water_mode_options
             else None
         ),
-        parameter_lambda=lambda key, api: [api.status.get_mop_intensity_code(key)],
+        parameter_lambda=lambda key, api: [
+            {v: k for k, v in api.status.water_mode_mapping.items()}[key]
+        ],
     ),
     RoborockSelectDescription(
         key="mop_mode",
         translation_key="mop_mode",
         api_command=RoborockCommand.SET_MOP_MODE,
-        value_fn=lambda api: api.status.mop_mode_name,
+        value_fn=lambda api: api.status.mop_route_name,
         entity_category=EntityCategory.CONFIG,
         options_lambda=lambda api: (
-            api.status.mop_mode.keys() if api.status.mop_mode is not None else None
+            [mode.value for mode in api.status.mop_route_options]
+            if api.status.mop_route_options
+            else None
         ),
-        parameter_lambda=lambda key, api: [api.status.get_mop_mode_code(key)],
+        parameter_lambda=lambda key, api: [
+            {v: k for k, v in api.status.mop_route_mapping.items()}[key]
+        ],
     ),
     RoborockSelectDescription(
         key="dust_collection_mode",

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -118,9 +118,12 @@
           "max": "Max",
           "medium": "[%key:common::state::medium%]",
           "mild": "Mild",
+          "min": "Min",
           "moderate": "Moderate",
           "off": "[%key:common::state::off%]",
+          "slight": "Slight",
           "smart_mode": "[%key:component::roborock::entity::select::mop_mode::state::smart_mode%]",
+          "standard": "[%key:component::roborock::entity::select::mop_mode::state::standard%]",
           "vac_followed_by_mop": "Vacuum followed by mop"
         }
       },
@@ -448,6 +451,7 @@
               "max_plus": "Max plus",
               "medium": "[%key:common::state::medium%]",
               "off": "[%key:common::state::off%]",
+              "off_raise_main_brush": "Off (raised brush)",
               "quiet": "Quiet",
               "silent": "Silent",
               "smart_mode": "[%key:component::roborock::entity::select::mop_mode::state::smart_mode%]",

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -120,7 +120,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
     @property
     def fan_speed_list(self) -> list[str]:
         """Get the list of available fan speeds."""
-        return self._device_status.fan_power_options
+        return [mode.value for mode in self._device_status.fan_speed_options]
 
     @property
     def activity(self) -> VacuumActivity | None:
@@ -131,7 +131,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
     @property
     def fan_speed(self) -> str | None:
         """Return the fan speed of the vacuum cleaner."""
-        return self._device_status.fan_power_name
+        return self._device_status.fan_speed_name
 
     async def async_start(self) -> None:
         """Start the vacuum."""
@@ -170,7 +170,11 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         """Set vacuum fan speed."""
         await self.send(
             RoborockCommand.SET_CUSTOM_MODE,
-            [self._device_status.get_fan_speed_code(fan_speed)],
+            [
+                {v: k for k, v in self._device_status.fan_speed_mapping.items()}[
+                    fan_speed
+                ]
+            ],
         )
 
     async def async_set_vacuum_goto_position(self, x: int, y: int) -> None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2627,7 +2627,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==4.14.0
+python-roborock==4.17.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2627,7 +2627,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==4.17.0
+python-roborock==4.17.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2220,7 +2220,7 @@ python-pooldose==0.8.2
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==4.17.0
+python-roborock==4.17.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2220,7 +2220,7 @@ python-pooldose==0.8.2
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==4.14.0
+python-roborock==4.17.0
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -10,7 +10,14 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
-from roborock import HomeDataRoom, MultiMapsListMapInfo, RoborockCategory
+from roborock import (
+    CleanRoutes,
+    HomeDataRoom,
+    MultiMapsListMapInfo,
+    RoborockCategory,
+    VacuumModes,
+    WaterModes,
+)
 from roborock.data import (
     CombinedMapInfo,
     DnDTimer,
@@ -307,6 +314,20 @@ def create_v1_properties(network_info: NetworkInfo) -> AsyncMock:
         trait_spec=StatusTrait,
         dataclass_template=STATUS,
     )
+    _fan_speed_mapping = {m.code: m.value for m in VacuumModes}
+    _water_mode_mapping = {m.code: m.value for m in WaterModes}
+    _mop_route_mapping = {m.code: m.value for m in CleanRoutes}
+    v1_properties.status.fan_speed_options = list(VacuumModes)
+    v1_properties.status.fan_speed_mapping = _fan_speed_mapping
+    v1_properties.status.fan_speed_name = _fan_speed_mapping.get(STATUS.fan_power)
+    v1_properties.status.water_mode_options = list(WaterModes)
+    v1_properties.status.water_mode_mapping = _water_mode_mapping
+    v1_properties.status.water_mode_name = _water_mode_mapping.get(
+        STATUS.water_box_mode
+    )
+    v1_properties.status.mop_route_options = list(CleanRoutes)
+    v1_properties.status.mop_route_mapping = _mop_route_mapping
+    v1_properties.status.mop_route_name = _mop_route_mapping.get(STATUS.mop_mode)
     v1_properties.dnd = make_dnd_timer(dataclass_template=DND_TIMER)
     v1_properties.clean_summary = make_mock_trait(
         trait_spec=CleanSummaryTrait,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Some users will get new options and see previously missing clean options - however, some users who previously had incorrect clean options may see the incorrect cleaning option removed or renamed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This includes a change that switches from a static means of determining clean mods that were determined by users submitting their clean types to a dynamic means of determining exactly what clean types a devices has on runtime. This should result in a better experience for users. The changes made in this PR are required as the PR update was a breaking change.
Changes: https://github.com/Python-roborock/python-roborock/compare/v4.14.0...v4.17.1
Changelog: https://github.com/Python-roborock/python-roborock/blob/main/CHANGELOG.md

This should ONLY be included in a beta release and not a patch release.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
