### PR TITLE
Avoid KeyError for ignored Home Assistant Connect ZBT-2 entries

### DIFF
--- a/homeassistant/components/homeassistant_connect_zbt2/hardware.py
+++ b/homeassistant/components/homeassistant_connect_zbt2/hardware.py
@@ -37,6 +37,8 @@ def async_info(hass: HomeAssistant) -> list[HardwareInfo]:
             url=DOCUMENTATION_URL,
         )
         for entry in entries
-        # Ignore unmigrated config entries in the hardware page
+        # Ignore unmigrated or ignored discovery config entries in the hardware page
         if (entry.version, entry.minor_version) == EXPECTED_ENTRY_VERSION
+        and VID in entry.data
+        and PID in entry.data
     ]

--- a/tests/components/homeassistant_connect_zbt2/test_hardware.py
+++ b/tests/components/homeassistant_connect_zbt2/test_hardware.py
@@ -21,6 +21,36 @@ CONFIG_ENTRY_DATA = {
 }
 
 
+async def test_hardware_info_ignored_entry_missing_usb_data(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
+) -> None:
+    """Test ignored discovery entries without VID/PID are skipped."""
+    assert await async_setup_component(hass, USB_DOMAIN, {})
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+
+    ignored_entry = MockConfigEntry(
+        data={"device": CONFIG_ENTRY_DATA["device"]},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Connect ZBT-2",
+        unique_id="unique_ignored",
+        source="ignore",
+        version=1,
+        minor_version=1,
+    )
+    ignored_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(ignored_entry.entry_id)
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({"id": 1, "type": "hardware/info"})
+    msg = await client.receive_json()
+
+    assert msg["id"] == 1
+    assert msg["success"]
+    assert msg["result"] == {"hardware": []}
+
+
 async def test_hardware_info(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, addon_store_info
 ) -> None:


### PR DESCRIPTION
## Breaking change

No breaking change.

## Proposed change
This PR fixes a crash in Home Assistant Connect ZBT-2 hardware info when ignored discovery entries are incomplete and do not include USB metadata fields.

Before this change, hardware info generation could raise `KeyError` for missing `vid`/`pid` fields.

After this change, incomplete entries are safely ignored and valid entries continue to work as before.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #163900
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
