### PR TITLE
Fix ZHA number entity not using device class and mode

### DIFF
--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import functools
 import logging
+from typing import Any
 
-from homeassistant.components.number import RestoreNumber
+from homeassistant.components.number import NumberDeviceClass, NumberMode, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -15,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .entity import ZHAEntity
 from .helpers import (
     SIGNAL_ADD_ENTITIES,
+    EntityData,
     async_add_entities as zha_async_add_entities,
     convert_zha_error_to_ha_error,
     get_zha_data,
@@ -44,6 +46,14 @@ async def async_setup_entry(
 
 class ZhaNumber(ZHAEntity, RestoreNumber):
     """Representation of a ZHA Number entity."""
+
+    def __init__(self, entity_data: EntityData, **kwargs: Any) -> None:
+        """Initialize the ZHA number entity."""
+        super().__init__(entity_data, **kwargs)
+        entity = entity_data.entity
+        if entity.device_class is not None:
+            self._attr_device_class = NumberDeviceClass(entity.device_class)
+        self._attr_mode = NumberMode(entity.mode)
 
     @property
     def native_value(self) -> float | None:

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -94,14 +94,18 @@ async def test_number(
     entity_id = find_entity_id(Platform.NUMBER, zha_device_proxy, hass)
     assert entity_id is not None
 
-    assert hass.states.get(entity_id).state == "15.0"
+    hass_state = hass.states.get(entity_id)
+    assert hass_state is not None
+    assert hass_state.state == "15.0"
 
     # test attributes
-    assert hass.states.get(entity_id).attributes.get("min") == 1.0
-    assert hass.states.get(entity_id).attributes.get("max") == 100.0
-    assert hass.states.get(entity_id).attributes.get("step") == 1.1
-    assert hass.states.get(entity_id).attributes.get("icon") == "mdi:percent"
-    assert hass.states.get(entity_id).attributes.get("unit_of_measurement") == "%"
+    assert hass_state.attributes.get("min") == 1.0
+    assert hass_state.attributes.get("max") == 100.0
+    assert hass_state.attributes.get("step") == 1.1
+    assert hass_state.attributes.get("icon") == "mdi:percent"
+    assert hass_state.attributes.get("unit_of_measurement") == "%"
+    assert hass_state.attributes.get("mode") == "auto"
+    assert hass_state.attributes.get("device_class") is None
 
     assert (
         hass.states.get(entity_id).attributes.get("friendly_name")

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -6,6 +6,8 @@ from unittest.mock import call, patch
 import pytest
 from zigpy.device import Device
 from zigpy.profiles import zha
+from zigpy.quirks.v2 import QuirkBuilder
+from zigpy.quirks.v2.homeassistant.number import NumberDeviceClass
 from zigpy.typing import UNDEFINED
 from zigpy.zcl.clusters import general
 import zigpy.zcl.foundation as zcl_f
@@ -145,3 +147,51 @@ async def test_number(
     )
     assert hass.states.get(entity_id).state == "40.0"
     assert "present_value" in cluster.read_attributes.call_args[0][0]
+
+
+async def test_number_quirks_v2_metadata(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test that mode and device_class from quirks v2 metadata are passed through."""
+    (
+        QuirkBuilder("Test Manf", "Test Number Model")
+        .number(
+            attribute_name="current_level",
+            cluster_id=general.LevelControl.cluster_id,
+            min_value=0,
+            max_value=254,
+            mode="box",
+            device_class=NumberDeviceClass.TEMPERATURE,
+            fallback_name="Level",
+        )
+        .add_to_registry()
+    )
+
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [general.LevelControl.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+            }
+        },
+        manufacturer="Test Manf",
+        model="Test Number Model",
+    )
+
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "number.test_manf_test_number_model"
+    hass_state = hass.states.get(entity_id)
+    assert hass_state is not None
+
+    assert hass_state.attributes.get("mode") == "box"
+    assert hass_state.attributes.get("device_class") == "temperature"


### PR DESCRIPTION
## Proposed change
This fixes an issue that must have existed since the ZHA refactor (https://github.com/home-assistant/core/pull/120190) where the device class and number mode are not passed through for number entities. I guess no one really cared... 😅 

We have plenty of coverage in the ZHA repo for all possible entity combinations, but apparently forgot to simply passthrough* what ZHA exposes.
*: (and yes, we convert from the ZHA device class and ZHA number mode to the HA equivalent)

A test is also added that creates a quirks v2 number entity and verifies the correct device class and number is set.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
