### PR TITLE
Add test for Tuya event

### DIFF
--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import base64
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tuya_sharing import CustomerDevice, Manager
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -83,3 +84,60 @@ async def test_alarm_message_event(
     state = hass.states.get(entity_id)
     assert state.attributes == snapshot
     assert state.attributes["message"]
+
+
+@pytest.mark.parametrize(
+    "mock_device_code",
+    ["wxkg_l8yaz4um5b3pwyvf"],
+)
+@patch("homeassistant.components.tuya.PLATFORMS", [Platform.EVENT])
+@pytest.mark.freeze_time("2024-01-01")
+async def test_selective_state_update(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    mock_listener: MockDeviceListener,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test skip_update/last_reported."""
+    entity_id = "event.bathroom_smart_switch_button_1"
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    # Initial state is unknown
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+    # Device receives a data update - event gets triggered and state gets updated
+    freezer.tick(10)
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"switch_mode1": "click"}
+    )
+    assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
+
+    # Device goes offline
+    freezer.tick(10)
+    mock_device.online = False
+    await mock_listener.async_send_device_update(hass, mock_device, None)
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # Device comes back online - state should go back to last known value,
+    # not new datetime since no new data update has come in
+    freezer.tick(10)
+    mock_device.online = True
+    await mock_listener.async_send_device_update(hass, mock_device, None)
+    assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
+
+    # Device receives a new data update - event gets triggered and state gets updated
+    freezer.tick(10)
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"switch_mode1": "click"}
+    )
+    assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"
+
+    # Device receives a data update on a different datapoint - event doesn't
+    # get triggered and state doesn't get updated
+    freezer.tick(10)
+    await mock_listener.async_send_device_update(
+        hass, mock_device, {"switch_mode2": "click"}
+    )
+    assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -100,7 +100,7 @@ async def test_selective_state_update(
     mock_listener: MockDeviceListener,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test skip_update/last_reported."""
+    """Ensure event is only triggered when device reports actual data."""
     entity_id = "event.bathroom_smart_switch_button_1"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add regression tests for #163697 and #163382

(Issue already fixed via #163431 - the test added here fails in `2026.2.3`)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
