### PR TITLE
Add reauthentication flow for Powerfox Local integration

### DIFF
--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -40,7 +40,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the user step."""
-        errors: dict[str, str] = {}
+        errors = {}
 
         if user_input is not None:
             self._host = user_input[CONF_HOST]
@@ -102,7 +102,7 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle re-authentication confirmation."""
-        errors: dict[str, str] = {}
+        errors = {}
 
         if user_input is not None:
             self._api_key = user_input[CONF_API_KEY]

--- a/homeassistant/components/powerfox_local/config_flow.py
+++ b/homeassistant/components/powerfox_local/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError, PowerfoxLocal
@@ -17,6 +18,12 @@ from .const import DOMAIN
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
+        vol.Required(CONF_API_KEY): str,
+    }
+)
+
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
         vol.Required(CONF_API_KEY): str,
     }
 )
@@ -83,6 +90,45 @@ class PowerfoxLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a confirmation flow for zeroconf discovery."""
         return self._async_create_entry()
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication flow."""
+        self._host = entry_data[CONF_HOST]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication confirmation."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._api_key = user_input[CONF_API_KEY]
+            reauth_entry = self._get_reauth_entry()
+            client = PowerfoxLocal(
+                host=reauth_entry.data[CONF_HOST],
+                api_key=user_input[CONF_API_KEY],
+                session=async_get_clientsession(self.hass),
+            )
+            try:
+                await client.value()
+            except PowerfoxAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except PowerfoxConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+        )
 
     def _async_create_entry(self) -> ConfigFlowResult:
         """Create a config entry."""

--- a/homeassistant/components/powerfox_local/coordinator.py
+++ b/homeassistant/components/powerfox_local/coordinator.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
-from powerfox import LocalResponse, PowerfoxConnectionError, PowerfoxLocal
+from powerfox import (
+    LocalResponse,
+    PowerfoxAuthenticationError,
+    PowerfoxConnectionError,
+    PowerfoxLocal,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -40,6 +46,12 @@ class PowerfoxLocalDataUpdateCoordinator(DataUpdateCoordinator[LocalResponse]):
         """Fetch data from the local poweropti."""
         try:
             return await self.client.value()
+        except PowerfoxAuthenticationError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_auth",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except PowerfoxConnectionError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/powerfox_local/quality_scale.yaml
+++ b/homeassistant/components/powerfox_local/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/powerfox_local/strings.json
+++ b/homeassistant/components/powerfox_local/strings.json
@@ -2,13 +2,24 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "[%key:component::powerfox_local::config::step::user::data_description::api_key%]"
+        },
+        "description": "The API key for your Poweropti device is no longer valid.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
@@ -43,6 +54,9 @@
     }
   },
   "exceptions": {
+    "invalid_auth": {
+      "message": "Error while authenticating with the device: {error}"
+    },
     "update_failed": {
       "message": "Error while updating the device: {error}"
     }

--- a/tests/components/powerfox_local/test_config_flow.py
+++ b/tests/components/powerfox_local/test_config_flow.py
@@ -184,3 +184,70 @@ async def test_user_flow_exceptions(
         user_input={CONF_HOST: MOCK_HOST, CONF_API_KEY: MOCK_API_KEY},
     )
     assert result.get("type") is FlowResultType.CREATE_ENTRY
+
+
+async def test_step_reauth(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test re-authentication flow."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "reauth_successful"
+
+    assert mock_config_entry.data[CONF_API_KEY] == "new-api-key"
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (PowerfoxConnectionError, "cannot_connect"),
+        (PowerfoxAuthenticationError, "invalid_auth"),
+    ],
+)
+async def test_step_reauth_exceptions(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test exceptions during re-authentication flow."""
+    mock_powerfox_local_client.value.side_effect = exception
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("errors") == {"base": error}
+
+    # Recover from error
+    mock_powerfox_local_client.value.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_API_KEY: "new-api-key"},
+    )
+    assert result.get("type") is FlowResultType.ABORT
+    assert result.get("reason") == "reauth_successful"
+
+    assert mock_config_entry.data[CONF_API_KEY] == "new-api-key"

--- a/tests/components/powerfox_local/test_init.py
+++ b/tests/components/powerfox_local/test_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
-from powerfox import PowerfoxConnectionError
+from powerfox import PowerfoxAuthenticationError, PowerfoxConnectionError
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -43,3 +43,20 @@ async def test_config_entry_not_ready(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_exception(
+    hass: HomeAssistant,
+    mock_powerfox_local_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
+    mock_config_entry.add_to_hass(hass)
+    mock_powerfox_local_client.value.side_effect = PowerfoxAuthenticationError
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding a reauthentication flow for when a used API key is no longer valid. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
