### PR TITLE
Add vacuum area mapping not configured issue

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -63,6 +63,7 @@ SERVICE_STOP = "stop"
 DEFAULT_NAME = "Vacuum cleaner robot"
 
 ISSUE_SEGMENTS_CHANGED = "segments_changed"
+ISSUE_SEGMENTS_MAPPING_NOT_CONFIGURED = "segments_mapping_not_configured"
 
 _BATTERY_DEPRECATION_IGNORED_PLATFORMS = ("template",)
 
@@ -189,6 +190,9 @@ class StateVacuumEntity(
     _attr_activity: VacuumActivity | None = None
     _attr_supported_features: VacuumEntityFeature = VacuumEntityFeature(0)
 
+    _segments_not_configured_issue_created: bool = False
+    _segments_changed_last_seen: list[dict[str, Any]] | None = None
+
     __vacuum_legacy_battery_level: bool = False
     __vacuum_legacy_battery_icon: bool = False
     __vacuum_legacy_battery_feature: bool = False
@@ -231,6 +235,17 @@ class StateVacuumEntity(
             self._report_deprecated_battery_properties("battery_level")
         if self.__vacuum_legacy_battery_icon:
             self._report_deprecated_battery_properties("battery_icon")
+
+    @callback
+    def async_write_ha_state(self) -> None:
+        """Write the state to the state machine."""
+        super().async_write_ha_state()
+        self._async_check_segments_issues()
+
+    @callback
+    def async_registry_entry_updated(self) -> None:
+        """Run when the entity registry entry has been updated."""
+        self._async_check_segments_issues()
 
     @callback
     def _report_deprecated_battery_properties(self, property: str) -> None:
@@ -489,6 +504,61 @@ class StateVacuumEntity(
                 "entity_id": self.entity_id,
             },
         )
+        options: Mapping[str, Any] = self.registry_entry.options.get(DOMAIN, {})
+        self._segments_changed_last_seen = options.get("last_seen_segments")
+
+    @callback
+    def _async_check_segments_issues(self) -> None:
+        """Create or delete segment-related repair issues."""
+        if self.registry_entry is None:
+            return
+
+        options: Mapping[str, Any] = self.registry_entry.options.get(DOMAIN, {})
+        should_have_not_configured_issue = (
+            VacuumEntityFeature.CLEAN_AREA in self.supported_features
+            and options.get("area_mapping") is None
+        )
+
+        if (
+            should_have_not_configured_issue
+            and not self._segments_not_configured_issue_created
+        ):
+            issue_id = (
+                f"{ISSUE_SEGMENTS_MAPPING_NOT_CONFIGURED}_{self.registry_entry.id}"
+            )
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                issue_id,
+                data={
+                    "entry_id": self.registry_entry.id,
+                    "entity_id": self.entity_id,
+                },
+                is_fixable=False,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key=ISSUE_SEGMENTS_MAPPING_NOT_CONFIGURED,
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                },
+            )
+            self._segments_not_configured_issue_created = True
+        elif (
+            not should_have_not_configured_issue
+            and self._segments_not_configured_issue_created
+        ):
+            issue_id = (
+                f"{ISSUE_SEGMENTS_MAPPING_NOT_CONFIGURED}_{self.registry_entry.id}"
+            )
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            self._segments_not_configured_issue_created = False
+
+        if self._segments_changed_last_seen is not None and (
+            VacuumEntityFeature.CLEAN_AREA not in self.supported_features
+            or options.get("last_seen_segments") != self._segments_changed_last_seen
+        ):
+            issue_id = f"{ISSUE_SEGMENTS_CHANGED}_{self.registry_entry.id}"
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            self._segments_changed_last_seen = None
 
     def locate(self, **kwargs: Any) -> None:
         """Locate the vacuum cleaner."""

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -93,6 +93,10 @@
     "segments_changed": {
       "description": "",
       "title": "Vacuum segments have changed for {entity_id}"
+    },
+    "segments_mapping_not_configured": {
+      "description": "",
+      "title": "Vacuum segment mapping not configured for {entity_id}"
     }
   },
   "selector": {

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -430,10 +430,10 @@ async def test_last_seen_segments(
 
 
 @pytest.mark.usefixtures("config_flow_fixture")
-async def test_last_seen_segments_and_issue_creation(
+async def test_segments_changed_issue(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test last_seen_segments property and segments issue creation."""
+    """Test segments changed issue."""
     mock_vacuum = MockVacuumWithCleanArea(name="Testing", entity_id="vacuum.testing")
 
     config_entry = MockConfigEntry(domain="test")
@@ -452,6 +452,17 @@ async def test_last_seen_segments_and_issue_creation(
     await hass.async_block_till_done()
 
     entity_entry = entity_registry.async_get(mock_vacuum.entity_id)
+
+    entity_registry.async_update_entity_options(
+        mock_vacuum.entity_id,
+        DOMAIN,
+        {
+            "area_mapping": {"area_1": ["seg_1"]},
+            "last_seen_segments": [asdict(segment) for segment in mock_vacuum.segments],
+        },
+    )
+    await hass.async_block_till_done()
+
     mock_vacuum.async_create_segments_issue()
 
     issue_id = f"segments_changed_{entity_entry.id}"
@@ -459,6 +470,95 @@ async def test_last_seen_segments_and_issue_creation(
     assert issue is not None
     assert issue.severity == ir.IssueSeverity.WARNING
     assert issue.translation_key == "segments_changed"
+
+    entity_registry.async_update_entity_options(
+        mock_vacuum.entity_id,
+        DOMAIN,
+        {
+            "area_mapping": {"area_1": ["seg_1"], "area_2": ["seg_new"]},
+            "last_seen_segments": [
+                {"id": "seg_1", "name": "Kitchen"},
+                {"id": "seg_new", "name": "New Room"},
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+
+
+@pytest.mark.usefixtures("config_flow_fixture")
+@pytest.mark.parametrize("area_mapping", [{"area_1": ["seg_1"]}, {}])
+async def test_segments_mapping_not_configured_issue(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    area_mapping: dict[str, list[str]],
+) -> None:
+    """Test segments_mapping_not_configured issue."""
+    mock_vacuum = MockVacuumWithCleanArea(name="Testing", entity_id="vacuum.testing")
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+    )
+    setup_test_component_platform(hass, DOMAIN, [mock_vacuum], from_config_entry=True)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(mock_vacuum.entity_id)
+
+    issue_id = f"segments_mapping_not_configured_{entity_entry.id}"
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.translation_key == "segments_mapping_not_configured"
+
+    entity_registry.async_update_entity_options(
+        mock_vacuum.entity_id,
+        DOMAIN,
+        {
+            "area_mapping": area_mapping,
+            "last_seen_segments": [asdict(segment) for segment in mock_vacuum.segments],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert ir.async_get(hass).async_get_issue(DOMAIN, issue_id) is None
+
+
+@pytest.mark.usefixtures("config_flow_fixture")
+async def test_no_segments_mapping_issue_without_clean_area(
+    hass: HomeAssistant,
+) -> None:
+    """Test no repair issue is created when CLEAN_AREA is not supported."""
+    mock_vacuum = MockVacuum(name="Testing", entity_id="vacuum.testing")
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+    )
+    setup_test_component_platform(hass, DOMAIN, [mock_vacuum], from_config_entry=True)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issues = ir.async_get(hass).issues
+    assert not any(
+        issue_id[1].startswith("segments_mapping_not_configured") for issue_id in issues
+    )
 
 
 @pytest.mark.parametrize(("is_built_in", "log_warnings"), [(True, 0), (False, 3)])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add vacuum area mapping not configured issue.

When vacuum supports area cleaning, but has no mapping configured by user, a repair will be shown, so that the problem can be easily seen and action taken.

This PR also fixes segments changed issue removal. The assumption was that the frontend would remove the issue once fixed, but it doesn't and it probably makes more sense for Core to handle it anyway.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/29800

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
