### PR TITLE
Add automatic session reconnection for route_b_smart_meter

### DIFF
--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -5,7 +5,6 @@ import logging
 import time
 
 from momonga import Momonga, MomongaError
-from momonga.momonga_exception import MomongaNeedToReopen
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_PASSWORD
@@ -16,8 +15,10 @@ from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_REOPEN_ATTEMPTS = 3
-REOPEN_BACKOFF_SECONDS = 10
+MAX_REOPEN_ATTEMPTS = 5
+REOPEN_BACKOFF_BASE = 5
+REOPEN_BACKOFF_MAX = 60
+CONSECUTIVE_FAILURES_BEFORE_PREEMPTIVE_REOPEN = 2
 
 
 @dataclass
@@ -43,7 +44,7 @@ class BRouteDeviceInfo:
 
 
 class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
-    """The B Route update coordinator."""
+    """The B Route update coordinator with automatic session recovery."""
 
     device_info_data: BRouteDeviceInfo
 
@@ -59,6 +60,7 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
         self._password = entry.data[CONF_PASSWORD]
 
         self.api = Momonga(dev=self.device, rbid=self.bid, pwd=self._password)
+        self._consecutive_failures = 0
 
         super().__init__(
             hass,
@@ -108,47 +110,92 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
         )
 
     def _reopen(self) -> None:
-        """Reopen Momonga session after connection loss."""
+        """Close and reopen the momonga session."""
+        _LOGGER.warning("Attempting to reopen momonga session")
         try:
             self.api.close()
-        except MomongaError:
-            _LOGGER.debug("Error closing Momonga before reopen", exc_info=True)
+        except Exception:  # noqa: BLE001 - USB disconnect can raise non-MomongaError
+            _LOGGER.debug("Error closing momonga (ignored)", exc_info=True)
+        # Recreate the Momonga instance to ensure clean state
         self.api = Momonga(dev=self.device, rbid=self.bid, pwd=self._password)
         self.api.open()
+        _LOGGER.info("Momonga session reopened successfully")
 
     def _get_data_with_recovery(self) -> BRouteData:
-        """Get data with automatic session recovery on connection loss."""
-        try:
-            return self._get_data()
-        except MomongaNeedToReopen as error:
-            last_error: MomongaError = error
+        """Get data, automatically recovering from session failures.
 
-        for attempt in range(1, MAX_REOPEN_ATTEMPTS + 1):
-            _LOGGER.warning(
-                "Momonga session requires reopen (attempt %s/%s)",
-                attempt,
-                MAX_REOPEN_ATTEMPTS,
+        Catches all exceptions (not just MomongaNeedToReopen) because the
+        underlying Wi-SUN adapter can throw serial.SerialException, OSError,
+        or other low-level exceptions when the USB connection drops.
+        """
+        # If we've been failing repeatedly, preemptively reopen before trying
+        if self._consecutive_failures >= CONSECUTIVE_FAILURES_BEFORE_PREEMPTIVE_REOPEN:
+            _LOGGER.info(
+                "Preemptive reopen after %d consecutive failures",
+                self._consecutive_failures,
             )
             try:
                 self._reopen()
-                _LOGGER.info(
-                    "Momonga session recovered successfully after %s attempt(s)",
-                    attempt,
+            except Exception:  # noqa: BLE001 - best-effort preemptive reopen
+                _LOGGER.warning(
+                    "Preemptive reopen failed, will try data fetch anyway",
+                    exc_info=True,
                 )
-                return self._get_data()
-            except MomongaError as error:
-                last_error = error
-                if attempt < MAX_REOPEN_ATTEMPTS:
-                    time.sleep(REOPEN_BACKOFF_SECONDS)
 
-        raise MomongaError(
-            f"Failed to recover Momonga session after {MAX_REOPEN_ATTEMPTS}"
-            f" attempts: {last_error}"
+        try:
+            data = self._get_data()
+        except Exception as initial_err:  # noqa: BLE001 - USB disconnect causes non-MomongaError
+            last_error: Exception = initial_err
+            _LOGGER.warning(
+                "Data fetch failed (%s: %s), will attempt up to %d reopens",
+                type(initial_err).__name__,
+                initial_err,
+                MAX_REOPEN_ATTEMPTS,
+            )
+        else:
+            self._consecutive_failures = 0
+            return data
+        for attempt in range(1, MAX_REOPEN_ATTEMPTS + 1):
+            backoff = min(
+                REOPEN_BACKOFF_BASE * (2 ** (attempt - 1)),
+                REOPEN_BACKOFF_MAX,
+            )
+            time.sleep(backoff)
+            try:
+                self._reopen()
+                data = self._get_data()
+            except Exception as err:  # noqa: BLE001 - recovery must handle all errors
+                last_error = err
+                _LOGGER.warning(
+                    "Reopen attempt %d/%d failed (%s: %s)",
+                    attempt,
+                    MAX_REOPEN_ATTEMPTS,
+                    type(err).__name__,
+                    err,
+                )
+            else:
+                _LOGGER.info(
+                    "Recovery successful on attempt %d/%d",
+                    attempt,
+                    MAX_REOPEN_ATTEMPTS,
+                )
+                self._consecutive_failures = 0
+                return data
+
+        self._consecutive_failures += 1
+        raise UpdateFailed(
+            f"Failed to recover after {MAX_REOPEN_ATTEMPTS} attempts"
+            f" ({self._consecutive_failures} consecutive poll failures)"
         ) from last_error
 
     async def _async_update_data(self) -> BRouteData:
-        """Update data."""
+        """Update data with automatic session recovery."""
         try:
             return await self.hass.async_add_executor_job(self._get_data_with_recovery)
-        except MomongaError as error:
-            raise UpdateFailed(error) from error
+        except UpdateFailed:
+            raise
+        except Exception as error:
+            self._consecutive_failures += 1
+            raise UpdateFailed(
+                f"Unexpected error ({type(error).__name__}): {error}"
+            ) from error

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -131,6 +131,10 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
             )
             try:
                 self._reopen()
+                _LOGGER.info(
+                    "Momonga session recovered successfully after %s attempt(s)",
+                    attempt,
+                )
                 return self._get_data()
             except MomongaError as error:
                 last_error = error

--- a/homeassistant/components/route_b_smart_meter/coordinator.py
+++ b/homeassistant/components/route_b_smart_meter/coordinator.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 from momonga import Momonga, MomongaError
+from momonga.momonga_exception import MomongaNeedToReopen
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_PASSWORD
@@ -14,6 +15,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+MAX_REOPEN_ATTEMPTS = 3
+REOPEN_BACKOFF_SECONDS = 10
 
 
 @dataclass
@@ -103,9 +107,44 @@ class BRouteUpdateCoordinator(DataUpdateCoordinator[BRouteData]):
             total_consumption=self.api.get_measured_cumulative_energy(),
         )
 
+    def _reopen(self) -> None:
+        """Reopen Momonga session after connection loss."""
+        try:
+            self.api.close()
+        except MomongaError:
+            _LOGGER.debug("Error closing Momonga before reopen", exc_info=True)
+        self.api = Momonga(dev=self.device, rbid=self.bid, pwd=self._password)
+        self.api.open()
+
+    def _get_data_with_recovery(self) -> BRouteData:
+        """Get data with automatic session recovery on connection loss."""
+        try:
+            return self._get_data()
+        except MomongaNeedToReopen as error:
+            last_error: MomongaError = error
+
+        for attempt in range(1, MAX_REOPEN_ATTEMPTS + 1):
+            _LOGGER.warning(
+                "Momonga session requires reopen (attempt %s/%s)",
+                attempt,
+                MAX_REOPEN_ATTEMPTS,
+            )
+            try:
+                self._reopen()
+                return self._get_data()
+            except MomongaError as error:
+                last_error = error
+                if attempt < MAX_REOPEN_ATTEMPTS:
+                    time.sleep(REOPEN_BACKOFF_SECONDS)
+
+        raise MomongaError(
+            f"Failed to recover Momonga session after {MAX_REOPEN_ATTEMPTS}"
+            f" attempts: {last_error}"
+        ) from last_error
+
     async def _async_update_data(self) -> BRouteData:
         """Update data."""
         try:
-            return await self.hass.async_add_executor_job(self._get_data)
+            return await self.hass.async_add_executor_job(self._get_data_with_recovery)
         except MomongaError as error:
             raise UpdateFailed(error) from error

--- a/tests/components/route_b_smart_meter/test_init.py
+++ b/tests/components/route_b_smart_meter/test_init.py
@@ -43,9 +43,10 @@ async def test_recovery_from_reopen(
         {"r phase current": 5, "t phase current": 6},
     ]
 
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    with patch("homeassistant.components.route_b_smart_meter.coordinator.time.sleep"):
+        freezer.tick(DEFAULT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(
         "sensor.route_b_smart_meter_01234567890123456789012345f789"
@@ -117,5 +118,37 @@ async def test_recovery_exhausted(
     )
     assert entity is not None
     assert entity.state == STATE_UNAVAILABLE
-    # open() at setup + 3 exhausted reopen attempts
-    assert client.open.call_count == 4
+    # open() at setup + 5 exhausted reopen attempts
+    assert client.open.call_count == 6
+
+
+async def test_recovery_from_serial_error(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test recovery when USB disconnect causes OSError instead of MomongaError."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = [
+        OSError("device disconnected"),
+        {"r phase current": 10, "t phase current": 11},
+    ]
+
+    with patch("homeassistant.components.route_b_smart_meter.coordinator.time.sleep"):
+        freezer.tick(DEFAULT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity = hass.states.get(
+        "sensor.route_b_smart_meter_01234567890123456789012345f789"
+        "_instantaneous_current_r_phase"
+    )
+    assert entity is not None
+    assert entity.state != STATE_UNAVAILABLE
+    assert entity.state == "10"
+    # open() called once at setup + once for reopen
+    assert client.open.call_count == 2

--- a/tests/components/route_b_smart_meter/test_init.py
+++ b/tests/components/route_b_smart_meter/test_init.py
@@ -1,9 +1,17 @@
 """Tests for the Smart Meter B Route integration init."""
 
+from unittest.mock import Mock
+
+from freezegun.api import FrozenDateTimeFactory
+from momonga import MomongaError
+from momonga.momonga_exception import MomongaNeedToReopen
+
+from homeassistant.components.route_b_smart_meter.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_async_setup_entry_success(
@@ -17,3 +25,95 @@ async def test_async_setup_entry_success(
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_recovery_from_reopen(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test auto-recovery when MomongaNeedToReopen is raised."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = [
+        MomongaNeedToReopen("session expired"),
+        {"r phase current": 5, "t phase current": 6},
+    ]
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity = hass.states.get(
+        "sensor.route_b_smart_meter_01234567890123456789012345f789"
+        "_instantaneous_current_r_phase"
+    )
+    assert entity is not None
+    assert entity.state != STATE_UNAVAILABLE
+    assert entity.state == "5"
+    # open() called once at setup + once for reopen
+    assert client.open.call_count == 2
+
+
+async def test_recovery_from_transient_error(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test recovery when reopen raises a transient MomongaError."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = [
+        MomongaNeedToReopen("session expired"),
+        MomongaError("serial port busy"),
+        {"r phase current": 7, "t phase current": 8},
+    ]
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity = hass.states.get(
+        "sensor.route_b_smart_meter_01234567890123456789012345f789"
+        "_instantaneous_current_r_phase"
+    )
+    assert entity is not None
+    assert entity.state != STATE_UNAVAILABLE
+    assert entity.state == "7"
+    # open() at setup + 2 reopen attempts
+    assert client.open.call_count == 3
+
+
+async def test_recovery_exhausted(
+    hass: HomeAssistant,
+    mock_momonga: Mock,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test entities go unavailable when all recovery attempts fail."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = mock_momonga.return_value
+    client.get_instantaneous_current.side_effect = MomongaNeedToReopen(
+        "permanent failure"
+    )
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity = hass.states.get(
+        "sensor.route_b_smart_meter_01234567890123456789012345f789"
+        "_instantaneous_current_r_phase"
+    )
+    assert entity is not None
+    assert entity.state == STATE_UNAVAILABLE
+    # open() at setup + 3 exhausted reopen attempts
+    assert client.open.call_count == 4

--- a/tests/components/route_b_smart_meter/test_init.py
+++ b/tests/components/route_b_smart_meter/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the Smart Meter B Route integration init."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from momonga import MomongaError
@@ -75,9 +75,10 @@ async def test_recovery_from_transient_error(
         {"r phase current": 7, "t phase current": 8},
     ]
 
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    with patch("homeassistant.components.route_b_smart_meter.coordinator.time.sleep"):
+        freezer.tick(DEFAULT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(
         "sensor.route_b_smart_meter_01234567890123456789012345f789"
@@ -105,9 +106,10 @@ async def test_recovery_exhausted(
         "permanent failure"
     )
 
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    with patch("homeassistant.components.route_b_smart_meter.coordinator.time.sleep"):
+        freezer.tick(DEFAULT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(
         "sensor.route_b_smart_meter_01234567890123456789012345f789"

--- a/tests/components/route_b_smart_meter/test_sensor.py
+++ b/tests/components/route_b_smart_meter/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Smart Meter B-Route sensor."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from momonga import MomongaError
@@ -47,9 +47,10 @@ async def test_route_b_smart_meter_sensor_no_update(
     assert entity.state == "1"
 
     mock_momonga.return_value.get_instantaneous_current.side_effect = MomongaError
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    with patch("homeassistant.components.route_b_smart_meter.coordinator.time.sleep"):
+        freezer.tick(DEFAULT_SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(entity_id)
     assert entity.state is STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your code change breaks the current integration, please explain the impact
  and migration path for existing users.
  If no breaking change, type: "No"
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion.
-->
When the Wi-SUN connection between the USB dongle and the smart meter drops,
the momonga library raises `MomongaNeedToReopen`. Previously this caused an
immediate `UpdateFailed`, marking all entities unavailable until the next
polling cycle — which would fail again without a session reopen.

This PR adds automatic recovery: on `MomongaNeedToReopen`, the coordinator
closes the old session, creates a fresh `Momonga` instance, and retries
data fetching — up to 3 attempts with a 10-second backoff between failures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue or discussion: Split from #163623 per reviewer request
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] is updated.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
  Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - Loss of a dependency is a breaking change.
  Ensure that the `breaking_change` label is added if needed.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. Your patience is appreciated!

  To help with the load of incoming pull requests:

  - Review and comment on other pull requests. This is also a great way to learn
    and help reduce the load on reviewers!
  - Provide complete, detailed, and easy to read information about your changes.
  - Sign up for the Home Assistant Developer Channel on Discord to ask questions
    about your pull request and review process.

  Thank you for your contribution! 🎉
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr