### PR TITLE
Fix MatterValve state handling and allow None values for attributes

### DIFF
--- a/homeassistant/components/matter/valve.py
+++ b/homeassistant/components/matter/valve.py
@@ -69,34 +69,37 @@ class MatterValve(MatterEntity, ValveEntity):
     def _update_from_device(self) -> None:
         """Update from device."""
         self._calculate_features()
-        current_state: int
+        self._attr_is_opening = False
+        self._attr_is_closing = False
+
+        current_state: int | None
         current_state = self.get_matter_attribute_value(
             ValveConfigurationAndControl.Attributes.CurrentState
         )
-        target_state: int
+        target_state: int | None
         target_state = self.get_matter_attribute_value(
             ValveConfigurationAndControl.Attributes.TargetState
         )
-        if (
-            current_state == ValveStateEnum.kTransitioning
-            and target_state == ValveStateEnum.kOpen
+
+        if current_state is None:
+            self._attr_is_closed = None
+        elif current_state == ValveStateEnum.kTransitioning and (
+            target_state == ValveStateEnum.kOpen
         ):
             self._attr_is_opening = True
-            self._attr_is_closing = False
-        elif (
-            current_state == ValveStateEnum.kTransitioning
-            and target_state == ValveStateEnum.kClosed
+            self._attr_is_closed = None
+        elif current_state == ValveStateEnum.kTransitioning and (
+            target_state == ValveStateEnum.kClosed
         ):
-            self._attr_is_opening = False
             self._attr_is_closing = True
+            self._attr_is_closed = None
         elif current_state == ValveStateEnum.kClosed:
-            self._attr_is_opening = False
-            self._attr_is_closing = False
             self._attr_is_closed = True
-        else:
-            self._attr_is_opening = False
-            self._attr_is_closing = False
+        elif current_state == ValveStateEnum.kOpen:
             self._attr_is_closed = False
+        else:
+            self._attr_is_closed = None
+
         # handle optional position
         if self.supported_features & ValveEntityFeature.SET_POSITION:
             self._attr_current_valve_position = self.get_matter_attribute_value(
@@ -145,6 +148,7 @@ DISCOVERY_SCHEMAS = [
             ValveConfigurationAndControl.Attributes.CurrentState,
             ValveConfigurationAndControl.Attributes.TargetState,
         ),
+        allow_none_value=True,
         optional_attributes=(ValveConfigurationAndControl.Attributes.CurrentLevel,),
         device_type=(device_types.WaterValve,),
     ),

--- a/tests/components/matter/snapshots/test_valve.ambr
+++ b/tests/components/matter/snapshots/test_valve.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_valves[mock_valve][valve.mock_valve-entry]
+# name: test_valves[mock_valve][mock_valve][valve.mock_valve-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +35,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_valves[mock_valve][valve.mock_valve-state]
+# name: test_valves[mock_valve][mock_valve][valve.mock_valve-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'water',

--- a/tests/components/matter/test_valve.py
+++ b/tests/components/matter/test_valve.py
@@ -1,5 +1,6 @@
 """Test Matter valve."""
 
+from typing import Any
 from unittest.mock import MagicMock, call
 
 from chip.clusters import Objects as clusters
@@ -18,13 +19,21 @@ from .common import (
 )
 
 
-@pytest.mark.usefixtures("matter_devices")
+@pytest.fixture(name="attributes")
+def attributes_fixture(request: pytest.FixtureRequest) -> dict[str, Any]:
+    """Override node attributes for a parametrized test."""
+    return getattr(request, "param", {})
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_valve"])
 async def test_valves(
     hass: HomeAssistant,
+    matter_node: MatterNode,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test valves."""
+    assert matter_node
     snapshot_matter_entities(hass, entity_registry, snapshot, Platform.VALVE)
 
 
@@ -152,3 +161,39 @@ async def test_valve(
         command=clusters.ValveConfigurationAndControl.Commands.Close(),
     )
     matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_valve"])
+@pytest.mark.parametrize(
+    "attributes",
+    [{"1/129/4": None, "1/129/5": None}],
+    indirect=True,
+)
+async def test_valve_discovery_with_nullable_states(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test valve discovery when CurrentState and TargetState are nullable."""
+    assert matter_node.node_id == 60
+
+    state = hass.states.get("valve.mock_valve")
+    assert state
+    assert state.state == "unknown"
+    assert state.attributes["friendly_name"] == "Mock Valve"
+
+    await hass.services.async_call(
+        "valve",
+        "open_valve",
+        {
+            "entity_id": "valve.mock_valve",
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.ValveConfigurationAndControl.Commands.Open(),
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix MatterValve state handling and allow None values for attributes `CurrentState` and `TargetState`.
These values are permitted in Matter specifications.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
