### PR TITLE
Improve configuration url in Uptime Kuma

### DIFF
--- a/homeassistant/components/uptime_kuma/const.py
+++ b/homeassistant/components/uptime_kuma/const.py
@@ -24,3 +24,5 @@ HAS_HOST = HAS_PORT | {
     MonitorType.TAILSCALE_PING,
     MonitorType.DNS,
 }
+
+LOCAL_INSTANCE = ("127.0.0.1", "a0d7b954-uptime-kuma")

--- a/homeassistant/components/uptime_kuma/const.py
+++ b/homeassistant/components/uptime_kuma/const.py
@@ -25,4 +25,4 @@ HAS_HOST = HAS_PORT | {
     MonitorType.DNS,
 }
 
-LOCAL_INSTANCE = ("127.0.0.1", "a0d7b954-uptime-kuma")
+LOCAL_INSTANCE = ("127.0.0.1", "localhost", "a0d7b954-uptime-kuma")

--- a/homeassistant/components/uptime_kuma/sensor.py
+++ b/homeassistant/components/uptime_kuma/sensor.py
@@ -256,13 +256,12 @@ class UptimeKumaSensorEntity(
         )
 
         url = URL(coordinator.config_entry.data[CONF_URL]) / "dashboard"
-        configuration_url = (
-            None
-            if url.host in LOCAL_INSTANCE
-            else url / str(monitor)
-            if isinstance(monitor, int)
-            else url
-        )
+        if url.host in LOCAL_INSTANCE:
+            configuration_url = None
+        elif isinstance(monitor, int):
+            configuration_url = url / str(monitor)
+        else:
+            configuration_url = url
 
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/uptime_kuma/sensor.py
+++ b/homeassistant/components/uptime_kuma/sensor.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pythonkuma import MonitorType, UptimeKumaMonitor
 from pythonkuma.models import MonitorStatus
+from yarl import URL
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -23,7 +24,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, HAS_CERT, HAS_HOST, HAS_PORT, HAS_URL
+from .const import DOMAIN, HAS_CERT, HAS_HOST, HAS_PORT, HAS_URL, LOCAL_INSTANCE
 from .coordinator import UptimeKumaConfigEntry, UptimeKumaDataUpdateCoordinator
 
 PARALLEL_UPDATES = 0
@@ -253,16 +254,22 @@ class UptimeKumaSensorEntity(
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{monitor!s}_{entity_description.key}"
         )
+
+        url = URL(coordinator.config_entry.data[CONF_URL]) / "dashboard"
+        configuration_url = (
+            None
+            if url.host in LOCAL_INSTANCE
+            else url / str(monitor)
+            if isinstance(monitor, int)
+            else url
+        )
+
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             name=coordinator.data[monitor].monitor_name,
             identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_{monitor!s}")},
             manufacturer="Uptime Kuma",
-            configuration_url=(
-                None
-                if "127.0.0.1" in (url := coordinator.config_entry.data[CONF_URL])
-                else url
-            ),
+            configuration_url=configuration_url,
             sw_version=coordinator.api.version.version,
         )
 

--- a/homeassistant/components/uptime_kuma/update.py
+++ b/homeassistant/components/uptime_kuma/update.py
@@ -68,12 +68,8 @@ class UptimeKumaUpdateEntity(
         super().__init__(coordinator)
         self.update_checker = update_coordinator
 
-        configuration_url = (
-            None
-            if (url := URL(coordinator.config_entry.data[CONF_URL]) / "dashboard")
-            and url.host in LOCAL_INSTANCE
-            else url
-        )
+        url = URL(coordinator.config_entry.data[CONF_URL]) / "dashboard"
+        configuration_url = None if url.host in LOCAL_INSTANCE else url
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             name=coordinator.config_entry.title,

--- a/homeassistant/components/uptime_kuma/update.py
+++ b/homeassistant/components/uptime_kuma/update.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from yarl import URL
+
 from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityDescription,
@@ -16,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import UPTIME_KUMA_KEY
-from .const import DOMAIN
+from .const import DOMAIN, LOCAL_INSTANCE
 from .coordinator import (
     UptimeKumaConfigEntry,
     UptimeKumaDataUpdateCoordinator,
@@ -66,12 +68,18 @@ class UptimeKumaUpdateEntity(
         super().__init__(coordinator)
         self.update_checker = update_coordinator
 
+        configuration_url = (
+            None
+            if (url := URL(coordinator.config_entry.data[CONF_URL]) / "dashboard")
+            and url.host in LOCAL_INSTANCE
+            else url
+        )
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             name=coordinator.config_entry.title,
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             manufacturer="Uptime Kuma",
-            configuration_url=coordinator.config_entry.data[CONF_URL],
+            configuration_url=configuration_url,
             sw_version=coordinator.api.version.version,
         )
         self._attr_unique_id = (


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Since Uptime Kuma now exposes the monitor ID it is now possible to directly link to the corresponding monitor dashboard.
- The Uptime Kuma Home Assistant app was added as a local instance. In this case the configuration url is not set.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
