### PR TITLE
Fix AccuWeather daily forecast crash when humidity average is missing

### DIFF
--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -191,7 +191,7 @@ class AccuWeatherEntity(
             {
                 ATTR_FORECAST_TIME: utc_from_timestamp(item["EpochDate"]).isoformat(),
                 ATTR_FORECAST_CLOUD_COVERAGE: item["CloudCoverDay"],
-                ATTR_FORECAST_HUMIDITY: item["RelativeHumidityDay"]["Average"],
+                ATTR_FORECAST_HUMIDITY: item["RelativeHumidityDay"].get("Average"),
                 ATTR_FORECAST_NATIVE_TEMP: item["TemperatureMax"][ATTR_VALUE],
                 ATTR_FORECAST_NATIVE_TEMP_LOW: item["TemperatureMin"][ATTR_VALUE],
                 ATTR_FORECAST_NATIVE_APPARENT_TEMP: item["RealFeelTemperatureMax"][

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -136,6 +136,31 @@ async def test_forecast_service(
     assert response == snapshot
 
 
+async def test_forecast_daily_missing_average_humidity(
+    hass: HomeAssistant,
+    mock_accuweather_client: AsyncMock,
+) -> None:
+    """Test daily forecast does not crash when average humidity is missing."""
+    mock_accuweather_client.async_get_daily_forecast.return_value[0][
+        "RelativeHumidityDay"
+    ] = {}
+
+    await init_integration(hass)
+
+    response = await hass.services.async_call(
+        WEATHER_DOMAIN,
+        SERVICE_GET_FORECASTS,
+        {
+            "entity_id": "weather.home",
+            "type": "daily",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response["weather.home"]["forecast"][0][ATTR_FORECAST_HUMIDITY] is None
+
+
 async def test_forecast_subscription(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -158,7 +158,7 @@ async def test_forecast_daily_missing_average_humidity(
         return_response=True,
     )
 
-    assert response["weather.home"]["forecast"][0][ATTR_FORECAST_HUMIDITY] is None
+    assert response["weather.home"]["forecast"][0].get("humidity") is None
 
 
 async def test_forecast_subscription(


### PR DESCRIPTION
## Breaking change

No breaking change.

## Proposed change
This PR fixes an AccuWeather forecast crash when daily forecast payloads include `RelativeHumidityDay` but omit `Average`.

Before this change, Home Assistant could raise `KeyError: 'Average'` while building daily forecast output.

After this change, missing humidity average is handled safely and exposed as `None` instead of crashing.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #163952
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
