### PR TITLE
Deprecate Libre Hardware Monitor versions below v0.9.5

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/__init__.py
+++ b/homeassistant/components/libre_hardware_monitor/__init__.py
@@ -6,7 +6,11 @@ import logging
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 
 from .const import DOMAIN
 from .coordinator import (
@@ -79,6 +83,18 @@ async def async_setup_entry(
 
     lhm_coordinator = LibreHardwareMonitorCoordinator(hass, config_entry)
     await lhm_coordinator.async_config_entry_first_refresh()
+
+    if lhm_coordinator.data.is_deprecated_version:
+        issue_id = f"deprecated_api_{config_entry.entry_id}"
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            breaks_in_ha_version="2026.9.0",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="deprecated_api",
+        )
 
     config_entry.runtime_data = lhm_coordinator
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/libre_hardware_monitor/__init__.py
+++ b/homeassistant/components/libre_hardware_monitor/__init__.py
@@ -94,6 +94,9 @@ async def async_setup_entry(
             is_fixable=False,
             severity=ir.IssueSeverity.WARNING,
             translation_key="deprecated_api",
+            translation_placeholders={
+                "lhm_releases_url": "https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases"
+            },
         )
 
     config_entry.runtime_data = lhm_coordinator

--- a/homeassistant/components/libre_hardware_monitor/coordinator.py
+++ b/homeassistant/components/libre_hardware_monitor/coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -50,7 +50,7 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             config_entry=config_entry,
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
-
+        self._entry_id = config_entry.entry_id
         self._api = LibreHardwareMonitorClient(
             host=config_entry.data[CONF_HOST],
             port=config_entry.data[CONF_PORT],
@@ -59,13 +59,14 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             session=async_create_clientsession(hass),
         )
         device_entries: list[DeviceEntry] = dr.async_entries_for_config_entry(
-            registry=dr.async_get(self.hass), config_entry_id=config_entry.entry_id
+            registry=dr.async_get(self.hass), config_entry_id=self._entry_id
         )
         self._previous_devices: dict[DeviceId, DeviceName] = {
             DeviceId(next(iter(device.identifiers))[1]): DeviceName(device.name)
             for device in device_entries
             if device.identifiers and device.name
         }
+        self._is_deprecated_version: bool | None = None
 
     async def _async_update_data(self) -> LibreHardwareMonitorData:
         try:
@@ -79,6 +80,12 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
             raise ConfigEntryAuthFailed("Authentication failed") from err
         except LibreHardwareMonitorNoDevicesError as err:
             raise UpdateFailed("No sensor data available, will retry") from err
+
+        # Check whether user has upgraded LHM from a deprecated version while the integration is running
+        if self._is_deprecated_version and not lhm_data.is_deprecated_version:
+            # Clear deprecation issue
+            ir.async_delete_issue(self.hass, DOMAIN, f"deprecated_api_{self._entry_id}")
+        self._is_deprecated_version = lhm_data.is_deprecated_version
 
         await self._async_handle_changes_in_devices(
             dict(lhm_data.main_device_ids_and_names)

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -9,7 +9,6 @@ from librehardwaremonitor_api.sensor_type import SensorType
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -53,12 +52,10 @@ class LibreHardwareMonitorSensor(
     ) -> None:
         """Initialize an LibreHardwareMonitor sensor."""
         super().__init__(coordinator)
-        self._entry_id = entry_id
-        self._is_deprecated_lhm_version = coordinator.data.is_deprecated_version
 
         self._attr_name: str = sensor_data.name
 
-        self._set_state(self._is_deprecated_lhm_version, sensor_data)
+        self._set_state(coordinator.data.is_deprecated_version, sensor_data)
         self._attr_unique_id: str = f"{entry_id}_{sensor_data.sensor_id}"
 
         self._sensor_id: str = sensor_data.sensor_id
@@ -80,22 +77,13 @@ class LibreHardwareMonitorSensor(
         max_value = sensor_data.max
         unit = sensor_data.unit
 
-        if not is_deprecated_lhm_version:
-            # Check whether user has upgraded LHM from a deprecated version while the integration is running
-            if self._is_deprecated_lhm_version:
-                self._is_deprecated_lhm_version = False
-                # Clear deprecation issue
-                ir.async_delete_issue(
-                    self.hass, DOMAIN, f"deprecated_api_{self._entry_id}"
-                )
-
-            if sensor_data.type == SensorType.THROUGHPUT:
-                # Temporary fix: convert the B/s value to KB/s to not break existing entries
-                # This will be migrated properly once SensorDeviceClass is introduced
-                value = f"{(float(value) / 1024):.1f}" if value else None
-                min_value = f"{(float(min_value) / 1024):.1f}" if min_value else None
-                max_value = f"{(float(max_value) / 1024):.1f}" if max_value else None
-                unit = "KB/s"
+        if not is_deprecated_lhm_version and sensor_data.type == SensorType.THROUGHPUT:
+            # Temporary fix: convert the B/s value to KB/s to not break existing entries
+            # This will be migrated properly once SensorDeviceClass is introduced
+            value = f"{(float(value) / 1024):.1f}" if value else None
+            min_value = f"{(float(min_value) / 1024):.1f}" if min_value else None
+            max_value = f"{(float(max_value) / 1024):.1f}" if max_value else None
+            unit = "KB/s"
 
         self._attr_native_value: str | None = value
         self._attr_extra_state_attributes: dict[str, Any] = {

--- a/homeassistant/components/libre_hardware_monitor/sensor.py
+++ b/homeassistant/components/libre_hardware_monitor/sensor.py
@@ -9,6 +9,7 @@ from librehardwaremonitor_api.sensor_type import SensorType
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -52,10 +53,12 @@ class LibreHardwareMonitorSensor(
     ) -> None:
         """Initialize an LibreHardwareMonitor sensor."""
         super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._is_deprecated_lhm_version = coordinator.data.is_deprecated_version
 
         self._attr_name: str = sensor_data.name
 
-        self._set_state(coordinator.data.is_deprecated_version, sensor_data)
+        self._set_state(self._is_deprecated_lhm_version, sensor_data)
         self._attr_unique_id: str = f"{entry_id}_{sensor_data.sensor_id}"
 
         self._sensor_id: str = sensor_data.sensor_id
@@ -77,13 +80,22 @@ class LibreHardwareMonitorSensor(
         max_value = sensor_data.max
         unit = sensor_data.unit
 
-        if not is_deprecated_lhm_version and sensor_data.type == SensorType.THROUGHPUT:
-            # Temporary fix: convert the B/s value to KB/s to not break existing entries
-            # This will be migrated properly once SensorDeviceClass is introduced
-            value = f"{(float(value) / 1024):.1f}" if value else None
-            min_value = f"{(float(min_value) / 1024):.1f}" if min_value else None
-            max_value = f"{(float(max_value) / 1024):.1f}" if max_value else None
-            unit = "KB/s"
+        if not is_deprecated_lhm_version:
+            # Check whether user has upgraded LHM from a deprecated version while the integration is running
+            if self._is_deprecated_lhm_version:
+                self._is_deprecated_lhm_version = False
+                # Clear deprecation issue
+                ir.async_delete_issue(
+                    self.hass, DOMAIN, f"deprecated_api_{self._entry_id}"
+                )
+
+            if sensor_data.type == SensorType.THROUGHPUT:
+                # Temporary fix: convert the B/s value to KB/s to not break existing entries
+                # This will be migrated properly once SensorDeviceClass is introduced
+                value = f"{(float(value) / 1024):.1f}" if value else None
+                min_value = f"{(float(min_value) / 1024):.1f}" if min_value else None
+                max_value = f"{(float(max_value) / 1024):.1f}" if max_value else None
+                unit = "KB/s"
 
         self._attr_native_value: str | None = value
         self._attr_extra_state_attributes: dict[str, Any] = {

--- a/homeassistant/components/libre_hardware_monitor/strings.json
+++ b/homeassistant/components/libre_hardware_monitor/strings.json
@@ -33,5 +33,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "deprecated_api": {
+      "description": "Your version of Libre Hardware Monitor is deprecated. Please update to v0.9.5 or later for full support.",
+      "title": "Deprecated Libre Hardware Monitor version"
+    }
   }
 }

--- a/homeassistant/components/libre_hardware_monitor/strings.json
+++ b/homeassistant/components/libre_hardware_monitor/strings.json
@@ -36,7 +36,7 @@
   },
   "issues": {
     "deprecated_api": {
-      "description": "Your version of Libre Hardware Monitor is deprecated. Please update to v0.9.5 or later for full support.",
+      "description": "Your version of Libre Hardware Monitor is deprecated and may not provide stable sensor data. To fix this issue:\n\n1. Download version 0.9.5 or later from {lhm_releases_url}\n2. Close Libre Hardware Monitor on your computer\n3. Install or extract the new version and start Libre Hardware Monitor again (you might have to re-enable the remote web server)\n4. Home Assistant will detect the new version and this issue will clear automatically",
       "title": "Deprecated Libre Hardware Monitor version"
     }
   }

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -27,7 +27,11 @@ from homeassistant.components.libre_hardware_monitor.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from . import init_integration
@@ -312,3 +316,53 @@ async def test_integration_does_not_log_new_devices_on_first_refresh(
             if record.name.startswith("homeassistant.components.libre_hardware_monitor")
         ]
         assert len(libre_hardware_monitor_logs) == 0
+
+
+async def test_non_deprecated_version_does_not_raise_issue(
+    hass: HomeAssistant,
+    mock_lhm_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test that a non-deprecated Libre Hardware Monitor version does not raise an issue."""
+    await init_integration(hass, mock_config_entry)
+
+    assert (
+        DOMAIN,
+        f"deprecated_api_{mock_config_entry.entry_id}",
+    ) not in issue_registry.issues
+
+
+async def test_deprecated_version_raises_issue_and_is_removed_after_update(
+    hass: HomeAssistant,
+    mock_lhm_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test that a deprecated Libre Hardware Monitor version raises an issue that is removed after updating."""
+    mock_lhm_client.get_data.return_value = replace(
+        mock_lhm_client.get_data.return_value,
+        is_deprecated_version=True,
+    )
+
+    await init_integration(hass, mock_config_entry)
+
+    assert (
+        DOMAIN,
+        f"deprecated_api_{mock_config_entry.entry_id}",
+    ) in issue_registry.issues
+
+    mock_lhm_client.get_data.return_value = replace(
+        mock_lhm_client.get_data.return_value,
+        is_deprecated_version=False,
+    )
+
+    freezer.tick(timedelta(DEFAULT_SCAN_INTERVAL))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        DOMAIN,
+        f"deprecated_api_{mock_config_entry.entry_id}",
+    ) not in issue_registry.issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate versions of LHM < 0.9.5 due to several reasons:
- They cannot provide stable units for throughput sensors, see https://github.com/home-assistant/core/issues/154139 which prevents introduction of sensor device classes (without maintaining a complete legacy version of the integration)
- They use an old WinRing0 driver that has security vulnerabilities which have been fixed by migrating to a new underlying driver (PawnIO). More context about this can be found [here](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/984). While this doesn't prevent the integration from working, I believe it is a valid reason to require upgrading

The integration will now raise an issue if a deprecated version is detected. If the user upgrades Libre Hardware Monitor, the integration will detect that upgrade and delete the issue automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
