### PR TITLE
Add diagnostics support to homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/diagnostics.py
+++ b/homeassistant/components/homematicip_cloud/diagnostics.py
@@ -10,10 +10,9 @@ from homematicip.base.helpers import handle_config
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
-from .const import HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_PIN
 from .hap import HomematicIPConfigEntry
 
-TO_REDACT = {HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_PIN}
+TO_REDACT_CONFIG = {"city", "latitude", "longitude"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -23,8 +22,6 @@ async def async_get_config_entry_diagnostics(
     hap = config_entry.runtime_data
     json_state = await hap.home.download_configuration_async()
     anonymized = handle_config(json_state, anonymize=True)
+    config = json.loads(anonymized)
 
-    return {
-        "config_entry_data": async_redact_data(dict(config_entry.data), TO_REDACT),
-        "home_configuration": json.loads(anonymized),
-    }
+    return async_redact_data(config, TO_REDACT_CONFIG)

--- a/homeassistant/components/homematicip_cloud/diagnostics.py
+++ b/homeassistant/components/homematicip_cloud/diagnostics.py
@@ -1,0 +1,30 @@
+"""Diagnostics support for HomematicIP Cloud."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from homematicip.base.helpers import handle_config
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .const import HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_PIN
+from .hap import HomematicIPConfigEntry
+
+TO_REDACT = {HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_PIN}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: HomematicIPConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    hap = config_entry.runtime_data
+    json_state = await hap.home.download_configuration_async()
+    anonymized = handle_config(json_state, anonymize=True)
+
+    return {
+        "config_entry_data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "home_configuration": json.loads(anonymized),
+    }

--- a/homeassistant/components/homematicip_cloud/diagnostics.py
+++ b/homeassistant/components/homematicip_cloud/diagnostics.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from .hap import HomematicIPConfigEntry
 
-TO_REDACT_CONFIG = {"city", "latitude", "longitude"}
+TO_REDACT_CONFIG = {"city", "latitude", "longitude", "refreshToken"}
 
 
 async def async_get_config_entry_diagnostics(

--- a/tests/components/homematicip_cloud/fixtures/diagnostics.json
+++ b/tests/components/homematicip_cloud/fixtures/diagnostics.json
@@ -1,0 +1,27 @@
+{
+    "accessPointId": "3014F7110000000000000001",
+    "home": {
+        "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+        "location": {
+            "city": "Berlin, Germany",
+            "latitude": "52.520008",
+            "longitude": "13.404954"
+        },
+        "weather": { "temperature": 18.3 }
+    },
+    "devices": {
+        "3014F7110000000000000002": {
+            "id": "3014F7110000000000000002",
+            "label": "Living Room Thermostat",
+            "type": "WALL_MOUNTED_THERMOSTAT_PRO",
+            "serializedGlobalTradeItemNumber": "ABCDEFGHIJKLMNOPQRSTUVWX"
+        }
+    },
+    "clients": {
+        "a1b2c3d4-e5f6-1234-abcd-ef0123456789": {
+            "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+            "label": "Home Assistant",
+            "refreshToken": "secret-refresh-token"
+        }
+    }
+}

--- a/tests/components/homematicip_cloud/fixtures/diagnostics.json
+++ b/tests/components/homematicip_cloud/fixtures/diagnostics.json
@@ -1,27 +1,29 @@
 {
-    "accessPointId": "3014F7110000000000000001",
-    "home": {
-        "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
-        "location": {
-            "city": "Berlin, Germany",
-            "latitude": "52.520008",
-            "longitude": "13.404954"
-        },
-        "weather": { "temperature": 18.3 }
+  "accessPointId": "3014F7110000000000000001",
+  "home": {
+    "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+    "location": {
+      "city": "Berlin, Germany",
+      "latitude": "52.520008",
+      "longitude": "13.404954"
     },
-    "devices": {
-        "3014F7110000000000000002": {
-            "id": "3014F7110000000000000002",
-            "label": "Living Room Thermostat",
-            "type": "WALL_MOUNTED_THERMOSTAT_PRO",
-            "serializedGlobalTradeItemNumber": "ABCDEFGHIJKLMNOPQRSTUVWX"
-        }
-    },
-    "clients": {
-        "a1b2c3d4-e5f6-1234-abcd-ef0123456789": {
-            "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
-            "label": "Home Assistant",
-            "refreshToken": "secret-refresh-token"
-        }
+    "weather": {
+      "temperature": 18.3
     }
+  },
+  "devices": {
+    "3014F7110000000000000002": {
+      "id": "3014F7110000000000000002",
+      "label": "Living Room Thermostat",
+      "type": "WALL_MOUNTED_THERMOSTAT_PRO",
+      "serializedGlobalTradeItemNumber": "ABCDEFGHIJKLMNOPQRSTUVWX"
+    }
+  },
+  "clients": {
+    "a1b2c3d4-e5f6-1234-abcd-ef0123456789": {
+      "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+      "label": "Home Assistant",
+      "refreshToken": "secret-refresh-token"
+    }
+  }
 }

--- a/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
@@ -1,39 +1,31 @@
 # serializer version: 1
 # name: test_diagnostics
   dict({
-    'config_entry_data': dict({
-      'authtoken': '**REDACTED**',
-      'hapid': '**REDACTED**',
-      'name': '',
-      'pin': '**REDACTED**',
-    }),
-    'home_configuration': dict({
-      'accessPointId': '3014F7110000000000000000',
-      'clients': dict({
-        '00000000-0000-0000-0000-000000000000': dict({
-          'id': '00000000-0000-0000-0000-000000000000',
-          'label': 'Home Assistant',
-          'refreshToken': None,
-        }),
-      }),
-      'devices': dict({
-        '3014F7110000000000000001': dict({
-          'id': '3014F7110000000000000001',
-          'label': 'Living Room Thermostat',
-          'serializedGlobalTradeItemNumber': '3014F7110000000000000002',
-          'type': 'WALL_MOUNTED_THERMOSTAT_PRO',
-        }),
-      }),
-      'home': dict({
+    'accessPointId': '3014F7110000000000000000',
+    'clients': dict({
+      '00000000-0000-0000-0000-000000000000': dict({
         'id': '00000000-0000-0000-0000-000000000000',
-        'location': dict({
-          'city': '1010, Vienna, Austria',
-          'latitude': '48.208088',
-          'longitude': '16.358608',
-        }),
-        'weather': dict({
-          'temperature': 18.3,
-        }),
+        'label': 'Home Assistant',
+        'refreshToken': None,
+      }),
+    }),
+    'devices': dict({
+      '3014F7110000000000000001': dict({
+        'id': '3014F7110000000000000001',
+        'label': 'Living Room Thermostat',
+        'serializedGlobalTradeItemNumber': '3014F7110000000000000002',
+        'type': 'WALL_MOUNTED_THERMOSTAT_PRO',
+      }),
+    }),
+    'home': dict({
+      'id': '00000000-0000-0000-0000-000000000000',
+      'location': dict({
+        'city': '**REDACTED**',
+        'latitude': '**REDACTED**',
+        'longitude': '**REDACTED**',
+      }),
+      'weather': dict({
+        'temperature': 18.3,
       }),
     }),
   })

--- a/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/homematicip_cloud/snapshots/test_diagnostics.ambr
@@ -1,0 +1,40 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'config_entry_data': dict({
+      'authtoken': '**REDACTED**',
+      'hapid': '**REDACTED**',
+      'name': '',
+      'pin': '**REDACTED**',
+    }),
+    'home_configuration': dict({
+      'accessPointId': '3014F7110000000000000000',
+      'clients': dict({
+        '00000000-0000-0000-0000-000000000000': dict({
+          'id': '00000000-0000-0000-0000-000000000000',
+          'label': 'Home Assistant',
+          'refreshToken': None,
+        }),
+      }),
+      'devices': dict({
+        '3014F7110000000000000001': dict({
+          'id': '3014F7110000000000000001',
+          'label': 'Living Room Thermostat',
+          'serializedGlobalTradeItemNumber': '3014F7110000000000000002',
+          'type': 'WALL_MOUNTED_THERMOSTAT_PRO',
+        }),
+      }),
+      'home': dict({
+        'id': '00000000-0000-0000-0000-000000000000',
+        'location': dict({
+          'city': '1010, Vienna, Austria',
+          'latitude': '48.208088',
+          'longitude': '16.358608',
+        }),
+        'weather': dict({
+          'temperature': 18.3,
+        }),
+      }),
+    }),
+  })
+# ---

--- a/tests/components/homematicip_cloud/test_diagnostics.py
+++ b/tests/components/homematicip_cloud/test_diagnostics.py
@@ -51,20 +51,3 @@ async def test_diagnostics(
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
 
     assert result == snapshot
-
-    # Verify config entry data is redacted
-    config_data = result["config_entry_data"]
-    assert config_data["authtoken"] == "**REDACTED**"
-    assert config_data["hapid"] == "**REDACTED**"
-    assert config_data["pin"] == "**REDACTED**"
-
-    # Verify home configuration is anonymized by handle_config
-    home_config = result["home_configuration"]
-    home_str = str(home_config)
-    # Location should be replaced with Vienna dummy
-    assert "Berlin" not in home_str
-    assert "52.520008" not in home_str
-    # Refresh token should be removed
-    assert "secret-refresh-token" not in home_str
-    # GUIDs should be replaced with sequential dummy GUIDs
-    assert "a1b2c3d4-e5f6-1234-abcd-ef0123456789" not in home_str

--- a/tests/components/homematicip_cloud/test_diagnostics.py
+++ b/tests/components/homematicip_cloud/test_diagnostics.py
@@ -5,7 +5,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.homematicip_cloud.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from tests.common import load_json_object_fixture
+from tests.common import async_load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -18,7 +18,7 @@ async def test_diagnostics(
 ) -> None:
     """Test diagnostics for config entry."""
     mock_hap_with_service.home.download_configuration_async.return_value = (
-        load_json_object_fixture("diagnostics.json", DOMAIN)
+        await async_load_json_object_fixture(hass, "diagnostics.json", DOMAIN)
     )
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/components/homematicip_cloud/test_diagnostics.py
+++ b/tests/components/homematicip_cloud/test_diagnostics.py
@@ -5,36 +5,9 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.homematicip_cloud.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
+from tests.common import load_json_object_fixture
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
-
-MOCK_CONFIG = {
-    "accessPointId": "3014F7110000000000000001",
-    "home": {
-        "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
-        "location": {
-            "city": "Berlin, Germany",
-            "latitude": "52.520008",
-            "longitude": "13.404954",
-        },
-        "weather": {"temperature": 18.3},
-    },
-    "devices": {
-        "3014F7110000000000000002": {
-            "id": "3014F7110000000000000002",
-            "label": "Living Room Thermostat",
-            "type": "WALL_MOUNTED_THERMOSTAT_PRO",
-            "serializedGlobalTradeItemNumber": "ABCDEFGHIJKLMNOPQRSTUVWX",
-        }
-    },
-    "clients": {
-        "a1b2c3d4-e5f6-1234-abcd-ef0123456789": {
-            "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
-            "label": "Home Assistant",
-            "refreshToken": "secret-refresh-token",
-        }
-    },
-}
 
 
 async def test_diagnostics(
@@ -44,7 +17,9 @@ async def test_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics for config entry."""
-    mock_hap_with_service.home.download_configuration_async.return_value = MOCK_CONFIG
+    mock_hap_with_service.home.download_configuration_async.return_value = (
+        load_json_object_fixture("diagnostics.json", DOMAIN)
+    )
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 

--- a/tests/components/homematicip_cloud/test_diagnostics.py
+++ b/tests/components/homematicip_cloud/test_diagnostics.py
@@ -1,0 +1,70 @@
+"""Tests for HomematicIP Cloud diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.homematicip_cloud.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+MOCK_CONFIG = {
+    "accessPointId": "3014F7110000000000000001",
+    "home": {
+        "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+        "location": {
+            "city": "Berlin, Germany",
+            "latitude": "52.520008",
+            "longitude": "13.404954",
+        },
+        "weather": {"temperature": 18.3},
+    },
+    "devices": {
+        "3014F7110000000000000002": {
+            "id": "3014F7110000000000000002",
+            "label": "Living Room Thermostat",
+            "type": "WALL_MOUNTED_THERMOSTAT_PRO",
+            "serializedGlobalTradeItemNumber": "ABCDEFGHIJKLMNOPQRSTUVWX",
+        }
+    },
+    "clients": {
+        "a1b2c3d4-e5f6-1234-abcd-ef0123456789": {
+            "id": "a1b2c3d4-e5f6-1234-abcd-ef0123456789",
+            "label": "Home Assistant",
+            "refreshToken": "secret-refresh-token",
+        }
+    },
+}
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_hap_with_service,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics for config entry."""
+    mock_hap_with_service.home.download_configuration_async.return_value = MOCK_CONFIG
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
+
+    assert result == snapshot
+
+    # Verify config entry data is redacted
+    config_data = result["config_entry_data"]
+    assert config_data["authtoken"] == "**REDACTED**"
+    assert config_data["hapid"] == "**REDACTED**"
+    assert config_data["pin"] == "**REDACTED**"
+
+    # Verify home configuration is anonymized by handle_config
+    home_config = result["home_configuration"]
+    home_str = str(home_config)
+    # Location should be replaced with Vienna dummy
+    assert "Berlin" not in home_str
+    assert "52.520008" not in home_str
+    # Refresh token should be removed
+    assert "secret-refresh-token" not in home_str
+    # GUIDs should be replaced with sequential dummy GUIDs
+    assert "a1b2c3d4-e5f6-1234-abcd-ef0123456789" not in home_str


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Add diagnostics platform support to the HomematicIP Cloud integration. This allows users to download anonymized device configuration dumps directly from the HA UI via Settings > Devices > Diagnostics, instead of needing to set up `hmip_cli` separately.

The implementation uses the library's built-in `handle_config(anonymize=True)` which replaces GUIDs, SGTINs, refresh tokens, and location data with dummy values. Config entry credentials (auth token, HAP ID, PIN) are additionally redacted.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr