### PR TITLE
Use show in sidebar property instead of removing panel title and icon

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -297,6 +297,9 @@ class Panel:
     # If the panel should only be visible to admins
     require_admin = False
 
+    # If the panel should be shown in the sidebar
+    show_in_sidebar = True
+
     # If the panel is a configuration panel for a integration
     config_panel_domain: str | None = None
 
@@ -310,6 +313,7 @@ class Panel:
         config: dict[str, Any] | None,
         require_admin: bool,
         config_panel_domain: str | None,
+        show_in_sidebar: bool,
     ) -> None:
         """Initialize a built-in panel."""
         self.component_name = component_name
@@ -319,6 +323,7 @@ class Panel:
         self.config = config
         self.require_admin = require_admin
         self.config_panel_domain = config_panel_domain
+        self.show_in_sidebar = show_in_sidebar
         self.sidebar_default_visible = sidebar_default_visible
 
     @callback
@@ -335,18 +340,17 @@ class Panel:
             "url_path": self.frontend_url_path,
             "require_admin": self.require_admin,
             "config_panel_domain": self.config_panel_domain,
+            "show_in_sidebar": self.show_in_sidebar,
         }
         if config_override:
             if "require_admin" in config_override:
                 response["require_admin"] = config_override["require_admin"]
-            if config_override.get("show_in_sidebar") is False:
-                response["title"] = None
-                response["icon"] = None
-            else:
-                if "icon" in config_override:
-                    response["icon"] = config_override["icon"]
-                if "title" in config_override:
-                    response["title"] = config_override["title"]
+            if "show_in_sidebar" in config_override:
+                response["show_in_sidebar"] = config_override["show_in_sidebar"]
+            if "icon" in config_override:
+                response["icon"] = config_override["icon"]
+            if "title" in config_override:
+                response["title"] = config_override["title"]
         return response
 
 
@@ -364,6 +368,7 @@ def async_register_built_in_panel(
     *,
     update: bool = False,
     config_panel_domain: str | None = None,
+    show_in_sidebar: bool = True,
 ) -> None:
     """Register a built-in panel."""
     panel = Panel(
@@ -375,6 +380,7 @@ def async_register_built_in_panel(
         config,
         require_admin,
         config_panel_domain,
+        show_in_sidebar,
     )
 
     panels = hass.data.setdefault(DATA_PANELS, {})
@@ -570,28 +576,28 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         "light",
         sidebar_icon="mdi:lamps",
         sidebar_title="light",
-        sidebar_default_visible=False,
+        show_in_sidebar=False,
     )
     async_register_built_in_panel(
         hass,
         "security",
         sidebar_icon="mdi:security",
         sidebar_title="security",
-        sidebar_default_visible=False,
+        show_in_sidebar=False,
     )
     async_register_built_in_panel(
         hass,
         "climate",
         sidebar_icon="mdi:home-thermometer",
         sidebar_title="climate",
-        sidebar_default_visible=False,
+        show_in_sidebar=False,
     )
     async_register_built_in_panel(
         hass,
         "home",
         sidebar_icon="mdi:home",
         sidebar_title="home",
-        sidebar_default_visible=False,
+        show_in_sidebar=False,
     )
 
     async_register_built_in_panel(hass, "profile")
@@ -1085,3 +1091,4 @@ class PanelResponse(TypedDict):
     url_path: str
     require_admin: bool
     config_panel_domain: str | None
+    show_in_sidebar: bool

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -353,13 +353,10 @@ def _register_panel(
     kwargs = {
         "frontend_url_path": url_path,
         "require_admin": config[CONF_REQUIRE_ADMIN],
+        "show_in_sidebar": config[CONF_SHOW_IN_SIDEBAR],
         "config": {"mode": mode},
         "update": update,
     }
-
-    if config[CONF_SHOW_IN_SIDEBAR]:
-        kwargs["sidebar_title"] = config[CONF_TITLE]
-        kwargs["sidebar_icon"] = config.get(CONF_ICON, DEFAULT_ICON)
 
     frontend.async_register_built_in_panel(hass, DOMAIN, **kwargs)
 

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -354,6 +354,8 @@ def _register_panel(
         "frontend_url_path": url_path,
         "require_admin": config[CONF_REQUIRE_ADMIN],
         "show_in_sidebar": config[CONF_SHOW_IN_SIDEBAR],
+        "sidebar_title": config[CONF_TITLE],
+        "sidebar_icon": config.get(CONF_ICON, DEFAULT_ICON),
         "config": {"mode": mode},
         "update": update,
     }

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -1268,7 +1268,7 @@ async def test_update_panel_partial(
     assert msg["result"]["climate"]["title"] == "HVAC"
     assert msg["result"]["climate"]["icon"] == "mdi:home-thermometer"
     assert msg["result"]["climate"]["require_admin"] is False
-    assert msg["result"]["climate"]["default_visible"] is False
+    assert msg["result"]["climate"]["default_visible"] is True
 
 
 async def test_update_panel_not_found(ws_client: MockHAClientWebSocket) -> None:
@@ -1376,35 +1376,37 @@ async def test_update_panel_reset_param(
     assert msg["result"]["security"]["icon"] == "mdi:security"
 
 
-async def test_update_panel_hide_sidebar(
+async def test_update_panel_toggle_show_in_sidebar(
     hass: HomeAssistant, ws_client: MockHAClientWebSocket
 ) -> None:
-    """Test that show_in_sidebar=false clears title and icon like lovelace."""
+    """Test that show_in_sidebar is returned without altering title and icon."""
     # Verify initial state has title and icon
     await ws_client.send_json({"id": 1, "type": "get_panels"})
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
+    assert msg["result"]["light"]["show_in_sidebar"] is False
 
-    # Hide from sidebar
+    # Show in sidebar
     await ws_client.send_json(
         {
             "id": 2,
             "type": "frontend/update_panel",
             "url_path": "light",
-            "show_in_sidebar": False,
+            "show_in_sidebar": True,
         }
     )
     msg = await ws_client.receive_json()
     assert msg["success"]
 
-    # Title and icon should be None
+    # Title and icon should remain unchanged and show_in_sidebar should be True
     await ws_client.send_json({"id": 3, "type": "get_panels"})
     msg = await ws_client.receive_json()
-    assert msg["result"]["light"]["title"] is None
-    assert msg["result"]["light"]["icon"] is None
+    assert msg["result"]["light"]["title"] == "light"
+    assert msg["result"]["light"]["icon"] == "mdi:lamps"
+    assert msg["result"]["light"]["show_in_sidebar"] is True
 
-    # Show in sidebar again by resetting show_in_sidebar
+    # Reset show_in_sidebar to panel default
     await ws_client.send_json(
         {
             "id": 4,
@@ -1416,11 +1418,12 @@ async def test_update_panel_hide_sidebar(
     msg = await ws_client.receive_json()
     assert msg["success"]
 
-    # Title and icon should be restored
+    # show_in_sidebar should be restored to built-in default
     await ws_client.send_json({"id": 5, "type": "get_panels"})
     msg = await ws_client.receive_json()
     assert msg["result"]["light"]["title"] == "light"
     assert msg["result"]["light"]["icon"] == "mdi:lamps"
+    assert msg["result"]["light"]["show_in_sidebar"] is False
 
 
 async def test_panels_config_invalid_storage(

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -260,6 +260,7 @@ async def test_setup_api_panel(
         },
         "url_path": "hassio",
         "require_admin": True,
+        "show_in_sidebar": True,
         "config_panel_domain": None,
     }
 
@@ -281,6 +282,7 @@ async def test_setup_app_panel(hass: HomeAssistant) -> None:
         "config": None,
         "url_path": "app",
         "require_admin": False,
+        "show_in_sidebar": True,
         "config_panel_domain": None,
     }
 


### PR DESCRIPTION
## Breaking change

The home, light, climate and security panels are now using `show_in_sidebar` instead of `sidebar_default_visible` to be consistent with dashboards. This means, previous users that added these panels to their sidebar will need to re-add using dashboards config panel.

## Proposed change

The title and icon are not only used in the sidebar but in other places (e.g navigation picker, dashboard list, default dashboard picker...)
Adding this extra property will allow displaying the title and icon in those place even if it's not added to the sidebar.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/29815

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
