### PR TITLE
Avoid adding Content-Type to non-body responses

### DIFF
--- a/homeassistant/components/hassio/ingress.py
+++ b/homeassistant/components/hassio/ingress.py
@@ -181,8 +181,7 @@ class HassIOIngress(HomeAssistantView):
             skip_auto_headers={hdrs.CONTENT_TYPE},
         ) as result:
             headers = _response_header(result)
-            content_length_int = 0
-            content_length = result.headers.get(hdrs.CONTENT_LENGTH, UNDEFINED)
+
             # Avoid parsing content_type in simple cases for better performance
             if maybe_content_type := result.headers.get(hdrs.CONTENT_TYPE):
                 content_type: str = (maybe_content_type.partition(";"))[0].strip()
@@ -190,17 +189,30 @@ class HassIOIngress(HomeAssistantView):
                 # default value according to RFC 2616
                 content_type = "application/octet-stream"
 
+            # Empty body responses (304, 204, HEAD, etc.) should not be streamed,
+            # otherwise aiohttp < 3.9.0 may generate an invalid "0\r\n\r\n" chunk
+            # This also avoids setting content_type for empty responses.
+            if must_be_empty_body(request.method, result.status):
+                # If upstream contains content-type, preserve it (e.g. for HEAD requests)
+                # Note: This still is omitting content-length. We can't simply forward
+                # the upstream length since the proxy might change the body length
+                # (e.g. due to compression).
+                if maybe_content_type:
+                    headers[hdrs.CONTENT_TYPE] = content_type
+                return web.Response(
+                    headers=headers,
+                    status=result.status,
+                )
+
             # Simple request
-            if (empty_body := must_be_empty_body(result.method, result.status)) or (
+            content_length_int = 0
+            content_length = result.headers.get(hdrs.CONTENT_LENGTH, UNDEFINED)
+            if (
                 content_length is not UNDEFINED
                 and (content_length_int := int(content_length))
                 <= MAX_SIMPLE_RESPONSE_SIZE
             ):
-                # Return Response
-                if empty_body:
-                    body = None
-                else:
-                    body = await result.read()
+                body = await result.read()
                 simple_response = web.Response(
                     headers=headers,
                     status=result.status,

--- a/tests/components/hassio/test_ingress.py
+++ b/tests/components/hassio/test_ingress.py
@@ -3,7 +3,12 @@
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
-from aiohttp.hdrs import X_FORWARDED_FOR, X_FORWARDED_HOST, X_FORWARDED_PROTO
+from aiohttp.hdrs import (
+    CONTENT_TYPE,
+    X_FORWARDED_FOR,
+    X_FORWARDED_HOST,
+    X_FORWARDED_PROTO,
+)
 from multidict import CIMultiDict
 import pytest
 
@@ -322,6 +327,106 @@ async def test_ingress_request_head(
     assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_FOR]
     assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_HOST]
     assert aioclient_mock.mock_calls[-1][3][X_FORWARDED_PROTO]
+
+
+async def test_ingress_request_head_with_content_type(
+    hassio_noauth_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test HEAD request preserves content-type from upstream."""
+    aioclient_mock.head(
+        "http://127.0.0.1/ingress/core/index.html",
+        text="",
+        headers={"Content-Type": "text/html; charset=utf-8"},
+    )
+
+    resp = await hassio_noauth_client.head(
+        "/api/hassio_ingress/core/index.html",
+    )
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.text()
+    assert body == ""
+    assert resp.headers[CONTENT_TYPE] == "text/html"
+
+
+async def test_ingress_request_head_without_content_type(
+    hassio_noauth_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test HEAD request without upstream content-type omits it."""
+    aioclient_mock.head(
+        "http://127.0.0.1/ingress/core/index.html",
+        text="",
+    )
+
+    resp = await hassio_noauth_client.head(
+        "/api/hassio_ingress/core/index.html",
+    )
+
+    assert resp.status == HTTPStatus.OK
+    body = await resp.text()
+    assert body == ""
+    assert CONTENT_TYPE not in resp.headers
+
+
+async def test_ingress_request_304_no_content_type(
+    hassio_noauth_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test 304 Not Modified does not include content-type when upstream omits it."""
+    aioclient_mock.get(
+        "http://127.0.0.1/ingress/core/index.html",
+        text="",
+        status=HTTPStatus.NOT_MODIFIED,
+    )
+
+    resp = await hassio_noauth_client.get(
+        "/api/hassio_ingress/core/index.html",
+    )
+
+    assert resp.status == HTTPStatus.NOT_MODIFIED
+    body = await resp.text()
+    assert body == ""
+    assert CONTENT_TYPE not in resp.headers
+
+
+async def test_ingress_request_304_with_content_type(
+    hassio_noauth_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test 304 Not Modified preserves content-type when upstream provides it."""
+    aioclient_mock.get(
+        "http://127.0.0.1/ingress/core/index.html",
+        text="",
+        status=HTTPStatus.NOT_MODIFIED,
+        headers={"Content-Type": "text/html"},
+    )
+
+    resp = await hassio_noauth_client.get(
+        "/api/hassio_ingress/core/index.html",
+    )
+
+    assert resp.status == HTTPStatus.NOT_MODIFIED
+    body = await resp.text()
+    assert body == ""
+    assert resp.headers[CONTENT_TYPE] == "text/html"
+
+
+async def test_ingress_request_204_no_content(
+    hassio_noauth_client, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test 204 No Content does not include content-type."""
+    aioclient_mock.get(
+        "http://127.0.0.1/ingress/core/api/status",
+        text="",
+        status=HTTPStatus.NO_CONTENT,
+    )
+
+    resp = await hassio_noauth_client.get(
+        "/api/hassio_ingress/core/api/status",
+    )
+
+    assert resp.status == HTTPStatus.NO_CONTENT
+    body = await resp.text()
+    assert body == ""
+    assert CONTENT_TYPE not in resp.headers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current code sets the content-type header for all responses to the result's content_type property if upstream does not set a content_type. The default value for content_type is "application/octet-stream".

For responses that do not have a body (like 204 No Content or 304 Not Modified), setting a content-type header is unnecessary and potentially misleading. Follow HTTP standards by only adding the content-type header to responses that actually contain a body.

This mirrors a similar change in Supervisor PR https://github.com/home-assistant/supervisor/pull/6266.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
