### PR TITLE
Add DHW operating mode select entity to ViCare integration

### DIFF
--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -12,6 +12,7 @@ PLATFORMS = [
     Platform.CLIMATE,
     Platform.FAN,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.WATER_HEATER,
 ]

--- a/homeassistant/components/vicare/select.py
+++ b/homeassistant/components/vicare/select.py
@@ -1,0 +1,101 @@
+"""Viessmann ViCare select device."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+import logging
+
+from PyViCare.PyViCareDevice import Device as PyViCareDevice
+from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
+from PyViCare.PyViCareUtils import (
+    PyViCareInvalidDataError,
+    PyViCareNotSupportedFeatureError,
+    PyViCareRateLimitError,
+)
+import requests
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import ViCareEntity
+from .types import ViCareConfigEntry, ViCareDevice
+from .utils import get_device_serial, is_supported
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _build_entities(
+    device_list: list[ViCareDevice],
+) -> list[ViCareDHWOperatingModeSelect]:
+    """Create ViCare select entities for a device."""
+    return [
+        ViCareDHWOperatingModeSelect(
+            get_device_serial(device.api),
+            device.config,
+            device.api,
+        )
+        for device in device_list
+        if is_supported(
+            "dhw_operating_mode",
+            lambda api: api.getDomesticHotWaterActiveOperatingMode(),
+            device.api,
+        )
+    ]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ViCareConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the ViCare select platform."""
+    async_add_entities(
+        await hass.async_add_executor_job(
+            _build_entities,
+            config_entry.runtime_data.devices,
+        )
+    )
+
+
+class ViCareDHWOperatingModeSelect(ViCareEntity, SelectEntity):
+    """Representation of the ViCare DHW operating mode select entity."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "dhw_operating_mode"
+
+    def __init__(
+        self,
+        device_serial: str | None,
+        device_config: PyViCareDeviceConfig,
+        device: PyViCareDevice,
+    ) -> None:
+        """Initialize the DHW operating mode select entity."""
+        super().__init__("dhw_operating_mode", device_serial, device_config, device)
+        self._attr_options = device.getDomesticHotWaterOperatingModes()
+        self._attr_current_option = device.getDomesticHotWaterActiveOperatingMode()
+
+    def update(self) -> None:
+        """Update state from the ViCare API."""
+        try:
+            with suppress(PyViCareNotSupportedFeatureError):
+                self._attr_options = self._api.getDomesticHotWaterOperatingModes()
+
+            with suppress(PyViCareNotSupportedFeatureError):
+                self._attr_current_option = (
+                    self._api.getDomesticHotWaterActiveOperatingMode()
+                )
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from ViCare server")
+        except PyViCareRateLimitError as limit_exception:
+            _LOGGER.error("Vicare API rate limit exceeded: %s", limit_exception)
+        except ValueError:
+            _LOGGER.error("Unable to decode data from ViCare server")
+        except PyViCareInvalidDataError as invalid_data_exception:
+            _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
+
+    def select_option(self, option: str) -> None:
+        """Set the DHW operating mode."""
+        self._api.setDomesticHotWaterOperatingMode(option)
+        self._attr_current_option = option

--- a/homeassistant/components/vicare/select.py
+++ b/homeassistant/components/vicare/select.py
@@ -25,6 +25,14 @@ from .utils import get_device_serial, is_supported
 
 _LOGGER = logging.getLogger(__name__)
 
+# Map API values to snake_case for HA, and back
+DHW_MODE_API_TO_HA: dict[str, str] = {
+    "efficient": "efficient",
+    "efficientWithMinComfort": "efficient_with_min_comfort",
+    "off": "off",
+}
+DHW_MODE_HA_TO_API: dict[str, str] = {v: k for k, v in DHW_MODE_API_TO_HA.items()}
+
 
 def _build_entities(
     device_list: list[ViCareDevice],
@@ -73,19 +81,25 @@ class ViCareDHWOperatingModeSelect(ViCareEntity, SelectEntity):
     ) -> None:
         """Initialize the DHW operating mode select entity."""
         super().__init__("dhw_operating_mode", device_serial, device_config, device)
-        self._attr_options = device.getDomesticHotWaterOperatingModes()
-        self._attr_current_option = device.getDomesticHotWaterActiveOperatingMode()
+        self._attr_options = [
+            DHW_MODE_API_TO_HA.get(mode, mode)
+            for mode in device.getDomesticHotWaterOperatingModes()
+        ]
+        active = device.getDomesticHotWaterActiveOperatingMode()
+        self._attr_current_option = DHW_MODE_API_TO_HA.get(active, active)
 
     def update(self) -> None:
         """Update state from the ViCare API."""
         try:
             with suppress(PyViCareNotSupportedFeatureError):
-                self._attr_options = self._api.getDomesticHotWaterOperatingModes()
+                self._attr_options = [
+                    DHW_MODE_API_TO_HA.get(mode, mode)
+                    for mode in self._api.getDomesticHotWaterOperatingModes()
+                ]
 
             with suppress(PyViCareNotSupportedFeatureError):
-                self._attr_current_option = (
-                    self._api.getDomesticHotWaterActiveOperatingMode()
-                )
+                active = self._api.getDomesticHotWaterActiveOperatingMode()
+                self._attr_current_option = DHW_MODE_API_TO_HA.get(active, active)
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from ViCare server")
         except PyViCareRateLimitError as limit_exception:
@@ -97,5 +111,7 @@ class ViCareDHWOperatingModeSelect(ViCareEntity, SelectEntity):
 
     def select_option(self, option: str) -> None:
         """Set the DHW operating mode."""
-        self._api.setDomesticHotWaterOperatingMode(option)
+        api_mode = DHW_MODE_HA_TO_API.get(option, option)
+        self._api.setDomesticHotWaterOperatingMode(api_mode)
         self._attr_current_option = option
+        self.schedule_update_ha_state()

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -162,7 +162,12 @@
     },
     "select": {
       "dhw_operating_mode": {
-        "name": "DHW operating mode"
+        "name": "DHW operating mode",
+        "state": {
+          "efficient": "Efficient",
+          "efficient_with_min_comfort": "Efficient with minimum comfort",
+          "off": "[%key:common::state::off%]"
+        }
       }
     },
     "sensor": {

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -160,6 +160,11 @@
         "name": "Reduced temperature"
       }
     },
+    "select": {
+      "dhw_operating_mode": {
+        "name": "DHW operating mode"
+      }
+    },
     "sensor": {
       "boiler_supply_temperature": {
         "name": "Boiler supply temperature"

--- a/tests/components/vicare/snapshots/test_select.ambr
+++ b/tests/components/vicare/snapshots/test_select.ambr
@@ -6,7 +6,7 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'efficientWithMinComfort',
+        'efficient_with_min_comfort',
         'efficient',
         'off',
       ]),
@@ -46,7 +46,7 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'model0 DHW operating mode',
       'options': list([
-        'efficientWithMinComfort',
+        'efficient_with_min_comfort',
         'efficient',
         'off',
       ]),

--- a/tests/components/vicare/snapshots/test_select.ambr
+++ b/tests/components/vicare/snapshots/test_select.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[select.model0-entry]
+# name: test_all_entities[select.model0_dhw_operating_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -18,7 +18,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.model0',
+    'entity_id': 'select.model0_dhw_operating_mode',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -26,12 +26,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'DHW operating mode',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'DHW operating mode',
     'platform': 'vicare',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -41,10 +41,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[select.model0-state]
+# name: test_all_entities[select.model0_dhw_operating_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'model0',
+      'friendly_name': 'model0 DHW operating mode',
       'options': list([
         'efficientWithMinComfort',
         'efficient',
@@ -52,7 +52,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.model0',
+    'entity_id': 'select.model0_dhw_operating_mode',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/vicare/snapshots/test_select.ambr
+++ b/tests/components/vicare/snapshots/test_select.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_all_entities[select.model0-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'efficientWithMinComfort',
+        'efficient',
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.model0',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'vicare',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhw_operating_mode',
+    'unique_id': 'gateway0_deviceSerialVitocal250A-dhw_operating_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[select.model0-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'model0',
+      'options': list([
+        'efficientWithMinComfort',
+        'efficient',
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.model0',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'efficient',
+  })
+# ---

--- a/tests/components/vicare/test_select.py
+++ b/tests/components/vicare/test_select.py
@@ -1,0 +1,35 @@
+"""Test ViCare select entity."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import MODULE, setup_integration
+from .conftest import Fixture, MockPyViCare
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    fixtures: list[Fixture] = [
+        Fixture({"type:heatpump"}, "vicare/Vitocal250A.json"),
+    ]
+    with (
+        patch(f"{MODULE}.login", return_value=MockPyViCare(fixtures)),
+        patch(f"{MODULE}.PLATFORMS", [Platform.SELECT]),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
## Proposed change

Add a select entity for the domestic hot water (DHW) operating mode to the ViCare integration. This allows users to switch between DHW operating modes (e.g. `efficient`, `efficientWithMinComfort`, `off`) directly from Home Assistant.

The entity is device-level (not per-circuit), uses `EntityCategory.CONFIG`, and dynamically fetches available modes from the device. Only created for devices that support the `heating.dhw.operating.modes.active` data point.

Uses `getDomesticHotWaterOperatingModes()`, `getDomesticHotWaterActiveOperatingMode()`, and `setDomesticHotWaterOperatingMode()` from PyViCare, available since PyViCare 2.58.0 ([bumped in #163686](https://github.com/home-assistant/core/pull/163686), merged).

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #154414
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43707
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr