### PR TITLE
vicare: add dhw circulation boost workflow and schedule visibility

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -3,26 +3,57 @@
 from __future__ import annotations
 
 from contextlib import suppress
+import json
 import logging
 import os
+from typing import Any, cast
 
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareUtils import (
     PyViCareInvalidConfigurationError,
     PyViCareInvalidCredentialsError,
+    PyViCareInvalidDataError,
+    PyViCareNotSupportedFeatureError,
+    PyViCareRateLimitError,
 )
+import requests
+import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_ENTITY_ID, CONF_DEVICE_ID
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.storage import STORAGE_DIR
 
+from .circulation import (
+    DhwCirculationBoostState,
+    async_activate_dhw_circulation_boost,
+    async_get_device_from_call,
+)
 from .const import (
+    CONF_HEAT_TIMEOUT_MINUTES,
+    CONF_MIN_BOOST_TEMPERATURE,
+    CONF_WARM_WATER_DELAY_MINUTES,
     DEFAULT_CACHE_DURATION,
+    DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+    DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+    DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
     DOMAIN,
     PLATFORMS,
+    SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST,
+    SERVICE_GET_DEVICE_RAW_FEATURES,
+    SERVICE_GET_DHW_CIRCULATION_SCHEDULE,
     UNSUPPORTED_DEVICES,
     VICARE_TOKEN_FILENAME,
 )
@@ -35,12 +66,15 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bool:
     """Set up from config entry."""
     _LOGGER.debug("Setting up ViCare component")
+    hass.data.setdefault(DOMAIN, {})
     try:
         entry.runtime_data = await hass.async_add_executor_job(
             setup_vicare_api, hass, entry
         )
     except (PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError) as err:
         raise ConfigEntryAuthFailed("Authentication failed") from err
+
+    _async_register_services(hass, entry)
 
     for device in entry.runtime_data.devices:
         # Migration can be removed in 2025.4.0
@@ -49,6 +83,186 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_register_services(hass: HomeAssistant, entry: ViCareConfigEntry) -> None:
+    """Register ViCare services once."""
+    if hass.data[DOMAIN].get("services_registered"):
+        return
+
+    async def async_get_dhw_circulation_schedule(
+        call: ServiceCall,
+    ) -> ServiceResponse:
+        """Return DHW circulation schedule and supported modes."""
+        devices = await hass.async_add_executor_job(
+            _get_dhw_circulation_schedule_data, entry.runtime_data.devices
+        )
+        return cast(ServiceResponse, {"devices": devices})
+
+    async def async_get_device_raw_features(
+        call: ServiceCall,
+    ) -> ServiceResponse:
+        """Return raw device data from the ViCare API."""
+        devices = await hass.async_add_executor_job(
+            _get_device_raw_features_data, entry.runtime_data.devices
+        )
+        return cast(ServiceResponse, {"devices": devices})
+
+    async def async_activate_dhw_circulation_boost_service(
+        call: ServiceCall,
+    ) -> None:
+        """Activate DHW circulation boost for a device."""
+        duration_minutes = int(call.data["duration_minutes"])
+        min_storage_temperature = call.data.get("min_storage_temperature")
+        min_boost_temperature = call.data.get("min_boost_temperature")
+        if min_boost_temperature is None and min_storage_temperature is None:
+            min_boost_temperature = entry.options.get(
+                CONF_MIN_BOOST_TEMPERATURE, DEFAULT_DHW_BOOST_MIN_TEMPERATURE
+            )
+        target_setpoint = call.data.get("target_setpoint")
+        heat_timeout_minutes = call.data.get(
+            "heat_timeout_minutes",
+            entry.options.get(
+                CONF_HEAT_TIMEOUT_MINUTES, DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES
+            ),
+        )
+        warm_water_delay_minutes = call.data.get(
+            "warm_water_delay_minutes",
+            entry.options.get(
+                CONF_WARM_WATER_DELAY_MINUTES,
+                DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+            ),
+        )
+        entity_ids = call.data.get(ATTR_ENTITY_ID)
+        device_ids = call.data.get(CONF_DEVICE_ID)
+        entity_id = entity_ids[0] if isinstance(entity_ids, list) else entity_ids
+        device_id = device_ids[0] if isinstance(device_ids, list) else device_ids
+
+        device = await async_get_device_from_call(
+            hass,
+            entry.runtime_data.devices,
+            entity_id,
+            device_id,
+        )
+        state_map: dict[str, DhwCirculationBoostState] = hass.data[DOMAIN].setdefault(
+            "dhw_circulation_boost", {}
+        )
+        await async_activate_dhw_circulation_boost(
+            hass,
+            device,
+            duration_minutes,
+            state_map,
+            min_boost_temperature=min_boost_temperature,
+            min_storage_temperature=min_storage_temperature,
+            target_setpoint=target_setpoint,
+            heat_timeout_minutes=heat_timeout_minutes,
+            warm_water_delay_minutes=warm_water_delay_minutes,
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_DHW_CIRCULATION_SCHEDULE,
+        async_get_dhw_circulation_schedule,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_DEVICE_RAW_FEATURES,
+        async_get_device_raw_features,
+        supports_response=SupportsResponse.ONLY,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST,
+        async_activate_dhw_circulation_boost_service,
+        schema=vol.Schema(
+            {
+                vol.Required("duration_minutes"): vol.All(
+                    cv.positive_int, vol.Range(min=10, max=240)
+                ),
+                vol.Optional("min_storage_temperature"): vol.All(
+                    vol.Coerce(float), vol.Range(min=20, max=70)
+                ),
+                vol.Optional("min_boost_temperature"): vol.All(
+                    vol.Coerce(float), vol.Range(min=20, max=70)
+                ),
+                vol.Optional("target_setpoint"): vol.All(
+                    vol.Coerce(float), vol.Range(min=30, max=70)
+                ),
+                vol.Optional("heat_timeout_minutes"): vol.All(
+                    cv.positive_int, vol.Range(min=10, max=240)
+                ),
+                vol.Optional("warm_water_delay_minutes"): vol.All(
+                    cv.positive_int, vol.Range(min=1, max=240)
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        ),
+    )
+    hass.data[DOMAIN]["services_registered"] = True
+
+
+def _get_dhw_circulation_schedule_data(
+    devices: list[ViCareDevice],
+) -> list[dict[str, Any]]:
+    """Return DHW circulation schedule and supported modes for devices."""
+    results: list[dict[str, object]] = []
+    for device in devices:
+        device_config = device.config
+        device_serial = get_device_serial(device.api)
+        device_info = {
+            "gateway_serial": device_config.getConfig().serial,
+            "device_id": device_config.getId(),
+            "device_serial": device_serial,
+            "device_model": device_config.getModel(),
+            "supported": True,
+        }
+
+        try:
+            schedule = device.api.getDomesticHotWaterCirculationSchedule()
+            modes = device.api.getDomesticHotWaterCirculationScheduleModes()
+        except PyViCareNotSupportedFeatureError:
+            device_info["supported"] = False
+            device_info["error"] = "not_supported"
+        except PyViCareRateLimitError as err:
+            device_info["supported"] = False
+            device_info["error"] = f"rate_limited: {err}"
+        except PyViCareInvalidDataError as err:
+            device_info["supported"] = False
+            device_info["error"] = f"invalid_data: {err}"
+        except requests.exceptions.ConnectionError:
+            device_info["supported"] = False
+            device_info["error"] = "connection_error"
+        except ValueError:
+            device_info["supported"] = False
+            device_info["error"] = "decode_error"
+        else:
+            device_info["schedule"] = schedule
+            device_info["schedule_modes"] = modes
+
+        results.append(device_info)
+    return results
+
+
+def _get_device_raw_features_data(
+    devices: list[ViCareDevice],
+) -> list[dict[str, Any]]:
+    """Return raw device data for devices."""
+    results: list[dict[str, object]] = []
+    for device in devices:
+        device_config = device.config
+        device_info: dict[str, object] = {
+            "gateway_serial": device_config.getConfig().serial,
+            "device_id": device_config.getId(),
+            "device_model": device_config.getModel(),
+        }
+        dump = device_config.dump_secure()
+        try:
+            device_info["raw_features"] = json.loads(dump)
+        except json.JSONDecodeError:
+            device_info["raw_features"] = dump
+        results.append(device_info)
+    return results
 
 
 def setup_vicare_api(hass: HomeAssistant, entry: ViCareConfigEntry) -> PyViCare:

--- a/homeassistant/components/vicare/button.py
+++ b/homeassistant/components/vicare/button.py
@@ -20,6 +20,16 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .circulation import DhwCirculationBoostState, async_activate_dhw_circulation_boost
+from .const import (
+    CONF_HEAT_TIMEOUT_MINUTES,
+    CONF_MIN_BOOST_TEMPERATURE,
+    CONF_WARM_WATER_DELAY_MINUTES,
+    DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+    DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+    DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+    DOMAIN,
+)
 from .entity import ViCareEntity
 from .types import ViCareConfigEntry, ViCareDevice, ViCareRequiredKeysMixinWithSet
 from .utils import get_device_serial, is_supported
@@ -32,6 +42,13 @@ class ViCareButtonEntityDescription(
     ButtonEntityDescription, ViCareRequiredKeysMixinWithSet
 ):
     """Describes ViCare button entity."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class ViCareDhwCirculationBoostButtonDescription(ButtonEntityDescription):
+    """Describes ViCare DHW circulation boost button entity."""
+
+    duration_minutes: int
 
 
 BUTTON_DESCRIPTIONS: tuple[ViCareButtonEntityDescription, ...] = (
@@ -52,22 +69,60 @@ BUTTON_DESCRIPTIONS: tuple[ViCareButtonEntityDescription, ...] = (
 )
 
 
+BOOST_BUTTON_DESCRIPTIONS: tuple[ViCareDhwCirculationBoostButtonDescription, ...] = (
+    ViCareDhwCirculationBoostButtonDescription(
+        key="dhw_circulation_boost_30m",
+        translation_key="dhw_circulation_boost_30m",
+        entity_category=EntityCategory.CONFIG,
+        duration_minutes=30,
+    ),
+    ViCareDhwCirculationBoostButtonDescription(
+        key="dhw_circulation_boost_60m",
+        translation_key="dhw_circulation_boost_60m",
+        entity_category=EntityCategory.CONFIG,
+        duration_minutes=60,
+    ),
+)
+
+
 def _build_entities(
     device_list: list[ViCareDevice],
-) -> list[ViCareButton]:
+    min_boost_temperature: float,
+    heat_timeout_minutes: int,
+    warm_water_delay_minutes: int,
+) -> list[ButtonEntity]:
     """Create ViCare button entities for a device."""
 
-    return [
-        ViCareButton(
-            description,
-            get_device_serial(device.api),
-            device.config,
-            device.api,
+    entities: list[ButtonEntity] = []
+    for device in device_list:
+        entities.extend(
+            ViCareButton(
+                description,
+                get_device_serial(device.api),
+                device.config,
+                device.api,
+            )
+            for description in BUTTON_DESCRIPTIONS
+            if is_supported(description.key, description.value_getter, device.api)
         )
-        for device in device_list
-        for description in BUTTON_DESCRIPTIONS
-        if is_supported(description.key, description.value_getter, device.api)
-    ]
+        if is_supported(
+            "getDomesticHotWaterCirculationSchedule",
+            lambda api: api.getDomesticHotWaterCirculationSchedule(),
+            device.api,
+        ):
+            entities.extend(
+                ViCareDhwCirculationBoostButton(
+                    description,
+                    get_device_serial(device.api),
+                    device.config,
+                    device,
+                    min_boost_temperature,
+                    heat_timeout_minutes,
+                    warm_water_delay_minutes,
+                )
+                for description in BOOST_BUTTON_DESCRIPTIONS
+            )
+    return entities
 
 
 async def async_setup_entry(
@@ -76,10 +131,29 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Create the ViCare button entities."""
+    min_boost_temperature = float(
+        config_entry.options.get(
+            CONF_MIN_BOOST_TEMPERATURE, DEFAULT_DHW_BOOST_MIN_TEMPERATURE
+        )
+    )
+    heat_timeout_minutes = int(
+        config_entry.options.get(
+            CONF_HEAT_TIMEOUT_MINUTES, DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES
+        )
+    )
+    warm_water_delay_minutes = int(
+        config_entry.options.get(
+            CONF_WARM_WATER_DELAY_MINUTES,
+            DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+        )
+    )
     async_add_entities(
         await hass.async_add_executor_job(
             _build_entities,
             config_entry.runtime_data.devices,
+            min_boost_temperature,
+            heat_timeout_minutes,
+            warm_water_delay_minutes,
         )
     )
 
@@ -113,3 +187,42 @@ class ViCareButton(ViCareEntity, ButtonEntity):
             _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
         except PyViCareInvalidDataError as invalid_data_exception:
             _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+
+
+class ViCareDhwCirculationBoostButton(ViCareEntity, ButtonEntity):
+    """Representation of a DHW circulation boost button."""
+
+    entity_description: ViCareDhwCirculationBoostButtonDescription
+
+    def __init__(
+        self,
+        description: ViCareDhwCirculationBoostButtonDescription,
+        device_serial: str | None,
+        device_config: PyViCareDeviceConfig,
+        device: ViCareDevice,
+        min_boost_temperature: float,
+        heat_timeout_minutes: int,
+        warm_water_delay_minutes: int,
+    ) -> None:
+        """Initialize the boost button."""
+        super().__init__(description.key, device_serial, device_config, device.api)
+        self.entity_description = description
+        self._device = device
+        self._min_boost_temperature = min_boost_temperature
+        self._heat_timeout_minutes = heat_timeout_minutes
+        self._warm_water_delay_minutes = warm_water_delay_minutes
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        state_map: dict[str, DhwCirculationBoostState] = self.hass.data[
+            DOMAIN
+        ].setdefault("dhw_circulation_boost", {})
+        await async_activate_dhw_circulation_boost(
+            self.hass,
+            self._device,
+            self.entity_description.duration_minutes,
+            state_map,
+            min_boost_temperature=self._min_boost_temperature,
+            heat_timeout_minutes=self._heat_timeout_minutes,
+            warm_water_delay_minutes=self._warm_water_delay_minutes,
+        )

--- a/homeassistant/components/vicare/circulation.py
+++ b/homeassistant/components/vicare/circulation.py
@@ -1,0 +1,666 @@
+"""Helpers for domestic hot water circulation boosts."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
+from typing import Any
+
+from PyViCare.PyViCareUtils import (
+    PyViCareInvalidDataError,
+    PyViCareNotSupportedFeatureError,
+    PyViCareRateLimitError,
+)
+import requests
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+    DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+    DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+    DOMAIN,
+)
+from .types import ViCareDevice
+from .utils import get_device_serial
+
+_LOGGER = logging.getLogger(__name__)
+
+_DAY_KEYS: tuple[str, ...] = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+
+_DEFAULT_MAX_ENTRIES = 4
+_DEFAULT_RESOLUTION_MINUTES = 10
+_DEFAULT_MODE = "on"
+_DEFAULT_DEFAULT_MODE = "off"
+_BOOST_EVENT = "vicare_dhw_circulation_boost"
+
+
+@dataclass(slots=True)
+class DhwCirculationBoostState:
+    """Track an active circulation boost."""
+
+    original_schedule: dict[str, Any]
+    restore_task: Any
+    original_setpoint: float | None = None
+    setpoint_changed: bool = False
+    original_dhw_schedule: dict[str, Any] | None = None
+    dhw_schedule_changed: bool = False
+    warm_water_task: Any | None = None
+
+
+@dataclass(slots=True)
+class DhwHeatingPreparation:
+    """Intermediate state for DHW heating preparation."""
+
+    storage_temperature: float | None
+    original_setpoint: float | None
+    setpoint_changed: bool
+    original_dhw_schedule: dict[str, Any] | None
+    dhw_schedule_changed: bool
+
+
+def _round_up_to_resolution(now: datetime, resolution: int) -> datetime | None:
+    """Round time up to the next resolution boundary."""
+    total_minutes = now.hour * 60 + now.minute
+    rounded_minutes = ((total_minutes + resolution - 1) // resolution) * resolution
+    if total_minutes % resolution == 0 and now.second == 0 and now.microsecond == 0:
+        rounded_minutes += resolution
+    if rounded_minutes >= 24 * 60:
+        return None
+    return now.replace(
+        hour=rounded_minutes // 60,
+        minute=rounded_minutes % 60,
+        second=0,
+        microsecond=0,
+    )
+
+
+def _format_time(value: datetime) -> str:
+    """Return a HH:MM string for a datetime."""
+    return f"{value.hour:02d}:{value.minute:02d}"
+
+
+def _parse_time_to_minutes(value: str) -> int:
+    """Return minutes from HH:MM."""
+    return int(value[0:2]) * 60 + int(value[3:5])
+
+
+def _sorted_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return entries sorted by start time."""
+    return sorted(entries, key=lambda entry: _parse_time_to_minutes(entry["start"]))
+
+
+def _with_positions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return entries with sequential positions."""
+    return [
+        {**entry, "position": position}
+        for position, entry in enumerate(_sorted_entries(entries))
+    ]
+
+
+def _schedule_to_set_payload(
+    schedule: dict[str, Any],
+) -> dict[str, Any]:
+    """Convert the read schedule to the set schedule payload."""
+    payload: dict[str, Any] = {"defaultMode": schedule.get("default_mode")}
+    for day in _DAY_KEYS:
+        payload[day] = schedule.get(day, [])
+    return payload
+
+
+def _apply_boost_entry(
+    entries: list[dict[str, Any]],
+    start: datetime,
+    end: datetime,
+    max_entries: int,
+    mode: str,
+) -> list[dict[str, Any]]:
+    """Return entries with a boost entry applied."""
+    new_entry = {"start": _format_time(start), "end": _format_time(end), "mode": mode}
+    current = _sorted_entries(entries)
+    if len(current) >= max_entries:
+        current[-1] = new_entry
+    else:
+        current.append(new_entry)
+    return _with_positions(current)
+
+
+def _get_schedule_constraints(
+    raw_features: list[dict[str, Any]], feature_name: str
+) -> dict[str, Any]:
+    """Extract schedule constraints from raw features."""
+    for feature in raw_features:
+        if feature.get("feature") != feature_name:
+            continue
+        commands = feature.get("commands", {})
+        constraints = (
+            commands.get("setSchedule", {})
+            .get("params", {})
+            .get("newSchedule", {})
+            .get("constraints", {})
+        )
+        return {
+            "defaultMode": constraints.get("defaultMode", _DEFAULT_DEFAULT_MODE),
+            "maxEntries": constraints.get("maxEntries", _DEFAULT_MAX_ENTRIES),
+            "resolution": constraints.get("resolution", _DEFAULT_RESOLUTION_MINUTES),
+            "modes": constraints.get("modes", [_DEFAULT_MODE]),
+        }
+    return {
+        "defaultMode": _DEFAULT_DEFAULT_MODE,
+        "maxEntries": _DEFAULT_MAX_ENTRIES,
+        "resolution": _DEFAULT_RESOLUTION_MINUTES,
+        "modes": [_DEFAULT_MODE],
+    }
+
+
+def _fire_boost_event(
+    hass: HomeAssistant,
+    *,
+    stage: str,
+    identifier: str,
+    duration_minutes: int,
+    min_boost_temperature: float,
+    target_setpoint: float | None,
+    heat_timeout_minutes: int,
+    warm_water_delay_minutes: int,
+    storage_temperature: float | None = None,
+) -> None:
+    """Emit a boost lifecycle event for automations."""
+    hass.bus.async_fire(
+        _BOOST_EVENT,
+        {
+            "stage": stage,
+            "device_identifier": identifier,
+            "duration_minutes": duration_minutes,
+            "min_boost_temperature": min_boost_temperature,
+            "target_setpoint": target_setpoint,
+            "heat_timeout_minutes": heat_timeout_minutes,
+            "warm_water_delay_minutes": warm_water_delay_minutes,
+            "storage_temperature": storage_temperature,
+        },
+    )
+
+
+async def _async_get_storage_temperature(
+    hass: HomeAssistant, device: ViCareDevice
+) -> float | None:
+    """Return DHW storage temperature."""
+    try:
+        return await hass.async_add_executor_job(
+            device.api.getDomesticHotWaterStorageTemperature
+        )
+    except PyViCareNotSupportedFeatureError as err:
+        raise ServiceValidationError(
+            "Domestic hot water storage temperature is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_storage_not_supported",
+        ) from err
+
+
+async def _async_get_target_setpoint(
+    hass: HomeAssistant, device: ViCareDevice
+) -> float | None:
+    """Return configured DHW target setpoint."""
+    try:
+        return await hass.async_add_executor_job(
+            device.api.getDomesticHotWaterConfiguredTemperature
+        )
+    except PyViCareNotSupportedFeatureError as err:
+        raise ServiceValidationError(
+            "Domestic hot water temperature is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_setpoint_not_supported",
+        ) from err
+
+
+async def _async_get_circulation_schedule(
+    hass: HomeAssistant, device: ViCareDevice
+) -> dict[str, Any]:
+    """Return DHW circulation schedule."""
+    try:
+        schedule = await hass.async_add_executor_job(
+            device.api.getDomesticHotWaterCirculationSchedule
+        )
+    except PyViCareNotSupportedFeatureError as err:
+        raise ServiceValidationError(
+            "Domestic hot water circulation schedule is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_not_supported",
+        ) from err
+    except PyViCareRateLimitError as err:
+        raise HomeAssistantError(f"Vicare API rate limit exceeded: {err}") from err
+    except PyViCareInvalidDataError as err:
+        raise HomeAssistantError(f"Invalid data from Vicare server: {err}") from err
+    except requests.exceptions.ConnectionError as err:
+        raise HomeAssistantError("Unable to retrieve data from ViCare server") from err
+    except ValueError as err:
+        raise HomeAssistantError("Unable to decode data from ViCare server") from err
+
+    if not isinstance(schedule, dict):
+        raise ServiceValidationError(
+            "Domestic hot water circulation schedule is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_not_supported",
+        )
+
+    return schedule
+
+
+async def _async_restore_existing_boost(
+    hass: HomeAssistant, device: ViCareDevice, existing: DhwCirculationBoostState
+) -> None:
+    """Restore state from an existing active boost."""
+    existing.restore_task.cancel()
+    if existing.warm_water_task is not None:
+        existing.warm_water_task.cancel()
+    await hass.async_add_executor_job(
+        device.api.setDomesticHotWaterCirculationSchedule,
+        existing.original_schedule,
+    )
+    if existing.setpoint_changed and existing.original_setpoint is not None:
+        await hass.async_add_executor_job(
+            device.api.setDomesticHotWaterTemperature,
+            existing.original_setpoint,
+        )
+    if existing.dhw_schedule_changed and existing.original_dhw_schedule is not None:
+        await hass.async_add_executor_job(
+            device.api.setProperty,
+            "heating.dhw.schedule",
+            "setSchedule",
+            {"newSchedule": existing.original_dhw_schedule},
+        )
+
+
+async def _async_prepare_heating_if_needed(
+    hass: HomeAssistant,
+    device: ViCareDevice,
+    *,
+    now: datetime,
+    target_setpoint: float | None,
+    min_boost_temperature: float,
+    heat_timeout_minutes: int,
+    warm_water_delay_minutes: int,
+    duration_minutes: int,
+    identifier: str,
+    dhw_constraints: dict[str, Any],
+) -> DhwHeatingPreparation:
+    """Prepare DHW heating by raising setpoint and temporarily enabling schedule."""
+    storage_temp = await _async_get_storage_temperature(hass, device)
+    if storage_temp is not None and storage_temp >= min_boost_temperature:
+        return DhwHeatingPreparation(
+            storage_temperature=storage_temp,
+            original_setpoint=None,
+            setpoint_changed=False,
+            original_dhw_schedule=None,
+            dhw_schedule_changed=False,
+        )
+
+    _fire_boost_event(
+        hass,
+        stage="water_heating",
+        identifier=identifier,
+        duration_minutes=duration_minutes,
+        min_boost_temperature=min_boost_temperature,
+        target_setpoint=target_setpoint,
+        heat_timeout_minutes=heat_timeout_minutes,
+        warm_water_delay_minutes=warm_water_delay_minutes,
+        storage_temperature=storage_temp,
+    )
+
+    original_setpoint: float | None = None
+    setpoint_changed = False
+    if target_setpoint is not None:
+        original_setpoint = await _async_get_target_setpoint(hass, device)
+        if original_setpoint is not None and target_setpoint > original_setpoint:
+            await hass.async_add_executor_job(
+                device.api.setDomesticHotWaterTemperature,
+                target_setpoint,
+            )
+            setpoint_changed = True
+
+    try:
+        dhw_schedule = await hass.async_add_executor_job(
+            device.api.getDomesticHotWaterSchedule
+        )
+    except PyViCareNotSupportedFeatureError as err:
+        raise ServiceValidationError(
+            "Domestic hot water schedule is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_dhw_schedule_not_supported",
+        ) from err
+
+    if not isinstance(dhw_schedule, dict):
+        raise ServiceValidationError(
+            "Domestic hot water schedule is not supported.",
+            translation_domain=DOMAIN,
+            translation_key="boost_dhw_schedule_not_supported",
+        )
+
+    original_dhw_schedule = _schedule_to_set_payload(dhw_schedule)
+    original_dhw_schedule["defaultMode"] = dhw_constraints.get(
+        "defaultMode", _DEFAULT_DEFAULT_MODE
+    )
+    dhw_schedule_payload = copy.deepcopy(original_dhw_schedule)
+    dhw_resolution = int(dhw_constraints["resolution"])
+    dhw_max_entries = int(dhw_constraints["maxEntries"])
+    dhw_mode = dhw_constraints.get("modes", [_DEFAULT_MODE])[0]
+    dhw_start = _round_up_to_resolution(now, dhw_resolution)
+    if dhw_start is None:
+        raise ServiceValidationError(
+            "Boost duration runs past midnight.",
+            translation_domain=DOMAIN,
+            translation_key="boost_too_late",
+        )
+    dhw_end = dhw_start + timedelta(minutes=heat_timeout_minutes)
+    if dhw_end.date() != dhw_start.date():
+        raise ServiceValidationError(
+            "Boost duration runs past midnight.",
+            translation_domain=DOMAIN,
+            translation_key="boost_too_late",
+        )
+
+    dhw_day_key = _DAY_KEYS[dhw_start.weekday()]
+    dhw_day_entries = list(dhw_schedule_payload.get(dhw_day_key, []))
+    dhw_schedule_payload[dhw_day_key] = _apply_boost_entry(
+        dhw_day_entries, dhw_start, dhw_end, dhw_max_entries, dhw_mode
+    )
+    await hass.async_add_executor_job(
+        device.api.setProperty,
+        "heating.dhw.schedule",
+        "setSchedule",
+        {"newSchedule": dhw_schedule_payload},
+    )
+    try:
+        timeout_seconds = heat_timeout_minutes * 60
+        elapsed = 0
+        while elapsed < timeout_seconds:
+            storage_temp = await _async_get_storage_temperature(hass, device)
+            if storage_temp is not None and storage_temp >= min_boost_temperature:
+                break
+            await asyncio.sleep(60)
+            elapsed += 60
+    finally:
+        await hass.async_add_executor_job(
+            device.api.setProperty,
+            "heating.dhw.schedule",
+            "setSchedule",
+            {"newSchedule": original_dhw_schedule},
+        )
+    return DhwHeatingPreparation(
+        storage_temperature=storage_temp,
+        original_setpoint=original_setpoint,
+        setpoint_changed=setpoint_changed,
+        original_dhw_schedule=original_dhw_schedule,
+        dhw_schedule_changed=True,
+    )
+
+
+async def _get_device_identifier(hass: HomeAssistant, device: ViCareDevice) -> str:
+    """Return the device identifier used in the device registry."""
+    gateway_serial = device.config.getConfig().serial
+    device_id = device.config.getId()
+    device_serial = await hass.async_add_executor_job(get_device_serial, device.api)
+    return (
+        f"{gateway_serial}_{device_serial.replace('-', '_')}"
+        if device_serial is not None
+        else f"{gateway_serial}_{device_id}"
+    )
+
+
+async def async_get_device_from_call(
+    hass: HomeAssistant,
+    devices: list[ViCareDevice],
+    entity_id: str | None,
+    device_id: str | None,
+) -> ViCareDevice:
+    """Return the ViCare device selected in the service call."""
+    if not entity_id and not device_id:
+        if len(devices) == 1:
+            return devices[0]
+        raise ServiceValidationError(
+            "Select a device for this service call.",
+            translation_domain=DOMAIN,
+            translation_key="boost_device_required",
+        )
+
+    if entity_id:
+        entity_entry = er.async_get(hass).async_get(entity_id)
+        if entity_entry is None or entity_entry.device_id is None:
+            raise ServiceValidationError(
+                "Entity is not linked to a device.",
+                translation_domain=DOMAIN,
+                translation_key="boost_entity_no_device",
+            )
+        device_id = entity_entry.device_id
+
+    if device_id is None:
+        raise ServiceValidationError(
+            "Select a device for this service call.",
+            translation_domain=DOMAIN,
+            translation_key="boost_device_required",
+        )
+
+    device_entry = dr.async_get(hass).async_get(device_id)
+    if device_entry is None:
+        raise ServiceValidationError(
+            "Device does not exist.",
+            translation_domain=DOMAIN,
+            translation_key="boost_device_missing",
+        )
+
+    identifiers = device_entry.identifiers
+    device_map: dict[str, ViCareDevice] = {}
+    for device in devices:
+        identifier = await _get_device_identifier(hass, device)
+        device_map[identifier] = device
+
+    for domain, identifier in identifiers:
+        if domain != DOMAIN:
+            continue
+        if matched_device := device_map.get(identifier):
+            return matched_device
+
+    raise ServiceValidationError(
+        "Selected device is not managed by ViCare.",
+        translation_domain=DOMAIN,
+        translation_key="boost_device_not_found",
+    )
+
+
+async def async_activate_dhw_circulation_boost(
+    hass: HomeAssistant,
+    device: ViCareDevice,
+    duration_minutes: int,
+    state_map: dict[str, DhwCirculationBoostState],
+    *,
+    min_boost_temperature: float | None = None,
+    min_storage_temperature: float | None = None,
+    target_setpoint: float | None = None,
+    heat_timeout_minutes: int | None = None,
+    warm_water_delay_minutes: int | None = None,
+) -> None:
+    """Activate a temporary DHW circulation boost."""
+    identifier = await _get_device_identifier(hass, device)
+    now = dt_util.now()
+    effective_min_boost_temperature = (
+        min_boost_temperature
+        if min_boost_temperature is not None
+        else (
+            min_storage_temperature
+            if min_storage_temperature is not None
+            else DEFAULT_DHW_BOOST_MIN_TEMPERATURE
+        )
+    )
+    effective_heat_timeout_minutes = (
+        heat_timeout_minutes
+        if heat_timeout_minutes is not None and heat_timeout_minutes > 0
+        else DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES
+    )
+    effective_warm_water_delay_minutes = (
+        warm_water_delay_minutes
+        if warm_water_delay_minutes is not None and warm_water_delay_minutes > 0
+        else DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES
+    )
+
+    try:
+        raw_features = await hass.async_add_executor_job(device.config.get_raw_json)
+    except requests.exceptions.ConnectionError, ValueError, PyViCareInvalidDataError:
+        _LOGGER.debug("Unable to fetch raw features for circulation constraints")
+        raw_features = {"data": []}
+
+    raw_data = raw_features.get("data", [])
+    circulation_constraints = _get_schedule_constraints(
+        raw_data, "heating.dhw.pumps.circulation.schedule"
+    )
+    dhw_constraints = _get_schedule_constraints(raw_data, "heating.dhw.schedule")
+    resolution = int(circulation_constraints["resolution"])
+    max_entries = int(circulation_constraints["maxEntries"])
+    mode = circulation_constraints.get("modes", [_DEFAULT_MODE])[0]
+
+    if duration_minutes % resolution != 0:
+        duration_minutes = (
+            (duration_minutes + resolution - 1) // resolution
+        ) * resolution
+
+    if existing := state_map.get(identifier):
+        await _async_restore_existing_boost(hass, device, existing)
+
+    _fire_boost_event(
+        hass,
+        stage="boost_initiated",
+        identifier=identifier,
+        duration_minutes=duration_minutes,
+        min_boost_temperature=effective_min_boost_temperature,
+        target_setpoint=target_setpoint,
+        heat_timeout_minutes=effective_heat_timeout_minutes,
+        warm_water_delay_minutes=effective_warm_water_delay_minutes,
+    )
+
+    schedule = await _async_get_circulation_schedule(hass, device)
+
+    original_schedule = _schedule_to_set_payload(schedule)
+    original_schedule["defaultMode"] = circulation_constraints.get(
+        "defaultMode", _DEFAULT_DEFAULT_MODE
+    )
+    heating_prep = await _async_prepare_heating_if_needed(
+        hass,
+        device,
+        now=now,
+        target_setpoint=target_setpoint,
+        min_boost_temperature=effective_min_boost_temperature,
+        heat_timeout_minutes=effective_heat_timeout_minutes,
+        warm_water_delay_minutes=effective_warm_water_delay_minutes,
+        duration_minutes=duration_minutes,
+        identifier=identifier,
+        dhw_constraints=dhw_constraints,
+    )
+
+    now = dt_util.now()
+    start = _round_up_to_resolution(now, resolution)
+    if start is None:
+        raise ServiceValidationError(
+            "Boost duration runs past midnight.",
+            translation_domain=DOMAIN,
+            translation_key="boost_too_late",
+        )
+    end = start + timedelta(minutes=duration_minutes)
+    if end.date() != start.date():
+        raise ServiceValidationError(
+            "Boost duration runs past midnight.",
+            translation_domain=DOMAIN,
+            translation_key="boost_too_late",
+        )
+
+    schedule_payload = copy.deepcopy(original_schedule)
+    day_key = _DAY_KEYS[start.weekday()]
+    day_entries = list(schedule_payload.get(day_key, []))
+    schedule_payload[day_key] = _apply_boost_entry(
+        day_entries, start, end, max_entries, mode
+    )
+
+    await hass.async_add_executor_job(
+        device.api.setDomesticHotWaterCirculationSchedule,
+        schedule_payload,
+    )
+    _fire_boost_event(
+        hass,
+        stage="water_circulation_started",
+        identifier=identifier,
+        duration_minutes=duration_minutes,
+        min_boost_temperature=effective_min_boost_temperature,
+        target_setpoint=target_setpoint,
+        heat_timeout_minutes=effective_heat_timeout_minutes,
+        warm_water_delay_minutes=effective_warm_water_delay_minutes,
+        storage_temperature=heating_prep.storage_temperature,
+    )
+
+    async def _warm_water_available() -> None:
+        """Fire warm water available event after configured delay."""
+        await asyncio.sleep(
+            timedelta(minutes=effective_warm_water_delay_minutes).total_seconds()
+        )
+        _fire_boost_event(
+            hass,
+            stage="warm_water_available",
+            identifier=identifier,
+            duration_minutes=duration_minutes,
+            min_boost_temperature=effective_min_boost_temperature,
+            target_setpoint=target_setpoint,
+            heat_timeout_minutes=effective_heat_timeout_minutes,
+            warm_water_delay_minutes=effective_warm_water_delay_minutes,
+        )
+
+    warm_water_task = hass.async_create_task(_warm_water_available())
+
+    async def _restore_schedule() -> None:
+        try:
+            await asyncio.sleep(timedelta(minutes=duration_minutes).total_seconds())
+            await hass.async_add_executor_job(
+                device.api.setDomesticHotWaterCirculationSchedule,
+                original_schedule,
+            )
+            if (
+                heating_prep.setpoint_changed
+                and heating_prep.original_setpoint is not None
+            ):
+                await hass.async_add_executor_job(
+                    device.api.setDomesticHotWaterTemperature,
+                    heating_prep.original_setpoint,
+                )
+            if (
+                heating_prep.dhw_schedule_changed
+                and heating_prep.original_dhw_schedule is not None
+            ):
+                await hass.async_add_executor_job(
+                    device.api.setProperty,
+                    "heating.dhw.schedule",
+                    "setSchedule",
+                    {"newSchedule": heating_prep.original_dhw_schedule},
+                )
+        except (
+            requests.exceptions.ConnectionError,
+            PyViCareInvalidDataError,
+            ValueError,
+        ) as err:
+            _LOGGER.error("Unable to restore DHW circulation schedule: %s", err)
+        except PyViCareRateLimitError as err:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", err)
+        finally:
+            state_map.pop(identifier, None)
+
+    restore_task = hass.async_create_task(_restore_schedule())
+    state_map[identifier] = DhwCirculationBoostState(
+        original_schedule=original_schedule,
+        restore_task=restore_task,
+        original_setpoint=heating_prep.original_setpoint,
+        setpoint_changed=heating_prep.setpoint_changed,
+        original_dhw_schedule=heating_prep.original_dhw_schedule,
+        dhw_schedule_changed=heating_prep.dhw_schedule_changed,
+        warm_water_task=warm_water_task,
+    )

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -12,14 +12,25 @@ from PyViCare.PyViCareUtils import (
 )
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import (
+    CONF_HEAT_TIMEOUT_MINUTES,
     CONF_HEATING_TYPE,
+    CONF_MIN_BOOST_TEMPERATURE,
+    CONF_WARM_WATER_DELAY_MINUTES,
+    DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+    DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+    DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
     DEFAULT_HEATING_TYPE,
     DOMAIN,
     VICARE_NAME,
@@ -52,6 +63,11 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> ViCareOptionsFlowHandler:
+        """Get options flow for this handler."""
+        return ViCareOptionsFlowHandler(config_entry)
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -64,7 +80,10 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self.hass.async_add_executor_job(login, self.hass, user_input)
-            except PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError:
+            except (
+                PyViCareInvalidConfigurationError,
+                PyViCareInvalidCredentialsError,
+            ):
                 errors["base"] = "invalid_auth"
             else:
                 return self.async_create_entry(title=VICARE_NAME, data=user_input)
@@ -99,7 +118,10 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
 
             try:
                 await self.hass.async_add_executor_job(login, self.hass, data)
-            except PyViCareInvalidConfigurationError, PyViCareInvalidCredentialsError:
+            except (
+                PyViCareInvalidConfigurationError,
+                PyViCareInvalidCredentialsError,
+            ):
                 errors["base"] = "invalid_auth"
             else:
                 return self.async_update_reload_and_abort(reauth_entry, data=data)
@@ -129,3 +151,47 @@ class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="single_instance_allowed")
 
         return await self.async_step_user()
+
+
+class ViCareOptionsFlowHandler(OptionsFlow):
+    """Handle ViCare options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage ViCare options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self._config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_MIN_BOOST_TEMPERATURE,
+                    default=options.get(
+                        CONF_MIN_BOOST_TEMPERATURE,
+                        DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+                    ),
+                ): vol.All(vol.Coerce(float), vol.Range(min=20, max=70)),
+                vol.Required(
+                    CONF_HEAT_TIMEOUT_MINUTES,
+                    default=options.get(
+                        CONF_HEAT_TIMEOUT_MINUTES,
+                        DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+                    ),
+                ): vol.All(cv.positive_int, vol.Range(min=10, max=240)),
+                vol.Required(
+                    CONF_WARM_WATER_DELAY_MINUTES,
+                    default=options.get(
+                        CONF_WARM_WATER_DELAY_MINUTES,
+                        DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+                    ),
+                ): vol.All(cv.positive_int, vol.Range(min=1, max=240)),
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -6,6 +6,10 @@ from homeassistant.const import Platform
 
 DOMAIN = "vicare"
 
+SERVICE_GET_DHW_CIRCULATION_SCHEDULE = "get_dhw_circulation_schedule"
+SERVICE_GET_DEVICE_RAW_FEATURES = "get_device_raw_features"
+SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST = "activate_dhw_circulation_boost"
+
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
@@ -31,8 +35,14 @@ VIESSMANN_DEVELOPER_PORTAL = "https://app.developer.viessmann-climatesolutions.c
 
 CONF_CIRCUIT = "circuit"
 CONF_HEATING_TYPE = "heating_type"
+CONF_MIN_BOOST_TEMPERATURE = "min_boost_temperature"
+CONF_HEAT_TIMEOUT_MINUTES = "heat_timeout_minutes"
+CONF_WARM_WATER_DELAY_MINUTES = "warm_water_delay_minutes"
 
 DEFAULT_CACHE_DURATION = 60
+DEFAULT_DHW_BOOST_MIN_TEMPERATURE = 45.0
+DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES = 60
+DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES = 20
 
 VICARE_BAR = "bar"
 VICARE_CELSIUS = "celsius"

--- a/homeassistant/components/vicare/icons.json
+++ b/homeassistant/components/vicare/icons.json
@@ -155,6 +155,15 @@
     }
   },
   "services": {
+    "activate_dhw_circulation_boost": {
+      "service": "mdi:water-pump"
+    },
+    "get_device_raw_features": {
+      "service": "mdi:api"
+    },
+    "get_dhw_circulation_schedule": {
+      "service": "mdi:calendar-clock"
+    },
     "set_vicare_mode": {
       "service": "mdi:cog"
     }

--- a/homeassistant/components/vicare/number.py
+++ b/homeassistant/components/vicare/number.py
@@ -26,10 +26,20 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import EntityCategory, UnitOfTemperature
+from homeassistant.const import EntityCategory, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import (
+    CONF_HEAT_TIMEOUT_MINUTES,
+    CONF_MIN_BOOST_TEMPERATURE,
+    CONF_WARM_WATER_DELAY_MINUTES,
+    DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES,
+    DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+    DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES,
+    DOMAIN,
+)
 from .entity import ViCareEntity
 from .types import (
     HeatingProgram,
@@ -51,6 +61,55 @@ class ViCareNumberEntityDescription(NumberEntityDescription, ViCareRequiredKeysM
     min_value_getter: Callable[[PyViCareDevice], float | None] | None = None
     max_value_getter: Callable[[PyViCareDevice], float | None] | None = None
     stepping_getter: Callable[[PyViCareDevice], float | None] | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class ViCareOptionNumberEntityDescription(NumberEntityDescription):
+    """Describes ViCare option number entity."""
+
+    option_key: str
+    default_value: float
+
+
+BOOST_OPTION_ENTITY_DESCRIPTIONS: tuple[ViCareOptionNumberEntityDescription, ...] = (
+    ViCareOptionNumberEntityDescription(
+        key="boost_min_temperature",
+        translation_key="boost_min_temperature",
+        option_key=CONF_MIN_BOOST_TEMPERATURE,
+        default_value=DEFAULT_DHW_BOOST_MIN_TEMPERATURE,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=20,
+        native_max_value=70,
+        native_step=1,
+    ),
+    ViCareOptionNumberEntityDescription(
+        key="boost_heat_timeout",
+        translation_key="boost_heat_timeout",
+        option_key=CONF_HEAT_TIMEOUT_MINUTES,
+        default_value=float(DEFAULT_DHW_BOOST_HEAT_TIMEOUT_MINUTES),
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_min_value=10,
+        native_max_value=240,
+        native_step=10,
+    ),
+    ViCareOptionNumberEntityDescription(
+        key="boost_warm_water_delay",
+        translation_key="boost_warm_water_delay",
+        option_key=CONF_WARM_WATER_DELAY_MINUTES,
+        default_value=float(DEFAULT_DHW_BOOST_WARM_WATER_DELAY_MINUTES),
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        native_min_value=1,
+        native_max_value=240,
+        native_step=1,
+    ),
+)
 
 
 DEVICE_ENTITY_DESCRIPTIONS: tuple[ViCareNumberEntityDescription, ...] = (
@@ -356,11 +415,19 @@ CIRCUIT_ENTITY_DESCRIPTIONS: tuple[ViCareNumberEntityDescription, ...] = (
 
 
 def _build_entities(
+    config_entry: ViCareConfigEntry,
     device_list: list[ViCareDevice],
-) -> list[ViCareNumber]:
+) -> list[NumberEntity]:
     """Create ViCare number entities for a device."""
 
-    entities: list[ViCareNumber] = []
+    entities: list[NumberEntity] = []
+    primary_device = device_list[0] if device_list else None
+
+    entities.extend(
+        ViCareOptionNumber(config_entry, description, primary_device)
+        for description in BOOST_OPTION_ENTITY_DESCRIPTIONS
+    )
+
     for device in device_list:
         # add device entities
         entities.extend(
@@ -398,6 +465,7 @@ async def async_setup_entry(
     async_add_entities(
         await hass.async_add_executor_job(
             _build_entities,
+            config_entry,
             config_entry.runtime_data.devices,
         )
     )
@@ -470,3 +538,55 @@ def _get_value(
     api: PyViCareHeatingDeviceComponent,
 ) -> float | None:
     return None if fn is None else fn(api)
+
+
+class ViCareOptionNumber(NumberEntity):
+    """Representation of a ViCare options-backed number."""
+
+    entity_description: ViCareOptionNumberEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        config_entry: ViCareConfigEntry,
+        description: ViCareOptionNumberEntityDescription,
+        device: ViCareDevice | None,
+    ) -> None:
+        """Initialize options-backed number entity."""
+        self.entity_description = description
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{config_entry.entry_id}-{description.key}"
+        self._attr_translation_key = description.translation_key
+        if device is not None:
+            gateway_serial = device.config.getConfig().serial
+            device_id = device.config.getId()
+            device_serial = get_device_serial(device.api)
+            identifier = (
+                f"{gateway_serial}_{device_serial.replace('-', '_')}"
+                if device_serial is not None
+                else f"{gateway_serial}_{device_id}"
+            )
+            model = device.config.getModel().replace("_", " ")
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, identifier)},
+                name=model,
+                manufacturer="Viessmann",
+                model=model,
+            )
+
+    @property
+    def native_value(self) -> float:
+        """Return current value from entry options."""
+        return float(
+            self._config_entry.options.get(
+                self.entity_description.option_key,
+                self.entity_description.default_value,
+            )
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set option value."""
+        options = dict(self._config_entry.options)
+        options[self.entity_description.option_key] = value
+        self.hass.config_entries.async_update_entry(self._config_entry, options=options)
+        self.async_write_ha_state()

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 import logging
+from typing import Any
 
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
 from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
@@ -1361,12 +1362,28 @@ INVERTER_SENSORS: tuple[ViCareSensorEntityDescription, ...] = (
 )
 
 
+def _discover_schedule_features(device_config: PyViCareDeviceConfig) -> list[str]:
+    """Return all schedule features exposed by the API for a device."""
+    raw_features = device_config.get_raw_json()
+    data = raw_features.get("data", [])
+
+    return sorted(
+        {
+            feature_name
+            for feature in data
+            if isinstance(feature, dict)
+            and isinstance(feature_name := feature.get("feature"), str)
+            and feature_name.endswith(".schedule")
+        }
+    )
+
+
 def _build_entities(
     device_list: list[ViCareDevice],
-) -> list[ViCareSensor]:
+) -> list[SensorEntity]:
     """Create ViCare sensor entities for a device."""
 
-    entities: list[ViCareSensor] = []
+    entities: list[SensorEntity] = []
     for device in device_list:
         # add device entities
         entities.extend(
@@ -1400,6 +1417,16 @@ def _build_entities(
                 for description in entity_description_list
                 if is_supported(description.key, description.value_getter, component)
             )
+
+        entities.extend(
+            ViCareScheduleSensor(
+                feature_name,
+                get_device_serial(device.api),
+                device.config,
+                device.api,
+            )
+            for feature_name in _discover_schedule_features(device.config)
+        )
     return entities
 
 
@@ -1471,3 +1498,96 @@ class ViCareSensor(ViCareEntity, SensorEntity):
             self._attr_native_unit_of_measurement = VICARE_UNIT_TO_HA_UNIT.get(
                 vicare_unit
             )
+
+
+def _extract_property_value(data: Any) -> Any:
+    """Return an unwrapped property value."""
+    if isinstance(data, dict) and "value" in data:
+        return data["value"]
+    return data
+
+
+class ViCareScheduleSensor(ViCareEntity, SensorEntity):
+    """Representation of a ViCare schedule feature."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        feature_name: str,
+        device_serial: str | None,
+        device_config: PyViCareDeviceConfig,
+        device: PyViCareDevice,
+    ) -> None:
+        """Initialize the schedule sensor."""
+        super().__init__(
+            f"schedule_{feature_name.replace('.', '_')}",
+            device_serial,
+            device_config,
+            device,
+        )
+        self._feature_name = feature_name
+        self._attr_name = feature_name
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return self._attr_native_value is not None
+
+    def update(self) -> None:
+        """Update state of schedule sensor."""
+        try:
+            feature = self._api.getProperty(self._feature_name)
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+            return
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+            return
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
+            return
+        except PyViCareInvalidDataError as invalid_data_exception:
+            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+            return
+        except PyViCareNotSupportedFeatureError:
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        if not isinstance(feature, dict):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        properties = feature.get("properties", {})
+        is_enabled = bool(feature.get("isEnabled", True))
+        is_ready = bool(feature.get("isReady", True))
+        active = _extract_property_value(properties.get("active"))
+        entries = _extract_property_value(properties.get("entries"))
+        commands = feature.get("commands", {})
+        constraints = (
+            commands.get("setSchedule", {})
+            .get("params", {})
+            .get("newSchedule", {})
+            .get("constraints", {})
+        )
+
+        if not is_enabled:
+            self._attr_native_value = "disabled"
+        elif isinstance(active, bool):
+            self._attr_native_value = "on" if active else "off"
+        else:
+            self._attr_native_value = "unknown"
+
+        self._attr_extra_state_attributes = {
+            "feature": self._feature_name,
+            "enabled": is_enabled,
+            "ready": is_ready,
+            "entries": entries if isinstance(entries, dict) else {},
+            "default_mode": constraints.get("defaultMode"),
+            "modes": constraints.get("modes"),
+            "max_entries": constraints.get("maxEntries"),
+            "resolution": constraints.get("resolution"),
+            "overlap_allowed": constraints.get("overlapAllowed"),
+        }

--- a/homeassistant/components/vicare/services.yaml
+++ b/homeassistant/components/vicare/services.yaml
@@ -16,3 +16,62 @@ set_vicare_mode:
             - "forcedReduced"
             - "heating"
             - "standby"
+
+get_dhw_circulation_schedule:
+  target:
+    entity:
+      integration: vicare
+
+get_device_raw_features:
+  target:
+    entity:
+      integration: vicare
+
+activate_dhw_circulation_boost:
+  target:
+    entity:
+      integration: vicare
+  fields:
+    duration_minutes:
+      required: true
+      selector:
+        number:
+          min: 10
+          max: 240
+          step: 10
+          unit_of_measurement: min
+    min_storage_temperature:
+      selector:
+        number:
+          min: 20
+          max: 70
+          step: 1
+          unit_of_measurement: °C
+    min_boost_temperature:
+      selector:
+        number:
+          min: 20
+          max: 70
+          step: 1
+          unit_of_measurement: °C
+    target_setpoint:
+      selector:
+        number:
+          min: 30
+          max: 70
+          step: 1
+          unit_of_measurement: °C
+    heat_timeout_minutes:
+      selector:
+        number:
+          min: 10
+          max: 240
+          step: 10
+          unit_of_measurement: min
+    warm_water_delay_minutes:
+      selector:
+        number:
+          min: 1
+          max: 240
+          step: 1
+          unit_of_measurement: min

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -89,6 +89,12 @@
       },
       "deactivate_onetimecharge": {
         "name": "Deactivate one-time charge"
+      },
+      "dhw_circulation_boost_30m": {
+        "name": "DHW circulation boost 30 min"
+      },
+      "dhw_circulation_boost_60m": {
+        "name": "DHW circulation boost 60 min"
       }
     },
     "climate": {
@@ -114,6 +120,15 @@
       }
     },
     "number": {
+      "boost_heat_timeout": {
+        "name": "Boost heating timeout"
+      },
+      "boost_min_temperature": {
+        "name": "Boost minimum temperature"
+      },
+      "boost_warm_water_delay": {
+        "name": "Boost warm water delay"
+      },
       "comfort_cooling_temperature": {
         "name": "Comfort cooling temperature"
       },
@@ -606,6 +621,33 @@
     }
   },
   "exceptions": {
+    "boost_device_missing": {
+      "message": "Device does not exist"
+    },
+    "boost_device_not_found": {
+      "message": "Selected device is not managed by ViCare"
+    },
+    "boost_device_required": {
+      "message": "Select a device for this service call"
+    },
+    "boost_dhw_schedule_not_supported": {
+      "message": "Domestic hot water schedule is not supported"
+    },
+    "boost_entity_no_device": {
+      "message": "Entity is not linked to a device"
+    },
+    "boost_not_supported": {
+      "message": "Domestic hot water circulation schedule is not supported"
+    },
+    "boost_setpoint_not_supported": {
+      "message": "Domestic hot water temperature is not supported"
+    },
+    "boost_storage_not_supported": {
+      "message": "Domestic hot water storage temperature is not supported"
+    },
+    "boost_too_late": {
+      "message": "Boost duration runs past midnight"
+    },
     "program_not_activated": {
       "message": "Unable to activate ViCare program {program}"
     },
@@ -616,7 +658,61 @@
       "message": "Cannot translate preset {preset} into a valid ViCare program"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "heat_timeout_minutes": "Heating timeout",
+          "min_boost_temperature": "Minimum boost temperature",
+          "warm_water_delay_minutes": "Warm water delay"
+        },
+        "data_description": {
+          "heat_timeout_minutes": "Maximum time to keep temporary DHW heating enabled before circulation starts.",
+          "min_boost_temperature": "Minimum storage temperature to reach before circulation starts.",
+          "warm_water_delay_minutes": "Delay after circulation starts before warm water available event is emitted."
+        }
+      }
+    }
+  },
   "services": {
+    "activate_dhw_circulation_boost": {
+      "description": "Temporarily enable domestic hot water circulation by adjusting the schedule.",
+      "fields": {
+        "duration_minutes": {
+          "description": "How long to keep circulation active.",
+          "name": "Duration"
+        },
+        "heat_timeout_minutes": {
+          "description": "Maximum time to wait for storage temperature before starting circulation.",
+          "name": "Heating timeout"
+        },
+        "min_boost_temperature": {
+          "description": "Minimum storage temperature required before circulation starts.",
+          "name": "Minimum boost temperature"
+        },
+        "min_storage_temperature": {
+          "description": "Legacy alias for minimum boost temperature.",
+          "name": "Minimum storage temperature"
+        },
+        "target_setpoint": {
+          "description": "Temporary domestic hot water setpoint to reach before circulation.",
+          "name": "Temporary setpoint"
+        },
+        "warm_water_delay_minutes": {
+          "description": "Delay after circulation starts before warm water available event is emitted.",
+          "name": "Warm water delay"
+        }
+      },
+      "name": "Activate DHW circulation boost"
+    },
+    "get_device_raw_features": {
+      "description": "Return raw device feature data from the ViCare API for each device.",
+      "name": "Get device raw features"
+    },
+    "get_dhw_circulation_schedule": {
+      "description": "Return the domestic hot water circulation schedule and supported modes for each device.",
+      "name": "Get DHW circulation schedule"
+    },
     "set_vicare_mode": {
       "description": "Sets the mode of the climate device as defined by Viessmann.",
       "fields": {

--- a/tests/components/vicare/snapshots/test_number.ambr
+++ b/tests/components/vicare/snapshots/test_number.ambr
@@ -1,4 +1,182 @@
 # serializer version: 1
+# name: test_all_entities[number.model0_boost_heating_timeout-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 240,
+      'min': 10,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 10,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.model0_boost_heating_timeout',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost heating timeout',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Boost heating timeout',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'boost_heat_timeout',
+    'unique_id': '1234-boost_heat_timeout',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.model0_boost_heating_timeout-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'model0 Boost heating timeout',
+      'max': 240,
+      'min': 10,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 10,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.model0_boost_heating_timeout',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60.0',
+  })
+# ---
+# name: test_all_entities[number.model0_boost_minimum_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 70,
+      'min': 20,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.model0_boost_minimum_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost minimum temperature',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Boost minimum temperature',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'boost_min_temperature',
+    'unique_id': '1234-boost_min_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[number.model0_boost_minimum_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'model0 Boost minimum temperature',
+      'max': 70,
+      'min': 20,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.model0_boost_minimum_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45.0',
+  })
+# ---
+# name: test_all_entities[number.model0_boost_warm_water_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 240,
+      'min': 1,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.model0_boost_warm_water_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost warm water delay',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Boost warm water delay',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'boost_warm_water_delay',
+    'unique_id': '1234-boost_warm_water_delay',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[number.model0_boost_warm_water_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'model0 Boost warm water delay',
+      'max': 240,
+      'min': 1,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.model0_boost_warm_water_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20.0',
+  })
+# ---
 # name: test_all_entities[number.model0_comfort_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/vicare/snapshots/test_sensor.ambr
+++ b/tests/components/vicare/snapshots/test_sensor.ambr
@@ -764,6 +764,1033 @@
     'state': '7.843',
   })
 # ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_0_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.0.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.0.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_0_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.0.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model0 heating.circuits.0.dhw.pumps.circulation.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_0_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_0_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.0.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.0.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_0_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.0.dhw.schedule',
+      'friendly_name': 'model0 heating.circuits.0.dhw.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_0_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_0_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.0.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.0.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_0_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_0_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'reduced',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.0.heating.schedule',
+      'friendly_name': 'model0 heating.circuits.0.heating.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'normal',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_0_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_1_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.1.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.1.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_1_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '06:30',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.1.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model0 heating.circuits.1.dhw.pumps.circulation.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_1_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_1_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.1.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.1.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_1_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '10:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '16:30',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '10:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '16:30',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '06:30',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '06:30',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '10:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '16:30',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '10:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '16:30',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '10:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '04:30',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '16:30',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.1.dhw.schedule',
+      'friendly_name': 'model0 heating.circuits.1.dhw.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_1_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_1_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.1.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.1.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_1_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_1_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'reduced',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.1.heating.schedule',
+      'friendly_name': 'model0 heating.circuits.1.heating.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'normal',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_1_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_2_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.2.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.2.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_2_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.2.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model0 heating.circuits.2.dhw.pumps.circulation.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_2_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_2_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.2.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.2.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_2_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.2.dhw.schedule',
+      'friendly_name': 'model0 heating.circuits.2.dhw.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_2_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_circuits_2_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.2.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.2.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_circuits_2_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_circuits_2_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.2.heating.schedule',
+      'friendly_name': 'model0 heating.circuits.2.heating.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_circuits_2_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model0 heating.dhw.pumps.circulation.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model0_heating_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway0_deviceSerialVitodens300W-schedule_heating_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model0_heating_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.dhw.schedule',
+      'friendly_name': 'model0 heating.dhw.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model0_heating_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
 # name: test_all_entities[sensor.model0_heating_gas_consumption_this_month-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -2466,6 +3493,745 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20.0',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_0_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_circuits_0_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.0.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.0.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_circuits_0_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_0_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'reduced',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '03:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+          dict({
+            'end': '05:00',
+            'mode': 'comfort',
+            'position': 1,
+            'start': '03:00',
+          }),
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 2,
+            'start': '05:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.0.heating.schedule',
+      'friendly_name': 'model1 heating.circuits.0.heating.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'normal',
+        'comfort',
+      ]),
+      'overlap_allowed': False,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_circuits_0_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_1_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_circuits_1_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.1.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.1.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_circuits_1_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_1_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.1.heating.schedule',
+      'friendly_name': 'model1 heating.circuits.1.heating.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_circuits_1_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_2_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_circuits_2_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.2.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.2.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_circuits_2_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_2_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.2.heating.schedule',
+      'friendly_name': 'model1 heating.circuits.2.heating.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_circuits_2_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_3_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_circuits_3_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.3.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.3.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_circuits_3_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_circuits_3_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.3.heating.schedule',
+      'friendly_name': 'model1 heating.circuits.3.heating.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_circuits_3_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '09:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '09:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '09:30',
+            'mode': 'on',
+            'position': 0,
+            'start': '07:00',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '09:30',
+            'mode': 'on',
+            'position': 0,
+            'start': '07:00',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '09:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '09:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '09:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '05:30',
+          }),
+          dict({
+            'end': '13:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '12:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': 'on',
+            'position': 2,
+            'start': '18:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model1 heating.dhw.pumps.circulation.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': False,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model1_heating_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway1_deviceSerialVitocal250A-schedule_heating_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model1_heating_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '03:00',
+            'mode': 'on',
+            'position': 0,
+            'start': '01:00',
+          }),
+          dict({
+            'end': '15:00',
+            'mode': 'on',
+            'position': 1,
+            'start': '13:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.dhw.schedule',
+      'friendly_name': 'model1 heating.dhw.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'on',
+      ]),
+      'overlap_allowed': False,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model1_heating_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[sensor.model1_heating_electricity_consumption_last_seven_days-entry]
@@ -4653,6 +6419,541 @@
     'state': '0.0',
   })
 # ---
+# name: test_all_entities[sensor.model2_heating_circuits_0_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_heating_circuits_0_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.0.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.0.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_heating_circuits_0_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_circuits_0_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'standby',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+        ]),
+        'mon': list([
+        ]),
+        'sat': list([
+        ]),
+        'sun': list([
+        ]),
+        'thu': list([
+        ]),
+        'tue': list([
+        ]),
+        'wed': list([
+        ]),
+      }),
+      'feature': 'heating.circuits.0.heating.schedule',
+      'friendly_name': 'model2 heating.circuits.0.heating.schedule',
+      'max_entries': 8,
+      'modes': list([
+        'reduced',
+        'normal',
+        'fixed',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_heating_circuits_0_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_circuits_1_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_heating_circuits_1_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.1.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.1.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_heating_circuits_1_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_circuits_1_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'standby',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '24:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.circuits.1.heating.schedule',
+      'friendly_name': 'model2 heating.circuits.1.heating.schedule',
+      'max_entries': 8,
+      'modes': list([
+        'reduced',
+        'normal',
+        'fixed',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_heating_circuits_1_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_circuits_2_heating_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_heating_circuits_2_heating_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.circuits.2.heating.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.circuits.2.heating.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_heating_circuits_2_heating_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_circuits_2_heating_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': None,
+      'enabled': False,
+      'entries': dict({
+      }),
+      'feature': 'heating.circuits.2.heating.schedule',
+      'friendly_name': 'model2 heating.circuits.2.heating.schedule',
+      'max_entries': None,
+      'modes': None,
+      'overlap_allowed': None,
+      'ready': True,
+      'resolution': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_heating_circuits_2_heating_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disabled',
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_dhw_pumps_circulation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_heating_dhw_pumps_circulation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.pumps.circulation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.pumps.circulation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_heating_dhw_pumps_circulation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_dhw_pumps_circulation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '08:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '06:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '08:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '06:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '09:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '07:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '09:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '07:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '08:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '06:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '08:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '06:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '08:00',
+            'mode': '5/25-cycles',
+            'position': 0,
+            'start': '06:00',
+          }),
+          dict({
+            'end': '20:00',
+            'mode': '5/25-cycles',
+            'position': 1,
+            'start': '18:00',
+          }),
+        ]),
+      }),
+      'feature': 'heating.dhw.pumps.circulation.schedule',
+      'friendly_name': 'model2 heating.dhw.pumps.circulation.schedule',
+      'max_entries': 8,
+      'modes': list([
+        '5/25-cycles',
+        '5/10-cycles',
+        'on',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_heating_dhw_pumps_circulation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_dhw_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_heating_dhw_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'heating.dhw.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'heating.dhw.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_heating_dhw_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_heating_dhw_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'off',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '22:00',
+            'mode': 'normal',
+            'position': 0,
+            'start': '05:30',
+          }),
+        ]),
+      }),
+      'feature': 'heating.dhw.schedule',
+      'friendly_name': 'model2 heating.dhw.schedule',
+      'max_entries': 8,
+      'modes': list([
+        'top',
+        'normal',
+        'temp-2',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_heating_dhw_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[sensor.model2_outside_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -5233,6 +7534,125 @@
     'state': 'schedule',
   })
 # ---
+# name: test_all_entities[sensor.model2_ventilation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model2_ventilation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'ventilation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ventilation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway2_################-schedule_ventilation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model2_ventilation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'levelOne',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '24:00',
+            'mode': 'levelThree',
+            'position': 0,
+            'start': '00:00',
+          }),
+        ]),
+      }),
+      'feature': 'ventilation.schedule',
+      'friendly_name': 'model2 ventilation.schedule',
+      'max_entries': 8,
+      'modes': list([
+        'levelTwo',
+        'levelThree',
+        'levelFour',
+      ]),
+      'overlap_allowed': True,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model2_ventilation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[sensor.model3_ventilation_level-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -5363,6 +7783,124 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'permanent',
+  })
+# ---
+# name: test_all_entities[sensor.model3_ventilation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model3_ventilation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'ventilation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ventilation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway3_deviceSerialViAir300F-schedule_ventilation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model3_ventilation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'levelOne',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+      }),
+      'feature': 'ventilation.schedule',
+      'friendly_name': 'model3 ventilation.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'levelTwo',
+        'levelThree',
+      ]),
+      'overlap_allowed': False,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model3_ventilation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_all_entities[sensor.model4_filter_hours-entry]
@@ -6141,6 +8679,126 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'sensordriven',
+  })
+# ---
+# name: test_all_entities[sensor.model4_ventilation_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.model4_ventilation_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'ventilation.schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'ventilation.schedule',
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'gateway4_deviceId4-schedule_ventilation_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.model4_ventilation_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'default_mode': 'standby',
+      'enabled': True,
+      'entries': dict({
+        'fri': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'mon': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sat': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'sun': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'thu': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'tue': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+        'wed': list([
+          dict({
+            'end': '22:00',
+            'mode': 'levelTwo',
+            'position': 0,
+            'start': '06:00',
+          }),
+        ]),
+      }),
+      'feature': 'ventilation.schedule',
+      'friendly_name': 'model4 ventilation.schedule',
+      'max_entries': 4,
+      'modes': list([
+        'levelOne',
+        'levelTwo',
+        'levelThree',
+        'levelFour',
+      ]),
+      'overlap_allowed': False,
+      'ready': True,
+      'resolution': 10,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.model4_ventilation_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[sensor.model5_battery_charge_total-entry]

--- a/tests/components/vicare/test_circulation.py
+++ b/tests/components/vicare/test_circulation.py
@@ -1,0 +1,128 @@
+"""Tests for ViCare DHW circulation boost service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.vicare.const import (
+    DOMAIN,
+    SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_capture_events
+
+
+def _schedule_fixture(active: bool = True) -> dict[str, object]:
+    """Return a minimal schedule payload."""
+    return {
+        "active": active,
+        "default_mode": "off",
+        "mon": [],
+        "tue": [],
+        "wed": [],
+        "thu": [],
+        "fri": [],
+        "sat": [],
+        "sun": [],
+    }
+
+
+async def test_boost_service_fires_lifecycle_events(
+    hass: HomeAssistant,
+    mock_vicare_gas_boiler,
+) -> None:
+    """Test that the boost service emits lifecycle events."""
+    events = async_capture_events(hass, "vicare_dhw_circulation_boost")
+    device = mock_vicare_gas_boiler.runtime_data.devices[0].api
+
+    with (
+        patch(
+            "homeassistant.components.vicare.circulation.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            device,
+            "getDomesticHotWaterStorageTemperature",
+            side_effect=[40.0, 46.0],
+        ),
+        patch.object(
+            device,
+            "getDomesticHotWaterCirculationSchedule",
+            return_value=_schedule_fixture(),
+        ),
+        patch.object(
+            device,
+            "getDomesticHotWaterSchedule",
+            return_value=_schedule_fixture(),
+        ),
+        patch.object(device, "setDomesticHotWaterCirculationSchedule"),
+        patch.object(device, "setProperty"),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST,
+            {
+                "duration_minutes": 30,
+                "min_boost_temperature": 45.0,
+                "target_setpoint": 55.0,
+                "heat_timeout_minutes": 10,
+                "warm_water_delay_minutes": 1,
+            },
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+
+    stages = [event.data["stage"] for event in events]
+    assert stages == [
+        "boost_initiated",
+        "water_heating",
+        "water_circulation_started",
+        "warm_water_available",
+    ]
+    assert all(event.data["min_boost_temperature"] == 45.0 for event in events)
+
+
+async def test_boost_service_uses_legacy_min_storage_alias(
+    hass: HomeAssistant,
+    mock_vicare_gas_boiler,
+) -> None:
+    """Test that legacy min_storage_temperature still controls heating threshold."""
+    events = async_capture_events(hass, "vicare_dhw_circulation_boost")
+    device = mock_vicare_gas_boiler.runtime_data.devices[0].api
+
+    with (
+        patch(
+            "homeassistant.components.vicare.circulation.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            device,
+            "getDomesticHotWaterStorageTemperature",
+            return_value=44.0,
+        ),
+        patch.object(
+            device,
+            "getDomesticHotWaterCirculationSchedule",
+            return_value=_schedule_fixture(),
+        ),
+        patch.object(device, "setDomesticHotWaterCirculationSchedule"),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ACTIVATE_DHW_CIRCULATION_BOOST,
+            {
+                "duration_minutes": 30,
+                "min_storage_temperature": 42.0,
+                "heat_timeout_minutes": 10,
+                "warm_water_delay_minutes": 1,
+            },
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+
+    stages = [event.data["stage"] for event in events]
+    assert "water_heating" not in stages
+    assert events[0].data["min_boost_temperature"] == 42.0

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -9,7 +9,12 @@ from PyViCare.PyViCareUtils import (
 )
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.vicare.const import DOMAIN
+from homeassistant.components.vicare.const import (
+    CONF_HEAT_TIMEOUT_MINUTES,
+    CONF_MIN_BOOST_TEMPERATURE,
+    CONF_WARM_WATER_DELAY_MINUTES,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -206,3 +211,32 @@ async def test_user_input_single_instance_allowed(hass: HomeAssistant) -> None:
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test options flow for boost defaults."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=VALID_CONFIG,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MIN_BOOST_TEMPERATURE: 46.0,
+            CONF_HEAT_TIMEOUT_MINUTES: 75,
+            CONF_WARM_WATER_DELAY_MINUTES: 18,
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {
+        CONF_MIN_BOOST_TEMPERATURE: 46.0,
+        CONF_HEAT_TIMEOUT_MINUTES: 75,
+        CONF_WARM_WATER_DELAY_MINUTES: 18,
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds new ViCare functionality for domestic hot water (DHW) boost handling and schedule visibility in Home Assistant.

Main additions:

- Add a new service `vicare.activate_dhw_circulation_boost` to trigger a temporary DHW circulation boost
- Add boost lifecycle events (`vicare_dhw_circulation_boost`) so automations can notify users (`boost_initiated`, `water_heating`, `water_circulation_started`, `warm_water_available`)
- Add optional temporary DHW heating preparation during boost:
  - configurable minimum boost temperature threshold
  - optional temporary setpoint increase
  - temporary DHW schedule override with restore
- Add 30 min / 60 min DHW boost buttons
- Add options flow settings for boost defaults
- Expose those boost defaults as config number entities in HA
- Add schedule visibility by creating sensor entities for all available `*.schedule` features exposed by the ViCare API
- Add helper services to inspect schedule/raw API data:
  - `vicare.get_dhw_circulation_schedule`
  - `vicare.get_device_raw_features`
- Add/adjust tests and snapshots for new behavior

The goal is to make DHW boost operation practical for real-world use (including delayed warm water availability) while keeping schedules and temporary changes transparent in HA. i.e. provide warm water outside of schedules on demand.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


Local validation performed:

- `ruff check homeassistant/components/vicare tests/components/vicare/test_circulation.py tests/components/vicare/test_number.py`
- `mypy homeassistant/components/vicare`
- `python -m script.hassfest`
- `python -m script.translations develop --all`
- `pytest tests/components/vicare/test_sensor.py -q --snapshot-update`
- `pytest tests/components/vicare/test_sensor.py -q`
- `pytest tests/components/vicare/test_number.py -q --snapshot-update`
- `pytest tests/components/vicare/test_number.py -q`
- `pytest tests/components/vicare/test_circulation.py -q`
- `pytest tests/components/vicare -q`

Result:
- ViCare test suite passed (`43 passed`)
- Ruff passed
- MyPy passed
- Hassfest passed
