### PR TITLE
Clean up duplicated code in Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 import asyncio
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 import io
 import logging
 import os
@@ -430,48 +430,35 @@ class TelegramNotificationService:
             params[ATTR_PARSER] = None
         return params
 
-    async def _send_msgs(
+    async def _send_msg_formatted(
         self,
-        func_send: Callable,
+        func_send: Callable[..., Awaitable[Message]],
         message_tag: str | None,
         *args_msg: Any,
         context: Context | None = None,
         **kwargs_msg: Any,
     ) -> dict[str, JsonValueType]:
-        """Sends a message to each of the targets.
-
-        If there is only 1 targtet, an error is raised if the send fails.
-        For multiple targets, errors are logged and the caller is responsible for checking which target is successful/failed based on the return value.
+        """Sends a message and formats the response.
 
         :return: dict with chat_id keys and message_id values for successful sends
         """
-        chat_ids = [kwargs_msg.pop(ATTR_CHAT_ID)]
-        msg_ids: dict[str, JsonValueType] = {}
-        for chat_id in chat_ids:
-            _LOGGER.debug("%s to chat ID %s", func_send.__name__, chat_id)
+        chat_id: int = kwargs_msg.pop(ATTR_CHAT_ID)
+        _LOGGER.debug("%s to chat ID %s", func_send.__name__, chat_id)
 
-            for file_type in _FILE_TYPES:
-                if file_type in kwargs_msg and isinstance(
-                    kwargs_msg[file_type], io.BytesIO
-                ):
-                    kwargs_msg[file_type].seek(0)
+        response: Message = await self._send_msg(
+            func_send,
+            message_tag,
+            chat_id,
+            *args_msg,
+            context=context,
+            **kwargs_msg,
+        )
 
-            response: Message = await self._send_msg(
-                func_send,
-                message_tag,
-                chat_id,
-                *args_msg,
-                context=context,
-                **kwargs_msg,
-            )
-            if response:
-                msg_ids[str(chat_id)] = response.id
-
-        return msg_ids
+        return {str(chat_id): response.id}
 
     async def _send_msg(
         self,
-        func_send: Callable,
+        func_send: Callable[..., Awaitable[Any]],
         message_tag: str | None,
         *args_msg: Any,
         context: Context | None = None,
@@ -518,7 +505,7 @@ class TelegramNotificationService:
         title = kwargs.get(ATTR_TITLE)
         text = f"{title}\n{message}" if title else message
         params = self._get_msg_kwargs(kwargs)
-        return await self._send_msgs(
+        return await self._send_msg_formatted(
             self.bot.send_message,
             params[ATTR_MESSAGE_TAG],
             text,
@@ -759,7 +746,7 @@ class TelegramNotificationService:
         )
 
         if file_type == SERVICE_SEND_PHOTO:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_photo,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -775,7 +762,7 @@ class TelegramNotificationService:
             )
 
         if file_type == SERVICE_SEND_STICKER:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_sticker,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -789,7 +776,7 @@ class TelegramNotificationService:
             )
 
         if file_type == SERVICE_SEND_VIDEO:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_video,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -805,7 +792,7 @@ class TelegramNotificationService:
             )
 
         if file_type == SERVICE_SEND_DOCUMENT:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_document,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -821,7 +808,7 @@ class TelegramNotificationService:
             )
 
         if file_type == SERVICE_SEND_VOICE:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_voice,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -836,7 +823,7 @@ class TelegramNotificationService:
             )
 
         # SERVICE_SEND_ANIMATION
-        return await self._send_msgs(
+        return await self._send_msg_formatted(
             self.bot.send_animation,
             params[ATTR_MESSAGE_TAG],
             chat_id=kwargs[ATTR_CHAT_ID],
@@ -861,7 +848,7 @@ class TelegramNotificationService:
         stickerid = kwargs.get(ATTR_STICKER_ID)
 
         if stickerid:
-            return await self._send_msgs(
+            return await self._send_msg_formatted(
                 self.bot.send_sticker,
                 params[ATTR_MESSAGE_TAG],
                 chat_id=kwargs[ATTR_CHAT_ID],
@@ -886,7 +873,7 @@ class TelegramNotificationService:
         latitude = float(latitude)
         longitude = float(longitude)
         params = self._get_msg_kwargs(kwargs)
-        return await self._send_msgs(
+        return await self._send_msg_formatted(
             self.bot.send_location,
             params[ATTR_MESSAGE_TAG],
             chat_id=kwargs[ATTR_CHAT_ID],
@@ -911,7 +898,7 @@ class TelegramNotificationService:
         """Send a poll."""
         params = self._get_msg_kwargs(kwargs)
         openperiod = kwargs.get(ATTR_OPEN_PERIOD)
-        return await self._send_msgs(
+        return await self._send_msg_formatted(
             self.bot.send_poll,
             params[ATTR_MESSAGE_TAG],
             chat_id=kwargs[ATTR_CHAT_ID],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Background

Currently, `bot.py:_send_msgs()` loops through the chat_ids based on the input parameter and then invokes the action once for each of the `chat_id`.

The logic to determine the chat_ids and looping is already in `__init__.py:_async_send_telegram_message()`.
Hence, `bot.py:_send_msgs()` will always only receive a single `chat_id` and the loop is redundant.

Side note: This refactoring came about because of the rework in https://github.com/home-assistant/core/pull/159745 which changed how chat_ids are being handled (i.e. chat_ids are parsed from notify entities).

### Changes
- Removed the duplicated logic.
- Renamed `_send_msgs` to `_send_msg_formatted` to better reflect the behavior of the function.
- Added missing type hints for `Callable`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
