### PR TITLE
Clean up evohome constants

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -41,14 +41,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from .const import (
-    ATTR_DURATION,
-    ATTR_DURATION_UNTIL,
-    ATTR_PERIOD,
-    ATTR_SETPOINT,
-    EVOHOME_DATA,
-    EvoService,
-)
+from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, EVOHOME_DATA, EvoService
 from .coordinator import EvoDataUpdateCoordinator
 from .entity import EvoChild, EvoEntity
 
@@ -179,20 +172,20 @@ class EvoZone(EvoChild, EvoClimateEntity):
 
     async def async_zone_svc_request(self, service: str, data: dict[str, Any]) -> None:
         """Process a service request (setpoint override) for a zone."""
-        if service == EvoService.RESET_ZONE_OVERRIDE:
+        if service == EvoService.CLEAR_ZONE_OVERRIDE:
             await self.coordinator.call_client_api(self._evo_device.reset())
             return
 
         # otherwise it is EvoService.SET_ZONE_OVERRIDE
         temperature = max(min(data[ATTR_SETPOINT], self.max_temp), self.min_temp)
 
-        if ATTR_DURATION_UNTIL in data:
-            duration: timedelta = data[ATTR_DURATION_UNTIL]
+        if ATTR_DURATION in data:
+            duration: timedelta = data[ATTR_DURATION]
             if duration.total_seconds() == 0:
                 await self._update_schedule()
                 until = self.setpoints.get("next_sp_from")
             else:
-                until = dt_util.now() + data[ATTR_DURATION_UNTIL]
+                until = dt_util.now() + data[ATTR_DURATION]
         else:
             until = None  # indefinitely
 

--- a/homeassistant/components/evohome/const.py
+++ b/homeassistant/components/evohome/const.py
@@ -28,7 +28,6 @@ ATTR_PERIOD: Final = "period"  # number of days
 ATTR_DURATION: Final = "duration"  # number of minutes, <24h
 
 ATTR_SETPOINT: Final = "setpoint"
-ATTR_DURATION_UNTIL: Final = "duration"
 
 
 @unique
@@ -39,4 +38,4 @@ class EvoService(StrEnum):
     SET_SYSTEM_MODE = "set_system_mode"
     RESET_SYSTEM = "reset_system"
     SET_ZONE_OVERRIDE = "set_zone_override"
-    RESET_ZONE_OVERRIDE = "clear_zone_override"
+    CLEAR_ZONE_OVERRIDE = "clear_zone_override"

--- a/homeassistant/components/evohome/entity.py
+++ b/homeassistant/components/evohome/entity.py
@@ -49,7 +49,7 @@ class EvoEntity(CoordinatorEntity[EvoDataUpdateCoordinator]):
             return
         if payload["service"] in (
             EvoService.SET_ZONE_OVERRIDE,
-            EvoService.RESET_ZONE_OVERRIDE,
+            EvoService.CLEAR_ZONE_OVERRIDE,
         ):
             await self.async_zone_svc_request(payload["service"], payload["data"])
             return

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -19,20 +19,13 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
 
-from .const import (
-    ATTR_DURATION,
-    ATTR_DURATION_UNTIL,
-    ATTR_PERIOD,
-    ATTR_SETPOINT,
-    DOMAIN,
-    EvoService,
-)
+from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, DOMAIN, EvoService
 from .coordinator import EvoDataUpdateCoordinator
 
 # system mode schemas are built dynamically when the services are registered
 # because supported modes can vary for edge-case systems
 
-RESET_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
+CLEAR_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
     {vol.Required(ATTR_ENTITY_ID): cv.entity_id}
 )
 SET_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
@@ -41,7 +34,7 @@ SET_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
         vol.Required(ATTR_SETPOINT): vol.All(
             vol.Coerce(float), vol.Range(min=4.0, max=35.0)
         ),
-        vol.Optional(ATTR_DURATION_UNTIL): vol.All(
+        vol.Optional(ATTR_DURATION): vol.All(
             cv.time_period,
             vol.Range(min=timedelta(days=0), max=timedelta(days=1)),
         ),
@@ -166,9 +159,9 @@ def setup_service_functions(
     # The zone modes are consistent across all systems and use the same schema
     hass.services.async_register(
         DOMAIN,
-        EvoService.RESET_ZONE_OVERRIDE,
+        EvoService.CLEAR_ZONE_OVERRIDE,
         set_zone_override,
-        schema=RESET_ZONE_OVERRIDE_SCHEMA,
+        schema=CLEAR_ZONE_OVERRIDE_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -125,7 +125,7 @@ async def test_zone_clear_zone_override(
     with patch("evohomeasync2.zone.Zone.reset") as mock_fcn:
         await hass.services.async_call(
             DOMAIN,
-            EvoService.RESET_ZONE_OVERRIDE,
+            EvoService.CLEAR_ZONE_OVERRIDE,
             {
                 ATTR_ENTITY_ID: zone_id,
             },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A small PR to tidy up three constants in **evohome**, in preparation for switching from domain- to entity-level services and then - ultimately - adding config flow.

- removes a duplicate string constant, `ATTR_DURATION_UNTIL`, in favor of `ATTR_DURATION`
- renames `EvoService.RESET_ZONE_OVERRIDE` to `EvoService.CLEAR_ZONE_OVERRIDE`
- renames `RESET_ZONE_OVERRIDE_SCHEMA` to `CLEAR_ZONE_OVERRIDE_SCHEMA`

Is related to #162700 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
