### PR TITLE
Pass encoding to AtomicWriter in write_utf8_file_atomic

### DIFF
--- a/homeassistant/util/file.py
+++ b/homeassistant/util/file.py
@@ -34,7 +34,7 @@ def write_utf8_file_atomic(
     """
     encoding = "utf-8" if "b" not in mode else None
     try:
-        with AtomicWriter(
+        with AtomicWriter(  # type: ignore[call-arg]  # atomicwrites-stubs is outdated, encoding is a valid kwarg
             filename, mode=mode, overwrite=True, encoding=encoding
         ).open() as fdesc:
             if not private:

--- a/homeassistant/util/file.py
+++ b/homeassistant/util/file.py
@@ -32,8 +32,11 @@ def write_utf8_file_atomic(
     Using this function frequently will significantly
     negatively impact performance.
     """
+    encoding = "utf-8" if "b" not in mode else None
     try:
-        with AtomicWriter(filename, mode=mode, overwrite=True).open() as fdesc:
+        with AtomicWriter(
+            filename, mode=mode, overwrite=True, encoding=encoding
+        ).open() as fdesc:
             if not private:
                 os.fchmod(fdesc.fileno(), 0o644)
             fdesc.write(utf8_data)

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -4,15 +4,17 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import py
 import pytest
 
 from homeassistant.util.file import WriteError, write_utf8_file, write_utf8_file_atomic
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_atomic_private(tmp_path: Path, func) -> None:
+def test_write_utf8_file_atomic_private(tmpdir: py.path.local, func) -> None:
     """Test files can be written as 0o600 or 0o644."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
 
     func(test_file, '{"some":"data"}', False)
     with open(test_file, encoding="utf8") as fh:
@@ -30,9 +32,10 @@ def test_write_utf8_file_atomic_private(tmp_path: Path, func) -> None:
     assert os.stat(test_file).st_mode & 0o777 == 0o600
 
 
-def test_write_utf8_file_fails_at_creation(tmp_path: Path) -> None:
+def test_write_utf8_file_fails_at_creation(tmpdir: py.path.local) -> None:
     """Test that failed creation of the temp file does not create an empty file."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
 
     with (
         pytest.raises(WriteError),
@@ -42,14 +45,15 @@ def test_write_utf8_file_fails_at_creation(tmp_path: Path) -> None:
     ):
         write_utf8_file(test_file, '{"some":"data"}', False)
 
-    assert not test_file.exists()
+    assert not os.path.exists(test_file)
 
 
 def test_write_utf8_file_fails_at_rename(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that if rename fails not not remove, we do not log the failed cleanup."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
 
     with (
         pytest.raises(WriteError),
@@ -57,16 +61,17 @@ def test_write_utf8_file_fails_at_rename(
     ):
         write_utf8_file(test_file, '{"some":"data"}', False)
 
-    assert not test_file.exists()
+    assert not os.path.exists(test_file)
 
     assert "File replacement cleanup failed" not in caplog.text
 
 
 def test_write_utf8_file_fails_at_rename_and_remove(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
+    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that if rename and remove both fail, we log the failed cleanup."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
 
     with (
         pytest.raises(WriteError),
@@ -79,9 +84,10 @@ def test_write_utf8_file_fails_at_rename_and_remove(
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_with_non_ascii_content(tmp_path: Path, func) -> None:
+def test_write_utf8_file_with_non_ascii_content(tmpdir: py.path.local, func) -> None:
     """Test files with non-ASCII content can be written even when locale is ASCII."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
     non_ascii_data = '{"name":"自动化","emoji":"🏠"}'
 
     with patch("locale.getpreferredencoding", return_value="ascii"):
@@ -91,9 +97,10 @@ def test_write_utf8_file_with_non_ascii_content(tmp_path: Path, func) -> None:
         assert fh.read() == non_ascii_data
 
 
-def test_write_utf8_file_atomic_fails(tmp_path: Path) -> None:
+def test_write_utf8_file_atomic_fails(tmpdir: py.path.local) -> None:
     """Test OSError from write_utf8_file_atomic is rethrown as WriteError."""
-    test_file = tmp_path / "test.json"
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
 
     with (
         pytest.raises(WriteError),
@@ -101,4 +108,4 @@ def test_write_utf8_file_atomic_fails(tmp_path: Path) -> None:
     ):
         write_utf8_file_atomic(test_file, '{"some":"data"}', False)
 
-    assert not test_file.exists()
+    assert not os.path.exists(test_file)

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -83,6 +83,22 @@ def test_write_utf8_file_fails_at_rename_and_remove(
     assert "File replacement cleanup failed" in caplog.text
 
 
+@pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
+def test_write_utf8_file_with_non_ascii_content(
+    tmpdir: py.path.local, func
+) -> None:
+    """Test files with non-ASCII content can be written even when locale is ASCII."""
+    test_dir = tmpdir.mkdir("files")
+    test_file = Path(test_dir / "test.json")
+    non_ascii_data = '{"name":"自动化","emoji":"🏠"}'
+
+    with patch("locale.getpreferredencoding", return_value="ascii"):
+        func(test_file, non_ascii_data, False)
+
+    with open(test_file, encoding="utf-8") as fh:
+        assert fh.read() == non_ascii_data
+
+
 def test_write_utf8_file_atomic_fails(tmpdir: py.path.local) -> None:
     """Test OSError from write_utf8_file_atomic is rethrown as WriteError."""
     test_dir = tmpdir.mkdir("files")

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -84,17 +84,16 @@ def test_write_utf8_file_fails_at_rename_and_remove(
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_with_non_ascii_content(tmpdir: py.path.local, func) -> None:
+def test_write_utf8_file_with_non_ascii_content(tmp_path: Path, func) -> None:
     """Test files with non-ASCII content can be written even when locale is ASCII."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
     non_ascii_data = '{"name":"自动化","emoji":"🏠"}'
 
     with patch("locale.getpreferredencoding", return_value="ascii"):
         func(test_file, non_ascii_data, False)
 
-    with open(test_file, encoding="utf-8") as fh:
-        assert fh.read() == non_ascii_data
+    file_text = test_file.read_text(encoding="utf-8")
+    assert file_text == non_ascii_data
 
 
 def test_write_utf8_file_atomic_fails(tmpdir: py.path.local) -> None:

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -84,9 +84,7 @@ def test_write_utf8_file_fails_at_rename_and_remove(
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_with_non_ascii_content(
-    tmpdir: py.path.local, func
-) -> None:
+def test_write_utf8_file_with_non_ascii_content(tmpdir: py.path.local, func) -> None:
     """Test files with non-ASCII content can be written even when locale is ASCII."""
     test_dir = tmpdir.mkdir("files")
     test_file = Path(test_dir / "test.json")

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -4,17 +4,15 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import py
 import pytest
 
 from homeassistant.util.file import WriteError, write_utf8_file, write_utf8_file_atomic
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_atomic_private(tmpdir: py.path.local, func) -> None:
+def test_write_utf8_file_atomic_private(tmp_path: Path, func) -> None:
     """Test files can be written as 0o600 or 0o644."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
 
     func(test_file, '{"some":"data"}', False)
     with open(test_file, encoding="utf8") as fh:
@@ -32,10 +30,9 @@ def test_write_utf8_file_atomic_private(tmpdir: py.path.local, func) -> None:
     assert os.stat(test_file).st_mode & 0o777 == 0o600
 
 
-def test_write_utf8_file_fails_at_creation(tmpdir: py.path.local) -> None:
+def test_write_utf8_file_fails_at_creation(tmp_path: Path) -> None:
     """Test that failed creation of the temp file does not create an empty file."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
 
     with (
         pytest.raises(WriteError),
@@ -45,15 +42,14 @@ def test_write_utf8_file_fails_at_creation(tmpdir: py.path.local) -> None:
     ):
         write_utf8_file(test_file, '{"some":"data"}', False)
 
-    assert not os.path.exists(test_file)
+    assert not test_file.exists()
 
 
 def test_write_utf8_file_fails_at_rename(
-    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that if rename fails not not remove, we do not log the failed cleanup."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
 
     with (
         pytest.raises(WriteError),
@@ -61,17 +57,16 @@ def test_write_utf8_file_fails_at_rename(
     ):
         write_utf8_file(test_file, '{"some":"data"}', False)
 
-    assert not os.path.exists(test_file)
+    assert not test_file.exists()
 
     assert "File replacement cleanup failed" not in caplog.text
 
 
 def test_write_utf8_file_fails_at_rename_and_remove(
-    tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test that if rename and remove both fail, we log the failed cleanup."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
 
     with (
         pytest.raises(WriteError),
@@ -84,10 +79,9 @@ def test_write_utf8_file_fails_at_rename_and_remove(
 
 
 @pytest.mark.parametrize("func", [write_utf8_file, write_utf8_file_atomic])
-def test_write_utf8_file_with_non_ascii_content(tmpdir: py.path.local, func) -> None:
+def test_write_utf8_file_with_non_ascii_content(tmp_path: Path, func) -> None:
     """Test files with non-ASCII content can be written even when locale is ASCII."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
     non_ascii_data = '{"name":"自动化","emoji":"🏠"}'
 
     with patch("locale.getpreferredencoding", return_value="ascii"):
@@ -97,10 +91,9 @@ def test_write_utf8_file_with_non_ascii_content(tmpdir: py.path.local, func) -> 
         assert fh.read() == non_ascii_data
 
 
-def test_write_utf8_file_atomic_fails(tmpdir: py.path.local) -> None:
+def test_write_utf8_file_atomic_fails(tmp_path: Path) -> None:
     """Test OSError from write_utf8_file_atomic is rethrown as WriteError."""
-    test_dir = tmpdir.mkdir("files")
-    test_file = Path(test_dir / "test.json")
+    test_file = tmp_path / "test.json"
 
     with (
         pytest.raises(WriteError),
@@ -108,4 +101,4 @@ def test_write_utf8_file_atomic_fails(tmpdir: py.path.local) -> None:
     ):
         write_utf8_file_atomic(test_file, '{"some":"data"}', False)
 
-    assert not os.path.exists(test_file)
+    assert not test_file.exists()


### PR DESCRIPTION
write_utf8_file_atomic does not pass encoding="utf-8" to AtomicWriter, causing UnicodeEncodeError when writing non-ASCII content on systems where PID 1 has no locale set (e.g. HA OS containers where only PATH is in /proc/1/environ). Python defaults to ASCII encoding in this case.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The sibling function write_utf8_file already correctly sets encoding. This change makes write_utf8_file_atomic consistent by passing encoding="utf-8" for text mode and None for binary mode.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Closes home-assistant/operating-system#4478 and #141728

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
