### PR TITLE
Add reconfigure flow to BSB-LAN

### DIFF
--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -231,7 +231,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_update_reload_and_abort(
             existing_entry,
-            data_updates=validate_data,
+            data_updates=user_input,
             reason="reconfigure_successful",
         )
 
@@ -295,7 +295,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                 ): str,
                 vol.Optional(
                     CONF_PASSWORD,
-                    default=defaults.get(CONF_PASSWORD) or vol.UNDEFINED,
+                    default=vol.UNDEFINED,
                 ): str,
             }
         )

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -227,6 +227,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         # Prevent reconfiguring to a different physical device
+        # it gets the unique ID from the device info when it validates credentials
         self._abort_if_unique_id_mismatch()
 
         return self.async_update_reload_and_abort(

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -269,6 +269,127 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
             existing_entry, data_updates=user_input, reason="reauth_successful"
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration flow."""
+        existing_entry = self._get_reconfigure_entry()
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_HOST,
+                            default=existing_entry.data.get(CONF_HOST, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_PORT,
+                            default=existing_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                        ): int,
+                        vol.Optional(
+                            CONF_PASSKEY,
+                            default=existing_entry.data.get(
+                                CONF_PASSKEY, vol.UNDEFINED
+                            ),
+                        ): str,
+                        vol.Optional(
+                            CONF_USERNAME,
+                            default=existing_entry.data.get(
+                                CONF_USERNAME, vol.UNDEFINED
+                            ),
+                        ): str,
+                        vol.Optional(
+                            CONF_PASSWORD,
+                            default=vol.UNDEFINED,
+                        ): str,
+                    }
+                ),
+            )
+
+        self.host = user_input[CONF_HOST]
+        self.port = user_input.get(CONF_PORT, DEFAULT_PORT)
+        self.passkey = user_input.get(CONF_PASSKEY)
+        self.username = user_input.get(CONF_USERNAME)
+        self.password = user_input.get(CONF_PASSWORD)
+
+        try:
+            await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)
+        except BSBLANAuthError:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_HOST,
+                            default=user_input.get(CONF_HOST, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_PORT,
+                            default=user_input.get(CONF_PORT, DEFAULT_PORT),
+                        ): int,
+                        vol.Optional(
+                            CONF_PASSKEY,
+                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_USERNAME,
+                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_PASSWORD,
+                            default=vol.UNDEFINED,
+                        ): str,
+                    }
+                ),
+                errors={"base": "invalid_auth"},
+            )
+        except BSBLANError:
+            return self.async_show_form(
+                step_id="reconfigure",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_HOST,
+                            default=user_input.get(CONF_HOST, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_PORT,
+                            default=user_input.get(CONF_PORT, DEFAULT_PORT),
+                        ): int,
+                        vol.Optional(
+                            CONF_PASSKEY,
+                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_USERNAME,
+                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
+                        ): str,
+                        vol.Optional(
+                            CONF_PASSWORD,
+                            default=vol.UNDEFINED,
+                        ): str,
+                    }
+                ),
+                errors={"base": "cannot_connect"},
+            )
+
+        # Prevent reconfiguring to a different physical device
+        self._abort_if_unique_id_mismatch()
+
+        return self.async_update_reload_and_abort(
+            existing_entry,
+            data_updates={
+                CONF_HOST: self.host,
+                CONF_PORT: self.port,
+                CONF_PASSKEY: self.passkey,
+                CONF_USERNAME: self.username,
+                CONF_PASSWORD: self.password,
+            },
+            reason="reconfigure_successful",
+        )
+
     @callback
     def _show_setup_form(
         self, errors: dict | None = None, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -208,14 +208,13 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # Combine existing data with the user's new input for validation.
         # This correctly handles adding, changing, and clearing credentials.
-        config_data = existing_entry.data.copy()
-        config_data.update(user_input)
+        validate_data = {**existing_entry.data, **user_input}
 
-        self.host = config_data[CONF_HOST]
-        self.port = config_data[CONF_PORT]
-        self.passkey = config_data.get(CONF_PASSKEY)
-        self.username = config_data.get(CONF_USERNAME)
-        self.password = config_data.get(CONF_PASSWORD)
+        self.host = validate_data[CONF_HOST]
+        self.port = validate_data[CONF_PORT]
+        self.passkey = validate_data.get(CONF_PASSKEY)
+        self.username = validate_data.get(CONF_USERNAME)
+        self.password = validate_data.get(CONF_PASSWORD)
 
         try:
             await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -190,15 +190,13 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                     {
                         vol.Optional(
                             CONF_PASSKEY,
-                            default=existing_entry.data.get(
-                                CONF_PASSKEY, vol.UNDEFINED
-                            ),
+                            default=existing_entry.data.get(CONF_PASSKEY)
+                            or vol.UNDEFINED,
                         ): str,
                         vol.Optional(
                             CONF_USERNAME,
-                            default=existing_entry.data.get(
-                                CONF_USERNAME, vol.UNDEFINED
-                            ),
+                            default=existing_entry.data.get(CONF_USERNAME)
+                            or vol.UNDEFINED,
                         ): str,
                         vol.Optional(
                             CONF_PASSWORD,
@@ -290,15 +288,13 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                         ): int,
                         vol.Optional(
                             CONF_PASSKEY,
-                            default=existing_entry.data.get(
-                                CONF_PASSKEY, vol.UNDEFINED
-                            ),
+                            default=existing_entry.data.get(CONF_PASSKEY)
+                            or vol.UNDEFINED,
                         ): str,
                         vol.Optional(
                             CONF_USERNAME,
-                            default=existing_entry.data.get(
-                                CONF_USERNAME, vol.UNDEFINED
-                            ),
+                            default=existing_entry.data.get(CONF_USERNAME)
+                            or vol.UNDEFINED,
                         ): str,
                         vol.Optional(
                             CONF_PASSWORD,
@@ -308,11 +304,15 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
                 ),
             )
 
-        self.host = user_input[CONF_HOST]
-        self.port = user_input.get(CONF_PORT, DEFAULT_PORT)
-        self.passkey = user_input.get(CONF_PASSKEY)
-        self.username = user_input.get(CONF_USERNAME)
-        self.password = user_input.get(CONF_PASSWORD)
+        # Merge existing data with user input so optional fields
+        # not re-entered (like password) are preserved during validation
+        validate_data = {**existing_entry.data, **user_input}
+
+        self.host = validate_data[CONF_HOST]
+        self.port = validate_data.get(CONF_PORT, DEFAULT_PORT)
+        self.passkey = validate_data.get(CONF_PASSKEY)
+        self.username = validate_data.get(CONF_USERNAME)
+        self.password = validate_data.get(CONF_PASSWORD)
 
         try:
             await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)
@@ -380,13 +380,7 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_update_reload_and_abort(
             existing_entry,
-            data_updates={
-                CONF_HOST: self.host,
-                CONF_PORT: self.port,
-                CONF_PASSKEY: self.passkey,
-                CONF_USERNAME: self.username,
-                CONF_PASSWORD: self.password,
-            },
+            data_updates=validate_data,
             reason="reconfigure_successful",
         )
 

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -183,85 +183,22 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         existing_entry = self._get_reauth_entry()
 
         if user_input is None:
-            # Preserve existing values as defaults
             return self.async_show_form(
                 step_id="reauth_confirm",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=existing_entry.data.get(CONF_PASSKEY)
-                            or vol.UNDEFINED,
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=existing_entry.data.get(CONF_USERNAME)
-                            or vol.UNDEFINED,
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
+                data_schema=self._build_credentials_schema(existing_entry.data),
             )
 
-        # Combine existing data with the user's new input for validation.
-        # This correctly handles adding, changing, and clearing credentials.
+        # Merge existing data with user input for validation
         validate_data = {**existing_entry.data, **user_input}
+        errors = await self._async_validate_credentials(validate_data)
 
-        self.host = validate_data[CONF_HOST]
-        self.port = validate_data[CONF_PORT]
-        self.passkey = validate_data.get(CONF_PASSKEY)
-        self.username = validate_data.get(CONF_USERNAME)
-        self.password = validate_data.get(CONF_PASSWORD)
-
-        try:
-            await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)
-        except BSBLANAuthError:
+        if errors:
             return self.async_show_form(
                 step_id="reauth_confirm",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
-                errors={"base": "invalid_auth"},
-            )
-        except BSBLANError:
-            return self.async_show_form(
-                step_id="reauth_confirm",
-                data_schema=vol.Schema(
-                    {
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
-                errors={"base": "cannot_connect"},
+                data_schema=self._build_credentials_schema(user_input),
+                errors=errors,
             )
 
-        # Update only the fields that were provided by the user
         return self.async_update_reload_and_abort(
             existing_entry, data_updates=user_input, reason="reauth_successful"
         )
@@ -275,103 +212,18 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input is None:
             return self.async_show_form(
                 step_id="reconfigure",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_HOST,
-                            default=existing_entry.data.get(CONF_HOST, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PORT,
-                            default=existing_entry.data.get(CONF_PORT, DEFAULT_PORT),
-                        ): int,
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=existing_entry.data.get(CONF_PASSKEY)
-                            or vol.UNDEFINED,
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=existing_entry.data.get(CONF_USERNAME)
-                            or vol.UNDEFINED,
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
+                data_schema=self._build_connection_schema(existing_entry.data),
             )
 
-        # Merge existing data with user input so optional fields
-        # not re-entered (like password) are preserved during validation
+        # Merge existing data with user input for validation
         validate_data = {**existing_entry.data, **user_input}
+        errors = await self._async_validate_credentials(validate_data)
 
-        self.host = validate_data[CONF_HOST]
-        self.port = validate_data.get(CONF_PORT, DEFAULT_PORT)
-        self.passkey = validate_data.get(CONF_PASSKEY)
-        self.username = validate_data.get(CONF_USERNAME)
-        self.password = validate_data.get(CONF_PASSWORD)
-
-        try:
-            await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)
-        except BSBLANAuthError:
+        if errors:
             return self.async_show_form(
                 step_id="reconfigure",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_HOST,
-                            default=user_input.get(CONF_HOST, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PORT,
-                            default=user_input.get(CONF_PORT, DEFAULT_PORT),
-                        ): int,
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
-                errors={"base": "invalid_auth"},
-            )
-        except BSBLANError:
-            return self.async_show_form(
-                step_id="reconfigure",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_HOST,
-                            default=user_input.get(CONF_HOST, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PORT,
-                            default=user_input.get(CONF_PORT, DEFAULT_PORT),
-                        ): int,
-                        vol.Optional(
-                            CONF_PASSKEY,
-                            default=user_input.get(CONF_PASSKEY, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_USERNAME,
-                            default=user_input.get(CONF_USERNAME, vol.UNDEFINED),
-                        ): str,
-                        vol.Optional(
-                            CONF_PASSWORD,
-                            default=vol.UNDEFINED,
-                        ): str,
-                    }
-                ),
-                errors={"base": "cannot_connect"},
+                data_schema=self._build_connection_schema(user_input),
+                errors=errors,
             )
 
         # Prevent reconfiguring to a different physical device
@@ -383,37 +235,79 @@ class BSBLANFlowHandler(ConfigFlow, domain=DOMAIN):
             reason="reconfigure_successful",
         )
 
+    async def _async_validate_credentials(self, data: dict[str, Any]) -> dict[str, str]:
+        """Validate connection credentials and return errors dict."""
+        self.host = data[CONF_HOST]
+        self.port = data.get(CONF_PORT, DEFAULT_PORT)
+        self.passkey = data.get(CONF_PASSKEY)
+        self.username = data.get(CONF_USERNAME)
+        self.password = data.get(CONF_PASSWORD)
+
+        errors: dict[str, str] = {}
+        try:
+            await self._get_bsblan_info(raise_on_progress=False, is_reauth=True)
+        except BSBLANAuthError:
+            errors["base"] = "invalid_auth"
+        except BSBLANError:
+            errors["base"] = "cannot_connect"
+        return errors
+
+    @callback
+    def _build_credentials_schema(self, defaults: Mapping[str, Any]) -> vol.Schema:
+        """Build schema for credentials-only forms (reauth)."""
+        return vol.Schema(
+            {
+                vol.Optional(
+                    CONF_PASSKEY,
+                    default=defaults.get(CONF_PASSKEY) or vol.UNDEFINED,
+                ): str,
+                vol.Optional(
+                    CONF_USERNAME,
+                    default=defaults.get(CONF_USERNAME) or vol.UNDEFINED,
+                ): str,
+                vol.Optional(
+                    CONF_PASSWORD,
+                    default=vol.UNDEFINED,
+                ): str,
+            }
+        )
+
+    @callback
+    def _build_connection_schema(self, defaults: Mapping[str, Any]) -> vol.Schema:
+        """Build schema for full connection forms (user and reconfigure)."""
+        return vol.Schema(
+            {
+                vol.Required(
+                    CONF_HOST,
+                    default=defaults.get(CONF_HOST, vol.UNDEFINED),
+                ): str,
+                vol.Optional(
+                    CONF_PORT,
+                    default=defaults.get(CONF_PORT, DEFAULT_PORT),
+                ): int,
+                vol.Optional(
+                    CONF_PASSKEY,
+                    default=defaults.get(CONF_PASSKEY) or vol.UNDEFINED,
+                ): str,
+                vol.Optional(
+                    CONF_USERNAME,
+                    default=defaults.get(CONF_USERNAME) or vol.UNDEFINED,
+                ): str,
+                vol.Optional(
+                    CONF_PASSWORD,
+                    default=defaults.get(CONF_PASSWORD) or vol.UNDEFINED,
+                ): str,
+            }
+        )
+
     @callback
     def _show_setup_form(
         self, errors: dict | None = None, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Show the setup form to the user."""
-        # Preserve user input if provided, otherwise use defaults
-        defaults = user_input or {}
-
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_HOST, default=defaults.get(CONF_HOST, vol.UNDEFINED)
-                    ): str,
-                    vol.Optional(
-                        CONF_PORT, default=defaults.get(CONF_PORT, DEFAULT_PORT)
-                    ): int,
-                    vol.Optional(
-                        CONF_PASSKEY, default=defaults.get(CONF_PASSKEY, vol.UNDEFINED)
-                    ): str,
-                    vol.Optional(
-                        CONF_USERNAME,
-                        default=defaults.get(CONF_USERNAME, vol.UNDEFINED),
-                    ): str,
-                    vol.Optional(
-                        CONF_PASSWORD,
-                        default=defaults.get(CONF_PASSWORD, vol.UNDEFINED),
-                    ): str,
-                }
-            ),
+            data_schema=self._build_connection_schema(user_input or {}),
             errors=errors or {},
         )
 

--- a/homeassistant/components/bsblan/quality_scale.yaml
+++ b/homeassistant/components/bsblan/quality_scale.yaml
@@ -58,7 +58,7 @@ rules:
   entity-translations: done
   exception-translations: done
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: |

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -3,7 +3,9 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "The device you are trying to reconfigure is not the same as the one previously configured."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -38,6 +40,24 @@
         },
         "description": "The BSB-LAN integration needs to re-authenticate with {name}",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "passkey": "[%key:component::bsblan::config::step::user::data::passkey%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "host": "[%key:component::bsblan::config::step::user::data_description::host%]",
+          "passkey": "[%key:component::bsblan::config::step::user::data_description::passkey%]",
+          "password": "[%key:component::bsblan::config::step::user::data_description::password%]",
+          "port": "[%key:component::bsblan::config::step::user::data_description::port%]",
+          "username": "[%key:component::bsblan::config::step::user::data_description::username%]"
+        },
+        "description": "Update connection settings for your BSB-LAN device.",
+        "title": "Reconfigure BSB-LAN"
       },
       "user": {
         "data": {

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from bsblan import BSBLANAuthError, BSBLANConnectionError, BSBLANError
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, SOURCE_ZEROCONF
@@ -236,7 +237,8 @@ async def test_authentication_error(
     assert port_field.default() == 8080
     assert passkey_field.default() == "secret"
     assert username_field.default() == "testuser"
-    assert password_field.default() == "wrongpassword"
+    # Password should never be pre-filled for security reasons
+    assert password_field.default is vol.UNDEFINED
 
 
 async def test_authentication_error_vs_connection_error(

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -1071,13 +1071,7 @@ async def test_reconfigure_flow_success(
     """Test successful reconfiguration flow."""
     mock_config_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": "reconfigure",
-            "entry_id": mock_config_entry.entry_id,
-        },
-    )
+    result = await mock_config_entry.start_reconfigure_flow(hass)
 
     _assert_form_result(result, "reconfigure")
 
@@ -1102,23 +1096,26 @@ async def test_reconfigure_flow_success(
     assert mock_config_entry.data[CONF_PASSWORD] == "new_password"
 
 
-async def test_reconfigure_flow_auth_error(
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (BSBLANAuthError, "invalid_auth"),
+        (BSBLANConnectionError, "cannot_connect"),
+    ],
+)
+async def test_reconfigure_flow_error_recovery(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
     mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    error: str,
 ) -> None:
-    """Test reconfigure flow with authentication error."""
+    """Test reconfigure flow can recover from errors."""
     mock_config_entry.add_to_hass(hass)
 
-    mock_bsblan.device.side_effect = BSBLANAuthError
+    mock_bsblan.device.side_effect = side_effect
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": "reconfigure",
-            "entry_id": mock_config_entry.entry_id,
-        },
-    )
+    result = await mock_config_entry.start_reconfigure_flow(hass)
 
     _assert_form_result(result, "reconfigure")
 
@@ -1134,60 +1131,30 @@ async def test_reconfigure_flow_auth_error(
         },
     )
 
-    _assert_form_result(result, "reconfigure", {"base": "invalid_auth"})
+    _assert_form_result(result, "reconfigure", {"base": error})
 
-    # Verify user input is preserved in the form
-    data_schema = result.get("data_schema")
-    assert data_schema is not None
-
-    host_field = next(
-        field for field in data_schema.schema if field.schema == CONF_HOST
-    )
-    passkey_field = next(
-        field for field in data_schema.schema if field.schema == CONF_PASSKEY
-    )
-    username_field = next(
-        field for field in data_schema.schema if field.schema == CONF_USERNAME
-    )
-
-    assert host_field.default() == "192.168.1.50"
-    assert passkey_field.default() == "wrong_key"
-    assert username_field.default() == "admin"
-
-
-async def test_reconfigure_flow_connection_error(
-    hass: HomeAssistant,
-    mock_bsblan: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test reconfigure flow with connection error."""
-    mock_config_entry.add_to_hass(hass)
-
-    mock_bsblan.device.side_effect = BSBLANConnectionError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": "reconfigure",
-            "entry_id": mock_config_entry.entry_id,
-        },
-    )
-
-    _assert_form_result(result, "reconfigure")
+    # Recover: clear the error and submit correct credentials
+    mock_bsblan.device.side_effect = None
 
     result = await _configure_flow(
         hass,
         result["flow_id"],
         {
             CONF_HOST: "192.168.1.50",
-            CONF_PORT: 80,
-            CONF_PASSKEY: "1234",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin1234",
+            CONF_PORT: 8080,
+            CONF_PASSKEY: "new_passkey",
+            CONF_USERNAME: "new_admin",
+            CONF_PASSWORD: "new_password",
         },
     )
 
-    _assert_form_result(result, "reconfigure", {"base": "cannot_connect"})
+    _assert_abort_result(result, "reconfigure_successful")
+
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.50"
+    assert mock_config_entry.data[CONF_PORT] == 8080
+    assert mock_config_entry.data[CONF_PASSKEY] == "new_passkey"
+    assert mock_config_entry.data[CONF_USERNAME] == "new_admin"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new_password"
 
 
 async def test_reconfigure_flow_unique_id_mismatch(
@@ -1202,13 +1169,7 @@ async def test_reconfigure_flow_unique_id_mismatch(
     device = mock_bsblan.device.return_value
     device.MAC = "aa:bb:cc:dd:ee:ff"
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={
-            "source": "reconfigure",
-            "entry_id": mock_config_entry.entry_id,
-        },
-    )
+    result = await mock_config_entry.start_reconfigure_flow(hass)
 
     _assert_form_result(result, "reconfigure")
 

--- a/tests/components/bsblan/test_config_flow.py
+++ b/tests/components/bsblan/test_config_flow.py
@@ -1059,3 +1059,167 @@ async def test_zeroconf_discovery_auth_error_during_confirm(
 
     # Should show the discovery_confirm form again with auth error
     _assert_form_result(result, "discovery_confirm", {"base": "invalid_auth"})
+
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test successful reconfiguration flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": mock_config_entry.entry_id,
+        },
+    )
+
+    _assert_form_result(result, "reconfigure")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 8080,
+            CONF_PASSKEY: "new_passkey",
+            CONF_USERNAME: "new_admin",
+            CONF_PASSWORD: "new_password",
+        },
+    )
+
+    _assert_abort_result(result, "reconfigure_successful")
+
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.50"
+    assert mock_config_entry.data[CONF_PORT] == 8080
+    assert mock_config_entry.data[CONF_PASSKEY] == "new_passkey"
+    assert mock_config_entry.data[CONF_USERNAME] == "new_admin"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new_password"
+
+
+async def test_reconfigure_flow_auth_error(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow with authentication error."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_bsblan.device.side_effect = BSBLANAuthError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": mock_config_entry.entry_id,
+        },
+    )
+
+    _assert_form_result(result, "reconfigure")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "wrong_key",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "wrong_password",
+        },
+    )
+
+    _assert_form_result(result, "reconfigure", {"base": "invalid_auth"})
+
+    # Verify user input is preserved in the form
+    data_schema = result.get("data_schema")
+    assert data_schema is not None
+
+    host_field = next(
+        field for field in data_schema.schema if field.schema == CONF_HOST
+    )
+    passkey_field = next(
+        field for field in data_schema.schema if field.schema == CONF_PASSKEY
+    )
+    username_field = next(
+        field for field in data_schema.schema if field.schema == CONF_USERNAME
+    )
+
+    assert host_field.default() == "192.168.1.50"
+    assert passkey_field.default() == "wrong_key"
+    assert username_field.default() == "admin"
+
+
+async def test_reconfigure_flow_connection_error(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow with connection error."""
+    mock_config_entry.add_to_hass(hass)
+
+    mock_bsblan.device.side_effect = BSBLANConnectionError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": mock_config_entry.entry_id,
+        },
+    )
+
+    _assert_form_result(result, "reconfigure")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.50",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+    )
+
+    _assert_form_result(result, "reconfigure", {"base": "cannot_connect"})
+
+
+async def test_reconfigure_flow_unique_id_mismatch(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow aborts when connecting to a different device."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Mock device returning a different MAC address
+    device = mock_bsblan.device.return_value
+    device.MAC = "aa:bb:cc:dd:ee:ff"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": "reconfigure",
+            "entry_id": mock_config_entry.entry_id,
+        },
+    )
+
+    _assert_form_result(result, "reconfigure")
+
+    result = await _configure_flow(
+        hass,
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.99",
+            CONF_PORT: 80,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+    )
+
+    _assert_abort_result(result, "unique_id_mismatch")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request adds support for a full reconfiguration flow to the BSB-LAN integration in Home Assistant, allowing users to update connection settings for an existing device. It introduces new form schemas, error handling, and tests to ensure robust handling of credential and connection changes. Additionally, it updates translation and quality scale files to reflect the new feature.

**Config flow and validation improvements:**

* Added a new `async_step_reconfigure` method to `config_flow.py` to handle reconfiguration of existing BSB-LAN devices, including validation of new credentials and prevention of reconfiguring to a different physical device. Supporting schema-building and validation methods were also added and refactored for clarity and reusability.

**User interface and translation updates:**

* Updated `strings.json` to include new abort reasons and user-facing strings for the reconfiguration flow, such as "reconfigure_successful" and "unique_id_mismatch", and added a new "reconfigure" step with appropriate field descriptions. [[1]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310L6-R8) [[2]](diffhunk://#diff-bd2756966f9b9532e6ceb5c889fa31222a957f246b0e01a70f36d60b823d6310R44-R61)

**Quality scale and documentation:**

* Marked the `reconfiguration-flow` as complete in `quality_scale.yaml`, indicating the integration now supports this required feature.

**Testing:**

* Added comprehensive tests for the reconfiguration flow in `test_config_flow.py`, covering successful reconfiguration, authentication errors, connection errors, and unique ID mismatches to ensure correct behavior and error handling.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
