### PR TITLE
Cache downloaded file for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 from telegram import Bot
 from telegram.constants import InputMediaType
@@ -470,11 +470,13 @@ async def _async_send_telegram_message(service: ServiceCall) -> ServiceResponse:
     service_responses: JsonValueType = []
     errors: list[tuple[Exception, str]] = []
 
+    cache: dict[str, Any] = {}
+
     # invoke the service for each target
     for target_config_entry, target_chat_id, target_notify_entity_id in targets:
         try:
             service_response = await _call_service(
-                service, target_config_entry.runtime_data, target_chat_id
+                service, target_config_entry.runtime_data, target_chat_id, cache
             )
 
             if service.service == SERVICE_DOWNLOAD_FILE:
@@ -527,7 +529,10 @@ async def _async_send_telegram_message(service: ServiceCall) -> ServiceResponse:
 
 
 async def _call_service(
-    service: ServiceCall, notify_service: TelegramNotificationService, chat_id: int
+    service: ServiceCall,
+    notify_service: TelegramNotificationService,
+    chat_id: int,
+    cache: dict[str, Any],
 ) -> dict[str, JsonValueType] | None:
     """Calls a Telegram bot service using the specified bot and chat_id."""
 
@@ -551,10 +556,15 @@ async def _call_service(
         SERVICE_SEND_DOCUMENT,
     ]:
         messages = await notify_service.send_file(
-            service_name, context=service.context, **kwargs
+            service_name,
+            cache,
+            context=service.context,
+            **kwargs,
         )
     elif service_name == SERVICE_SEND_STICKER:
-        messages = await notify_service.send_sticker(context=service.context, **kwargs)
+        messages = await notify_service.send_sticker(
+            cache, context=service.context, **kwargs
+        )
     elif service_name == SERVICE_SEND_LOCATION:
         messages = await notify_service.send_location(context=service.context, **kwargs)
     elif service_name == SERVICE_SEND_POLL:

--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -726,24 +726,30 @@ class TelegramNotificationService:
     async def send_file(
         self,
         file_type: str,
+        cache: dict[str, Any],
         context: Context | None = None,
         **kwargs: Any,
     ) -> dict[str, JsonValueType]:
         """Send a photo, sticker, video, or document."""
         params = self._get_msg_kwargs(kwargs)
-        file_content = await load_data(
-            self.hass,
-            url=kwargs.get(ATTR_URL),
-            filepath=kwargs.get(ATTR_FILE),
-            username=kwargs.get(ATTR_USERNAME, ""),
-            password=kwargs.get(ATTR_PASSWORD, ""),
-            authentication=kwargs.get(ATTR_AUTHENTICATION),
-            verify_ssl=(
-                get_default_context()
-                if kwargs.get(ATTR_VERIFY_SSL, False)
-                else get_default_no_verify_context()
-            ),
-        )
+
+        file_content: io.BytesIO | None = cache.get(ATTR_FILE)
+        if file_content is None:
+            file_content = await load_data(
+                self.hass,
+                url=kwargs.get(ATTR_URL),
+                filepath=kwargs.get(ATTR_FILE),
+                username=kwargs.get(ATTR_USERNAME, ""),
+                password=kwargs.get(ATTR_PASSWORD, ""),
+                authentication=kwargs.get(ATTR_AUTHENTICATION),
+                verify_ssl=(
+                    get_default_context()
+                    if kwargs.get(ATTR_VERIFY_SSL, False)
+                    else get_default_no_verify_context()
+                ),
+            )
+            cache[ATTR_FILE] = file_content
+        file_content.seek(0)
 
         if file_type == SERVICE_SEND_PHOTO:
             return await self._send_msg_formatted(
@@ -840,6 +846,7 @@ class TelegramNotificationService:
 
     async def send_sticker(
         self,
+        cache: dict[str, Any],
         context: Context | None = None,
         **kwargs: Any,
     ) -> dict[str, JsonValueType]:
@@ -860,7 +867,7 @@ class TelegramNotificationService:
                 message_thread_id=params[ATTR_MESSAGE_THREAD_ID],
                 context=context,
             )
-        return await self.send_file(SERVICE_SEND_STICKER, context, **kwargs)
+        return await self.send_file(SERVICE_SEND_STICKER, cache, context, **kwargs)
 
     async def send_location(
         self,

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -328,6 +328,7 @@ async def test_send_sticker_partial_error(
     with (
         patch(
             "homeassistant.components.telegram_bot.bot.load_data",
+            AsyncMock(return_value=io.BytesIO(b"mock data")),
         ) as mock_load_data,
         patch(
             "homeassistant.components.telegram_bot.bot.Bot.send_sticker"
@@ -349,7 +350,9 @@ async def test_send_sticker_partial_error(
 
     await hass.async_block_till_done()
 
-    assert mock_load_data.call_count == 2
+    # only 1 call count since load_data is cached
+    assert mock_load_data.call_count == 1
+
     assert mock_send_sticker.call_count == 2
     assert err.value.translation_key == "multiple_errors"
     assert err.value.translation_placeholders == {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Background

Currently, when using any of the `send_*` actions (for example `telegram_bot.send_video`), the file is downloaded first before it is sent to the recipient `chat_id`.
If there are multiple recipients, the same file is downloaded multiple times.
If the file is large, this will result in the action being unresponsive because of the long download times.

### Changes

Introduced a cache which stores the downloaded file.
For the first recipient, the file will be downloaded and stored in the cache.
For subsequent recipients, the file is simply loaded from cache.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
