### PR TITLE
Fix Sonos browse album art lookup for multi-segment A:ALBUM IDs

### DIFF
--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -585,10 +585,30 @@ def get_media(
         item_id = "A:ALBUMARTIST/" + "/".join(item_id.split("/")[2:])
 
     if item_id.startswith("A:ALBUM/") or search_type == "tracks":
-        search_term = urllib.parse.unquote(item_id.split("/")[-1])
+        # Some Sonos libraries return album ids in the shape:
+        # A:ALBUM/<album>/<artist>, where the artist part disambiguates results.
+        # Use the album segment for searching.
+        if item_id.startswith("A:ALBUM/"):
+            splits = item_id.split("/")
+            search_term = urllib.parse.unquote(splits[1]) if len(splits) > 1 else ""
+            title: str | None = search_term
+        else:
+            search_term = urllib.parse.unquote(item_id.split("/")[-1])
+            title = None
+
         matches = media_library.get_music_library_information(
             search_type, search_term=search_term, full_album_art_uri=True
         )
+        if item_id.startswith("A:ALBUM/") and len(matches) > 1:
+            if result := next(
+                (item for item in matches if item_id == item.item_id), None
+            ):
+                matches = [result]
+            elif title:
+                if result := next(
+                    (item for item in matches if title == item.title), None
+                ):
+                    matches = [result]
     elif search_type == SONOS_SHARE:
         # In order to get the MusicServiceItem, we browse the parent folder
         # and find one that matches on item_id.

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -591,10 +591,10 @@ def get_media(
         if item_id.startswith("A:ALBUM/"):
             splits = item_id.split("/")
             search_term = urllib.parse.unquote(splits[1]) if len(splits) > 1 else ""
-            title: str | None = search_term
+            album_title: str | None = search_term
         else:
             search_term = urllib.parse.unquote(item_id.split("/")[-1])
-            title = None
+            album_title = None
 
         matches = media_library.get_music_library_information(
             search_type, search_term=search_term, full_album_art_uri=True
@@ -604,9 +604,9 @@ def get_media(
                 (item for item in matches if item_id == item.item_id), None
             ):
                 matches = [result]
-            elif title:
+            elif album_title:
                 if result := next(
-                    (item for item in matches if title == item.title), None
+                    (item for item in matches if album_title == item.title), None
                 ):
                     matches = [result]
     elif search_type == SONOS_SHARE:

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -126,8 +126,64 @@ def test_get_media_multisegment_album_id_uses_album_segment() -> None:
     assert music_library.get_music_library_information.call_args.args == ("albums",)
     assert music_library.get_music_library_information.call_args.kwargs == {
         "search_term": "Abbey Road",
-        "full_album_art_uri": True
+        "full_album_art_uri": True,
     }
+
+
+def test_get_media_multisegment_album_id_prefers_exact_item_id_match() -> None:
+    """Test multi-match disambiguation prefers exact `item_id`."""
+    music_library = MagicMock()
+    exact_item = MockMusicServiceItem(
+        "Abbey Road (Remaster)",
+        "A:ALBUM/Abbey%20Road/The%20Beatles",
+        "A:ALBUM",
+        "object.container.album.musicAlbum",
+    )
+    music_library.get_music_library_information.return_value = [
+        MockMusicServiceItem(
+            "Abbey Road",
+            "A:ALBUM/Abbey%20Road/Someone%20Else",
+            "A:ALBUM",
+            "object.container.album.musicAlbum",
+        ),
+        exact_item,
+    ]
+
+    result = get_media(
+        music_library,
+        "A:ALBUM/Abbey%20Road/The%20Beatles",
+        "album",
+    )
+
+    assert result is exact_item
+
+
+def test_get_media_multisegment_album_id_falls_back_to_exact_title_match() -> None:
+    """Test multi-match disambiguation falls back to exact title match."""
+    music_library = MagicMock()
+    title_match_item = MockMusicServiceItem(
+        "Abbey Road",
+        "A:ALBUM/Abbey%20Road/The%20Beatles%20(Remaster)",
+        "A:ALBUM",
+        "object.container.album.musicAlbum",
+    )
+    music_library.get_music_library_information.return_value = [
+        MockMusicServiceItem(
+            "Abbey Road (Live)",
+            "A:ALBUM/Abbey%20Road/The%20Beatles%20(Live)",
+            "A:ALBUM",
+            "object.container.album.musicAlbum",
+        ),
+        title_match_item,
+    ]
+
+    result = get_media(
+        music_library,
+        "A:ALBUM/Abbey%20Road/The%20Beatles",
+        "album",
+    )
+
+    assert result is title_match_item
 
 
 async def test_browse_media_root(

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -1,6 +1,7 @@
 """Tests for the Sonos Media Browser."""
 
 from functools import partial
+from unittest.mock import MagicMock
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -15,6 +16,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.sonos.const import MEDIA_TYPE_DIRECTORY
 from homeassistant.components.sonos.media_browser import (
     build_item_response,
+    get_media,
     get_thumbnail_url_full,
 )
 from homeassistant.const import ATTR_ENTITY_ID
@@ -107,6 +109,25 @@ async def test_build_item_response(
         browse_item.children[1].media_content_id
         == "x-file-cifs://192.168.42.10/music/The%20Beatles/Abbey%20Road/03%20Something.mp3"
     )
+
+
+def test_get_media_multisegment_album_id_uses_album_segment() -> None:
+    """Test `A:ALBUM/<album>/<artist>` uses album name as lookup search term."""
+    music_library = MagicMock()
+    music_library.get_music_library_information.return_value = []
+    result = get_media(
+        music_library,
+        "A:ALBUM/Abbey%20Road/The%20Beatles",
+        "album",
+    )
+
+    assert result is None
+    assert music_library.get_music_library_information.call_count == 1
+    assert music_library.get_music_library_information.call_args.args == ("albums",)
+    assert music_library.get_music_library_information.call_args.kwargs == {
+        "search_term": "Abbey Road",
+        "full_album_art_uri": True
+    }
 
 
 async def test_browse_media_root(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
N/A

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This fixes Sonos media browser artwork lookup for music library album IDs that include multiple path segments, for example `A:ALBUM/<album>/<artist>`.

**Root cause:**
  - `get_media()` handled `A:ALBUM/...` by taking the last path segment as the album search term.
  - For multi-segment IDs, that last segment can be artist/disambiguation data instead of album title.
  - This caused album lookup misses and could lead to browse image proxy `500` responses when no image data was found.

**Why this likely surfaced now:**
  - Sonos announced a music library metadata/grouping change on March 25, 2025, with stronger reliance on `Album Artist` for grouping/sorting.  
  Context on related Sonos change:
    - https://en.community.sonos.com/tutorials-and-how-to-s-229149/music-library-album-artist-metadata-change-6927831
    - https://support.sonos.com/en-us/article/local-music-library-grouping-and-sorting
  - That appears to produce more specific/disambiguated album IDs in browse responses, exposing HA’s previous `A:ALBUM` parsing assumption.

**Fix:**
  - For `A:ALBUM/...`, use the album segment (`<album>`) as `search_term`.
  - If multiple matches are returned, disambiguate by:
    1. exact `item_id` match
    1. fallback exact title match

  Test coverage:
  - Added a regression test that verifies `A:ALBUM/Abbey%20Road/The%20Beatles` uses `search_term="Abbey Road"`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
