### PR TITLE
Bring aladdin_connect to silver quality scale

### DIFF
--- a/homeassistant/components/aladdin_connect/coordinator.py
+++ b/homeassistant/components/aladdin_connect/coordinator.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
+import aiohttp
 from genie_partner_sdk.client import AladdinConnectClient
 from genie_partner_sdk.model import GarageDoor
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
 type AladdinConnectConfigEntry = ConfigEntry[dict[str, AladdinConnectCoordinator]]
@@ -40,7 +41,10 @@ class AladdinConnectCoordinator(DataUpdateCoordinator[GarageDoor]):
 
     async def _async_update_data(self) -> GarageDoor:
         """Fetch data from the Aladdin Connect API."""
-        await self.client.update_door(self.data.device_id, self.data.door_number)
+        try:
+            await self.client.update_door(self.data.device_id, self.data.door_number)
+        except aiohttp.ClientError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
         self.data.status = self.client.get_door_status(
             self.data.device_id, self.data.door_number
         )

--- a/homeassistant/components/aladdin_connect/cover.py
+++ b/homeassistant/components/aladdin_connect/cover.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
+import aiohttp
+
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import SUPPORTED_FEATURES
+from .const import DOMAIN, SUPPORTED_FEATURES
 from .coordinator import AladdinConnectConfigEntry, AladdinConnectCoordinator
 from .entity import AladdinConnectEntity
+
+PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
@@ -40,11 +45,23 @@ class AladdinCoverEntity(AladdinConnectEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Issue open command to cover."""
-        await self.client.open_door(self._device_id, self._number)
+        try:
+            await self.client.open_door(self._device_id, self._number)
+        except aiohttp.ClientError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="open_door_failed",
+            ) from err
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Issue close command to cover."""
-        await self.client.close_door(self._device_id, self._number)
+        try:
+            await self.client.close_door(self._device_id, self._number)
+        except aiohttp.ClientError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="close_door_failed",
+            ) from err
 
     @property
     def is_closed(self) -> bool | None:

--- a/homeassistant/components/aladdin_connect/quality_scale.yaml
+++ b/homeassistant/components/aladdin_connect/quality_scale.yaml
@@ -26,20 +26,22 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
     comment: Integration does not have an options flow.
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable:
+    status: done
+    comment: Handled by the coordinator.
   integration-owner: done
-  log-when-unavailable: todo
-  parallel-updates: todo
+  log-when-unavailable:
+    status: done
+    comment: Handled by the coordinator.
+  parallel-updates: done
   reauthentication-flow: done
-  test-coverage:
-    status: todo
-    comment: Platform tests for cover and sensor need to be implemented to reach 95% coverage.
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/aladdin_connect/sensor.py
+++ b/homeassistant/components/aladdin_connect/sensor.py
@@ -20,6 +20,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import AladdinConnectConfigEntry, AladdinConnectCoordinator
 from .entity import AladdinConnectEntity
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class AladdinConnectSensorEntityDescription(SensorEntityDescription):

--- a/homeassistant/components/aladdin_connect/strings.json
+++ b/homeassistant/components/aladdin_connect/strings.json
@@ -32,5 +32,13 @@
         "title": "[%key:common::config_flow::title::reauth%]"
       }
     }
+  },
+  "exceptions": {
+    "close_door_failed": {
+      "message": "Failed to close the garage door"
+    },
+    "open_door_failed": {
+      "message": "Failed to open the garage door"
+    }
   }
 }

--- a/tests/components/aladdin_connect/snapshots/test_cover.ambr
+++ b/tests/components/aladdin_connect/snapshots/test_cover.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_cover_entities[cover.test_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.test_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <CoverDeviceClass.GARAGE: 'garage'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'aladdin_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <CoverEntityFeature: 3>,
+    'translation_key': None,
+    'unique_id': 'test_device_id-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_entities[cover.test_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'garage',
+      'friendly_name': 'Test Door',
+      'supported_features': <CoverEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.test_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'closed',
+  })
+# ---

--- a/tests/components/aladdin_connect/snapshots/test_sensor.ambr
+++ b/tests/components/aladdin_connect/snapshots/test_sensor.ambr
@@ -1,0 +1,55 @@
+# serializer version: 1
+# name: test_sensor_entities[sensor.test_door_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_door_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'aladdin_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_device_id-1-battery_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities[sensor.test_door_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Test Door Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_door_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---

--- a/tests/components/aladdin_connect/test_cover.py
+++ b/tests/components/aladdin_connect/test_cover.py
@@ -1,0 +1,165 @@
+"""Tests for the Aladdin Connect cover platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+ENTITY_ID = "cover.test_door"
+
+
+async def _setup(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up integration with only the cover platform."""
+    with patch("homeassistant.components.aladdin_connect.PLATFORMS", [Platform.COVER]):
+        await init_integration(hass, entry)
+
+
+async def test_cover_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the cover entity states and attributes."""
+    await _setup(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_open_cover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+) -> None:
+    """Test opening the cover."""
+    await _setup(hass, mock_config_entry)
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_aladdin_connect_api.open_door.assert_called_once_with("test_device_id", 1)
+
+
+async def test_close_cover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+) -> None:
+    """Test closing the cover."""
+    await _setup(hass, mock_config_entry)
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_aladdin_connect_api.close_door.assert_called_once_with("test_device_id", 1)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_closed", "expected_opening", "expected_closing"),
+    [
+        ("closed", True, False, False),
+        ("open", False, False, False),
+        ("opening", False, True, False),
+        ("closing", False, False, True),
+    ],
+)
+async def test_cover_states(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+    status: str,
+    expected_closed: bool,
+    expected_opening: bool,
+    expected_closing: bool,
+) -> None:
+    """Test cover state properties."""
+    mock_aladdin_connect_api.get_doors.return_value[0].status = status
+    await _setup(hass, mock_config_entry)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert (state.state == "closed") == expected_closed
+    assert (state.state == "opening") == expected_opening
+    assert (state.state == "closing") == expected_closing
+
+
+async def test_cover_none_status(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+) -> None:
+    """Test cover state when status is None."""
+    mock_aladdin_connect_api.get_doors.return_value[0].status = None
+    await _setup(hass, mock_config_entry)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("service", "mock_method", "translation_key"),
+    [
+        (SERVICE_OPEN_COVER, "open_door", "open_door_failed"),
+        (SERVICE_CLOSE_COVER, "close_door", "close_door_failed"),
+    ],
+)
+async def test_cover_action_exceptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+    service: str,
+    mock_method: str,
+    translation_key: str,
+) -> None:
+    """Test cover action raises HomeAssistantError on API failure."""
+    await _setup(hass, mock_config_entry)
+    getattr(mock_aladdin_connect_api, mock_method).side_effect = aiohttp.ClientError()
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            COVER_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == "aladdin_connect"
+    assert exc_info.value.translation_key == translation_key
+
+
+async def test_cover_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test cover becomes unavailable when coordinator update fails."""
+    await _setup(hass, mock_config_entry)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    mock_aladdin_connect_api.update_door.side_effect = aiohttp.ClientError()
+    freezer.tick(15)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/aladdin_connect/test_sensor.py
+++ b/tests/components/aladdin_connect/test_sensor.py
@@ -1,0 +1,59 @@
+"""Tests for the Aladdin Connect sensor platform."""
+
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+ENTITY_ID = "sensor.test_door_battery"
+
+
+async def _setup(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up integration with only the sensor platform."""
+    with patch("homeassistant.components.aladdin_connect.PLATFORMS", [Platform.SENSOR]):
+        await init_integration(hass, entry)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the sensor entity states and attributes."""
+    await _setup(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_aladdin_connect_api: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test sensor becomes unavailable when coordinator update fails."""
+    await _setup(hass, mock_config_entry)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    mock_aladdin_connect_api.update_door.side_effect = aiohttp.ClientError()
+    freezer.tick(15)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bring aladdin_connect to silver quality scale. Adds error handling for cover actions, `PARALLEL_UPDATES` constants, and platform tests for cover and sensor.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
