### PR TITLE
Add reconfiguration flow to NRGkick

### DIFF
--- a/homeassistant/components/nrgkick/config_flow.py
+++ b/homeassistant/components/nrgkick/config_flow.py
@@ -120,6 +120,31 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovered_name: str | None = None
         self._pending_host: str | None = None
 
+    async def _async_validate_host(
+        self,
+        host: str,
+        errors: dict[str, str],
+    ) -> tuple[dict[str, Any] | None, bool]:
+        """Validate host connection and populate errors dict on failure.
+
+        Returns (info, needs_auth). When needs_auth is True, the caller
+        should store the host and redirect to the appropriate auth step.
+        """
+        try:
+            return await validate_input(self.hass, host), False
+        except NRGkickApiClientApiDisabledError:
+            errors["base"] = "json_api_disabled"
+        except NRGkickApiClientAuthenticationError:
+            return None, True
+        except NRGkickApiClientInvalidResponseError:
+            errors["base"] = "invalid_response"
+        except NRGkickApiClientCommunicationError:
+            errors["base"] = "cannot_connect"
+        except NRGkickApiClientError:
+            _LOGGER.exception("Unexpected error")
+            errors["base"] = "unknown"
+        return None, False
+
     async def _async_validate_credentials(
         self,
         host: str,
@@ -156,21 +181,11 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             except vol.Invalid:
                 errors["base"] = "cannot_connect"
             else:
-                try:
-                    info = await validate_input(self.hass, host)
-                except NRGkickApiClientApiDisabledError:
-                    errors["base"] = "json_api_disabled"
-                except NRGkickApiClientAuthenticationError:
+                info, needs_auth = await self._async_validate_host(host, errors)
+                if needs_auth:
                     self._pending_host = host
                     return await self.async_step_user_auth()
-                except NRGkickApiClientInvalidResponseError:
-                    errors["base"] = "invalid_response"
-                except NRGkickApiClientCommunicationError:
-                    errors["base"] = "cannot_connect"
-                except NRGkickApiClientError:
-                    _LOGGER.exception("Unexpected error")
-                    errors["base"] = "unknown"
-                else:
+                if info:
                     await self.async_set_unique_id(
                         info["serial"], raise_on_progress=False
                     )
@@ -257,6 +272,81 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            try:
+                host = _normalize_host(user_input[CONF_HOST])
+            except vol.Invalid:
+                errors["base"] = "cannot_connect"
+            else:
+                info, needs_auth = await self._async_validate_host(host, errors)
+                if needs_auth:
+                    self._pending_host = host
+                    return await self.async_step_reconfigure_auth()
+                if info:
+                    await self.async_set_unique_id(
+                        info["serial"], raise_on_progress=False
+                    )
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry,
+                        data_updates={CONF_HOST: host},
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                reconfigure_entry.data,
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration authentication step."""
+        errors: dict[str, str] = {}
+
+        if TYPE_CHECKING:
+            assert self._pending_host is not None
+
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            if info := await self._async_validate_credentials(
+                self._pending_host,
+                errors,
+                username=user_input[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+            ):
+                await self.async_set_unique_id(info["serial"], raise_on_progress=False)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_HOST: self._pending_host,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure_auth",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_AUTH_DATA_SCHEMA,
+                reconfigure_entry.data,
+            ),
+            errors=errors,
+            description_placeholders={
+                "device_ip": self._pending_host,
+            },
+        )
+
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
@@ -321,21 +411,13 @@ class NRGkickConfigFlow(ConfigFlow, domain=DOMAIN):
             assert self._discovered_name is not None
 
         if user_input is not None:
-            try:
-                info = await validate_input(self.hass, self._discovered_host)
-            except NRGkickApiClientApiDisabledError:
-                errors["base"] = "json_api_disabled"
-            except NRGkickApiClientAuthenticationError:
+            info, needs_auth = await self._async_validate_host(
+                self._discovered_host, errors
+            )
+            if needs_auth:
                 self._pending_host = self._discovered_host
                 return await self.async_step_user_auth()
-            except NRGkickApiClientInvalidResponseError:
-                errors["base"] = "invalid_response"
-            except NRGkickApiClientCommunicationError:
-                errors["base"] = "cannot_connect"
-            except NRGkickApiClientError:
-                _LOGGER.exception("Unexpected error")
-                errors["base"] = "unknown"
-            else:
+            if info:
                 return self.async_create_entry(
                     title=info["title"], data={CONF_HOST: self._discovered_host}
                 )

--- a/homeassistant/components/nrgkick/quality_scale.yaml
+++ b/homeassistant/components/nrgkick/quality_scale.yaml
@@ -68,7 +68,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: exempt

--- a/homeassistant/components/nrgkick/strings.json
+++ b/homeassistant/components/nrgkick/strings.json
@@ -18,6 +18,17 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::nrgkick::config::step::user_auth::data_description::password%]",
+          "username": "[%key:component::nrgkick::config::step::user_auth::data_description::username%]"
+        },
+        "description": "Reauthenticate with your NRGkick device.\n\nGet your username and password in the NRGkick mobile app:\n1. Open the NRGkick mobile app \u2192 Extended \u2192 Local API\n2. Under Authentication (JSON), check or set your username and password"
+      },
       "reconfigure": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
@@ -37,17 +48,6 @@
           "username": "[%key:component::nrgkick::config::step::user_auth::data_description::username%]"
         },
         "description": "[%key:component::nrgkick::config::step::user_auth::description%]"
-      },
-      "reauth_confirm": {
-        "data": {
-          "password": "[%key:common::config_flow::data::password%]",
-          "username": "[%key:common::config_flow::data::username%]"
-        },
-        "data_description": {
-          "password": "[%key:component::nrgkick::config::step::user_auth::data_description::password%]",
-          "username": "[%key:component::nrgkick::config::step::user_auth::data_description::username%]"
-        },
-        "description": "Reauthenticate with your NRGkick device.\n\nGet your username and password in the NRGkick mobile app:\n1. Open the NRGkick mobile app \u2192 Extended \u2192 Local API\n2. Under Authentication (JSON), check or set your username and password"
       },
       "user": {
         "data": {

--- a/homeassistant/components/nrgkick/strings.json
+++ b/homeassistant/components/nrgkick/strings.json
@@ -6,6 +6,7 @@
       "json_api_disabled": "JSON API is disabled on the device. Enable it in the NRGkick mobile app under Extended \u2192 Local API \u2192 API Variants.",
       "no_serial_number": "Device does not provide a serial number",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unique_id_mismatch": "The device does not match the previous device"
     },
     "error": {
@@ -17,6 +18,26 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::nrgkick::config::step::user::data_description::host%]"
+        },
+        "description": "Reconfigure your NRGkick device. This allows you to change the IP address or hostname of your NRGkick device."
+      },
+      "reconfigure_auth": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::nrgkick::config::step::user_auth::data_description::password%]",
+          "username": "[%key:component::nrgkick::config::step::user_auth::data_description::username%]"
+        },
+        "description": "[%key:component::nrgkick::config::step::user_auth::description%]"
+      },
       "reauth_confirm": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/tests/components/nrgkick/test_config_flow.py
+++ b/tests/components/nrgkick/test_config_flow.py
@@ -775,3 +775,191 @@ async def test_reauth_flow_unique_id_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+) -> None:
+    """Test reconfiguration flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.200"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_with_credentials(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+) -> None:
+    """Test reconfiguration flow when authentication is required."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_nrgkick_api.test_connection.side_effect = NRGkickAuthenticationError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_auth"
+
+    mock_nrgkick_api.test_connection.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "new_user", CONF_PASSWORD: "new_pass"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.200"
+    assert mock_config_entry.data[CONF_USERNAME] == "new_user"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new_pass"
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (NRGkickAPIDisabledError, "json_api_disabled"),
+        (NRGkickApiClientInvalidResponseError, "invalid_response"),
+        (NRGkickConnectionError, "cannot_connect"),
+        (NRGkickApiClientError, "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test reconfiguration flow errors and recovery."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_nrgkick_api.test_connection.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": error}
+
+    mock_nrgkick_api.test_connection.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (NRGkickAPIDisabledError, "json_api_disabled"),
+        (NRGkickAuthenticationError, "invalid_auth"),
+        (NRGkickApiClientInvalidResponseError, "invalid_response"),
+        (NRGkickConnectionError, "cannot_connect"),
+        (NRGkickApiClientError, "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_auth_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test reconfiguration auth step errors and recovery."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    mock_nrgkick_api.test_connection.side_effect = NRGkickAuthenticationError
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_auth"
+
+    mock_nrgkick_api.test_connection.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_auth"
+    assert result["errors"] == {"base": error}
+
+    mock_nrgkick_api.test_connection.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_unique_id_mismatch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+) -> None:
+    """Test reconfiguration aborts on unique ID mismatch."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_nrgkick_api.get_info.return_value = {
+        "general": {"serial_number": "DIFFERENT123", "device_name": "Other"}
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"

--- a/tests/components/nrgkick/test_config_flow.py
+++ b/tests/components/nrgkick/test_config_flow.py
@@ -792,6 +792,14 @@ async def test_reconfigure_flow(
     assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: ""}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {CONF_HOST: "192.168.1.200"},
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds reconfiguration config flow and slightly optimizes config_flow.py for less code duplication.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163216
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
