### PR TITLE
Sonarr coordinator refactor

### DIFF
--- a/homeassistant/components/sonarr/__init__.py
+++ b/homeassistant/components/sonarr/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from aiopyarr.models.host_configuration import PyArrHostConfiguration
 from aiopyarr.sonarr_client import SonarrClient
 
@@ -37,6 +35,8 @@ from .coordinator import (
     DiskSpaceDataUpdateCoordinator,
     QueueDataUpdateCoordinator,
     SeriesDataUpdateCoordinator,
+    SonarrConfigEntry,
+    SonarrData,
     SonarrDataUpdateCoordinator,
     StatusDataUpdateCoordinator,
     WantedDataUpdateCoordinator,
@@ -54,7 +54,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: SonarrConfigEntry) -> bool:
     """Set up Sonarr from a config entry."""
     if not entry.options:
         options = {
@@ -76,29 +76,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         host_configuration=host_configuration,
         session=async_get_clientsession(hass),
     )
-    coordinators: dict[str, SonarrDataUpdateCoordinator[Any]] = {
-        "upcoming": CalendarDataUpdateCoordinator(
+    data = SonarrData(
+        upcoming=CalendarDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+        commands=CommandsDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+        diskspace=DiskSpaceDataUpdateCoordinator(
             hass, entry, host_configuration, sonarr
         ),
-        "commands": CommandsDataUpdateCoordinator(
-            hass, entry, host_configuration, sonarr
-        ),
-        "diskspace": DiskSpaceDataUpdateCoordinator(
-            hass, entry, host_configuration, sonarr
-        ),
-        "queue": QueueDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
-        "series": SeriesDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
-        "status": StatusDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
-        "wanted": WantedDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
-    }
+        queue=QueueDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+        series=SeriesDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+        status=StatusDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+        wanted=WantedDataUpdateCoordinator(hass, entry, host_configuration, sonarr),
+    )
     # Temporary, until we add diagnostic entities
     _version = None
-    for coordinator in coordinators.values():
+    coordinators: list[SonarrDataUpdateCoordinator] = [
+        data.upcoming,
+        data.commands,
+        data.diskspace,
+        data.queue,
+        data.series,
+        data.status,
+        data.wanted,
+    ]
+    for coordinator in coordinators:
         await coordinator.async_config_entry_first_refresh()
         if isinstance(coordinator, StatusDataUpdateCoordinator):
             _version = coordinator.data.version
         coordinator.system_version = _version
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
+    entry.runtime_data = data
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -128,11 +133,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: SonarrConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/sonarr/sensor.py
+++ b/homeassistant/components/sonarr/sensor.py
@@ -20,15 +20,13 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
-from .coordinator import SonarrDataT, SonarrDataUpdateCoordinator
+from .coordinator import SonarrConfigEntry, SonarrDataT, SonarrDataUpdateCoordinator
 from .entity import SonarrEntity
 
 
@@ -143,15 +141,12 @@ SENSOR_TYPES: dict[str, SonarrSensorEntityDescription[Any]] = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: SonarrConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Sonarr sensors based on a config entry."""
-    coordinators: dict[str, SonarrDataUpdateCoordinator[Any]] = hass.data[DOMAIN][
-        entry.entry_id
-    ]
     async_add_entities(
-        SonarrSensor(coordinators[coordinator_type], description)
+        SonarrSensor(getattr(entry.runtime_data, coordinator_type), description)
         for coordinator_type, description in SENSOR_TYPES.items()
     )
 

--- a/homeassistant/components/sonarr/services.py
+++ b/homeassistant/components/sonarr/services.py
@@ -134,7 +134,7 @@ async def _async_get_series(service: ServiceCall) -> dict[str, Any]:
     """Get all Sonarr series."""
     entry = _get_config_entry_from_service_data(service)
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
     series_list = await _handle_api_errors(api_client.async_get_series)
 
     base_url = entry.data[CONF_URL]
@@ -149,7 +149,7 @@ async def _async_get_episodes(service: ServiceCall) -> dict[str, Any]:
     series_id: int = service.data[CONF_SERIES_ID]
     season_number: int | None = service.data.get(CONF_SEASON_NUMBER)
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
     episodes = await _handle_api_errors(
         lambda: api_client.async_get_episodes(series_id, series=True)
     )
@@ -164,7 +164,7 @@ async def _async_get_queue(service: ServiceCall) -> dict[str, Any]:
     entry = _get_config_entry_from_service_data(service)
     max_items: int = service.data[CONF_MAX_ITEMS]
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
     # 0 means no limit - use a large page size to get all items
     page_size = max_items if max_items > 0 else 10000
     queue = await _handle_api_errors(
@@ -184,7 +184,7 @@ async def _async_get_diskspace(service: ServiceCall) -> dict[str, Any]:
     entry = _get_config_entry_from_service_data(service)
     space_unit: str = service.data[CONF_SPACE_UNIT]
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
     disks = await _handle_api_errors(api_client.async_get_diskspace)
 
     return {ATTR_DISKS: format_diskspace(disks, space_unit)}
@@ -195,7 +195,7 @@ async def _async_get_upcoming(service: ServiceCall) -> dict[str, Any]:
     entry = _get_config_entry_from_service_data(service)
     days: int = service.data[CONF_DAYS]
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
 
     local = dt_util.start_of_local_day().replace(microsecond=0)
     start = dt_util.as_utc(local)
@@ -218,7 +218,7 @@ async def _async_get_wanted(service: ServiceCall) -> dict[str, Any]:
     entry = _get_config_entry_from_service_data(service)
     max_items: int = service.data[CONF_MAX_ITEMS]
 
-    api_client = service.hass.data[DOMAIN][entry.entry_id]["status"].api_client
+    api_client = entry.runtime_data.status.api_client
     # 0 means no limit - use a large page size to get all items
     page_size = max_items if max_items > 0 else 10000
     wanted = await _handle_api_errors(

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -74,7 +74,6 @@ async def test_unload_config_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_config_entry.runtime_data is not None
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -74,13 +74,12 @@ async def test_unload_config_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert hass.data[DOMAIN][mock_config_entry.entry_id] is not None
+    assert mock_config_entry.runtime_data is not None
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    assert mock_config_entry.entry_id not in hass.data[DOMAIN]
 
 
 async def test_migrate_config_entry(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Refactor Sonarr coordinator storage to use runtime_data pattern

This PR modernizes the Sonarr integration to use the same coordinator storage pattern as its sister integration Radarr, aligning with new standards.

### Changes

**Coordinator Storage Pattern:**
- Define typed config entry: `type SonarrConfigEntry = ConfigEntry[SonarrData]`
- Store coordinators in a `SonarrData` dataclass instead of a dictionary
- Use `entry.runtime_data` instead of `hass.data[DOMAIN][entry.entry_id]`
- Remove manual `hass.data` cleanup in `async_unload_entry`

**Type System Improvements:**
- Remove `from typing import Any` (no longer needed)
- Add `SonarrConfigEntry` and `SonarrData` imports from coordinator module
- Update function signatures to use `SonarrConfigEntry` type
- Replace dict-based storage (`dict[str, SonarrDataUpdateCoordinator[Any]]`) with structured dataclass

**Service Access Pattern:**
- Update services to access coordinators via `entry.runtime_data.status.api_client`
- Previously: `service.hass.data[DOMAIN][entry.entry_id]["status"].api_client`

### Benefits

- **Type Safety**: Full type checking with mypy strict mode - typos in coordinator access are caught at development time
- **IDE Support**: Autocomplete now shows available coordinators and their types
- **Automatic Cleanup**: `entry.runtime_data` is automatically cleared when the entry is unloaded
- **Code Clarity**: Cleaner access pattern with dot notation instead of nested dictionary lookups
- **Consistency**: Matches the pattern used in Radarr and other modern integrations (UniFi, ESPHome, HEOS)
- **Quality Scale**: Improves code quality towards Platinum tier requirements (comprehensive type hints, PEP-561 compliance)

### References

This pattern is now standard in modern Home Assistant integrations:
- **Sister Integration**: Radarr (`homeassistant/components/radarr/coordinator.py`)
- **Documentation**: [Config Entry Runtime Data](https://developers.home-assistant.io/docs/config_entries_index/#runtime-data)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr