### PR TITLE
Limit color temperature to maximum Matter MIREDs value

### DIFF
--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -47,7 +47,7 @@ COLOR_MODE_MAP = {
     clusters.ColorControl.Enums.ColorModeEnum.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
 }
 
-# Maximum ireds value per the Matter spec is 65279
+# Maximum Mireds value per the Matter spec is 65279
 # Conversion between Kelvin and Mireds is 1,000,000 / Kelvin, so this corresponds to a minimum color temperature of ~15.3K
 # Which is shown in UI as 15 Kelvin due to rounding.
 # But converting 15 Kelvin back to Mireds gives 66666 which is above the maximum,

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -47,10 +47,10 @@ COLOR_MODE_MAP = {
     clusters.ColorControl.Enums.ColorModeEnum.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
 }
 
-# Maximum MIREDs value per the Matter spec is 65279
-# Conversion between Kelvin and MIREDs is 1,000,000 / Kelvin, so this corresponds to a minimum color temperature of ~15.3K
-# Which is shown in UI as 15K due to rounding.
-# But Converting 15 Kelvin back to MIREDS gives 66666 which is above the maximum,
+# Maximum ireds value per the Matter spec is 65279
+# Conversion between Kelvin and Mireds is 1,000,000 / Kelvin, so this corresponds to a minimum color temperature of ~15.3K
+# Which is shown in UI as 15 Kelvin due to rounding.
+# But converting 15 Kelvin back to Mireds gives 66666 which is above the maximum,
 # and causes Invoke error, so cap values over maximum when sending
 MATTER_MAX_MIREDS = 65279
 

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -47,6 +47,14 @@ COLOR_MODE_MAP = {
     clusters.ColorControl.Enums.ColorModeEnum.kColorTemperatureMireds: ColorMode.COLOR_TEMP,
 }
 
+# Maximum MIREDs value per the Matter spec is 65279
+# Conversion between Kelvin and MIREDs is 1,000,000 / Kelvin, so this corresponds to a minimum color temperature of ~15.3K
+# Which is shown in UI as 15K due to rounding.
+# But Converting 15 Kelvin back to MIREDS gives 66666 which is above the maximum,
+# and causes Invoke error, so cap values over maximum when sending
+MATTER_MAX_MIREDS = 65279
+
+
 # there's a bug in (at least) Espressif's implementation of light transitions
 # on devices based on Matter 1.0. Mark potential devices with this issue.
 # https://github.com/home-assistant/core/issues/113775
@@ -152,7 +160,7 @@ class MatterLight(MatterEntity, LightEntity):
         )
         await self.send_device_command(
             clusters.ColorControl.Commands.MoveToColorTemperature(
-                colorTemperatureMireds=color_temp_mired,
+                colorTemperatureMireds=min(color_temp_mired, MATTER_MAX_MIREDS),
                 # transition in matter is measured in tenths of a second
                 transitionTime=int(transition * 10),
                 # allow setting the color while the light is off,

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -248,6 +248,73 @@ async def test_color_temperature_light(
         ]
     )
     matter_client.send_device_command.reset_mock()
+    # Change color temperature
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": entity_id,
+            "color_temp_kelvin": 3333,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 2
+    matter_client.send_device_command.assert_has_calls(
+        [
+            call(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                command=clusters.ColorControl.Commands.MoveToColorTemperature(
+                    colorTemperatureMireds=300,
+                    transitionTime=0,
+                    optionsMask=1,
+                    optionsOverride=1,
+                ),
+            ),
+            call(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                command=clusters.OnOff.Commands.On(),
+            ),
+        ]
+    )
+    matter_client.send_device_command.reset_mock()
+
+    # Change color temperature with 15 Kelvin to test capping of mireds at 65279
+    # 15 Kelvin is 66666 Mireds which is above the maximum of 65279 Kelvin permitted by Matter,
+    # so it should be capped at 65279 mireds which is 15.3 Kelvin
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": entity_id,
+            "color_temp_kelvin": 15,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 2
+    matter_client.send_device_command.assert_has_calls(
+        [
+            call(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                command=clusters.ColorControl.Commands.MoveToColorTemperature(
+                    colorTemperatureMireds=65279,
+                    transitionTime=0,
+                    optionsMask=1,
+                    optionsOverride=1,
+                ),
+            ),
+            call(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                command=clusters.OnOff.Commands.On(),
+            ),
+        ]
+    )
+    matter_client.send_device_command.reset_mock()
 
     # Change color temperature with custom transition
     await hass.services.async_call(

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -282,7 +282,7 @@ async def test_color_temperature_light(
     matter_client.send_device_command.reset_mock()
 
     # Change color temperature with 15 Kelvin to test capping of mireds at 65279
-    # 15 Kelvin is 66666 Mireds which is above the maximum of 65279 Kelvin permitted by Matter,
+    # 15 Kelvin is 66666 Mireds which is above the maximum of 65279 Mireds permitted by Matter,
     # so it should be capped at 65279 mireds which is 15.3 Kelvin
     await hass.services.async_call(
         "light",

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -248,39 +248,6 @@ async def test_color_temperature_light(
         ]
     )
     matter_client.send_device_command.reset_mock()
-    # Change color temperature
-    await hass.services.async_call(
-        "light",
-        "turn_on",
-        {
-            "entity_id": entity_id,
-            "color_temp_kelvin": 3333,
-        },
-        blocking=True,
-    )
-
-    assert matter_client.send_device_command.call_count == 2
-    matter_client.send_device_command.assert_has_calls(
-        [
-            call(
-                node_id=matter_node.node_id,
-                endpoint_id=1,
-                command=clusters.ColorControl.Commands.MoveToColorTemperature(
-                    colorTemperatureMireds=300,
-                    transitionTime=0,
-                    optionsMask=1,
-                    optionsOverride=1,
-                ),
-            ),
-            call(
-                node_id=matter_node.node_id,
-                endpoint_id=1,
-                command=clusters.OnOff.Commands.On(),
-            ),
-        ]
-    )
-    matter_client.send_device_command.reset_mock()
-
     # Change color temperature with 15 Kelvin to test capping of mireds at 65279
     # 15 Kelvin is 66666 Mireds which is above the maximum of 65279 Mireds permitted by Matter,
     # so it should be capped at 65279 mireds which is 15.3 Kelvin


### PR DESCRIPTION
This is a simplified version of this prior PR which sent stale and didn't get merged: https://github.com/home-assistant/core/pull/152791

This simplified PR is directed to a math rounding error that occurs when converting between Kelvin as used on the HA user interface, and Mired values used by Matter.

Matter commands use Mired values to communicate color temperature. The Maximum Matter MIred value is 65279. When converted to Kelvin, this is 15.3 Kelvin, which HA rounds down to 15 and becomes the lowest value that can be selected from the ColorTemp UI. However, if 15 is selected, then during conversion back to Mired, it converts to 66666 which, if sent to a Matter device, causes an Invoke error. To avoid this, cap the maximum value sent to ensure it does not exceed the permitted range.
,
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
