### PR TITLE
Add select platform to Indevolt integration

### DIFF
--- a/homeassistant/components/indevolt/__init__.py
+++ b/homeassistant/components/indevolt/__init__.py
@@ -7,7 +7,12 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import IndevoltConfigEntry, IndevoltCoordinator
 
-PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: IndevoltConfigEntry) -> bool:

--- a/homeassistant/components/indevolt/select.py
+++ b/homeassistant/components/indevolt/select.py
@@ -1,0 +1,111 @@
+"""Select platform for Indevolt integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import IndevoltConfigEntry
+from .coordinator import IndevoltCoordinator
+from .entity import IndevoltEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class IndevoltSelectEntityDescription(SelectEntityDescription):
+    """Custom entity description class for Indevolt select entities."""
+
+    read_key: str
+    write_key: str
+    value_to_option: dict[int, str]
+    unavailable_values: list[int] = field(default_factory=list)
+    generation: list[int] = field(default_factory=lambda: [1, 2])
+
+
+SELECTS: Final = (
+    IndevoltSelectEntityDescription(
+        key="energy_mode",
+        translation_key="energy_mode",
+        read_key="7101",
+        write_key="47005",
+        value_to_option={
+            1: "self_consumed_prioritized",
+            4: "real_time_control",
+            5: "charge_discharge_schedule",
+        },
+        unavailable_values=[0],
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: IndevoltConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the select platform for Indevolt."""
+    coordinator = entry.runtime_data
+    device_gen = coordinator.generation
+
+    # Select initialization
+    async_add_entities(
+        IndevoltSelectEntity(coordinator=coordinator, description=description)
+        for description in SELECTS
+        if device_gen in description.generation
+    )
+
+
+class IndevoltSelectEntity(IndevoltEntity, SelectEntity):
+    """Represents a select entity for Indevolt devices."""
+
+    entity_description: IndevoltSelectEntityDescription
+
+    def __init__(
+        self,
+        coordinator: IndevoltCoordinator,
+        description: IndevoltSelectEntityDescription,
+    ) -> None:
+        """Initialize the Indevolt select entity."""
+        super().__init__(coordinator)
+
+        self.entity_description = description
+        self._attr_unique_id = f"{self.serial_number}_{description.key}"
+        self._attr_options = list(description.value_to_option.values())
+        self._option_to_value = {v: k for k, v in description.value_to_option.items()}
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected option."""
+        raw_value = self.coordinator.data.get(self.entity_description.read_key)
+        if raw_value is None:
+            return None
+
+        return self.entity_description.value_to_option.get(raw_value)
+
+    @property
+    def available(self) -> bool:
+        """Return False when the device is in a mode that cannot be selected."""
+        if not super().available:
+            return False
+
+        raw_value = self.coordinator.data.get(self.entity_description.read_key)
+        return raw_value not in self.entity_description.unavailable_values
+
+    async def async_select_option(self, option: str) -> None:
+        """Select a new option."""
+        value = self._option_to_value[option]
+        success = await self.coordinator.async_push_data(
+            self.entity_description.write_key, value
+        )
+
+        if success:
+            await self.coordinator.async_request_refresh()
+
+        else:
+            raise HomeAssistantError(f"Failed to set option {option} for {self.name}")

--- a/homeassistant/components/indevolt/strings.json
+++ b/homeassistant/components/indevolt/strings.json
@@ -37,6 +37,16 @@
         "name": "Max AC output power"
       }
     },
+    "select": {
+      "energy_mode": {
+        "name": "[%key:component::indevolt::entity::sensor::energy_mode::name%]",
+        "state": {
+          "charge_discharge_schedule": "[%key:component::indevolt::entity::sensor::energy_mode::state::charge_discharge_schedule%]",
+          "real_time_control": "[%key:component::indevolt::entity::sensor::energy_mode::state::real_time_control%]",
+          "self_consumed_prioritized": "[%key:component::indevolt::entity::sensor::energy_mode::state::self_consumed_prioritized%]"
+        }
+      }
+    },
     "sensor": {
       "ac_input_power": {
         "name": "AC input power"

--- a/tests/components/indevolt/snapshots/test_select.ambr
+++ b/tests/components/indevolt/snapshots/test_select.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_select[2][select.cms_sf2000_energy_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'self_consumed_prioritized',
+        'real_time_control',
+        'charge_discharge_schedule',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.cms_sf2000_energy_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Energy mode',
+    'platform': 'indevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_mode',
+    'unique_id': 'SolidFlex2000-87654321_energy_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[2][select.cms_sf2000_energy_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'CMS-SF2000 Energy mode',
+      'options': list([
+        'self_consumed_prioritized',
+        'real_time_control',
+        'charge_discharge_schedule',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.cms_sf2000_energy_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'self_consumed_prioritized',
+  })
+# ---

--- a/tests/components/indevolt/snapshots/test_select.ambr
+++ b/tests/components/indevolt/snapshots/test_select.ambr
@@ -1,4 +1,64 @@
 # serializer version: 1
+# name: test_select[1][select.bk1600_energy_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'self_consumed_prioritized',
+        'real_time_control',
+        'charge_discharge_schedule',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.bk1600_energy_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Energy mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Energy mode',
+    'platform': 'indevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_mode',
+    'unique_id': 'BK1600-12345678_energy_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select[1][select.bk1600_energy_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BK1600 Energy mode',
+      'options': list([
+        'self_consumed_prioritized',
+        'real_time_control',
+        'charge_discharge_schedule',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.bk1600_energy_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charge_discharge_schedule',
+  })
+# ---
 # name: test_select[2][select.cms_sf2000_energy_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/indevolt/test_select.py
+++ b/tests/components/indevolt/test_select.py
@@ -1,0 +1,157 @@
+"""Tests for the Indevolt select platform."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.indevolt.coordinator import SCAN_INTERVAL
+from homeassistant.components.select import SERVICE_SELECT_OPTION
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+KEY_READ_ENERGY_MODE = "7101"
+KEY_WRITE_ENERGY_MODE = "47005"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("generation", [2], indirect=True)
+async def test_select(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_indevolt: AsyncMock,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test select entity registration and states."""
+    with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize("generation", [2], indirect=True)
+@pytest.mark.parametrize(
+    ("option", "expected_value"),
+    [
+        ("self_consumed_prioritized", 1),
+        ("real_time_control", 4),
+        ("charge_discharge_schedule", 5),
+    ],
+)
+async def test_select_option(
+    hass: HomeAssistant,
+    mock_indevolt: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    option: str,
+    expected_value: int,
+) -> None:
+    """Test selecting all valid energy mode options."""
+    with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Reset mock call count for this iteration
+    mock_indevolt.set_data.reset_mock()
+
+    # Update mock data to reflect the new value
+    mock_indevolt.fetch_data.return_value[KEY_READ_ENERGY_MODE] = expected_value
+
+    # Attempt to change option
+    await hass.services.async_call(
+        Platform.SELECT,
+        SERVICE_SELECT_OPTION,
+        {"entity_id": "select.cms_sf2000_energy_mode", "option": option},
+        blocking=True,
+    )
+
+    # Verify set_data was called with correct parameters
+    mock_indevolt.set_data.assert_called_with(KEY_WRITE_ENERGY_MODE, expected_value)
+
+    # Verify updated state
+    assert (state := hass.states.get("select.cms_sf2000_energy_mode")) is not None
+    assert state.state == option
+
+
+@pytest.mark.parametrize("generation", [2], indirect=True)
+async def test_select_set_option_error(
+    hass: HomeAssistant,
+    mock_indevolt: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test error handling when selecting an option."""
+    with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Mock set_data to raise an error
+    mock_indevolt.set_data.side_effect = HomeAssistantError(
+        "Device communication failed"
+    )
+
+    # Attempt to change option
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            Platform.SELECT,
+            SERVICE_SELECT_OPTION,
+            {
+                "entity_id": "select.cms_sf2000_energy_mode",
+                "option": "real_time_control",
+            },
+            blocking=True,
+        )
+
+    # Verify set_data was called before failing
+    mock_indevolt.set_data.assert_called_once()
+
+
+@pytest.mark.parametrize("generation", [2], indirect=True)
+async def test_select_unavailable_outdoor_portable(
+    hass: HomeAssistant,
+    mock_indevolt: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that entity is unavailable when device is in outdoor/portable mode (value 0)."""
+
+    # Update mock data to fake outdoor/portable mode
+    mock_indevolt.fetch_data.return_value[KEY_READ_ENERGY_MODE] = 0
+
+    # Initialize platform to test availability logic
+    with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Verify entity state is unavailable
+    assert (state := hass.states.get("select.cms_sf2000_energy_mode")) is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("generation", [2], indirect=True)
+async def test_select_availability(
+    hass: HomeAssistant,
+    mock_indevolt: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test select entity availability when coordinator fails."""
+    with patch("homeassistant.components.indevolt.PLATFORMS", [Platform.SELECT]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Confirm initial state is available
+    assert (state := hass.states.get("select.cms_sf2000_energy_mode")) is not None
+    assert state.state != STATE_UNAVAILABLE
+
+    # Simulate a fetch error
+    mock_indevolt.fetch_data.side_effect = ConnectionError
+    freezer.tick(delta=timedelta(seconds=SCAN_INTERVAL))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Verify entity state is unavailable
+    assert (state := hass.states.get("select.cms_sf2000_energy_mode")) is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/indevolt/test_select.py
+++ b/tests/components/indevolt/test_select.py
@@ -23,7 +23,7 @@ KEY_WRITE_ENERGY_MODE = "47005"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-@pytest.mark.parametrize("generation", [2], indirect=True)
+@pytest.mark.parametrize("generation", [2, 1], indirect=True)
 async def test_select(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds select platform to the Indevolt integration allowing the configuration of the energy mode. This is a prerequisite for #43725 as it allows users to (re)set the energy mode after using services for real-time control.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43725
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
