### PR TITLE
Accept `entity_id: none` for state trigger

### DIFF
--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -9,7 +9,13 @@ import logging
 import voluptuous as vol
 
 from homeassistant import exceptions
-from homeassistant.const import CONF_ATTRIBUTE, CONF_FOR, CONF_PLATFORM, MATCH_ALL
+from homeassistant.const import (
+    CONF_ATTRIBUTE,
+    CONF_FOR,
+    CONF_PLATFORM,
+    ENTITY_MATCH_NONE,
+    MATCH_ALL,
+)
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
@@ -43,7 +49,9 @@ CONF_NOT_TO = "not_to"
 BASE_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "state",
-        vol.Required(CONF_ENTITY_ID): cv.entity_ids_or_uuids,
+        vol.Required(CONF_ENTITY_ID): vol.Any(
+            ENTITY_MATCH_NONE, cv.entity_ids_or_uuids
+        ),
         vol.Optional(CONF_FOR): cv.positive_time_period_template,
         vol.Optional(CONF_ATTRIBUTE): cv.match_all,
     }
@@ -84,9 +92,10 @@ async def async_validate_trigger_config(
         config = TRIGGER_STATE_SCHEMA(config)
 
     registry = er.async_get(hass)
-    config[CONF_ENTITY_ID] = er.async_validate_entity_ids(
-        registry, cv.entity_ids_or_uuids(config[CONF_ENTITY_ID])
-    )
+    if config[CONF_ENTITY_ID] != ENTITY_MATCH_NONE:
+        config[CONF_ENTITY_ID] = er.async_validate_entity_ids(
+            registry, cv.entity_ids_or_uuids(config[CONF_ENTITY_ID])
+        )
 
     return config
 
@@ -101,6 +110,9 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     entity_ids = config[CONF_ENTITY_ID]
+
+    if entity_ids == ENTITY_MATCH_NONE:
+        return lambda: None
 
     if (from_state := config.get(CONF_FROM)) is not None:
         match_from_state = process_state_match(from_state)

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -11,6 +11,7 @@ from homeassistant.components.homeassistant.triggers import state as state_trigg
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
+    ENTITY_MATCH_NONE,
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
@@ -1769,3 +1770,29 @@ async def test_variables_priority(
     await hass.async_block_till_done()
     assert len(service_calls) == 2
     assert service_calls[1].data["some"] == "test.entity_2 - 0:00:10"
+
+
+async def test_trigger_on_none(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test for a trigger with no entity."""
+    hass.states.async_set("test.entity", "hello")
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "state", "entity_id": ENTITY_MATCH_NONE},
+                "action": {
+                    "service": "test.automation",
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
     SERVICE_TURN_OFF,
+    STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import Context, HomeAssistant, ServiceCall
@@ -1795,4 +1796,8 @@ async def test_trigger_on_none(
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
+    # Check the automation setup successfully
+    assert hass.states.get("automation.automation_0").state == STATE_ON
+    assert hass.states.get("automation.automation_0").attributes.get("current") == 0
+    # Check that the automation has never triggered
     assert len(service_calls) == 0


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Blueprints currently lack a clean way to create a state trigger on an optional entity. You can create an optional entity selector, but if you try to use this entity in a state trigger, there is no nullish default that can be used, as only strict entity ids are accepted by validation for the state trigger. 

This PR allows `entity_id: "none"` to be a valid syntax for a state trigger, so that a blueprint can use "none" as the fallback for an unselected entity id. 

This matches similar syntax used by actions/target selector which accept the magic value `entity_id: none` for a target. 

This was also a previous syntax [suggested by Frenck](https://github.com/home-assistant/core/pull/117937#issuecomment-2199868468) as the way to handle this.

Some BPs currently use `entity_id: []` as a default, which kind of works in a similar way, but this is problematic for frontend as using an array value for an entity selector is unexpected, which only expected a single element/string.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/161168
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/29015
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
