### PR TITLE
Replace discovery with user flow in Philips Hue BLE

### DIFF
--- a/homeassistant/components/hue_ble/config_flow.py
+++ b/homeassistant/components/hue_ble/config_flow.py
@@ -6,6 +6,7 @@ from enum import Enum
 import logging
 from typing import Any
 
+from bleak.backends.scanner import AdvertisementData
 from HueBLE import ConnectionError, HueBleError, HueBleLight, PairingError
 import voluptuous as vol
 
@@ -24,6 +25,19 @@ from .const import DOMAIN, URL_FACTORY_RESET, URL_PAIRING_MODE
 from .light import get_available_color_modes
 
 _LOGGER = logging.getLogger(__name__)
+
+
+SERVICE_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
+SERVICE_DATA_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
+
+
+def device_filter(advertisement_data: AdvertisementData) -> bool:
+    """Return True if the device is supported."""
+    uuids = advertisement_data.service_uuids
+    if SERVICE_UUID in uuids or SERVICE_DATA_UUID in uuids:
+        return True
+
+    return False
 
 
 async def validate_input(hass: HomeAssistant, address: str) -> Error | None:
@@ -70,7 +84,55 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
+        self._discovered_devices: dict[str, bluetooth.BluetoothServiceInfoBleak] = {}
         self._discovery_info: bluetooth.BluetoothServiceInfoBleak | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the user step to pick discovered device."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            unique_id = dr.format_mac(user_input[CONF_MAC])
+            # Don't raise on progress because there may be discovery flows
+            await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            # Guard against the user selecting a device which has been configured by
+            # another flow.
+            self._abort_if_unique_id_configured()
+            self._discovery_info = self._discovered_devices[user_input[CONF_MAC]]
+            return await self.async_step_confirm()
+
+        current_addresses = self._async_current_ids(include_ignore=False)
+        for discovery in bluetooth.async_discovered_service_info(self.hass):
+            if (
+                discovery.address in current_addresses
+                or discovery.address in self._discovered_devices
+                or not device_filter(discovery.advertisement)
+            ):
+                continue
+            self._discovered_devices[discovery.address] = discovery
+
+        if not self._discovered_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_MAC): vol.In(
+                    {
+                        service_info.address: (
+                            f"{service_info.name} ({service_info.address})"
+                        )
+                        for service_info in self._discovered_devices.values()
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: bluetooth.BluetoothServiceInfoBleak
@@ -78,20 +140,10 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the home assistant scanner."""
 
         _LOGGER.debug(
-            "HA found light %s. Will show in UI but not auto connect",
+            "HA found light %s. Use user flow to show in UI and connect",
             discovery_info.name,
         )
-
-        unique_id = dr.format_mac(discovery_info.address)
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
-
-        name = f"{discovery_info.name} ({discovery_info.address})"
-        self.context.update({"title_placeholders": {CONF_NAME: name}})
-
-        self._discovery_info = discovery_info
-
-        return await self.async_step_confirm()
+        return self.async_abort(reason="discovery_unsupported")
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -103,7 +155,10 @@ class HueBleConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             unique_id = dr.format_mac(self._discovery_info.address)
-            await self.async_set_unique_id(unique_id)
+            # Don't raise on progress because there may be discovery flows
+            await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            # Guard against the user selecting a device which has been configured by
+            # another flow.
             self._abort_if_unique_id_configured()
             error = await validate_input(self.hass, unique_id)
             if error:

--- a/homeassistant/components/hue_ble/config_flow.py
+++ b/homeassistant/components/hue_ble/config_flow.py
@@ -27,17 +27,15 @@ from .light import get_available_color_modes
 _LOGGER = logging.getLogger(__name__)
 
 
-SERVICE_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
-SERVICE_DATA_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
+SERVICE_UUID = SERVICE_DATA_UUID = "0000fe0f-0000-1000-8000-00805f9b34fb"
 
 
 def device_filter(advertisement_data: AdvertisementData) -> bool:
     """Return True if the device is supported."""
-    uuids = advertisement_data.service_uuids
-    if SERVICE_UUID in uuids or SERVICE_DATA_UUID in uuids:
-        return True
-
-    return False
+    return (
+        SERVICE_UUID in advertisement_data.service_uuids
+        and SERVICE_DATA_UUID in advertisement_data.service_data
+    )
 
 
 async def validate_input(hass: HomeAssistant, address: str) -> Error | None:

--- a/homeassistant/components/hue_ble/strings.json
+++ b/homeassistant/components/hue_ble/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "discovery_unsupported": "Discovery flow is not supported by the Hue BLE integration.",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     },
     "error": {

--- a/homeassistant/components/hue_ble/strings.json
+++ b/homeassistant/components/hue_ble/strings.json
@@ -14,7 +14,7 @@
     },
     "step": {
       "confirm": {
-        "description": "Do you want to set up {name} ({mac})?\n Make sure the light is [made discoverable to voice assistants]({url_pairing_mode}) or has been [factory reset]({url_factory_reset})."
+        "description": "Do you want to set up {name} ({mac})?\nMake sure the light is [made discoverable to voice assistants]({url_pairing_mode}) or has been [factory reset]({url_factory_reset})."
       },
       "user": {
         "data": {

--- a/homeassistant/components/hue_ble/strings.json
+++ b/homeassistant/components/hue_ble/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "not_implemented": "This integration can only be set up via discovery."
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -14,7 +14,16 @@
     },
     "step": {
       "confirm": {
-        "description": "Do you want to set up {name} ({mac})?. Make sure the light is [made discoverable to voice assistants]({url_pairing_mode}) or has been [factory reset]({url_factory_reset})."
+        "description": "Do you want to set up {name} ({mac})?\n Make sure the light is [made discoverable to voice assistants]({url_pairing_mode}) or has been [factory reset]({url_factory_reset})."
+      },
+      "user": {
+        "data": {
+          "mac": "[%key:common::config_flow::data::device%]"
+        },
+        "data_description": {
+          "mac": "Select the Hue device you want to set up"
+        },
+        "description": "[%key:component::bluetooth::config::step::user::description%]"
       }
     }
   }

--- a/tests/components/hue_ble/__init__.py
+++ b/tests/components/hue_ble/__init__.py
@@ -42,3 +42,21 @@ HUE_BLE_SERVICE_INFO = BluetoothServiceInfoBleak(
     connectable=True,
     tx_power=-127,
 )
+
+NOT_HUE_BLE_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="Not",
+    address="AA:BB:CC:DD:EE:F2",
+    rssi=-60,
+    manufacturer_data={
+        33: b"\x00\x00\xd1\xf0b;\xd8\x1dE\xd6\xba\xeeL\xdd]\xf5\xb2\xe9",
+        21: b"\x061\x00Z\x8f\x93\xb2\xec\x85\x06\x00i\x00\x02\x02Q\xed\x1d\xf0",
+    },
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:F2", name="Aug"),
+    advertisement=generate_advertisement_data(),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)

--- a/tests/components/hue_ble/test_config_flow.py
+++ b/tests/components/hue_ble/test_config_flow.py
@@ -2,23 +2,28 @@
 
 from unittest.mock import AsyncMock, PropertyMock, patch
 
+from habluetooth import BluetoothServiceInfoBleak
 from HueBLE import ConnectionError, HueBleError, PairingError
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.hue_ble.config_flow import Error
 from homeassistant.components.hue_ble.const import (
     DOMAIN,
     URL_FACTORY_RESET,
     URL_PAIRING_MODE,
 )
-from homeassistant.config_entries import SOURCE_BLUETOOTH
+from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.const import CONF_MAC, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 
-from . import HUE_BLE_SERVICE_INFO, TEST_DEVICE_MAC, TEST_DEVICE_NAME
+from . import (
+    HUE_BLE_SERVICE_INFO,
+    NOT_HUE_BLE_DISCOVERY_INFO,
+    TEST_DEVICE_MAC,
+    TEST_DEVICE_NAME,
+)
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import BLEDevice, generate_ble_device
@@ -27,17 +32,34 @@ AUTH_ERROR = ConnectionError()
 AUTH_ERROR.__cause__ = PairingError()
 
 
-async def test_bluetooth_form(
+async def test_user_form(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test bluetooth discovery form."""
+    """Test user form."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_BLUETOOTH},
-        data=HUE_BLE_SERVICE_INFO,
+    with patch(
+        "homeassistant.components.hue_ble.config_flow.bluetooth.async_discovered_service_info",
+        return_value=[NOT_HUE_BLE_DISCOVERY_INFO, HUE_BLE_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"].schema[CONF_MAC].container == {
+        HUE_BLE_SERVICE_INFO.address: (
+            f"{HUE_BLE_SERVICE_INFO.name} ({HUE_BLE_SERVICE_INFO.address})"
+        ),
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MAC: HUE_BLE_SERVICE_INFO.address},
     )
+
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
     assert result["description_placeholders"] == {
@@ -76,6 +98,27 @@ async def test_bluetooth_form(
     assert result["result"].data == {}
 
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("discovery_info", [[NOT_HUE_BLE_DISCOVERY_INFO], []])
+async def test_user_form_no_device(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    discovery_info: list[BluetoothServiceInfoBleak],
+) -> None:
+    """Test user form with no devices."""
+
+    with patch(
+        "homeassistant.components.hue_ble.config_flow.bluetooth.async_discovered_service_info",
+        return_value=discovery_info,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
 
 
 @pytest.mark.parametrize(
@@ -155,7 +198,7 @@ async def test_bluetooth_form(
         "unknown",
     ],
 )
-async def test_bluetooth_form_exception(
+async def test_user_form_exception(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
     mock_return_device: BLEDevice | None,
@@ -165,13 +208,30 @@ async def test_bluetooth_form_exception(
     mock_poll_state: Exception | None,
     error: Error,
 ) -> None:
-    """Test bluetooth discovery form with errors."""
+    """Test user form with errors."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_BLUETOOTH},
-        data=HUE_BLE_SERVICE_INFO,
+    with patch(
+        "homeassistant.components.hue_ble.config_flow.bluetooth.async_discovered_service_info",
+        return_value=[NOT_HUE_BLE_DISCOVERY_INFO, HUE_BLE_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"].schema[CONF_MAC].container == {
+        HUE_BLE_SERVICE_INFO.address: (
+            f"{HUE_BLE_SERVICE_INFO.name} ({HUE_BLE_SERVICE_INFO.address})"
+        ),
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MAC: HUE_BLE_SERVICE_INFO.address},
     )
+
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "confirm"
 
@@ -232,17 +292,19 @@ async def test_bluetooth_form_exception(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_user_form_exception(
+async def test_bluetooth_discovery_aborts(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test the user form raises a discovery only error."""
+    """Test bluetooth form aborts."""
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=HUE_BLE_SERVICE_INFO,
     )
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "not_implemented"
+    assert result["reason"] == "discovery_unsupported"
 
 
 async def test_bluetooth_form_exception_already_set_up(
@@ -258,6 +320,40 @@ async def test_bluetooth_form_exception_already_set_up(
         DOMAIN,
         context={"source": SOURCE_BLUETOOTH},
         data=HUE_BLE_SERVICE_INFO,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "discovery_unsupported"
+
+
+async def test_user_form_exception_already_set_up(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test user form when device is already set up."""
+
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.hue_ble.config_flow.bluetooth.async_discovered_service_info",
+        return_value=[NOT_HUE_BLE_DISCOVERY_INFO, HUE_BLE_SERVICE_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"].schema[CONF_MAC].container == {
+        HUE_BLE_SERVICE_INFO.address: (
+            f"{HUE_BLE_SERVICE_INFO.name} ({HUE_BLE_SERVICE_INFO.address})"
+        ),
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_MAC: HUE_BLE_SERVICE_INFO.address},
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace discovery with user flow in Philips Hue BLE

Rationale: The Hue BLE integration has very limited functionality compared to the Philips Hue integration and it's confusing to users that adding a device picked up via BLE discovery sets up the limited integration.

User step allows user to pick a discovered device
<img width="405" height="301" alt="image" src="https://github.com/user-attachments/assets/22f0e394-65b7-4baf-ae49-33a9342b1854" />

Confirm step:
<img width="601" height="255" alt="image" src="https://github.com/user-attachments/assets/70a572b0-0e61-43ca-b5a6-a4c7c6a049b3" />


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
