### PR TITLE
Handle invalid stored Roborock user data by starting reauth

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -62,7 +62,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def _get_user_data(entry: RoborockConfigEntry) -> UserData:
+def _get_user_data(entry: RoborockConfigEntry) -> UserData:
     """Get user data from config entry."""
     try:
         return cast(UserData, UserData.from_dict(entry.data[CONF_USER_DATA]))
@@ -78,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
     """Set up roborock from a config entry."""
     await async_cleanup_map_storage(hass, entry.entry_id)
 
-    user_data = await _get_user_data(entry)
+    user_data = _get_user_data(entry)
     user_params = UserParams(
         username=entry.data[CONF_USERNAME],
         user_data=user_data,
@@ -217,10 +217,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -
 
     # 1->2: Migrate from unique id as email address to unique id as rruid
     if entry.minor_version == 1:
-        try:
-            user_data = UserData.from_dict(entry.data[CONF_USER_DATA])
-        except TypeError:
-            return False
+        user_data = UserData.from_dict(entry.data[CONF_USER_DATA])
         _LOGGER.debug("Updating unique id to %s", user_data.rruid)
         hass.config_entries.async_update_entry(
             entry,

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -62,11 +62,23 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+async def _get_user_data(entry: RoborockConfigEntry) -> UserData:
+    """Get user data from config entry."""
+    try:
+        return UserData.from_dict(entry.data[CONF_USER_DATA])
+    except TypeError as err:
+        raise ConfigEntryAuthFailed(
+            "Stored user data is invalid",
+            translation_domain=DOMAIN,
+            translation_key="invalid_credentials",
+        ) from err
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> bool:
     """Set up roborock from a config entry."""
     await async_cleanup_map_storage(hass, entry.entry_id)
 
-    user_data = UserData.from_dict(entry.data[CONF_USER_DATA])
+    user_data = await _get_user_data(entry)
     user_params = UserParams(
         username=entry.data[CONF_USERNAME],
         user_data=user_data,
@@ -205,7 +217,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -
 
     # 1->2: Migrate from unique id as email address to unique id as rruid
     if entry.minor_version == 1:
-        user_data = UserData.from_dict(entry.data[CONF_USER_DATA])
+        try:
+            user_data = UserData.from_dict(entry.data[CONF_USER_DATA])
+        except TypeError:
+            return False
         _LOGGER.debug("Updating unique id to %s", user_data.rruid)
         hass.config_entries.async_update_entry(
             entry,

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Coroutine
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, cast
 
 from roborock import (
     RoborockException,
@@ -65,7 +65,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def _get_user_data(entry: RoborockConfigEntry) -> UserData:
     """Get user data from config entry."""
     try:
-        return UserData.from_dict(entry.data[CONF_USER_DATA])
+        return cast(UserData, UserData.from_dict(entry.data[CONF_USER_DATA]))
     except TypeError as err:
         raise ConfigEntryAuthFailed(
             "Stored user data is invalid",

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -100,7 +100,7 @@ async def test_reauth_started_when_stored_user_data_invalid(
     invalid_data = dict(mock_roborock_entry.data)
     invalid_data[CONF_USER_DATA] = dict(mock_roborock_entry.data[CONF_USER_DATA])
     del invalid_data[CONF_USER_DATA]["rriot"]
-    mock_roborock_entry.data = invalid_data
+    hass.config_entries.async_update_entry(mock_roborock_entry, data=invalid_data)
 
     await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -98,11 +98,8 @@ async def test_reauth_started_when_stored_user_data_invalid(
 ) -> None:
     """Test reauth flow starts when stored user data cannot be parsed."""
     invalid_data = dict(mock_roborock_entry.data)
-    invalid_data[CONF_USER_DATA] = {
-        key: value
-        for key, value in mock_roborock_entry.data[CONF_USER_DATA].items()
-        if key != "rriot"
-    }
+    invalid_data[CONF_USER_DATA] = dict(mock_roborock_entry.data[CONF_USER_DATA])
+    del invalid_data[CONF_USER_DATA]["rriot"]
     mock_roborock_entry.data = invalid_data
 
     await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.roborock.const import DOMAIN
+from homeassistant.components.roborock.const import CONF_USER_DATA, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
@@ -87,6 +87,29 @@ async def test_reauth_started(
         await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert mock_roborock_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+
+async def test_reauth_started_when_stored_user_data_invalid(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow starts when stored user data cannot be parsed."""
+    invalid_data = dict(mock_roborock_entry.data)
+    invalid_data[CONF_USER_DATA] = {
+        key: value
+        for key, value in mock_roborock_entry.data[CONF_USER_DATA].items()
+        if key != "rriot"
+    }
+    mock_roborock_entry.data = invalid_data
+
+    await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert mock_roborock_entry.state is ConfigEntryState.SETUP_ERROR
+
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
     assert flows[0]["step_id"] == "reauth_confirm"


### PR DESCRIPTION
## Breaking change

No breaking change.

## Proposed change
This PR hardens Roborock setup behavior when stored `user_data` is invalid or no longer matches expected schema.

Before this change, parsing invalid stored user data could raise a `TypeError` and break setup.

After this change, invalid stored user data triggers reauthentication flow (`ConfigEntryAuthFailed`) instead of hard failure.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #163914
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
