### PR TITLE
Roborock: Q7 Model Split and Refactor

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -144,18 +144,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         for coord in coordinators
         if isinstance(coord, RoborockDataUpdateCoordinatorA01)
     ]
-    b01_coords = [
+    b01_q7_coords = [
         coord
         for coord in coordinators
-        if isinstance(coord, RoborockDataUpdateCoordinatorB01)
+        if isinstance(coord, RoborockB01Q7UpdateCoordinator)
     ]
-    if len(v1_coords) + len(a01_coords) + len(b01_coords) == 0:
+    if len(v1_coords) + len(a01_coords) + len(b01_q7_coords) == 0:
         raise ConfigEntryNotReady(
             "No devices were able to successfully setup",
             translation_domain=DOMAIN,
             translation_key="no_coordinators",
         )
-    entry.runtime_data = RoborockCoordinators(v1_coords, a01_coords, b01_coords)
+    entry.runtime_data = RoborockCoordinators(v1_coords, a01_coords, b01_q7_coords)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -64,17 +64,17 @@ class RoborockCoordinators:
 
     v1: list[RoborockDataUpdateCoordinator]
     a01: list[RoborockDataUpdateCoordinatorA01]
-    b01: list[RoborockDataUpdateCoordinatorB01]
+    b01_q7: list[RoborockB01Q7UpdateCoordinator]
 
     def values(
         self,
     ) -> list[
         RoborockDataUpdateCoordinator
         | RoborockDataUpdateCoordinatorA01
-        | RoborockDataUpdateCoordinatorB01
+        | RoborockB01Q7UpdateCoordinator
     ]:
         """Return all coordinators."""
-        return self.v1 + self.a01 + self.b01
+        return self.v1 + self.a01 + self.b01_q7
 
 
 type RoborockConfigEntry = ConfigEntry[RoborockCoordinators]

--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -14,9 +14,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import (
+    RoborockB01Q7UpdateCoordinator,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
-    RoborockDataUpdateCoordinatorB01,
 )
 
 
@@ -130,17 +130,18 @@ class RoborockCoordinatedEntityA01(
         self._attr_unique_id = unique_id
 
 
-class RoborockCoordinatedEntityB01(
-    RoborockEntity, CoordinatorEntity[RoborockDataUpdateCoordinatorB01]
+class RoborockCoordinatedEntityB01Q7(
+    RoborockEntity, CoordinatorEntity[RoborockB01Q7UpdateCoordinator]
 ):
     """Representation of coordinated Roborock Entity."""
 
     def __init__(
         self,
         unique_id: str,
-        coordinator: RoborockDataUpdateCoordinatorB01,
+        coordinator: RoborockB01Q7UpdateCoordinator,
     ) -> None:
         """Initialize the coordinated Roborock Device."""
+        CoordinatorEntity.__init__(self, coordinator=coordinator)
         RoborockEntity.__init__(
             self,
             unique_id=unique_id,

--- a/homeassistant/components/roborock/entity.py
+++ b/homeassistant/components/roborock/entity.py
@@ -147,5 +147,4 @@ class RoborockCoordinatedEntityB01Q7(
             unique_id=unique_id,
             device_info=coordinator.device_info,
         )
-        CoordinatorEntity.__init__(self, coordinator=coordinator)
         self._attr_unique_id = unique_id

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -26,7 +26,7 @@ from .coordinator import (
     RoborockConfigEntry,
     RoborockDataUpdateCoordinator,
 )
-from .entity import RoborockCoordinatedEntityB01, RoborockCoordinatedEntityV1
+from .entity import RoborockCoordinatedEntityB01Q7, RoborockCoordinatedEntityV1
 
 PARALLEL_UPDATES = 0
 
@@ -159,14 +159,13 @@ async def async_setup_entry(
     )
     async_add_entities(
         RoborockB01SelectEntity(coordinator, description, options)
-        for coordinator in config_entry.runtime_data.b01
+        for coordinator in config_entry.runtime_data.b01_q7
         for description in B01_SELECT_DESCRIPTIONS
-        if isinstance(coordinator, RoborockB01Q7UpdateCoordinator)
         if (options := description.options_lambda(coordinator.api)) is not None
     )
 
 
-class RoborockB01SelectEntity(RoborockCoordinatedEntityB01, SelectEntity):
+class RoborockB01SelectEntity(RoborockCoordinatedEntityB01Q7, SelectEntity):
     """Select entity for Roborock B01 devices."""
 
     entity_description: RoborockB01SelectDescription

--- a/homeassistant/components/roborock/sensor.py
+++ b/homeassistant/components/roborock/sensor.py
@@ -33,14 +33,14 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .coordinator import (
+    RoborockB01Q7UpdateCoordinator,
     RoborockConfigEntry,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
-    RoborockDataUpdateCoordinatorB01,
 )
 from .entity import (
     RoborockCoordinatedEntityA01,
-    RoborockCoordinatedEntityB01,
+    RoborockCoordinatedEntityB01Q7,
     RoborockCoordinatedEntityV1,
     RoborockEntity,
 )
@@ -422,8 +422,8 @@ async def async_setup_entry(
         if description.data_protocol in coordinator.request_protocols
     )
     entities.extend(
-        RoborockSensorEntityB01(coordinator, description)
-        for coordinator in coordinators.b01
+        RoborockSensorEntityB01Q7(coordinator, description)
+        for coordinator in coordinators.b01_q7
         for description in Q7_B01_SENSOR_DESCRIPTIONS
         if description.value_fn(coordinator.data) is not None
     )
@@ -515,14 +515,14 @@ class RoborockSensorEntityA01(RoborockCoordinatedEntityA01, SensorEntity):
         return self.coordinator.data[self.entity_description.data_protocol]
 
 
-class RoborockSensorEntityB01(RoborockCoordinatedEntityB01, SensorEntity):
-    """Representation of a B01 Roborock sensor."""
+class RoborockSensorEntityB01Q7(RoborockCoordinatedEntityB01Q7, SensorEntity):
+    """Representation of a B01 Q7 Roborock sensor."""
 
     entity_description: RoborockSensorDescriptionB01
 
     def __init__(
         self,
-        coordinator: RoborockDataUpdateCoordinatorB01,
+        coordinator: RoborockB01Q7UpdateCoordinator,
         description: RoborockSensorDescriptionB01,
     ) -> None:
         """Initialize the entity."""

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -478,6 +478,9 @@
     "mqtt_unauthorized": {
       "message": "Roborock MQTT servers rejected the connection due to rate limiting or invalid credentials. You may either attempt to reauthenticate or wait and reload the integration."
     },
+    "multiple_maps_in_clean": {
+      "message": "All segments must belong to the same map. Got segments from maps: {map_flags}"
+    },
     "no_coordinators": {
       "message": "No devices were able to successfully setup"
     },
@@ -486,6 +489,9 @@
     },
     "position_not_found": {
       "message": "Robot position not found"
+    },
+    "segment_id_parse_error": {
+      "message": "Invalid segment ID format: {segment_id}"
     },
     "update_data_fail": {
       "message": "Failed to update data"

--- a/homeassistant/components/roborock/vacuum.py
+++ b/homeassistant/components/roborock/vacuum.py
@@ -1,5 +1,6 @@
 """Support for Roborock vacuum class."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -8,21 +9,22 @@ from roborock.exceptions import RoborockException
 from roborock.roborock_typing import RoborockCommand
 
 from homeassistant.components.vacuum import (
+    Segment,
     StateVacuumEntity,
     VacuumActivity,
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant, ServiceResponse
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, MAP_SLEEP
 from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
     RoborockConfigEntry,
     RoborockDataUpdateCoordinator,
 )
-from .entity import RoborockCoordinatedEntityB01, RoborockCoordinatedEntityV1
+from .entity import RoborockCoordinatedEntityB01Q7, RoborockCoordinatedEntityV1
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,8 +84,7 @@ async def async_setup_entry(
     )
     async_add_entities(
         RoborockQ7Vacuum(coordinator)
-        for coordinator in config_entry.runtime_data.b01
-        if isinstance(coordinator, RoborockB01Q7UpdateCoordinator)
+        for coordinator in config_entry.runtime_data.b01_q7
     )
 
 
@@ -101,6 +102,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         | VacuumEntityFeature.CLEAN_SPOT
         | VacuumEntityFeature.STATE
         | VacuumEntityFeature.START
+        | VacuumEntityFeature.CLEAN_AREA
     )
     _attr_translation_key = DOMAIN
     _attr_name = None
@@ -116,6 +118,8 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
             coordinator.duid_slug,
             coordinator,
         )
+        self._home_trait = coordinator.properties_api.home
+        self._maps_trait = coordinator.properties_api.maps
 
     @property
     def fan_speed_list(self) -> list[str]:
@@ -177,6 +181,72 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         """Send vacuum to a specific target point."""
         await self.send(RoborockCommand.APP_GOTO_TARGET, [x, y])
 
+    async def async_get_segments(self) -> list[Segment]:
+        """Get the segments that can be cleaned."""
+        home_map_info = self._home_trait.home_map_info
+        if not home_map_info:
+            return []
+        return [
+            Segment(
+                id=f"{map_flag}:{room.segment_id}",
+                name=room.name,
+                group=map_info.name,
+            )
+            for map_flag, map_info in home_map_info.items()
+            for room in map_info.rooms
+        ]
+
+    async def async_clean_segments(self, segment_ids: list[str], **kwargs: Any) -> None:
+        """Clean the specified segments."""
+        parsed: list[tuple[int, int]] = []
+        for seg_id in segment_ids:
+            # Segment id is mapflag:segment_id
+            parts = seg_id.split(":")
+            if len(parts) != 2:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="segment_id_parse_error",
+                    translation_placeholders={"segment_id": seg_id},
+                )
+            try:
+                # We need to make sure both parts are ints.
+                parsed.append((int(parts[0]), int(parts[1])))
+            except ValueError as err:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="segment_id_parse_error",
+                    translation_placeholders={"segment_id": seg_id},
+                ) from err
+
+        # Because segment_ids can overlap for each map,
+        # we need to make sure that only one map is passed in.
+        unique_map_flags = {map_flag for map_flag, _ in parsed}
+        if len(unique_map_flags) > 1:
+            map_flags_str = ", ".join(str(flag) for flag in sorted(unique_map_flags))
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="multiple_maps_in_clean",
+                translation_placeholders={"map_flags": map_flags_str},
+            )
+        target_map_flag = next(iter(unique_map_flags))
+        if self._maps_trait.current_map != target_map_flag:
+            # If the user is attempting to clean an area on a map that is not selected, we should try to change.
+            try:
+                await self._maps_trait.set_current_map(target_map_flag)
+            except RoborockException as err:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="command_failed",
+                    translation_placeholders={"command": "load_multi_map"},
+                ) from err
+            await asyncio.sleep(MAP_SLEEP)
+
+        # We can now confirm all segments are on our current map, so clean them all.
+        await self.send(
+            RoborockCommand.APP_SEGMENT_CLEAN,
+            [{"segments": [seg_id for _, seg_id in parsed]}],
+        )
+
     async def async_send_command(
         self,
         command: str,
@@ -232,7 +302,7 @@ class RoborockVacuum(RoborockCoordinatedEntityV1, StateVacuumEntity):
         }
 
 
-class RoborockQ7Vacuum(RoborockCoordinatedEntityB01, StateVacuumEntity):
+class RoborockQ7Vacuum(RoborockCoordinatedEntityB01Q7, StateVacuumEntity):
     """General Representation of a Roborock vacuum."""
 
     _attr_icon = "mdi:robot-vacuum"
@@ -256,7 +326,7 @@ class RoborockQ7Vacuum(RoborockCoordinatedEntityB01, StateVacuumEntity):
     ) -> None:
         """Initialize a vacuum."""
         StateVacuumEntity.__init__(self)
-        RoborockCoordinatedEntityB01.__init__(
+        RoborockCoordinatedEntityB01Q7.__init__(
             self,
             coordinator.duid_slug,
             coordinator,

--- a/tests/components/roborock/test_vacuum.py
+++ b/tests/components/roborock/test_vacuum.py
@@ -17,6 +17,7 @@ from homeassistant.components.roborock.services import (
 )
 from homeassistant.components.vacuum import (
     DOMAIN as VACUUM_DOMAIN,
+    SERVICE_CLEAN_AREA,
     SERVICE_CLEAN_SPOT,
     SERVICE_LOCATE,
     SERVICE_PAUSE,
@@ -28,7 +29,7 @@ from homeassistant.components.vacuum import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -36,6 +37,7 @@ from .conftest import FakeDevice, set_trait_attributes
 from .mock_data import STATUS
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 ENTITY_ID = "vacuum.roborock_s7_maxv"
 DEVICE_ID = "abc123"
@@ -282,6 +284,250 @@ async def test_get_current_position_no_robot_position(
         )
 
 
+async def test_get_segments(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that async_get_segments returns segments from both maps."""
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": ENTITY_ID}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {
+        "segments": [
+            {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+            {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+            {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+            {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+            {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+            {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+        ]
+    }
+
+
+async def test_get_segments_no_map(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that async_get_segments returns empty list when no map data."""
+    fake_vacuum.v1_properties.home.home_map_info = {}
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": ENTITY_ID}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] == {"segments": []}
+
+
+async def test_clean_segments(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+    vacuum_command: Mock,
+) -> None:
+    """Test that clean_area service sends the correct segment clean command."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["1:16", "1:17"]},
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        SERVICE_CLEAN_AREA,
+        {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+        blocking=True,
+    )
+
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_count == 0
+    assert vacuum_command.send.call_count == 1
+    assert vacuum_command.send.call_args == call(
+        RoborockCommand.APP_SEGMENT_CLEAN,
+        params=[{"segments": [16, 17]}],
+    )
+
+
+async def test_clean_segments_different_map(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+    vacuum_command: Mock,
+) -> None:
+    """Test that clean_area service switches maps when needed."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {
+                "area_1": ["0:16", "0:17"],
+                "area_2": ["0:18"],
+                "area_3": ["1:16"],
+            },
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        SERVICE_CLEAN_AREA,
+        {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+        blocking=True,
+    )
+
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_count == 1
+    assert fake_vacuum.v1_properties.maps.set_current_map.call_args == call(0)
+    assert vacuum_command.send.call_count == 1
+    assert vacuum_command.send.call_args == call(
+        RoborockCommand.APP_SEGMENT_CLEAN,
+        params=[{"segments": [16, 17]}],
+    )
+
+
+async def test_clean_segments_multiple_maps_error(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area service raises error when segments from multiple maps."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["0:16", "1:17"]},
+            "last_seen_segments": [
+                {"id": "0:16", "name": "Example room 1", "group": "Upstairs"},
+                {"id": "0:17", "name": "Example room 2", "group": "Upstairs"},
+                {"id": "0:18", "name": "Example room 3", "group": "Upstairs"},
+                {"id": "1:16", "name": "Example room 1", "group": "Downstairs"},
+                {"id": "1:17", "name": "Example room 2", "group": "Downstairs"},
+                {"id": "1:18", "name": "Example room 3", "group": "Downstairs"},
+            ],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="All segments must belong to the same map",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
+async def test_clean_segments_malformed_id_wrong_parts(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area raises ServiceValidationError for a segment ID missing the colon separator."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Invalid segment ID format: 16",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
+async def test_clean_segments_malformed_id_non_integer(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that clean_area raises ServiceValidationError for a segment ID with non-integer parts."""
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            "area_mapping": {"area_1": ["abc:16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Invalid segment ID format: abc:16",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
+async def test_clean_segments_map_switch_fails(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test that clean_area raises ServiceValidationError when switching to the target map fails."""
+    fake_vacuum.v1_properties.maps.set_current_map.side_effect = RoborockException()
+    entity_registry.async_update_entity_options(
+        ENTITY_ID,
+        VACUUM_DOMAIN,
+        {
+            # Map flag 0 (Upstairs) differs from current map flag 1 (Downstairs),
+            # so a map switch will be attempted and will fail.
+            "area_mapping": {"area_1": ["0:16"]},
+            "last_seen_segments": [],
+        },
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Error while calling load_multi_map",
+    ):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_CLEAN_AREA,
+            {ATTR_ENTITY_ID: ENTITY_ID, "cleaning_area_id": ["area_1"]},
+            blocking=True,
+        )
+
+
 # Tests for RoborockQ7Vacuum
 
 
@@ -363,7 +609,7 @@ async def test_q7_state_changing_commands(
     # Verify the entity state was updated
     assert fake_q7_vacuum.b01_q7_properties is not None
     # Force coordinator refresh to get updated state
-    coordinator = setup_entry.runtime_data.b01[0]
+    coordinator = setup_entry.runtime_data.b01_q7[0]
 
     await coordinator.async_refresh()
     await hass.async_block_till_done()
@@ -489,7 +735,7 @@ async def test_q7_activity_none_status(
     fake_q7_vacuum.b01_q7_properties._props_data.status = None
 
     # Force coordinator refresh to get updated state
-    coordinator = setup_entry.runtime_data.b01[0]
+    coordinator = setup_entry.runtime_data.b01_q7[0]
     await coordinator.async_refresh()
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR separates and refactors all logic related to the Roborock Q7 model in the Home Assistant integration. The Q7-specific code is now unified under the `b01_q7` coordinator, and all platform files (`vacuum.py`, `sensor.py`, `select.py`, etc.) have been updated to use this new structure. Duplicate class definitions have been removed, and all references to Q7 coordinators are now consistent.
To prepare for https://github.com/home-assistant/core/pull/163112.

### Key Changes

- Unified Q7 coordinator access under `b01_q7` in all relevant modules.
- Removed duplicate `RoborockB01Q7UpdateCoordinator` class definition.
- Updated `__init__.py`, `coordinator.py`, `vacuum.py`, `sensor.py`, `select.py`, and related test files to use the new Q7 structure.
- Fixed all import and attribute errors related to the Q7 split.
- Ensured all tests pass after the refactor.
- Merged latest changes from `dev` and resolved all conflicts.

### Motivation

- Improve maintainability and clarity by isolating Q7 logic.
- Prepare for future Q7-specific features and bugfixes.
- Ensure a clean and consistent codebase for both Q7 and other Roborock models.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
