### PR TITLE
Bump ZHA to 1.0.0

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==0.0.90", "serialx==0.6.2"],
+  "requirements": ["zha==1.0.0", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -858,7 +858,7 @@
         "name": "Occupied to unoccupied delay"
       },
       "pir_u_to_o_delay": {
-        "name": "Occupied to unoccupied delay"
+        "name": "Unoccupied to occupied delay"
       },
       "portion_weight": {
         "name": "Portion weight"

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -335,17 +335,38 @@
       }
     },
     "button": {
+      "boost_mode": {
+        "name": "Boost mode"
+      },
       "calibrate_valve": {
         "name": "Calibrate valve"
       },
       "calibrate_z_axis": {
         "name": "Calibrate Z axis"
       },
+      "delete_all_limits": {
+        "name": "Delete all limits"
+      },
+      "delete_lower_limit": {
+        "name": "Delete lower limit"
+      },
+      "delete_upper_limit": {
+        "name": "Delete upper limit"
+      },
+      "enter_calibration_mode": {
+        "name": "Enter calibration mode"
+      },
+      "exit_calibration_mode": {
+        "name": "Exit calibration mode"
+      },
       "feed": {
         "name": "Feed"
       },
       "frost_lock_reset": {
         "name": "Frost lock reset"
+      },
+      "prepare_manual_calibration": {
+        "name": "Prepare manual calibration"
       },
       "reset_alarm": {
         "name": "Reset alarm"
@@ -368,8 +389,20 @@
       "restart_device": {
         "name": "Restart device"
       },
+      "run_auto_calibration": {
+        "name": "Run auto-calibration"
+      },
       "self_test": {
         "name": "Self-test"
+      },
+      "set_lower_limit": {
+        "name": "Set lower limit"
+      },
+      "set_upper_limit": {
+        "name": "Set upper limit"
+      },
+      "timer_mode": {
+        "name": "Timer mode"
       }
     },
     "climate": {
@@ -425,6 +458,9 @@
       }
     },
     "number": {
+      "additional_steps": {
+        "name": "Additional steps"
+      },
       "alarm_duration": {
         "name": "Alarm duration"
       },
@@ -487,6 +523,12 @@
       },
       "calibration_vertical_run_time_up": {
         "name": "Calibration vertical run time up"
+      },
+      "closed_limit_lift": {
+        "name": "Closed limit lift"
+      },
+      "closed_limit_tilt": {
+        "name": "Closed limit tilt"
       },
       "closing_duration": {
         "name": "Closing duration"
@@ -629,6 +671,9 @@
       "impulse_mode_duration": {
         "name": "Impulse mode duration"
       },
+      "inactive_power_threshold": {
+        "name": "Inactive power threshold"
+      },
       "installation_height": {
         "name": "Height from sensor to tank bottom"
       },
@@ -701,6 +746,9 @@
       "max_temperature": {
         "name": "Max temperature"
       },
+      "maximum_dimming_level": {
+        "name": "Maximum dimming level"
+      },
       "maximum_level": {
         "name": "Maximum load dimming level"
       },
@@ -728,8 +776,14 @@
       "mini_set": {
         "name": "Liquid minimal percentage"
       },
+      "minimum_dimming_level": {
+        "name": "Minimum dimming level"
+      },
       "minimum_level": {
         "name": "Minimum load dimming level"
+      },
+      "minimum_on_level": {
+        "name": "Minimum on level"
       },
       "motion_detection_sensitivity": {
         "name": "Motion detection sensitivity"
@@ -776,6 +830,12 @@
       "open_delay_time": {
         "name": "Open delay time"
       },
+      "open_limit_lift": {
+        "name": "Open limit lift"
+      },
+      "open_limit_tilt": {
+        "name": "Open limit tilt"
+      },
       "open_window_detection_guard_period": {
         "name": "Open window detection guard period"
       },
@@ -793,6 +853,12 @@
       },
       "output_time": {
         "name": "Output time"
+      },
+      "pir_o_to_u_delay": {
+        "name": "Occupied to unoccupied delay"
+      },
+      "pir_u_to_o_delay": {
+        "name": "Occupied to unoccupied delay"
       },
       "portion_weight": {
         "name": "Portion weight"
@@ -842,6 +908,9 @@
       "sensitivity": {
         "name": "Sensitivity"
       },
+      "sensitivity_level": {
+        "name": "Sensitivity level"
+      },
       "serving_size": {
         "name": "Serving to dispense"
       },
@@ -875,6 +944,9 @@
       "start_up_current_level": {
         "name": "Start-up current level"
       },
+      "startup_time": {
+        "name": "Startup time"
+      },
       "state_after_power_restored": {
         "name": "Start-up default dimming level"
       },
@@ -902,20 +974,38 @@
       "temperature_sensitivity": {
         "name": "Temperature sensitivity"
       },
+      "temporary_mode_duration": {
+        "name": "Temporary mode duration"
+      },
       "tilt_open_close_and_step_time": {
         "name": "Tilt open close and step time"
       },
       "tilt_position_percentage_after_move_to_level": {
         "name": "Tilt position percentage after move to level"
       },
+      "tilt_turn_time_close_to_open": {
+        "name": "Tilt turn time (close to open)"
+      },
+      "tilt_turn_time_open_to_close": {
+        "name": "Tilt turn time (open to close)"
+      },
       "timer_duration": {
         "name": "Timer duration"
+      },
+      "timer_mode_target_temperature": {
+        "name": "Timer mode target temperature"
       },
       "timer_time_left": {
         "name": "Timer time left"
       },
       "transmit_power": {
         "name": "Transmit power"
+      },
+      "travel_time_close_to_open": {
+        "name": "Travel time (close to open)"
+      },
+      "travel_time_open_to_close": {
+        "name": "Travel time (open to close)"
       },
       "turn_off_delay": {
         "name": "Turn off delay"
@@ -934,6 +1024,9 @@
       },
       "turn_on_delay_right": {
         "name": "Turn on delay right"
+      },
+      "turnaround_guard_time": {
+        "name": "Turnaround guard time"
       },
       "up_movement": {
         "name": "Up movement"
@@ -1093,6 +1186,12 @@
       "increased_non_neutral_output": {
         "name": "Increased non-neutral output"
       },
+      "input_mode": {
+        "name": "Input mode"
+      },
+      "input_mode_id": {
+        "name": "Input mode {input_id}"
+      },
       "irrigation_mode": {
         "name": "Irrigation mode"
       },
@@ -1132,6 +1231,9 @@
       "motion_state": {
         "name": "Motion state"
       },
+      "motor_direction": {
+        "name": "Motor direction"
+      },
       "motor_thrust": {
         "name": "Motor thrust"
       },
@@ -1152,6 +1254,9 @@
       },
       "phase": {
         "name": "Phase"
+      },
+      "phase_control": {
+        "name": "Phase control"
       },
       "pilot_wire_mode": {
         "name": "Pilot wire mode"
@@ -1234,6 +1339,9 @@
       "window_covering_mode": {
         "name": "Curtain mode"
       },
+      "window_covering_type": {
+        "name": "Window covering type"
+      },
       "work_mode": {
         "name": "Work mode"
       },
@@ -1244,6 +1352,15 @@
     "sensor": {
       "ac_frequency": {
         "name": "AC frequency"
+      },
+      "acceleration_x": {
+        "name": "Acceleration X"
+      },
+      "acceleration_y": {
+        "name": "Acceleration Y"
+      },
+      "acceleration_z": {
+        "name": "Acceleration Z"
       },
       "active_power_ph_b": {
         "name": "Power phase B"
@@ -1274,6 +1391,9 @@
       },
       "analog_input": {
         "name": "Analog input"
+      },
+      "auto_calibration_state": {
+        "name": "Auto-calibration state"
       },
       "average_light_intensity_20mins": {
         "name": "Average light intensity last 20 min"
@@ -1657,6 +1777,9 @@
       "adaptation_run_enabled": {
         "name": "Adaptation run enabled"
       },
+      "adaptive_mode": {
+        "name": "Adaptive mode"
+      },
       "auto_clean": {
         "name": "Autoclean"
       },
@@ -1686,6 +1809,12 @@
       },
       "detach_relay": {
         "name": "Detach relay"
+      },
+      "detached": {
+        "name": "Detached mode"
+      },
+      "detached_id": {
+        "name": "Detached mode {input_id}"
       },
       "dimmer_mode": {
         "name": "Dimmer mode"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3344,7 +3344,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.90
+zha==1.0.0
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2814,7 +2814,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==0.0.90
+zha==1.0.0
 
 # homeassistant.components.zinvolt
 zinvolt==0.1.0


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [1.0.0](https://github.com/zigpy/zha/releases/tag/1.0.0) (full diff: https://github.com/zigpy/zha/compare/0.0.90...1.0.0).
These dependency upgrades are bundled with it: 

- `zigpy` [1.0.0](https://github.com/zigpy/zigpy/releases/tag/1.0.0)
full diff: https://github.com/zigpy/zigpy/compare/0.92.0...1.0.0

- `zha-quirks` [1.0.0](https://github.com/zigpy/zha-device-handlers/releases/tag/1.0.0)
full diff: https://github.com/zigpy/zha-device-handlers/compare/0.0.157...1.0.0

Note: The releases have been arbitrarily tagged 1.0.0 to properly use SemVer.
New strings for ZHA and quirks v2 entities have also been added.

A quick overview of the changes in this ZHA release:
- Support for Ubisys devices has been drastically improved (switches, dimmer, shutter control)
- New features were added for Frient devices
- New features were added to the Sonoff TRVZB
  - An [OTA update](https://github.com/zigpy/zigpy-ota/pull/24) will be pushed to HA users shortly for this
- Handling for attribute reports colliding with a ZCL attribute ID is improved
- Other small fixes and improvements...

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: addresses https://github.com/home-assistant/core/issues/163118
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
