### PR TITLE
Add energy sensor to bsblan

### DIFF
--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 # This significantly reduces response time (~0.2s per parameter saved)
 STATE_INCLUDE = ["current_temperature", "target_temperature", "hvac_mode"]
 SENSOR_INCLUDE = ["current_temperature", "outside_temperature"]
+SENSOR_INCLUDE = ["current_temperature", "outside_temperature", "total_energy"]
 DHW_STATE_INCLUDE = [
     "operating_mode",
     "nominal_setpoint",

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -29,8 +29,12 @@ if TYPE_CHECKING:
 
 # Filter lists for optimized API calls - only fetch parameters we actually use
 # This significantly reduces response time (~0.2s per parameter saved)
-STATE_INCLUDE = ["current_temperature", "target_temperature", "hvac_mode"]
-SENSOR_INCLUDE = ["current_temperature", "outside_temperature"]
+STATE_INCLUDE = [
+    "current_temperature",
+    "target_temperature",
+    "hvac_mode",
+    "hvac_action",
+]
 SENSOR_INCLUDE = ["current_temperature", "outside_temperature", "total_energy"]
 DHW_STATE_INCLUDE = [
     "operating_mode",

--- a/homeassistant/components/bsblan/sensor.py
+++ b/homeassistant/components/bsblan/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfEnergy, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -57,6 +57,19 @@ SENSOR_TYPES: tuple[BSBLanSensorEntityDescription, ...] = (
             else None
         ),
         exists_fn=lambda data: data.sensor.outside_temperature is not None,
+    ),
+    BSBLanSensorEntityDescription(
+        key="total_energy",
+        translation_key="total_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: (
+            data.sensor.total_energy.value
+            if data.sensor.total_energy is not None
+            else None
+        ),
+        exists_fn=lambda data: data.sensor.total_energy is not None,
     ),
 )
 

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -66,6 +66,9 @@
       },
       "outside_temperature": {
         "name": "Outside temperature"
+      },
+      "total_energy": {
+        "name": "Total energy"
       }
     }
   },

--- a/tests/components/bsblan/fixtures/sensor.json
+++ b/tests/components/bsblan/fixtures/sensor.json
@@ -16,5 +16,14 @@
     "dataType": 0,
     "readonly": 1,
     "unit": "&deg;C"
+  },
+  "total_energy": {
+    "name": "Total energy",
+    "error": 0,
+    "value": "7968",
+    "desc": "",
+    "dataType": 0,
+    "readonly": 1,
+    "unit": "kWh"
   }
 }

--- a/tests/components/bsblan/snapshots/test_diagnostics.ambr
+++ b/tests/components/bsblan/snapshots/test_diagnostics.ambr
@@ -102,7 +102,19 @@
           'unit': '&deg;C',
           'value': 6.1,
         }),
-        'total_energy': None,
+        'total_energy': dict({
+          'data_type': 0,
+          'data_type_family': '',
+          'data_type_name': '',
+          'desc': '',
+          'error': 0,
+          'name': 'Total energy',
+          'precision': None,
+          'readonly': 1,
+          'readwrite': 0,
+          'unit': 'kWh',
+          'value': 7968,
+        }),
       }),
       'state': dict({
         'current_temperature': dict({

--- a/tests/components/bsblan/snapshots/test_sensor.ambr
+++ b/tests/components/bsblan/snapshots/test_sensor.ambr
@@ -56,6 +56,63 @@
     'state': '18.6',
   })
 # ---
+# name: test_sensor_entity_properties[sensor.bsb_lan_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bsb_lan_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Energy',
+    'platform': 'bsblan',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_energy',
+    'unique_id': '00:80:41:19:69:90-total_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor_entity_properties[sensor.bsb_lan_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'BSB-LAN Energy',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bsb_lan_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7968',
+  })
+# ---
 # name: test_sensor_entity_properties[sensor.bsb_lan_outside_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/bsblan/snapshots/test_sensor.ambr
+++ b/tests/components/bsblan/snapshots/test_sensor.ambr
@@ -56,63 +56,6 @@
     'state': '18.6',
   })
 # ---
-# name: test_sensor_entity_properties[sensor.bsb_lan_energy-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.bsb_lan_energy',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Energy',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
-    'original_icon': None,
-    'original_name': 'Energy',
-    'platform': 'bsblan',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'total_energy',
-    'unique_id': '00:80:41:19:69:90-total_energy',
-    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-  })
-# ---
-# name: test_sensor_entity_properties[sensor.bsb_lan_energy-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'BSB-LAN Energy',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bsb_lan_energy',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '7968',
-  })
-# ---
 # name: test_sensor_entity_properties[sensor.bsb_lan_outside_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -168,5 +111,62 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6.1',
+  })
+# ---
+# name: test_sensor_entity_properties[sensor.bsb_lan_total_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bsb_lan_total_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Total energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Total energy',
+    'platform': 'bsblan',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_energy',
+    'unique_id': '00:80:41:19:69:90-total_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensor_entity_properties[sensor.bsb_lan_total_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'BSB-LAN Total energy',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bsb_lan_total_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7968',
   })
 # ---

--- a/tests/components/bsblan/test_sensor.py
+++ b/tests/components/bsblan/test_sensor.py
@@ -15,6 +15,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 ENTITY_CURRENT_TEMP = "sensor.bsb_lan_current_temperature"
 ENTITY_OUTSIDE_TEMP = "sensor.bsb_lan_outside_temperature"
+ENTITY_TOTAL_ENERGY = "sensor.bsb_lan_total_energy"
 
 
 async def test_sensor_entity_properties(
@@ -40,6 +41,7 @@ async def test_sensors_not_created_when_data_unavailable(
     # Set all sensor data to None to simulate no sensors available
     mock_bsblan.sensor.return_value.current_temperature = None
     mock_bsblan.sensor.return_value.outside_temperature = None
+    mock_bsblan.sensor.return_value.total_energy = None
 
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
 
@@ -58,8 +60,9 @@ async def test_partial_sensors_created_when_some_data_available(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test only available sensors are created when some sensor data is available."""
-    # Only current temperature available, outside temperature not
+    # Only current temperature available, outside temperature and energy not
     mock_bsblan.sensor.return_value.outside_temperature = None
+    mock_bsblan.sensor.return_value.total_energy = None
 
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds support for a new `total_energy` sensor to the BSBLan integration in Home Assistant. The changes include updating the coordinator to fetch the new parameter, defining the sensor entity, updating translations, and extending test coverage to ensure correct behavior.

New sensor support:

* Added `total_energy` to the `SENSOR_INCLUDE` list in `coordinator.py` to ensure the value is fetched from the API.
* Defined a new `BSBLanSensorEntityDescription` for `total_energy`, specifying device class, unit, and state class, and handling its existence and value extraction in `sensor.py`.
* Updated `strings.json` to include a translation entry for `total_energy`.

Enable hvac-action:
The hvac-action state was not retrieved and therefor not reporting. Just added it to the payload list.

Testing enhancements:

* Added a `total_energy` fixture and updated diagnostics and sensor snapshot tests to verify the sensor's presence, attributes, and correct value handling. [[1]](diffhunk://#diff-1c88c911c657806708f36275954d781bfb71c856aaaf77d79ac76d664dacfdccR19-R27) [[2]](diffhunk://#diff-c062017bbe8fdaef8d2a11f99797f3d9a8149ca65a75ee09f9786be172bed52cL105-R117) [[3]](diffhunk://#diff-6717f217a24f09f4a2a1f24f01c086a7a246a3f852a85c0e6f8c70196d7e7623R116-R172)
* Extended test cases to handle scenarios where `total_energy` data is unavailable, ensuring sensors are only created when data exists. [[1]](diffhunk://#diff-ad64326d8815f1468cc04c24d815ce676cf9ac8c28d6d2a5021259f972238ff4R18) [[2]](diffhunk://#diff-ad64326d8815f1468cc04c24d815ce676cf9ac8c28d6d2a5021259f972238ff4R44) [[3]](diffhunk://#diff-ad64326d8815f1468cc04c24d815ce676cf9ac8c28d6d2a5021259f972238ff4L61-R65)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43712
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
