### PR TITLE
Skip unknown entity types in ESPHome integration

### DIFF
--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -302,6 +302,8 @@ class RuntimeEntryData:
                 needed_platforms.add(Platform.BINARY_SENSOR)
                 needed_platforms.add(Platform.SELECT)
 
+        # Make a dict of the EntityInfo by type and send
+        # them to the listeners for each specific EntityInfo type
         info_types_to_platform = INFO_TYPE_TO_PLATFORM
         infos_by_type: defaultdict[type[EntityInfo], list[EntityInfo]] = defaultdict(
             list

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -250,10 +250,12 @@ class RuntimeEntryData:
         # Remove from entity registry first so the entity is fully removed
         ent_reg = er.async_get(hass)
         for info in static_infos:
-            if entry := ent_reg.async_get_entity_id(
-                INFO_TYPE_TO_PLATFORM[type(info)],
-                DOMAIN,
-                build_device_unique_id(mac, info),
+            if (platform := INFO_TYPE_TO_PLATFORM.get(type(info))) and (
+                entry := ent_reg.async_get_entity_id(
+                    platform,
+                    DOMAIN,
+                    build_device_unique_id(mac, info),
+                )
             ):
                 ent_reg.async_remove(entry)
 
@@ -300,7 +302,19 @@ class RuntimeEntryData:
                 needed_platforms.add(Platform.BINARY_SENSOR)
                 needed_platforms.add(Platform.SELECT)
 
-        needed_platforms.update(INFO_TYPE_TO_PLATFORM[type(info)] for info in infos)
+        info_types_to_platform = INFO_TYPE_TO_PLATFORM
+        for info in infos:
+            info_type = type(info)
+            if info_type not in info_types_to_platform:
+                _LOGGER.warning(
+                    "Entity type %s is not supported in this version of Home Assistant",
+                    info_type,
+                )
+        needed_platforms.update(
+            info_types_to_platform[type(info)]
+            for info in infos
+            if type(info) in info_types_to_platform
+        )
         await self._ensure_platforms_loaded(hass, entry, needed_platforms)
 
         # Make a dict of the EntityInfo by type and send
@@ -309,7 +323,8 @@ class RuntimeEntryData:
             list
         )
         for info in infos:
-            infos_by_type[type(info)].append(info)
+            if type(info) in info_types_to_platform:
+                infos_by_type[type(info)].append(info)
 
         for type_, callbacks in self.entity_info_callbacks.items():
             # If all entities for a type are removed, we

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -250,12 +250,10 @@ class RuntimeEntryData:
         # Remove from entity registry first so the entity is fully removed
         ent_reg = er.async_get(hass)
         for info in static_infos:
-            if (platform := INFO_TYPE_TO_PLATFORM.get(type(info))) and (
-                entry := ent_reg.async_get_entity_id(
-                    platform,
-                    DOMAIN,
-                    build_device_unique_id(mac, info),
-                )
+            if entry := ent_reg.async_get_entity_id(
+                INFO_TYPE_TO_PLATFORM[type(info)],
+                DOMAIN,
+                build_device_unique_id(mac, info),
             ):
                 ent_reg.async_remove(entry)
 

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -303,28 +303,20 @@ class RuntimeEntryData:
                 needed_platforms.add(Platform.SELECT)
 
         info_types_to_platform = INFO_TYPE_TO_PLATFORM
-        for info in infos:
-            info_type = type(info)
-            if info_type not in info_types_to_platform:
-                _LOGGER.warning(
-                    "Entity type %s is not supported in this version of Home Assistant",
-                    info_type,
-                )
-        needed_platforms.update(
-            info_types_to_platform[type(info)]
-            for info in infos
-            if type(info) in info_types_to_platform
-        )
-        await self._ensure_platforms_loaded(hass, entry, needed_platforms)
-
-        # Make a dict of the EntityInfo by type and send
-        # them to the listeners for each specific EntityInfo type
         infos_by_type: defaultdict[type[EntityInfo], list[EntityInfo]] = defaultdict(
             list
         )
         for info in infos:
-            if type(info) in info_types_to_platform:
-                infos_by_type[type(info)].append(info)
+            info_type = type(info)
+            if platform := info_types_to_platform.get(info_type):
+                needed_platforms.add(platform)
+                infos_by_type[info_type].append(info)
+            else:
+                _LOGGER.warning(
+                    "Entity type %s is not supported in this version of Home Assistant",
+                    info_type,
+                )
+        await self._ensure_platforms_loaded(hass, entry, needed_platforms)
 
         for type_, callbacks in self.entity_info_callbacks.items():
             # If all entities for a type are removed, we

--- a/tests/components/esphome/test_entry_data.py
+++ b/tests/components/esphome/test_entry_data.py
@@ -5,9 +5,11 @@ from unittest.mock import Mock, patch
 from aioesphomeapi import (
     APIClient,
     EntityCategory as ESPHomeEntityCategory,
+    EntityInfo,
     SensorInfo,
     SensorState,
 )
+import pytest
 
 from homeassistant.components.esphome import DOMAIN
 from homeassistant.components.esphome.entry_data import RuntimeEntryData
@@ -152,3 +154,42 @@ async def test_discover_zwave_without_home_id() -> None:
         )
         # Verify async_create_flow was NOT called when zwave_home_id is 0
         mock_create_flow.assert_not_called()
+
+
+async def test_unknown_entity_type_skipped(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that unknown entity types are skipped gracefully."""
+
+    class UnknownInfo(EntityInfo):
+        """Mock unknown entity info type."""
+
+    entity_info = [
+        SensorInfo(
+            object_id="mysensor",
+            key=1,
+            name="my sensor",
+        ),
+        UnknownInfo(
+            object_id="unknown",
+            key=2,
+            name="unknown entity",
+        ),
+    ]
+    states = [SensorState(key=1, state=42)]
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    assert "UnknownInfo" in caplog.text
+    assert "not supported in this version of Home Assistant" in caplog.text
+
+    # Known entity still works
+    state = hass.states.get("sensor.test_my_sensor")
+    assert state is not None
+    assert state.state == "42"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a newer version of `aioesphomeapi` introduces entity types that Home Assistant doesn't yet have a platform mapping for (e.g., `InfraredInfo`), the ESPHome integration crashes with a `KeyError` during connection, preventing the device from connecting entirely.

This change gracefully skips unknown entity types instead of crashing, logs a warning that the entity type is not supported in this version of Home Assistant, and allows all known entities to continue working normally.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/esphome/esphome/issues/14218
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr