### PR TITLE
Add diagnostics to NRGkick integration

### DIFF
--- a/homeassistant/components/nrgkick/diagnostics.py
+++ b/homeassistant/components/nrgkick/diagnostics.py
@@ -1,0 +1,30 @@
+"""Diagnostics support for NRGkick."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .coordinator import NRGkickConfigEntry
+
+TO_REDACT = {
+    CONF_PASSWORD,
+    CONF_USERNAME,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: NRGkickConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return async_redact_data(
+        {
+            "entry_data": entry.data,
+            "coordinator_data": asdict(entry.runtime_data.data),
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/nrgkick/quality_scale.yaml
+++ b/homeassistant/components/nrgkick/quality_scale.yaml
@@ -48,7 +48,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery: done
   discovery-update-info: done
   docs-data-update: done

--- a/tests/components/nrgkick/snapshots/test_diagnostics.ambr
+++ b/tests/components/nrgkick/snapshots/test_diagnostics.ambr
@@ -1,0 +1,117 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'coordinator_data': dict({
+      'control': dict({
+        'charge_pause': 0,
+        'current_set': 16.0,
+        'energy_limit': 0,
+        'phase_count': 3,
+      }),
+      'info': dict({
+        'cellular': dict({
+          'mode': 3,
+          'operator': 'Test operator',
+          'rssi': -85,
+        }),
+        'connector': dict({
+          'max_current': 32.0,
+          'phase_count': 3,
+          'serial_number': 'CONN123',
+          'type': 3,
+        }),
+        'general': dict({
+          'device_name': 'NRGkick Test',
+          'json_api_version': 'v1',
+          'model_type': 'NRGkick Gen2 SIM',
+          'rated_current': 32.0,
+          'serial_number': 'TEST123456',
+        }),
+        'grid': dict({
+          'frequency': 50.0,
+          'phases': 7,
+          'voltage': 230,
+        }),
+        'hardware': dict({
+          'bluetooth_version': '1.2.3',
+          'smartmodule_version': '4.0.0.0',
+        }),
+        'network': dict({
+          'ip_address': '192.168.1.100',
+          'mac_address': 'AA:BB:CC:DD:EE:FF',
+          'wifi_rssi': -45,
+          'wifi_ssid': 'TestNetwork',
+        }),
+        'software': dict({
+          'firmware_version': '2.1.0',
+        }),
+      }),
+      'values': dict({
+        'energy': dict({
+          'charged_energy': 5000,
+          'total_charged_energy': 100000,
+        }),
+        'general': dict({
+          'charge_count': 5,
+          'charging_rate': 11.0,
+          'error_code': 0,
+          'rcd_trigger': 0,
+          'status': 3,
+          'vehicle_charging_time': 50,
+          'vehicle_connect_time': 100,
+          'warning_code': 0,
+        }),
+        'powerflow': dict({
+          'charging_current': 16.0,
+          'charging_voltage': 230.0,
+          'grid_frequency': 50.0,
+          'l1': dict({
+            'active_power': 3680,
+            'apparent_power': 3680,
+            'current': 16.0,
+            'power_factor': 100,
+            'reactive_power': 0,
+            'voltage': 230.0,
+          }),
+          'l2': dict({
+            'active_power': 3680,
+            'apparent_power': 3680,
+            'current': 16.0,
+            'power_factor': 100,
+            'reactive_power': 0,
+            'voltage': 230.0,
+          }),
+          'l3': dict({
+            'active_power': 3680,
+            'apparent_power': 3680,
+            'current': 16.0,
+            'power_factor': 100,
+            'reactive_power': 0,
+            'voltage': 230.0,
+          }),
+          'n': dict({
+            'current': 0.0,
+          }),
+          'peak_power': 11000,
+          'total_active_power': 11000,
+          'total_apparent_power': 11040,
+          'total_power_factor': 100,
+          'total_reactive_power': 0,
+        }),
+        'temperatures': dict({
+          'connector_l1': 28.0,
+          'connector_l2': 29.0,
+          'connector_l3': 28.5,
+          'domestic_plug_1': 25.0,
+          'domestic_plug_2': 25.0,
+          'housing': 35.0,
+        }),
+      }),
+    }),
+    'entry_data': dict({
+      'host': '192.168.1.100',
+      'password': '**REDACTED**',
+      'username': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/nrgkick/test_diagnostics.py
+++ b/tests/components/nrgkick/test_diagnostics.py
@@ -1,0 +1,30 @@
+"""Tests for the diagnostics data provided by the NRGkick integration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    await setup_integration(hass, mock_config_entry)
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics to NRGkick

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
