### PR TITLE
Bump python-bsblan to 5.0.1

### DIFF
--- a/homeassistant/components/bsblan/diagnostics.py
+++ b/homeassistant/components/bsblan/diagnostics.py
@@ -17,24 +17,24 @@ async def async_get_config_entry_diagnostics(
 
     # Build diagnostic data from both coordinators
     diagnostics = {
-        "info": data.info.to_dict(),
-        "device": data.device.to_dict(),
+        "info": data.info.model_dump(),
+        "device": data.device.model_dump(),
         "fast_coordinator_data": {
-            "state": data.fast_coordinator.data.state.to_dict(),
-            "sensor": data.fast_coordinator.data.sensor.to_dict(),
-            "dhw": data.fast_coordinator.data.dhw.to_dict(),
+            "state": data.fast_coordinator.data.state.model_dump(),
+            "sensor": data.fast_coordinator.data.sensor.model_dump(),
+            "dhw": data.fast_coordinator.data.dhw.model_dump(),
         },
-        "static": data.static.to_dict(),
+        "static": data.static.model_dump(),
     }
 
     # Add DHW config and schedule from slow coordinator if available
     if data.slow_coordinator.data:
         slow_data = {}
         if data.slow_coordinator.data.dhw_config:
-            slow_data["dhw_config"] = data.slow_coordinator.data.dhw_config.to_dict()
+            slow_data["dhw_config"] = data.slow_coordinator.data.dhw_config.model_dump()
         if data.slow_coordinator.data.dhw_schedule:
             slow_data["dhw_schedule"] = (
-                data.slow_coordinator.data.dhw_schedule.to_dict()
+                data.slow_coordinator.data.dhw_schedule.model_dump()
             )
         if slow_data:
             diagnostics["slow_coordinator_data"] = slow_data

--- a/homeassistant/components/bsblan/manifest.json
+++ b/homeassistant/components/bsblan/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["bsblan"],
-  "requirements": ["python-bsblan==4.2.1"],
+  "requirements": ["python-bsblan==5.0.1"],
   "zeroconf": [
     {
       "name": "bsb-lan*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2524,7 +2524,7 @@ python-awair==0.2.5
 python-blockchain-api==0.0.2
 
 # homeassistant.components.bsblan
-python-bsblan==4.2.1
+python-bsblan==5.0.1
 
 # homeassistant.components.citybikes
 python-citybikes==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2147,7 +2147,7 @@ python-MotionMount==2.3.0
 python-awair==0.2.5
 
 # homeassistant.components.bsblan
-python-bsblan==4.2.1
+python-bsblan==5.0.1
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/bsblan/conftest.py
+++ b/tests/components/bsblan/conftest.py
@@ -55,25 +55,29 @@ def mock_bsblan() -> Generator[MagicMock]:
         patch("homeassistant.components.bsblan.config_flow.BSBLAN", new=bsblan_mock),
     ):
         bsblan = bsblan_mock.return_value
-        bsblan.info.return_value = Info.from_json(load_fixture("info.json", DOMAIN))
-        bsblan.device.return_value = Device.from_json(
+        bsblan.info.return_value = Info.model_validate_json(
+            load_fixture("info.json", DOMAIN)
+        )
+        bsblan.device.return_value = Device.model_validate_json(
             load_fixture("device.json", DOMAIN)
         )
-        bsblan.state.return_value = State.from_json(load_fixture("state.json", DOMAIN))
-        bsblan.static_values.return_value = StaticState.from_json(
+        bsblan.state.return_value = State.model_validate_json(
+            load_fixture("state.json", DOMAIN)
+        )
+        bsblan.static_values.return_value = StaticState.model_validate_json(
             load_fixture("static.json", DOMAIN)
         )
-        bsblan.sensor.return_value = Sensor.from_json(
+        bsblan.sensor.return_value = Sensor.model_validate_json(
             load_fixture("sensor.json", DOMAIN)
         )
-        bsblan.hot_water_state.return_value = HotWaterState.from_json(
+        bsblan.hot_water_state.return_value = HotWaterState.model_validate_json(
             load_fixture("dhw_state.json", DOMAIN)
         )
         # Mock new config methods using fixture files
-        bsblan.hot_water_config.return_value = HotWaterConfig.from_json(
+        bsblan.hot_water_config.return_value = HotWaterConfig.model_validate_json(
             load_fixture("dhw_config.json", DOMAIN)
         )
-        bsblan.hot_water_schedule.return_value = HotWaterSchedule.from_json(
+        bsblan.hot_water_schedule.return_value = HotWaterSchedule.model_validate_json(
             load_fixture("dhw_schedule.json", DOMAIN)
         )
         # mock get_temperature_unit property

--- a/tests/components/bsblan/fixtures/dhw_schedule.json
+++ b/tests/components/bsblan/fixtures/dhw_schedule.json
@@ -65,9 +65,9 @@
   "dhw_time_program_standard_values": {
     "name": "DHW time program standard values",
     "error": 0,
-    "value": "06:00-22:00",
-    "desc": "",
-    "dataType": 7,
+    "value": "1",
+    "desc": "Yes",
+    "dataType": 1,
     "readonly": 0,
     "unit": ""
   }

--- a/tests/components/bsblan/snapshots/test_diagnostics.ambr
+++ b/tests/components/bsblan/snapshots/test_diagnostics.ambr
@@ -102,6 +102,7 @@
           'unit': '&deg;C',
           'value': 6.1,
         }),
+        'total_energy': None,
       }),
       'state': dict({
         'current_temperature': dict({
@@ -155,7 +156,7 @@
           'readonly': 1,
           'readwrite': 0,
           'unit': '°C',
-          'value': '22.5',
+          'value': 22.5,
         }),
         'room1_thermostat_mode': dict({
           'data_type': 1,
@@ -382,17 +383,17 @@
           'value': '08:00-09:00 19:00-23:00',
         }),
         'dhw_time_program_standard_values': dict({
-          'data_type': 7,
+          'data_type': 1,
           'data_type_family': '',
           'data_type_name': '',
-          'desc': '',
+          'desc': 'Yes',
           'error': 0,
           'name': 'DHW time program standard values',
           'precision': None,
           'readonly': 0,
           'readwrite': 0,
           'unit': '',
-          'value': '06:00-22:00',
+          'value': 1,
         }),
         'dhw_time_program_sunday': dict({
           'data_type': 7,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -452,7 +452,7 @@ async def test_sync_time_service(
     assert device is not None
 
     # Mock device time that differs from HA time
-    mock_bsblan.time.return_value = DeviceTime.from_json(
+    mock_bsblan.time.return_value = DeviceTime.model_validate_json(
         '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
     )
 
@@ -490,7 +490,7 @@ async def test_sync_time_service_no_update_when_same(
 
     # Mock device time that matches HA time
     current_time_str = dt_util.now().strftime("%d.%m.%Y %H:%M:%S")
-    mock_bsblan.time.return_value = DeviceTime.from_json(
+    mock_bsblan.time.return_value = DeviceTime.model_validate_json(
         f'{{"time": {{"name": "Time", "value": "{current_time_str}", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}}}'
     )
 
@@ -553,7 +553,7 @@ async def test_sync_time_service_set_time_error(
     assert device is not None
 
     # Mock device time that differs
-    mock_bsblan.time.return_value = DeviceTime.from_json(
+    mock_bsblan.time.return_value = DeviceTime.model_validate_json(
         '{"time": {"name": "Time", "value": "01.01.2020 00:00:00", "unit": "", "desc": "", "dataType": 0, "readonly": 0, "error": 0}}'
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request updates the `bsblan` integration to support the latest version of the `python-bsblan` library and refactors code to use new serialization and validation methods. The changes improve compatibility, streamline data handling, and update test fixtures and snapshots to match the new library's data formats.

Moved from mashumaro to pydantic 2.0 to support handle conversion of raw BSB-LAN values before validation.
https://github.com/liudger/python-bsblan/compare/v4.2.1...v5.0.1
This also required diagnostics.py and some tests to be updated.

**Dependency update:**

* Upgraded `python-bsblan` requirement from `4.2.1` to `5.0.1` in `manifest.json`, `requirements_all.txt`, and `requirements_test_all.txt` to ensure compatibility with new features and methods. [[1]](diffhunk://#diff-fbd49835c369530338a67413a9b235d801f9a0affb21aa1a4645440499c5fef6L10-R10) [[2]](diffhunk://#diff-ae66cd41e5a8644fe0cdd7b9a2f0fee97b5deabe5f3793da15b73fa6353d2128L2527-R2527) [[3]](diffhunk://#diff-f946654c97927cbf41d54a07e10b9f92e95e9a43c0a7e2455d30acc696f08019L2150-R2150)

**Code refactoring for new library methods:**

* Replaced `.to_dict()` calls with `.model_dump()` in `homeassistant/components/bsblan/diagnostics.py` to use the new serialization method provided by `python-bsblan` 5.0.1.
* Updated test mocks in `tests/components/bsblan/conftest.py` and `tests/components/bsblan/test_services.py` to use `.model_validate_json()` instead of `.from_json()` for object creation, reflecting the new validation API. [[1]](diffhunk://#diff-75a9935d2cfa130ae2018b6cb999bbd98582efa7ba03478836e062337ae22cc4L58-R80) [[2]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L455-R455) [[3]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L493-R493) [[4]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L556-R556)

**Test fixture and snapshot updates:**

* Modified `dhw_schedule.json` fixture to update data types, values, and descriptions to match the new library's expected format.
* Updated `test_diagnostics.ambr` snapshot values and types to reflect changes in the underlying data model, including new fields and type corrections. [[1]](diffhunk://#diff-c062017bbe8fdaef8d2a11f99797f3d9a8149ca65a75ee09f9786be172bed52cR105) [[2]](diffhunk://#diff-c062017bbe8fdaef8d2a11f99797f3d9a8149ca65a75ee09f9786be172bed52cL158-R159) [[3]](diffhunk://#diff-c062017bbe8fdaef8d2a11f99797f3d9a8149ca65a75ee09f9786be172bed52cL385-R396)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
