### PR TITLE
Add v6 firmware support to airOS

### DIFF
--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -6,6 +6,13 @@ import logging
 
 from airos.airos6 import AirOS6
 from airos.airos8 import AirOS8
+from airos.exceptions import (
+    AirOSConnectionAuthenticationError,
+    AirOSConnectionSetupError,
+    AirOSDataMissingError,
+    AirOSDeviceConnectionError,
+    AirOSKeyDataMissingError,
+)
 from airos.helpers import DetectDeviceData, async_get_firmware_data
 
 from homeassistant.const import (
@@ -17,6 +24,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    ConfigEntryNotReady,
+)
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -50,7 +62,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
     }
 
     # Determine firmware version before creating the device instance
-    device_data: DetectDeviceData = await async_get_firmware_data(**conn_data)
+    try:
+        device_data: DetectDeviceData = await async_get_firmware_data(**conn_data)
+    except (
+        AirOSConnectionSetupError,
+        AirOSDeviceConnectionError,
+        TimeoutError,
+    ) as err:
+        raise ConfigEntryNotReady from err
+    except (
+        AirOSConnectionAuthenticationError,
+        AirOSDataMissingError,
+    ) as err:
+        raise ConfigEntryAuthFailed from err
+    except AirOSKeyDataMissingError as err:
+        raise ConfigEntryError("key_data_missing") from err
+    except Exception as err:
+        raise ConfigEntryError("unknown") from err
+
     airos_class: type[AirOS8 | AirOS6] = (
         AirOS8 if device_data["fw_major"] == 8 else AirOS6
     )

--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 
+from airos.airos6 import AirOS6
 from airos.airos8 import AirOS8
+from airos.helpers import DetectDeviceData, async_get_firmware_data
 
 from homeassistant.const import (
     CONF_HOST,
@@ -39,15 +41,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> boo
         hass, verify_ssl=entry.data[SECTION_ADVANCED_SETTINGS][CONF_VERIFY_SSL]
     )
 
-    airos_device = AirOS8(
-        host=entry.data[CONF_HOST],
-        username=entry.data[CONF_USERNAME],
-        password=entry.data[CONF_PASSWORD],
-        session=session,
-        use_ssl=entry.data[SECTION_ADVANCED_SETTINGS][CONF_SSL],
+    conn_data = {
+        CONF_HOST: entry.data[CONF_HOST],
+        CONF_USERNAME: entry.data[CONF_USERNAME],
+        CONF_PASSWORD: entry.data[CONF_PASSWORD],
+        "use_ssl": entry.data[SECTION_ADVANCED_SETTINGS][CONF_SSL],
+        "session": session,
+    }
+
+    # Determine firmware version before creating the device instance
+    device_data: DetectDeviceData = await async_get_firmware_data(**conn_data)
+    airos_class: type[AirOS8 | AirOS6] = (
+        AirOS8 if device_data["fw_major"] == 8 else AirOS6
     )
 
-    coordinator = AirOSDataUpdateCoordinator(hass, entry, airos_device)
+    airos_device = airos_class(**conn_data)
+
+    coordinator = AirOSDataUpdateCoordinator(hass, entry, device_data, airos_device)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator

--- a/homeassistant/components/airos/binary_sensor.py
+++ b/homeassistant/components/airos/binary_sensor.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-import logging
+from typing import Generic, TypeVar
+
+from airos.data import AirOSDataBaseClass
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -18,25 +20,24 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import AirOS8Data, AirOSConfigEntry, AirOSDataUpdateCoordinator
 from .entity import AirOSEntity
 
-_LOGGER = logging.getLogger(__name__)
-
 PARALLEL_UPDATES = 0
+
+AirOSDataModel = TypeVar("AirOSDataModel", bound=AirOSDataBaseClass)
 
 
 @dataclass(frozen=True, kw_only=True)
-class AirOSBinarySensorEntityDescription(BinarySensorEntityDescription):
+class AirOSBinarySensorEntityDescription(
+    BinarySensorEntityDescription,
+    Generic[AirOSDataModel],
+):
     """Describe an AirOS binary sensor."""
 
-    value_fn: Callable[[AirOS8Data], bool]
+    value_fn: Callable[[AirOSDataModel], bool]
 
 
-BINARY_SENSORS: tuple[AirOSBinarySensorEntityDescription, ...] = (
-    AirOSBinarySensorEntityDescription(
-        key="portfw",
-        translation_key="port_forwarding",
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.portfw,
-    ),
+AirOS8BinarySensorEntityDescription = AirOSBinarySensorEntityDescription[AirOS8Data]
+
+COMMON_BINARY_SENSORS: tuple[AirOSBinarySensorEntityDescription, ...] = (
     AirOSBinarySensorEntityDescription(
         key="dhcp_client",
         translation_key="dhcp_client",
@@ -53,19 +54,28 @@ BINARY_SENSORS: tuple[AirOSBinarySensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
     ),
     AirOSBinarySensorEntityDescription(
-        key="dhcp6_server",
-        translation_key="dhcp6_server",
-        device_class=BinarySensorDeviceClass.RUNNING,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda data: data.services.dhcp6d_stateful,
-        entity_registry_enabled_default=False,
-    ),
-    AirOSBinarySensorEntityDescription(
         key="pppoe",
         translation_key="pppoe",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda data: data.services.pppoe,
+        entity_registry_enabled_default=False,
+    ),
+)
+
+AIROS8_BINARY_SENSORS: tuple[AirOS8BinarySensorEntityDescription, ...] = (
+    AirOS8BinarySensorEntityDescription(
+        key="portfw",
+        translation_key="port_forwarding",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.portfw,
+    ),
+    AirOS8BinarySensorEntityDescription(
+        key="dhcp6_server",
+        translation_key="dhcp6_server",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.services.dhcp6d_stateful,
         entity_registry_enabled_default=False,
     ),
 )
@@ -80,8 +90,15 @@ async def async_setup_entry(
     coordinator = config_entry.runtime_data
 
     async_add_entities(
-        AirOSBinarySensor(coordinator, description) for description in BINARY_SENSORS
+        AirOSBinarySensor(coordinator, description)
+        for description in COMMON_BINARY_SENSORS
     )
+
+    if coordinator.device_data["fw_major"] == 8:
+        async_add_entities(
+            AirOSBinarySensor(coordinator, description)
+            for description in AIROS8_BINARY_SENSORS
+        )
 
 
 class AirOSBinarySensor(AirOSEntity, BinarySensorEntity):

--- a/homeassistant/components/airos/binary_sensor.py
+++ b/homeassistant/components/airos/binary_sensor.py
@@ -89,16 +89,19 @@ async def async_setup_entry(
     """Set up the AirOS binary sensors from a config entry."""
     coordinator = config_entry.runtime_data
 
-    async_add_entities(
+    entities: list[BinarySensorEntity] = []
+    entities.extend(
         AirOSBinarySensor(coordinator, description)
         for description in COMMON_BINARY_SENSORS
     )
 
     if coordinator.device_data["fw_major"] == 8:
-        async_add_entities(
+        entities.extend(
             AirOSBinarySensor(coordinator, description)
             for description in AIROS8_BINARY_SENSORS
         )
+
+    async_add_entities(entities)
 
 
 class AirOSBinarySensor(AirOSEntity, BinarySensorEntity):

--- a/homeassistant/components/airos/button.py
+++ b/homeassistant/components/airos/button.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from airos.exceptions import AirOSException
 
 from homeassistant.components.button import (
@@ -17,8 +15,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import DOMAIN, AirOSConfigEntry, AirOSDataUpdateCoordinator
 from .entity import AirOSEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/airos/config_flow.py
+++ b/homeassistant/components/airos/config_flow.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+from airos.airos6 import AirOS6
+from airos.airos8 import AirOS8
 from airos.discovery import airos_discover_devices
 from airos.exceptions import (
     AirOSConnectionAuthenticationError,
@@ -17,6 +19,7 @@ from airos.exceptions import (
     AirOSKeyDataMissingError,
     AirOSListenerError,
 )
+from airos.helpers import DetectDeviceData, async_get_firmware_data
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -53,9 +56,10 @@ from .const import (
     MAC_ADDRESS,
     SECTION_ADVANCED_SETTINGS,
 )
-from .coordinator import AirOS8
 
 _LOGGER = logging.getLogger(__name__)
+
+AirOSDeviceDetect = AirOS8 | AirOS6
 
 # Discovery duration in seconds, airOS announces every 20 seconds
 DISCOVER_INTERVAL: int = 30
@@ -92,7 +96,7 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         super().__init__()
-        self.airos_device: AirOS8
+        self.airos_device: AirOSDeviceDetect
         self.errors: dict[str, str] = {}
         self.discovered_devices: dict[str, dict[str, Any]] = {}
         self.discovery_abort_reason: str | None = None
@@ -135,16 +139,14 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
             verify_ssl=config_data[SECTION_ADVANCED_SETTINGS][CONF_VERIFY_SSL],
         )
 
-        airos_device = AirOS8(
-            host=config_data[CONF_HOST],
-            username=config_data[CONF_USERNAME],
-            password=config_data[CONF_PASSWORD],
-            session=session,
-            use_ssl=config_data[SECTION_ADVANCED_SETTINGS][CONF_SSL],
-        )
         try:
-            await airos_device.login()
-            airos_data = await airos_device.status()
+            device_data: DetectDeviceData = await async_get_firmware_data(
+                host=config_data[CONF_HOST],
+                username=config_data[CONF_USERNAME],
+                password=config_data[CONF_PASSWORD],
+                session=session,
+                use_ssl=config_data[SECTION_ADVANCED_SETTINGS][CONF_SSL],
+            )
 
         except (
             AirOSConnectionSetupError,
@@ -159,14 +161,14 @@ class AirOSConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception during credential validation")
             self.errors["base"] = "unknown"
         else:
-            await self.async_set_unique_id(airos_data.derived.mac)
+            await self.async_set_unique_id(device_data["mac"])
 
             if self.source in [SOURCE_REAUTH, SOURCE_RECONFIGURE]:
                 self._abort_if_unique_id_mismatch()
             else:
                 self._abort_if_unique_id_configured()
 
-            return {"title": airos_data.host.hostname, "data": config_data}
+            return {"title": device_data["hostname"], "data": config_data}
 
         return None
 

--- a/homeassistant/components/airos/sensor.py
+++ b/homeassistant/components/airos/sensor.py
@@ -186,7 +186,7 @@ async def async_setup_entry(
         AirOSSensor(coordinator, description) for description in COMMON_SENSORS
     )
 
-    if coordinator.device_data.get("fw_major") == 8:
+    if coordinator.device_data["fw_major"] == 8:
         async_add_entities(
             AirOSSensor(coordinator, description) for description in AIROS8_SENSORS
         )

--- a/homeassistant/components/airos/sensor.py
+++ b/homeassistant/components/airos/sensor.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
+from typing import Generic, TypeVar
 
-from airos.data import DerivedWirelessMode, DerivedWirelessRole, NetRole
+from airos.data import (
+    AirOSDataBaseClass,
+    DerivedWirelessMode,
+    DerivedWirelessRole,
+    NetRole,
+)
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -37,15 +43,19 @@ WIRELESS_ROLE_OPTIONS = [mode.value for mode in DerivedWirelessRole]
 
 PARALLEL_UPDATES = 0
 
+AirOSDataModel = TypeVar("AirOSDataModel", bound=AirOSDataBaseClass)
+
 
 @dataclass(frozen=True, kw_only=True)
-class AirOSSensorEntityDescription(SensorEntityDescription):
+class AirOSSensorEntityDescription(SensorEntityDescription, Generic[AirOSDataModel]):
     """Describe an AirOS sensor."""
 
-    value_fn: Callable[[AirOS8Data], StateType]
+    value_fn: Callable[[AirOSDataModel], StateType]
 
 
-SENSORS: tuple[AirOSSensorEntityDescription, ...] = (
+AirOS8SensorEntityDescription = AirOSSensorEntityDescription[AirOS8Data]
+
+COMMON_SENSORS: tuple[AirOSSensorEntityDescription, ...] = (
     AirOSSensorEntityDescription(
         key="host_cpuload",
         translation_key="host_cpuload",
@@ -74,54 +84,6 @@ SENSORS: tuple[AirOSSensorEntityDescription, ...] = (
         key="wireless_essid",
         translation_key="wireless_essid",
         value_fn=lambda data: data.wireless.essid,
-    ),
-    AirOSSensorEntityDescription(
-        key="wireless_antenna_gain",
-        translation_key="wireless_antenna_gain",
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda data: data.wireless.antenna_gain,
-    ),
-    AirOSSensorEntityDescription(
-        key="wireless_throughput_tx",
-        translation_key="wireless_throughput_tx",
-        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
-        value_fn=lambda data: data.wireless.throughput.tx,
-    ),
-    AirOSSensorEntityDescription(
-        key="wireless_throughput_rx",
-        translation_key="wireless_throughput_rx",
-        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
-        value_fn=lambda data: data.wireless.throughput.rx,
-    ),
-    AirOSSensorEntityDescription(
-        key="wireless_polling_dl_capacity",
-        translation_key="wireless_polling_dl_capacity",
-        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
-        value_fn=lambda data: data.wireless.polling.dl_capacity,
-    ),
-    AirOSSensorEntityDescription(
-        key="wireless_polling_ul_capacity",
-        translation_key="wireless_polling_ul_capacity",
-        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
-        device_class=SensorDeviceClass.DATA_RATE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
-        value_fn=lambda data: data.wireless.polling.ul_capacity,
     ),
     AirOSSensorEntityDescription(
         key="host_uptime",
@@ -158,6 +120,57 @@ SENSORS: tuple[AirOSSensorEntityDescription, ...] = (
         options=WIRELESS_ROLE_OPTIONS,
         entity_registry_enabled_default=False,
     ),
+    AirOSSensorEntityDescription(
+        key="wireless_antenna_gain",
+        translation_key="wireless_antenna_gain",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: data.wireless.antenna_gain,
+    ),
+    AirOSSensorEntityDescription(
+        key="wireless_polling_dl_capacity",
+        translation_key="wireless_polling_dl_capacity",
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        value_fn=lambda data: data.wireless.polling.dl_capacity,
+    ),
+    AirOSSensorEntityDescription(
+        key="wireless_polling_ul_capacity",
+        translation_key="wireless_polling_ul_capacity",
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        value_fn=lambda data: data.wireless.polling.ul_capacity,
+    ),
+)
+
+AIROS8_SENSORS: tuple[AirOS8SensorEntityDescription, ...] = (
+    AirOS8SensorEntityDescription(
+        key="wireless_throughput_tx",
+        translation_key="wireless_throughput_tx",
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        value_fn=lambda data: data.wireless.throughput.tx,
+    ),
+    AirOS8SensorEntityDescription(
+        key="wireless_throughput_rx",
+        translation_key="wireless_throughput_rx",
+        native_unit_of_measurement=UnitOfDataRate.KILOBITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        value_fn=lambda data: data.wireless.throughput.rx,
+    ),
 )
 
 
@@ -169,7 +182,14 @@ async def async_setup_entry(
     """Set up the AirOS sensors from a config entry."""
     coordinator = config_entry.runtime_data
 
-    async_add_entities(AirOSSensor(coordinator, description) for description in SENSORS)
+    async_add_entities(
+        AirOSSensor(coordinator, description) for description in COMMON_SENSORS
+    )
+
+    if coordinator.device_data.get("fw_major") == 8:
+        async_add_entities(
+            AirOSSensor(coordinator, description) for description in AIROS8_SENSORS
+        )
 
 
 class AirOSSensor(AirOSEntity, SensorEntity):

--- a/tests/components/airos/__init__.py
+++ b/tests/components/airos/__init__.py
@@ -1,9 +1,14 @@
 """Tests for the Ubiquity airOS integration."""
 
+from airos.airos6 import AirOS6Data
+from airos.airos8 import AirOS8Data
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, patch
+
+AirOSData = AirOS8Data | AirOS6Data
 
 
 async def setup_integration(

--- a/tests/components/airos/conftest.py
+++ b/tests/components/airos/conftest.py
@@ -105,14 +105,17 @@ def mock_async_get_firmware_data(ap_fixture: AirOSData):
         mac=ap_fixture.derived.mac,
         hostname=ap_fixture.host.hostname,
     )
+
+    mock = AsyncMock(return_value=return_value)
+
     with (
         patch(
             "homeassistant.components.airos.config_flow.async_get_firmware_data",
-            new=AsyncMock(return_value=return_value),
+            new=mock,
         ),
         patch(
             "homeassistant.components.airos.async_get_firmware_data",
-            new=AsyncMock(return_value=return_value),
+            new=mock,
         ),
     ):
-        yield
+        yield mock

--- a/tests/components/airos/conftest.py
+++ b/tests/components/airos/conftest.py
@@ -3,19 +3,36 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from airos.airos6 import AirOS6Data
 from airos.airos8 import AirOS8Data
+from airos.helpers import DetectDeviceData
 import pytest
 
 from homeassistant.components.airos.const import DEFAULT_USERNAME, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
+from . import AirOSData
+
 from tests.common import MockConfigEntry, load_json_object_fixture
 
 
 @pytest.fixture
-def ap_fixture():
-    """Load fixture data for AP mode."""
+def ap_fixture(request: pytest.FixtureRequest) -> AirOSData:
+    """Load fixture data for airOS device."""
     json_data = load_json_object_fixture("airos_loco5ac_ap-ptp.json", DOMAIN)
+    if hasattr(request, "param"):
+        json_data = load_json_object_fixture(request.param, DOMAIN)
+
+    fwversion = json_data.get("host", {}).get("fwversion", "v0.0.0")
+    try:
+        fw_major = int(fwversion.lstrip("v").split(".", 1)[0])
+    except (ValueError, AttributeError) as err:
+        raise RuntimeError(
+            f"Could not parse firmware version from '{fwversion}'"
+        ) from err
+
+    if fw_major == 6:
+        return AirOS6Data.from_dict(json_data)
     return AirOS8Data.from_dict(json_data)
 
 
@@ -33,15 +50,18 @@ def mock_airos_class() -> Generator[MagicMock]:
     """Fixture to mock the AirOS class itself."""
     with (
         patch("homeassistant.components.airos.AirOS8", autospec=True) as mock_class,
+        patch("homeassistant.components.airos.AirOS6", new=mock_class),
         patch("homeassistant.components.airos.config_flow.AirOS8", new=mock_class),
+        patch("homeassistant.components.airos.config_flow.AirOS6", new=mock_class),
         patch("homeassistant.components.airos.coordinator.AirOS8", new=mock_class),
+        patch("homeassistant.components.airos.coordinator.AirOS6", new=mock_class),
     ):
         yield mock_class
 
 
 @pytest.fixture
 def mock_airos_client(
-    mock_airos_class: MagicMock, ap_fixture: AirOS8Data
+    mock_airos_class: MagicMock, ap_fixture: AirOSData
 ) -> Generator[AsyncMock]:
     """Fixture to mock the AirOS API client."""
     client = mock_airos_class.return_value
@@ -74,3 +94,25 @@ def mock_discovery_method() -> Generator[AsyncMock]:
         new_callable=AsyncMock,
     ) as mock_method:
         yield mock_method
+
+
+@pytest.fixture
+def mock_async_get_firmware_data(ap_fixture: AirOSData):
+    """Fixture to mock async_get_firmware_data to not do a network call."""
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    return_value = DetectDeviceData(
+        fw_major=fw_major,
+        mac=ap_fixture.derived.mac,
+        hostname=ap_fixture.host.hostname,
+    )
+    with (
+        patch(
+            "homeassistant.components.airos.config_flow.async_get_firmware_data",
+            new=AsyncMock(return_value=return_value),
+        ),
+        patch(
+            "homeassistant.components.airos.async_get_firmware_data",
+            new=AsyncMock(return_value=return_value),
+        ),
+    ):
+        yield

--- a/tests/components/airos/fixtures/airos_NanoStation_M5_sta_v6.3.16.json
+++ b/tests/components/airos/fixtures/airos_NanoStation_M5_sta_v6.3.16.json
@@ -1,0 +1,168 @@
+{
+  "airview": {
+    "enabled": 0
+  },
+  "derived": {
+    "access_point": false,
+    "fw_major": 6,
+    "mac": "XX:XX:XX:XX:XX:XX",
+    "mac_interface": "br0",
+    "mode": "point_to_point",
+    "ptmp": false,
+    "ptp": true,
+    "role": "station",
+    "sku": "NSM5",
+    "station": true
+  },
+  "firewall": {
+    "eb6tables": false,
+    "ebtables": true,
+    "ip6tables": false,
+    "iptables": false
+  },
+  "genuine": "/images/genuine.png",
+  "host": {
+    "cpubusy": 3786414,
+    "cpuload": 25.51,
+    "cputotal": 14845531,
+    "devmodel": "NanoStation M5 ",
+    "freeram": 42516480,
+    "fwprefix": "XW",
+    "fwversion": "v6.3.16",
+    "hostname": "NanoStation M5",
+    "netrole": "bridge",
+    "totalram": 63627264,
+    "uptime": 148479
+  },
+  "interfaces": [
+    {
+      "enabled": true,
+      "hwaddr": "00:00:00:00:00:00",
+      "ifname": "lo",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "XX:XX:XX:XX:XX:XX",
+      "ifname": "eth0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 100
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "XX:XX:XX:XX:XX:XX",
+      "ifname": "eth1",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": false,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "XX:XX:XX:XX:XX:XX",
+      "ifname": "wifi0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "XX:XX:XX:XX:XX:XX",
+      "ifname": "ath0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "XX:XX:XX:XX:XX:XX",
+      "ifname": "br0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    }
+  ],
+  "services": {
+    "dhcpc": false,
+    "dhcpd": false,
+    "pppoe": false
+  },
+  "unms": {
+    "status": 1,
+    "timestamp": ""
+  },
+  "wireless": {
+    "ack": 5,
+    "antenna": "Built in - 16 dBi",
+    "antenna_gain": 16,
+    "apmac": "xxxxxxxx",
+    "aprepeater": 0,
+    "cac_nol": 0,
+    "ccq": 991,
+    "chains": "2X2",
+    "chanbw": 40,
+    "channel": 36,
+    "countrycode": 840,
+    "dfs": 0,
+    "distance": 750,
+    "essid": "Nano",
+    "frequency": 5180,
+    "hide_essid": 0,
+    "ieeemode": "11NAHT40PLUS",
+    "mode": "sta",
+    "noisef": -99,
+    "nol_chans": 0,
+    "opmode": "11NAHT40PLUS",
+    "qos": "No QoS",
+    "rssi": 32,
+    "rstatus": 5,
+    "rxrate": "216",
+    "security": "WPA2",
+    "signal": -64,
+    "throughput": {
+      "rx": 216,
+      "tx": 270
+    },
+    "txpower": 24,
+    "txrate": "270",
+    "wds": 1
+  }
+}

--- a/tests/components/airos/fixtures/airos_NanoStation_loco_M5_v6.3.16_XM_sta.json
+++ b/tests/components/airos/fixtures/airos_NanoStation_loco_M5_v6.3.16_XM_sta.json
@@ -1,0 +1,154 @@
+{
+  "airview": {
+    "enabled": 0
+  },
+  "derived": {
+    "access_point": false,
+    "fw_major": 6,
+    "mac": "YY:YY:YY:YY:YY:YY",
+    "mac_interface": "br0",
+    "mode": "point_to_point",
+    "ptmp": false,
+    "ptp": true,
+    "role": "station",
+    "sku": "LocoM5",
+    "station": true
+  },
+  "firewall": {
+    "eb6tables": false,
+    "ebtables": true,
+    "ip6tables": false,
+    "iptables": false
+  },
+  "genuine": "/images/genuine.png",
+  "host": {
+    "cpubusy": 11150046,
+    "cpuload": 5.65,
+    "cputotal": 197455604,
+    "devmodel": "NanoStation loco M5 ",
+    "freeram": 8753152,
+    "fwprefix": "XM",
+    "fwversion": "v6.3.16",
+    "hostname": "NanoStation loco M5 Client",
+    "netrole": "bridge",
+    "totalram": 30220288,
+    "uptime": 1974859
+  },
+  "interfaces": [
+    {
+      "enabled": true,
+      "hwaddr": "00:00:00:00:00:00",
+      "ifname": "lo",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "YY:YY:YY:YY:YY:YY",
+      "ifname": "eth0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": false,
+        "ip6addr": null,
+        "plugged": false,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "YY:YY:YY:YY:YY:YY",
+      "ifname": "wifi0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "YY:YY:YY:YY:YY:YY",
+      "ifname": "ath0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 300
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "YY:YY:YY:YY:YY:YY",
+      "ifname": "br0",
+      "mtu": null,
+      "status": {
+        "cable_len": null,
+        "duplex": true,
+        "ip6addr": null,
+        "plugged": true,
+        "snr": null,
+        "speed": 0
+      }
+    }
+  ],
+  "services": {
+    "dhcpc": false,
+    "dhcpd": false,
+    "pppoe": false
+  },
+  "unms": {
+    "status": 0,
+    "timestamp": ""
+  },
+  "wireless": {
+    "ack": 28,
+    "antenna": "Built in - 13 dBi",
+    "antenna_gain": 13,
+    "apmac": "XX:XX:XX:XX:XX:XX",
+    "aprepeater": 0,
+    "cac_nol": 0,
+    "ccq": 738,
+    "chains": "2X2",
+    "chanbw": 40,
+    "channel": 140,
+    "countrycode": 616,
+    "dfs": 0,
+    "distance": 600,
+    "essid": "SOMETHING",
+    "frequency": 5700,
+    "hide_essid": 0,
+    "ieeemode": "11NAHT40MINUS",
+    "mode": "sta",
+    "noisef": -89,
+    "nol_chans": 0,
+    "opmode": "11naht40minus",
+    "qos": "No QoS",
+    "rssi": 50,
+    "rstatus": 5,
+    "rxrate": "180",
+    "security": "WPA2",
+    "signal": -46,
+    "throughput": {
+      "rx": 180,
+      "tx": 243
+    },
+    "txpower": 2,
+    "txrate": "243",
+    "wds": 1
+  }
+}

--- a/tests/components/airos/fixtures/airos_liteapgps_ap_ptmp_40mhz.json
+++ b/tests/components/airos/fixtures/airos_liteapgps_ap_ptmp_40mhz.json
@@ -1,0 +1,520 @@
+{
+  "chain_names": [
+    {
+      "name": "Chain 0",
+      "number": 1
+    },
+    {
+      "name": "Chain 1",
+      "number": 2
+    }
+  ],
+  "derived": {
+    "access_point": true,
+    "fw_major": 8,
+    "mac": "04:11:22:33:19:7E",
+    "mac_interface": "br0",
+    "mode": "point_to_multipoint",
+    "ptmp": true,
+    "ptp": false,
+    "role": "access_point",
+    "sku": "LAP-GPS",
+    "station": false
+  },
+  "firewall": {
+    "eb6tables": false,
+    "ebtables": false,
+    "ip6tables": false,
+    "iptables": false
+  },
+  "genuine": "/images/genuine.png",
+  "gps": {
+    "alt": 252.5,
+    "dim": 3,
+    "dop": 1.52,
+    "fix": 1,
+    "lat": 52.379894,
+    "lon": 4.901608,
+    "sats": 8,
+    "time_synced": null
+  },
+  "host": {
+    "cpuload": 59.595959,
+    "device_id": "b222d222222f2222f0e2ecbcc22d2e22",
+    "devmodel": "LiteAP GPS",
+    "freeram": 13541376,
+    "fwversion": "v8.7.18",
+    "height": null,
+    "hostname": "House-Bridge",
+    "loadavg": 0.188965,
+    "netrole": "bridge",
+    "power_time": 1461661,
+    "temperature": 0,
+    "time": "2025-08-06 16:37:55",
+    "timestamp": 2148019169,
+    "totalram": 63447040,
+    "uptime": 81655
+  },
+  "interfaces": [
+    {
+      "enabled": true,
+      "hwaddr": "05:11:22:33:19:7E",
+      "ifname": "eth0",
+      "mtu": 1500,
+      "status": {
+        "cable_len": 48,
+        "duplex": true,
+        "ip6addr": null,
+        "ipaddr": "0.0.0.0",
+        "plugged": true,
+        "rx_bytes": 17307482485,
+        "rx_dropped": 0,
+        "rx_errors": 0,
+        "rx_packets": 208585470,
+        "snr": [30, 30, 29, 29],
+        "speed": 1000,
+        "tx_bytes": 268785703196,
+        "tx_dropped": 1,
+        "tx_errors": 0,
+        "tx_packets": 212573426
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "04:11:22:33:19:7E",
+      "ifname": "ath0",
+      "mtu": 1500,
+      "status": {
+        "cable_len": null,
+        "duplex": false,
+        "ip6addr": null,
+        "ipaddr": "0.0.0.0",
+        "plugged": false,
+        "rx_bytes": 274358042002,
+        "rx_dropped": 0,
+        "rx_errors": 0,
+        "rx_packets": 212583924,
+        "snr": null,
+        "speed": 0,
+        "tx_bytes": 16450464430,
+        "tx_dropped": 227,
+        "tx_errors": 0,
+        "tx_packets": 150354889
+      }
+    },
+    {
+      "enabled": true,
+      "hwaddr": "04:11:22:33:19:7E",
+      "ifname": "br0",
+      "mtu": 1500,
+      "status": {
+        "cable_len": null,
+        "duplex": false,
+        "ip6addr": null,
+        "ipaddr": "127.0.0.85",
+        "plugged": true,
+        "rx_bytes": 6053730278,
+        "rx_dropped": 0,
+        "rx_errors": 0,
+        "rx_packets": 51908268,
+        "snr": null,
+        "speed": 0,
+        "tx_bytes": 38072153,
+        "tx_dropped": 0,
+        "tx_errors": 0,
+        "tx_packets": 99493
+      }
+    }
+  ],
+  "ntpclient": {
+    "last_sync": "2025-08-06 16:28:17"
+  },
+  "portfw": false,
+  "provmode": {},
+  "services": {
+    "airview": 2,
+    "dhcp6d_stateful": false,
+    "dhcpc": true,
+    "dhcpd": false,
+    "pppoe": false
+  },
+  "unms": {
+    "status": 0,
+    "timestamp": null
+  },
+  "wireless": {
+    "antenna_gain": 17,
+    "apmac": "03:11:22:33:19:7E",
+    "aprepeater": false,
+    "band": 2,
+    "cac_state": 0,
+    "cac_timeout": 0,
+    "center1_freq": 5690,
+    "chanbw": 40,
+    "compat_11n": 1,
+    "count": 2,
+    "dfs": 1,
+    "distance": 300,
+    "essid": "House-shed1",
+    "frequency": 5680,
+    "hide_essid": 0,
+    "ieeemode": "11ACVHT40",
+    "mode": "ap-ptmp",
+    "noisef": -92,
+    "nol_state": 0,
+    "nol_timeout": 0,
+    "polling": {
+      "atpc_status": 2,
+      "cb_capacity": 342000,
+      "dl_capacity": 342000,
+      "ff_cap_rep": false,
+      "fixed_frame": false,
+      "flex_mode": 1,
+      "gps_sync": false,
+      "rx_use": 98,
+      "tx_use": 168,
+      "ul_capacity": 342000,
+      "use": 266
+    },
+    "rstatus": 5,
+    "rx_chainmask": 3,
+    "rx_idx": 9,
+    "rx_nss": 2,
+    "security": "WPA2",
+    "service": {
+      "link": 1461418,
+      "time": 1461511
+    },
+    "sta": [
+      {
+        "airmax": {
+          "actual_priority": 2,
+          "atpc_status": 4,
+          "beam": 0,
+          "cb_capacity": 343800,
+          "desired_priority": 2,
+          "dl_capacity": 342000,
+          "rx": {
+            "cinr": 33,
+            "evm": [
+              [
+                33, 34, 37, 33, 34, 34, 35, 34, 35, 36, 33, 33, 31, 34, 33, 33,
+                33, 32, 32, 33, 34, 31, 33, 34, 34, 36, 33, 35, 34, 34, 33, 35,
+                34, 36, 33, 39, 31, 33, 34, 35, 31, 29, 32, 33, 36, 33, 33, 33,
+                32, 35, 33, 32, 32, 32, 35, 37, 34, 34, 32, 34, 36, 33, 32, 31
+              ],
+              [
+                42, 42, 42, 42, 43, 42, 42, 43, 43, 43, 42, 42, 42, 41, 43, 42,
+                42, 43, 42, 42, 42, 42, 43, 43, 43, 42, 44, 42, 42, 42, 42, 42,
+                43, 43, 41, 42, 42, 41, 42, 42, 42, 42, 42, 42, 41, 42, 41, 43,
+                41, 42, 42, 43, 41, 44, 43, 43, 43, 42, 44, 42, 42, 42, 42, 42
+              ]
+            ],
+            "usage": 34
+          },
+          "tx": {
+            "cinr": 33,
+            "evm": [
+              [
+                34, 31, 33, 35, 34, 35, 34, 31, 34, 33, 33, 29, 26, 35, 34, 35,
+                35, 28, 32, 32, 32, 27, 28, 36, 34, 32, 31, 33, 28, 34, 35, 33,
+                33, 34, 37, 33, 33, 32, 29, 32, 34, 37, 29, 33, 32, 33, 33, 32,
+                29, 32, 32, 31, 32, 32, 35, 32, 33, 31, 35, 33, 33, 30, 32, 33
+              ],
+              [
+                44, 43, 43, 43, 43, 43, 43, 44, 42, 44, 43, 43, 43, 44, 44, 44,
+                44, 44, 44, 44, 43, 43, 44, 44, 43, 42, 43, 43, 43, 44, 43, 43,
+                43, 43, 44, 44, 44, 43, 44, 43, 44, 43, 43, 43, 43, 43, 43, 43,
+                42, 43, 43, 43, 43, 43, 43, 43, 42, 43, 43, 43, 43, 43, 42, 44
+              ]
+            ],
+            "usage": 6
+          },
+          "ul_capacity": 345600
+        },
+        "airos_connected": true,
+        "cb_capacity_expect": 286000,
+        "chainrssi": [43, 41, 0],
+        "distance": 300,
+        "dl_avg_linkscore": 100,
+        "dl_capacity_expect": 260000,
+        "dl_linkscore": 100,
+        "dl_rate_expect": 7,
+        "dl_signal_expect": -68,
+        "last_disc": 0,
+        "lastip": "127.0.0.82",
+        "mac": "00:11:22:33:2E:05",
+        "noisefloor": -92,
+        "remote": {
+          "age": 3,
+          "airview": 2,
+          "antenna_gain": 19,
+          "cable_loss": 0,
+          "chainrssi": [44, 39, 0],
+          "compat_11n": 0,
+          "cpuload": 13.0,
+          "device_id": "22222dd22222c2e2b22d0d2222aedb38",
+          "distance": 300,
+          "ethlist": [
+            {
+              "cable_len": 1,
+              "duplex": true,
+              "enabled": true,
+              "ifname": "eth0",
+              "plugged": true,
+              "snr": [30, 29, 30, 30],
+              "speed": 1000
+            },
+            {
+              "cable_len": 0,
+              "duplex": true,
+              "enabled": true,
+              "ifname": "eth1",
+              "plugged": false,
+              "snr": [0, 0, 0, 0],
+              "speed": 0
+            }
+          ],
+          "freeram": 20488192,
+          "gps": {
+            "alt": null,
+            "dim": null,
+            "dop": null,
+            "fix": 0,
+            "lat": 52.379894,
+            "lon": 4.901608,
+            "sats": null,
+            "time_synced": null
+          },
+          "height": 2,
+          "hostname": "NanoBeam-shed2",
+          "ip6addr": null,
+          "ipaddr": ["127.0.0.82"],
+          "mode": "sta-ptmp",
+          "netrole": "bridge",
+          "noisefloor": -94,
+          "oob": false,
+          "platform": "NanoBeam 5AC",
+          "power_time": 16088831,
+          "rssi": 45,
+          "rx_bytes": 6168364701,
+          "rx_chainmask": 3,
+          "rx_throughput": 755,
+          "service": {
+            "link": 16087519,
+            "time": 16088594
+          },
+          "signal": -51,
+          "sys_id": "0xe7fc",
+          "temperature": 0,
+          "time": "2025-08-06 16:37:53",
+          "totalram": 63447040,
+          "tx_bytes": 35767943005,
+          "tx_power": -4,
+          "tx_ratedata": [2, 0, 1, 9, 4150, 89921, 4, 4, 28560, 7836817],
+          "tx_throughput": 4666,
+          "unms": {
+            "status": 0,
+            "timestamp": null
+          },
+          "uptime": 82335,
+          "version": "WA.ar934x.v8.7.18.48247.250728.0850"
+        },
+        "rssi": 45,
+        "rx_idx": 9,
+        "rx_nss": 2,
+        "signal": -51,
+        "stats": {
+          "rx_bytes": 35530195638,
+          "rx_packets": 30533587,
+          "rx_pps": 256,
+          "tx_bytes": 6597810092,
+          "tx_packets": 47272530,
+          "tx_pps": 0
+        },
+        "tx_idx": 9,
+        "tx_latency": 1,
+        "tx_lretries": 0,
+        "tx_nss": 2,
+        "tx_packets": 0,
+        "tx_ratedata": [2, 0, 1, 8, 8, 15523, 4, 4, 867, 7181836],
+        "tx_sretries": 0,
+        "ul_avg_linkscore": 100,
+        "ul_capacity_expect": 312000,
+        "ul_linkscore": 100,
+        "ul_rate_expect": 8,
+        "ul_signal_expect": -62,
+        "uptime": 81581
+      },
+      {
+        "airmax": {
+          "actual_priority": 2,
+          "atpc_status": 4,
+          "beam": 0,
+          "cb_capacity": 342000,
+          "desired_priority": 2,
+          "dl_capacity": 342000,
+          "rx": {
+            "cinr": 33,
+            "evm": [
+              [
+                32, 31, 34, 35, 32, 33, 31, 36, 35, 32, 41, 34, 34, 34, 31, 31,
+                33, 30, 34, 35, 32, 34, 31, 30, 33, 32, 29, 29, 36, 34, 32, 32,
+                32, 33, 33, 34, 33, 34, 35, 33, 34, 33, 33, 33, 33, 29, 32, 32,
+                31, 33, 33, 34, 34, 31, 34, 33, 29, 34, 34, 32, 30, 32, 32, 33
+              ],
+              [
+                50, 53, 51, 51, 51, 50, 53, 50, 52, 50, 51, 51, 50, 50, 49, 50,
+                52, 51, 50, 50, 51, 51, 50, 50, 52, 50, 50, 51, 50, 50, 50, 51,
+                50, 50, 49, 50, 50, 53, 51, 51, 50, 51, 52, 51, 51, 51, 51, 50,
+                50, 50, 52, 50, 50, 50, 50, 51, 51, 50, 51, 51, 52, 52, 53, 53
+              ]
+            ],
+            "usage": 62
+          },
+          "tx": {
+            "cinr": 34,
+            "evm": [
+              [
+                35, 34, 33, 34, 32, 32, 35, 31, 34, 32, 37, 34, 35, 33, 33, 32,
+                32, 33, 36, 33, 34, 33, 31, 35, 34, 35, 33, 33, 35, 32, 34, 34,
+                34, 33, 33, 34, 35, 36, 33, 33, 33, 36, 34, 36, 36, 33, 34, 34,
+                33, 34, 34, 34, 30, 32, 37, 35, 35, 35, 33, 35, 34, 32, 33, 34
+              ],
+              [
+                51, 52, 52, 50, 51, 52, 52, 51, 52, 51, 52, 52, 50, 52, 51, 52,
+                52, 51, 52, 51, 51, 51, 51, 51, 52, 51, 51, 51, 52, 51, 51, 51,
+                51, 51, 51, 51, 51, 51, 51, 52, 52, 51, 51, 51, 51, 51, 51, 51,
+                52, 51, 51, 51, 52, 52, 51, 50, 52, 52, 52, 51, 51, 52, 50, 51
+              ]
+            ],
+            "usage": 21
+          },
+          "ul_capacity": 342000
+        },
+        "airos_connected": true,
+        "cb_capacity_expect": 286000,
+        "chainrssi": [50, 51, 0],
+        "distance": 300,
+        "dl_avg_linkscore": 100,
+        "dl_capacity_expect": 260000,
+        "dl_linkscore": 100,
+        "dl_rate_expect": 7,
+        "dl_signal_expect": -68,
+        "last_disc": 0,
+        "lastip": "127.0.0.90",
+        "mac": "01:11:22:33:31:38",
+        "noisefloor": -92,
+        "remote": {
+          "age": 2,
+          "airview": 2,
+          "antenna_gain": 19,
+          "cable_loss": 0,
+          "chainrssi": [50, 52, 0],
+          "compat_11n": 0,
+          "cpuload": 23.5294,
+          "device_id": "2b2b22222b222222aa2fd22a22222c2c",
+          "distance": 300,
+          "ethlist": [
+            {
+              "cable_len": 1,
+              "duplex": true,
+              "enabled": true,
+              "ifname": "eth0",
+              "plugged": true,
+              "snr": [30, 30, 30, 30],
+              "speed": 1000
+            },
+            {
+              "cable_len": 0,
+              "duplex": true,
+              "enabled": true,
+              "ifname": "eth1",
+              "plugged": false,
+              "snr": [0, 0, 0, 0],
+              "speed": 0
+            }
+          ],
+          "freeram": 19714048,
+          "gps": {
+            "alt": null,
+            "dim": null,
+            "dop": null,
+            "fix": 0,
+            "lat": 52.379894,
+            "lon": 4.901608,
+            "sats": null,
+            "time_synced": null
+          },
+          "height": 2,
+          "hostname": "NanoBeam-shed1",
+          "ip6addr": null,
+          "ipaddr": ["127.0.0.90"],
+          "mode": "sta-ptmp",
+          "netrole": "bridge",
+          "noisefloor": -91,
+          "oob": false,
+          "platform": "NanoBeam 5AC",
+          "power_time": 1461670,
+          "rssi": 54,
+          "rx_bytes": 14205619701,
+          "rx_chainmask": 3,
+          "rx_throughput": 1322,
+          "service": {
+            "link": 1461239,
+            "time": 1461517
+          },
+          "signal": -42,
+          "sys_id": "0xe7fc",
+          "temperature": 0,
+          "time": "2025-08-06 16:37:53",
+          "totalram": 63447040,
+          "tx_bytes": 242792119032,
+          "tx_power": -4,
+          "tx_ratedata": [2, 0, 1, 8, 5296, 373316, 5, 788, 4003255, 21672948],
+          "tx_throughput": 23354,
+          "unms": {
+            "status": 0,
+            "timestamp": null
+          },
+          "uptime": 83207,
+          "version": "WA.ar934x.v8.7.18.48247.250728.0850"
+        },
+        "rssi": 54,
+        "rx_idx": 9,
+        "rx_nss": 2,
+        "signal": -42,
+        "stats": {
+          "rx_bytes": 238827846427,
+          "rx_packets": 182050337,
+          "rx_pps": 2641,
+          "tx_bytes": 14544700857,
+          "tx_packets": 131651046,
+          "tx_pps": 0
+        },
+        "tx_idx": 9,
+        "tx_latency": 1,
+        "tx_lretries": 0,
+        "tx_nss": 2,
+        "tx_packets": 0,
+        "tx_ratedata": [2, 0, 1, 8, 12, 31932, 4, 12, 363974, 20502633],
+        "tx_sretries": 0,
+        "ul_avg_linkscore": 100,
+        "ul_capacity_expect": 312000,
+        "ul_linkscore": 100,
+        "ul_rate_expect": 8,
+        "ul_signal_expect": -62,
+        "uptime": 81580
+      }
+    ],
+    "sta_disconnected": [],
+    "throughput": {
+      "rx": 24259,
+      "tx": 1565
+    },
+    "tx_chainmask": 3,
+    "tx_idx": 9,
+    "tx_nss": 2,
+    "txpower": -1
+  }
+}

--- a/tests/components/airos/fixtures/airos_loco5ac_ap-ptp.json
+++ b/tests/components/airos/fixtures/airos_loco5ac_ap-ptp.json
@@ -11,6 +11,7 @@
   ],
   "derived": {
     "access_point": true,
+    "fw_major": 8,
     "mac": "01:23:45:67:89:AB",
     "mac_interface": "br0",
     "mode": "point_to_point",

--- a/tests/components/airos/snapshots/test_binary_sensor.ambr
+++ b/tests/components/airos/snapshots/test_binary_sensor.ambr
@@ -1,5 +1,554 @@
 # serializer version: 1
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcp_client-entry]
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_dhcp_client-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_m5_dhcp_client',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP client',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP client',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_client',
+    'unique_id': 'XX:XX:XX:XX:XX:XX_dhcp_client',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_dhcp_client-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'NanoStation M5 DHCP client',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_m5_dhcp_client',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_dhcp_server-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_m5_dhcp_server',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP server',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP server',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_server',
+    'unique_id': 'XX:XX:XX:XX:XX:XX_dhcp_server',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_dhcp_server-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'NanoStation M5 DHCP server',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_m5_dhcp_server',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_pppoe_link-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_m5_pppoe_link',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PPPoE link',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'PPPoE link',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pppoe',
+    'unique_id': 'XX:XX:XX:XX:XX:XX_pppoe',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_M5_sta_v6.3.16.json][binary_sensor.nanostation_m5_pppoe_link-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'NanoStation M5 PPPoE link',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_m5_pppoe_link',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_dhcp_client-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_dhcp_client',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP client',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP client',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_client',
+    'unique_id': 'YY:YY:YY:YY:YY:YY_dhcp_client',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_dhcp_client-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'NanoStation loco M5 Client DHCP client',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_dhcp_client',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_dhcp_server-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_dhcp_server',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP server',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP server',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_server',
+    'unique_id': 'YY:YY:YY:YY:YY:YY_dhcp_server',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_dhcp_server-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'NanoStation loco M5 Client DHCP server',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_dhcp_server',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_pppoe_link-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_pppoe_link',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PPPoE link',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'PPPoE link',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pppoe',
+    'unique_id': 'YY:YY:YY:YY:YY:YY_pppoe',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_NanoStation_loco_M5_v6.3.16_XM_sta.json][binary_sensor.nanostation_loco_m5_client_pppoe_link-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'NanoStation loco M5 Client PPPoE link',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.nanostation_loco_m5_client_pppoe_link',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcp_client-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.house_bridge_dhcp_client',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP client',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP client',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_client',
+    'unique_id': '04:11:22:33:19:7E_dhcp_client',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcp_client-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'House-Bridge DHCP client',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.house_bridge_dhcp_client',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcp_server-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.house_bridge_dhcp_server',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCP server',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCP server',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp_server',
+    'unique_id': '04:11:22:33:19:7E_dhcp_server',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcp_server-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'House-Bridge DHCP server',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.house_bridge_dhcp_server',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcpv6_server-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.house_bridge_dhcpv6_server',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHCPv6 server',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'DHCPv6 server',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhcp6_server',
+    'unique_id': '04:11:22:33:19:7E_dhcp6_server',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_dhcpv6_server-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'House-Bridge DHCPv6 server',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.house_bridge_dhcpv6_server',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_port_forwarding-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.house_bridge_port_forwarding',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Port forwarding',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Port forwarding',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'port_forwarding',
+    'unique_id': '04:11:22:33:19:7E_portfw',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_port_forwarding-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'House-Bridge Port forwarding',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.house_bridge_port_forwarding',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_pppoe_link-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.house_bridge_pppoe_link',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'PPPoE link',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.CONNECTIVITY: 'connectivity'>,
+    'original_icon': None,
+    'original_name': 'PPPoE link',
+    'platform': 'airos',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pppoe',
+    'unique_id': '04:11:22:33:19:7E_pppoe',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[airos_liteapgps_ap_ptmp_40mhz.json][binary_sensor.house_bridge_pppoe_link-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'connectivity',
+      'friendly_name': 'House-Bridge PPPoE link',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.house_bridge_pppoe_link',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcp_client-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +584,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcp_client-state]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcp_client-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'running',
@@ -49,7 +598,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcp_server-entry]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcp_server-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -85,7 +634,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcp_server-state]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcp_server-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'running',
@@ -99,7 +648,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcpv6_server-entry]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcpv6_server-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -135,7 +684,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_dhcpv6_server-state]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_dhcpv6_server-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'running',
@@ -149,7 +698,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_port_forwarding-entry]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_port_forwarding-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -185,7 +734,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_port_forwarding-state]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_port_forwarding-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'NanoStation 5AC ap name Port forwarding',
@@ -198,7 +747,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_pppoe_link-entry]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_pppoe_link-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -234,7 +783,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[binary_sensor.nanostation_5ac_ap_name_pppoe_link-state]
+# name: test_all_entities[airos_loco5ac_ap-ptp.json][binary_sensor.nanostation_5ac_ap_name_pppoe_link-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'connectivity',

--- a/tests/components/airos/snapshots/test_diagnostics.ambr
+++ b/tests/components/airos/snapshots/test_diagnostics.ambr
@@ -14,7 +14,7 @@
       ]),
       'derived': dict({
         'access_point': True,
-        'fw_major': None,
+        'fw_major': 8,
         'mac': '**REDACTED**',
         'mac_interface': 'br0',
         'mode': 'point_to_point',

--- a/tests/components/airos/test_binary_sensor.py
+++ b/tests/components/airos/test_binary_sensor.py
@@ -14,13 +14,24 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.parametrize(
+    ("ap_fixture"),
+    [
+        "airos_loco5ac_ap-ptp.json",  # v8 ptp
+        "airos_liteapgps_ap_ptmp_40mhz.json",  # v8 ptmp
+        "airos_NanoStation_loco_M5_v6.3.16_XM_sta.json",  # v6 XM (different login process)
+        "airos_NanoStation_M5_sta_v6.3.16.json",  # v6 XW
+    ],
+    indirect=True,
+)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
-    mock_airos_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test all entities."""
     await setup_integration(hass, mock_config_entry, [Platform.BINARY_SENSOR])

--- a/tests/components/airos/test_button.py
+++ b/tests/components/airos/test_button.py
@@ -21,6 +21,7 @@ REBOOT_ENTITY_ID = "button.nanostation_5ac_ap_name_restart"
 async def test_reboot_button_press_success(
     hass: HomeAssistant,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -45,6 +46,7 @@ async def test_reboot_button_press_success(
 async def test_reboot_button_press_fail(
     hass: HomeAssistant,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that pressing the reboot button utilizes the correct calls."""
@@ -74,6 +76,7 @@ async def test_reboot_button_press_fail(
 async def test_reboot_button_press_exceptions(
     hass: HomeAssistant,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
     exception: Exception,
 ) -> None:

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Ubiquiti airOS config flow."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from airos.exceptions import (
     AirOSConnectionAuthenticationError,
@@ -11,6 +11,7 @@ from airos.exceptions import (
     AirOSKeyDataMissingError,
     AirOSListenerError,
 )
+from airos.helpers import DetectDeviceData
 import pytest
 import voluptuous as vol
 
@@ -22,7 +23,7 @@ from homeassistant.components.airos.const import (
     MAC_ADDRESS,
     SECTION_ADVANCED_SETTINGS,
 )
-from homeassistant.config_entries import SOURCE_DHCP, SOURCE_RECONFIGURE, SOURCE_USER
+from homeassistant.config_entries import SOURCE_DHCP, SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -33,6 +34,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+
+from . import AirOSData
 
 from tests.common import MockConfigEntry
 
@@ -76,9 +79,10 @@ MOCK_DISC_EXISTS = {
 
 async def test_manual_flow_creates_entry(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_airos_client: AsyncMock,
     ap_fixture: dict[str, Any],
+    mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test we get the user form and create the appropriate entry."""
     result = await hass.config_entries.flow.async_init(
@@ -110,6 +114,7 @@ async def test_manual_flow_creates_entry(
 async def test_form_duplicate_entry(
     hass: HomeAssistant,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test the form does not allow duplicate entries."""
     mock_entry = MockConfigEntry(
@@ -149,35 +154,48 @@ async def test_form_duplicate_entry(
 async def test_form_exception_handling(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
+    ap_fixture: dict[str, Any],
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     exception: Exception,
     error: str,
 ) -> None:
     """Test we handle exceptions."""
-    mock_airos_client.login.side_effect = exception
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=exception,
+    ):
+        flow_start = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
 
-    flow_start = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
+        menu = await hass.config_entries.flow.async_configure(
+            flow_start["flow_id"], {"next_step_id": "manual"}
+        )
 
-    menu = await hass.config_entries.flow.async_configure(
-        flow_start["flow_id"], {"next_step_id": "manual"}
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        menu["flow_id"], MOCK_CONFIG
-    )
+        result = await hass.config_entries.flow.async_configure(
+            menu["flow_id"], MOCK_CONFIG
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": error}
 
-    mock_airos_client.login.side_effect = None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        MOCK_CONFIG,
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    valid_data = DetectDeviceData(
+        fw_major=fw_major,
+        mac=ap_fixture.derived.mac,
+        hostname=ap_fixture.host.hostname,
     )
+
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        return_value=valid_data,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            MOCK_CONFIG,
+        )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "NanoStation 5AC ap name"
@@ -187,6 +205,7 @@ async def test_form_exception_handling(
 
 async def test_reauth_flow_scenario(
     hass: HomeAssistant,
+    ap_fixture: AirOSData,
     mock_airos_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -196,17 +215,36 @@ async def test_reauth_flow_scenario(
     mock_airos_client.login.side_effect = AirOSConnectionAuthenticationError
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
+    flow = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": mock_config_entry.entry_id},
+        data=mock_config_entry.data,
+    )
 
-    flow = flows[0]
+    assert flow["type"] == FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
-    mock_airos_client.login.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"],
-        user_input={CONF_PASSWORD: NEW_PASSWORD},
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    valid_data = DetectDeviceData(
+        fw_major=fw_major,
+        mac=ap_fixture.derived.mac,
+        hostname=ap_fixture.host.hostname,
     )
+
+    with (
+        patch(
+            "homeassistant.components.airos.config_flow.async_get_firmware_data",
+            new=AsyncMock(return_value=valid_data),
+        ),
+        patch(
+            "homeassistant.components.airos.async_get_firmware_data",
+            new=AsyncMock(return_value=valid_data),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            user_input={CONF_PASSWORD: NEW_PASSWORD},
+        )
 
     # Always test resolution
     assert result["type"] is FlowResultType.ABORT
@@ -233,41 +271,61 @@ async def test_reauth_flow_scenario(
 )
 async def test_reauth_flow_scenarios(
     hass: HomeAssistant,
+    ap_fixture: AirOSData,
+    expected_error: str,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
     reauth_exception: Exception,
-    expected_error: str,
 ) -> None:
     """Test reauthentication from start (failure) to finish (success)."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_airos_client.login.side_effect = AirOSConnectionAuthenticationError
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=AirOSConnectionAuthenticationError,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
+        flow = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": mock_config_entry.entry_id},
+            data=mock_config_entry.data,
+        )
 
-    flow = flows[0]
+    assert flow["type"] == FlowResultType.FORM
     assert flow["step_id"] == REAUTH_STEP
 
-    mock_airos_client.login.side_effect = reauth_exception
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=reauth_exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            user_input={CONF_PASSWORD: NEW_PASSWORD},
+        )
 
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"],
-        user_input={CONF_PASSWORD: NEW_PASSWORD},
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == REAUTH_STEP
+        assert result["errors"] == {"base": expected_error}
+
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    valid_data = DetectDeviceData(
+        fw_major=fw_major,
+        mac=ap_fixture.derived.mac,
+        hostname=ap_fixture.host.hostname,
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == REAUTH_STEP
-    assert result["errors"] == {"base": expected_error}
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        new=AsyncMock(return_value=valid_data),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            user_input={CONF_PASSWORD: NEW_PASSWORD},
+        )
 
-    mock_airos_client.login.side_effect = None
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"],
-        user_input={CONF_PASSWORD: NEW_PASSWORD},
-    )
-
-    assert result["type"] is FlowResultType.ABORT
+    assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
 
     updated_entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
@@ -276,25 +334,41 @@ async def test_reauth_flow_scenarios(
 
 async def test_reauth_unique_id_mismatch(
     hass: HomeAssistant,
+    ap_fixture: AirOSData,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reauthentication failure when the unique ID changes."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_airos_client.login.side_effect = AirOSConnectionAuthenticationError
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=AirOSConnectionAuthenticationError,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    flows = hass.config_entries.flow.async_progress()
-    flow = flows[0]
+        flow = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH, "entry_id": mock_config_entry.entry_id},
+            data=mock_config_entry.data,
+        )
 
-    mock_airos_client.login.side_effect = None
-    mock_airos_client.status.return_value.derived.mac = "FF:23:45:67:89:AB"
-
-    result = await hass.config_entries.flow.async_configure(
-        flow["flow_id"],
-        user_input={CONF_PASSWORD: NEW_PASSWORD},
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    valid_data = DetectDeviceData(
+        fw_major=fw_major,
+        mac="FF:23:45:67:89:AB",
+        hostname=ap_fixture.host.hostname,
     )
+
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        new=AsyncMock(return_value=valid_data),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"],
+            user_input={CONF_PASSWORD: NEW_PASSWORD},
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
@@ -306,6 +380,7 @@ async def test_reauth_unique_id_mismatch(
 async def test_successful_reconfigure(
     hass: HomeAssistant,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test successful reconfigure."""
@@ -363,10 +438,11 @@ async def test_successful_reconfigure(
 )
 async def test_reconfigure_flow_failure(
     hass: HomeAssistant,
+    expected_error: str,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
     reconfigure_exception: Exception,
-    expected_error: str,
 ) -> None:
     """Test reconfigure from start (failure) to finish (success)."""
     mock_config_entry.add_to_hass(hass)
@@ -386,18 +462,19 @@ async def test_reconfigure_flow_failure(
         },
     }
 
-    mock_airos_client.login.side_effect = reconfigure_exception
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=reconfigure_exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=user_input,
+        )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input=user_input,
-    )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == RECONFIGURE_STEP
+        assert result["errors"] == {"base": expected_error}
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == RECONFIGURE_STEP
-    assert result["errors"] == {"base": expected_error}
-
-    mock_airos_client.login.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input=user_input,
@@ -412,7 +489,9 @@ async def test_reconfigure_flow_failure(
 
 async def test_reconfigure_unique_id_mismatch(
     hass: HomeAssistant,
+    ap_fixture: AirOSData,
     mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test reconfiguration failure when the unique ID changes."""
@@ -425,7 +504,12 @@ async def test_reconfigure_unique_id_mismatch(
     )
     flow_id = result["flow_id"]
 
-    mock_airos_client.status.return_value.derived.mac = "FF:23:45:67:89:AB"
+    fw_major = int(ap_fixture.host.fwversion.lstrip("v").split(".", 1)[0])
+    mismatched_data = DetectDeviceData(
+        fw_major=fw_major,
+        mac="FF:23:45:67:89:AB",
+        hostname=ap_fixture.host.hostname,
+    )
 
     user_input = {
         CONF_PASSWORD: NEW_PASSWORD,
@@ -435,10 +519,14 @@ async def test_reconfigure_unique_id_mismatch(
         },
     }
 
-    result = await hass.config_entries.flow.async_configure(
-        flow_id,
-        user_input=user_input,
-    )
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        new=AsyncMock(return_value=mismatched_data),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input=user_input,
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
@@ -452,7 +540,8 @@ async def test_reconfigure_unique_id_mismatch(
 
 
 async def test_discover_flow_no_devices_found(
-    hass: HomeAssistant, mock_discovery_method
+    hass: HomeAssistant,
+    mock_discovery_method: AsyncMock,
 ) -> None:
     """Test discovery flow aborts when no devices are found."""
     mock_discovery_method.return_value = {}
@@ -474,7 +563,10 @@ async def test_discover_flow_no_devices_found(
 
 
 async def test_discover_flow_one_device_found(
-    hass: HomeAssistant, mock_discovery_method, mock_airos_client, mock_setup_entry
+    hass: HomeAssistant,
+    mock_airos_client: AsyncMock,
+    mock_discovery_method: AsyncMock,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test discovery flow goes straight to credentials when one device is found."""
     mock_discovery_method.return_value = {MOCK_DISC_DEV1[MAC_ADDRESS]: MOCK_DISC_DEV1}
@@ -494,18 +586,24 @@ async def test_discover_flow_one_device_found(
     assert result["step_id"] == "configure_device"
     assert result["description_placeholders"]["device_name"] == MOCK_DISC_DEV1[HOSTNAME]
 
-    # Provide credentials and complete the flow
-    mock_airos_client.status.return_value.derived.mac = MOCK_DISC_DEV1[MAC_ADDRESS]
-    mock_airos_client.status.return_value.host.hostname = MOCK_DISC_DEV1[HOSTNAME]
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_USERNAME: DEFAULT_USERNAME,
-            CONF_PASSWORD: "test-password",
-            SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
-        },
+    valid_data = DetectDeviceData(
+        fw_major=8,
+        mac=MOCK_DISC_DEV1[MAC_ADDRESS],
+        hostname=MOCK_DISC_DEV1[HOSTNAME],
     )
+
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        new=AsyncMock(return_value=valid_data),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: DEFAULT_USERNAME,
+                CONF_PASSWORD: "test-password",
+                SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
+            },
+        )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DISC_DEV1[HOSTNAME]
@@ -513,7 +611,11 @@ async def test_discover_flow_one_device_found(
 
 
 async def test_discover_flow_multiple_devices_found(
-    hass: HomeAssistant, mock_discovery_method, mock_airos_client, mock_setup_entry
+    hass: HomeAssistant,
+    mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
+    mock_discovery_method: AsyncMock,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test discovery flow with multiple devices found, requiring a selection step."""
     mock_discovery_method.return_value = {
@@ -560,18 +662,24 @@ async def test_discover_flow_multiple_devices_found(
     assert result["step_id"] == "configure_device"
     assert result["description_placeholders"]["device_name"] == MOCK_DISC_DEV1[HOSTNAME]
 
-    # Provide credentials and complete the flow
-    mock_airos_client.status.return_value.derived.mac = MOCK_DISC_DEV1[MAC_ADDRESS]
-    mock_airos_client.status.return_value.host.hostname = MOCK_DISC_DEV1[HOSTNAME]
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_USERNAME: DEFAULT_USERNAME,
-            CONF_PASSWORD: "test-password",
-            SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
-        },
+    valid_data = DetectDeviceData(
+        fw_major=8,
+        mac=MOCK_DISC_DEV1[MAC_ADDRESS],
+        hostname=MOCK_DISC_DEV1[HOSTNAME],
     )
+
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        new=AsyncMock(return_value=valid_data),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: DEFAULT_USERNAME,
+                CONF_PASSWORD: "test-password",
+                SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
+            },
+        )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_DISC_DEV1[HOSTNAME]
@@ -579,7 +687,9 @@ async def test_discover_flow_multiple_devices_found(
 
 
 async def test_discover_flow_with_existing_device(
-    hass: HomeAssistant, mock_discovery_method, mock_airos_client
+    hass: HomeAssistant,
+    mock_discovery_method: AsyncMock,
+    mock_airos_client: AsyncMock,
 ) -> None:
     """Test that discovery ignores devices that are already configured."""
     # Add a mock config entry for an existing device
@@ -642,7 +752,9 @@ async def test_discover_flow_discovery_exceptions(
 
 
 async def test_configure_device_flow_exceptions(
-    hass: HomeAssistant, mock_discovery_method, mock_airos_client
+    hass: HomeAssistant,
+    mock_discovery_method: AsyncMock,
+    mock_airos_client: AsyncMock,
 ) -> None:
     """Test configure_device step handles authentication and connection exceptions."""
     mock_discovery_method.return_value = {MOCK_DISC_DEV1[MAC_ADDRESS]: MOCK_DISC_DEV1}
@@ -654,30 +766,34 @@ async def test_configure_device_flow_exceptions(
         result["flow_id"], {"next_step_id": "discovery"}
     )
 
-    mock_airos_client.login.side_effect = AirOSConnectionAuthenticationError
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_USERNAME: "wrong-user",
-            CONF_PASSWORD: "wrong-password",
-            SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
-        },
-    )
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=AirOSConnectionAuthenticationError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "wrong-user",
+                CONF_PASSWORD: "wrong-password",
+                SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
+            },
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
-    mock_airos_client.login.side_effect = AirOSDeviceConnectionError
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_USERNAME: DEFAULT_USERNAME,
-            CONF_PASSWORD: "some-password",
-            SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
-        },
-    )
+    with patch(
+        "homeassistant.components.airos.config_flow.async_get_firmware_data",
+        side_effect=AirOSDeviceConnectionError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: DEFAULT_USERNAME,
+                CONF_PASSWORD: "some-password",
+                SECTION_ADVANCED_SETTINGS: MOCK_ADVANCED_SETTINGS,
+            },
+        )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/components/airos/test_config_flow.py
+++ b/tests/components/airos/test_config_flow.py
@@ -23,7 +23,12 @@ from homeassistant.components.airos.const import (
     MAC_ADDRESS,
     SECTION_ADVANCED_SETTINGS,
 )
-from homeassistant.config_entries import SOURCE_DHCP, SOURCE_REAUTH, SOURCE_RECONFIGURE, SOURCE_USER
+from homeassistant.config_entries import (
+    SOURCE_DHCP,
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,

--- a/tests/components/airos/test_diagnostics.py
+++ b/tests/components/airos/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Diagnostic tests for airOS."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -21,6 +21,7 @@ async def test_diagnostics(
     mock_config_entry: MockConfigEntry,
     ap_fixture: AirOS8Data,
     snapshot: SnapshotAssertion,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test diagnostics."""
 

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import ANY, AsyncMock, MagicMock
 
+from airos.exceptions import (
+    AirOSConnectionAuthenticationError,
+    AirOSConnectionSetupError,
+    AirOSDeviceConnectionError,
+    AirOSKeyDataMissingError,
+)
 import pytest
 
 from homeassistant.components.airos.const import (
@@ -247,3 +253,32 @@ async def test_load_unload_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    ("exception", "state"),
+    [
+        (AirOSConnectionAuthenticationError, ConfigEntryState.SETUP_ERROR),
+        (AirOSConnectionSetupError, ConfigEntryState.SETUP_RETRY),
+        (AirOSDeviceConnectionError, ConfigEntryState.SETUP_RETRY),
+        (AirOSKeyDataMissingError, ConfigEntryState.SETUP_ERROR),
+        (Exception, ConfigEntryState.SETUP_ERROR),
+    ],
+)
+async def test_setup_entry_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
+    exception: Exception,
+    state: ConfigEntryState,
+) -> None:
+    """Test config entry setup failure."""
+    mock_async_get_firmware_data.side_effect = exception
+
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert result is False
+    assert mock_config_entry.state == state

--- a/tests/components/airos/test_init.py
+++ b/tests/components/airos/test_init.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import ANY, MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -57,8 +57,9 @@ MOCK_CONFIG_V1_2 = {
 async def test_setup_entry_with_default_ssl(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_airos_client: MagicMock,
     mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test setting up a config entry with default SSL options."""
     mock_config_entry.add_to_hass(hass)
@@ -82,8 +83,9 @@ async def test_setup_entry_with_default_ssl(
 
 async def test_setup_entry_without_ssl(
     hass: HomeAssistant,
-    mock_airos_client: MagicMock,
     mock_airos_class: MagicMock,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test setting up a config entry adjusted to plain HTTP."""
     entry = MockConfigEntry(
@@ -114,7 +116,9 @@ async def test_setup_entry_without_ssl(
 
 
 async def test_ssl_migrate_entry(
-    hass: HomeAssistant, mock_airos_client: MagicMock
+    hass: HomeAssistant,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test migrate entry SSL options."""
     entry = MockConfigEntry(
@@ -145,11 +149,12 @@ async def test_ssl_migrate_entry(
 )
 async def test_uid_migrate_entry(
     hass: HomeAssistant,
-    mock_airos_client: MagicMock,
     device_registry: dr.DeviceRegistry,
     sensor_domain: str,
     sensor_name: str,
     mock_id: str,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test migrate entry unique id."""
     entity_registry = er.async_get(hass)
@@ -205,6 +210,7 @@ async def test_uid_migrate_entry(
 async def test_migrate_future_return(
     hass: HomeAssistant,
     mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test migrate entry unique id."""
     entry = MockConfigEntry(
@@ -225,8 +231,9 @@ async def test_migrate_future_return(
 
 async def test_load_unload_entry(
     hass: HomeAssistant,
-    mock_airos_client: MagicMock,
     mock_config_entry: MockConfigEntry,
+    mock_airos_client: MagicMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test setup and unload config entry."""
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/airos/test_sensor.py
+++ b/tests/components/airos/test_sensor.py
@@ -22,9 +22,10 @@ from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_plat
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
-    mock_airos_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    mock_airos_client: AsyncMock,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test all entities."""
     await setup_integration(hass, mock_config_entry, [Platform.SENSOR])
@@ -46,6 +47,7 @@ async def test_sensor_update_exception_handling(
     mock_config_entry: MockConfigEntry,
     exception: Exception,
     freezer: FrozenDateTimeFactory,
+    mock_async_get_firmware_data: AsyncMock,
 ) -> None:
     """Test entity update data handles exceptions."""
     await setup_integration(hass, mock_config_entry, [Platform.SENSOR])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR introduces full support for airOS v6 devices and refactors the integration to handle both v6 and v8 firmware cleanly. (Picking up from where we left off with https://github.com/home-assistant/core/pull/151458 )

These changes have been successfully through various v6 firmware fixtures in `python-airs` as well as field-tested by a user with v6 firmware devices using a prepared `custom_component`.

GenerAIted/modified summary from diff:

- Add firmware detection using `async_get_firmware_data` and dynamically select the correct API class (`AirOS6` keeping `AirOS8` as default).
- Introduce shared base data models and update entity descriptions to work generically across firmware versions.
- Split common vs. v8‑specific sensors and binary sensors; load only what each firmware supports.
- Update coordinator to handle mixed data types and expose detected firmware metadata.
- Add new v6 fixtures and extend test suite to cover both v6 and v8 devices.
- Remove unused loggers and minor cleanup of redundant code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #151145 fixes #151348 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43704
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
