### PR TITLE
Migrate evohome's zone services to entity-level services

### DIFF
--- a/homeassistant/components/evohome/entity.py
+++ b/homeassistant/components/evohome/entity.py
@@ -12,7 +12,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, EvoService
+from .const import DOMAIN
 from .coordinator import EvoDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,20 +47,10 @@ class EvoEntity(CoordinatorEntity[EvoDataUpdateCoordinator]):
             raise NotImplementedError
         if payload["unique_id"] != self._attr_unique_id:
             return
-        if payload["service"] in (
-            EvoService.SET_ZONE_OVERRIDE,
-            EvoService.CLEAR_ZONE_OVERRIDE,
-        ):
-            await self.async_zone_svc_request(payload["service"], payload["data"])
-            return
         await self.async_tcs_svc_request(payload["service"], payload["data"])
 
     async def async_tcs_svc_request(self, service: str, data: dict[str, Any]) -> None:
         """Process a service request (system mode) for a controller."""
-        raise NotImplementedError
-
-    async def async_zone_svc_request(self, service: str, data: dict[str, Any]) -> None:
-        """Process a service request (setpoint override) for a zone."""
         raise NotImplementedError
 
     @property

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -56,7 +56,7 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
         EvoService.SET_ZONE_OVERRIDE,
         entity_domain=CLIMATE_DOMAIN,
         schema=SET_ZONE_OVERRIDE_SCHEMA,
-        func=f"async_set_zone_override",
+        func="async_set_zone_override",
     )
 
 

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Final
+from typing import Any, Final
 
 from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
 from evohomeasync2.schemas.const import (
@@ -13,9 +13,10 @@ from evohomeasync2.schemas.const import (
 )
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
 
@@ -25,21 +26,38 @@ from .coordinator import EvoDataUpdateCoordinator
 # system mode schemas are built dynamically when the services are registered
 # because supported modes can vary for edge-case systems
 
-CLEAR_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
-    {vol.Required(ATTR_ENTITY_ID): cv.entity_id}
-)
-SET_ZONE_OVERRIDE_SCHEMA: Final = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-        vol.Required(ATTR_SETPOINT): vol.All(
-            vol.Coerce(float), vol.Range(min=4.0, max=35.0)
-        ),
-        vol.Optional(ATTR_DURATION): vol.All(
-            cv.time_period,
-            vol.Range(min=timedelta(days=0), max=timedelta(days=1)),
-        ),
-    }
-)
+# Zone service schemas (registered as entity services)
+CLEAR_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {}
+SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
+    vol.Required(ATTR_SETPOINT): vol.All(
+        vol.Coerce(float), vol.Range(min=4.0, max=35.0)
+    ),
+    vol.Optional(ATTR_DURATION): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(days=0), max=timedelta(days=1)),
+    ),
+}
+
+
+def _register_zone_entity_services(hass: HomeAssistant) -> None:
+    """Register entity-level services for zones."""
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        EvoService.CLEAR_ZONE_OVERRIDE,
+        entity_domain=CLIMATE_DOMAIN,
+        schema=CLEAR_ZONE_OVERRIDE_SCHEMA,
+        func=f"async_{EvoService.CLEAR_ZONE_OVERRIDE}",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        EvoService.SET_ZONE_OVERRIDE,
+        entity_domain=CLIMATE_DOMAIN,
+        schema=SET_ZONE_OVERRIDE_SCHEMA,
+        func=f"async_{EvoService.SET_ZONE_OVERRIDE}",
+    )
 
 
 @callback
@@ -51,9 +69,9 @@ def setup_service_functions(
     Not all Honeywell TCC-compatible systems support all operating modes. In addition,
     each mode will require any of four distinct service schemas. This has to be
     enumerated before registering the appropriate handlers.
-
-    It appears that all TCC-compatible systems support the same three zones modes.
     """
+
+    _register_zone_entity_services(hass)
 
     @verify_domain_control(DOMAIN)
     async def force_refresh(call: ServiceCall) -> None:
@@ -70,28 +88,6 @@ def setup_service_functions(
             "service": call.service,
             "data": call.data,
         }
-        async_dispatcher_send(hass, DOMAIN, payload)
-
-    @verify_domain_control(DOMAIN)
-    async def set_zone_override(call: ServiceCall) -> None:
-        """Set the zone override (setpoint)."""
-        entity_id = call.data[ATTR_ENTITY_ID]
-
-        registry = er.async_get(hass)
-        registry_entry = registry.async_get(entity_id)
-
-        if registry_entry is None or registry_entry.platform != DOMAIN:
-            raise ValueError(f"'{entity_id}' is not a known {DOMAIN} entity")
-
-        if registry_entry.domain != "climate":
-            raise ValueError(f"'{entity_id}' is not an {DOMAIN} controller/zone")
-
-        payload = {
-            "unique_id": registry_entry.unique_id,
-            "service": call.service,
-            "data": call.data,
-        }
-
         async_dispatcher_send(hass, DOMAIN, payload)
 
     assert coordinator.tcs is not None  # mypy
@@ -155,17 +151,3 @@ def setup_service_functions(
             set_system_mode,
             schema=vol.Schema(vol.Any(*system_mode_schemas)),
         )
-
-    # The zone modes are consistent across all systems and use the same schema
-    hass.services.async_register(
-        DOMAIN,
-        EvoService.CLEAR_ZONE_OVERRIDE,
-        set_zone_override,
-        schema=CLEAR_ZONE_OVERRIDE_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        EvoService.SET_ZONE_OVERRIDE,
-        set_zone_override,
-        schema=SET_ZONE_OVERRIDE_SCHEMA,
-    )

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -71,8 +71,6 @@ def setup_service_functions(
     enumerated before registering the appropriate handlers.
     """
 
-    _register_zone_entity_services(hass)
-
     @verify_domain_control(DOMAIN)
     async def force_refresh(call: ServiceCall) -> None:
         """Obtain the latest state data via the vendor's RESTful API."""
@@ -151,3 +149,5 @@ def setup_service_functions(
             set_system_mode,
             schema=vol.Schema(vol.Any(*system_mode_schemas)),
         )
+
+    _register_zone_entity_services(hass)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -56,7 +56,7 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
         EvoService.SET_ZONE_OVERRIDE,
         entity_domain=CLIMATE_DOMAIN,
         schema=SET_ZONE_OVERRIDE_SCHEMA,
-        func=f"async_{EvoService.SET_ZONE_OVERRIDE}",
+        func=f"async_set_zone_override",
     )
 
 

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -48,7 +48,7 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
         EvoService.CLEAR_ZONE_OVERRIDE,
         entity_domain=CLIMATE_DOMAIN,
         schema=CLEAR_ZONE_OVERRIDE_SCHEMA,
-        func=f"async_{EvoService.CLEAR_ZONE_OVERRIDE}",
+        func="async_clear_zone_override",
     )
     service.async_register_platform_entity_service(
         hass,

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -28,14 +28,11 @@ reset_system:
 refresh_system:
 
 set_zone_override:
+  target:
+    entity:
+      integration: evohome
+      domain: climate
   fields:
-    entity_id:
-      required: true
-      example: climate.bathroom
-      selector:
-        entity:
-          integration: evohome
-          domain: climate
     setpoint:
       required: true
       selector:
@@ -49,10 +46,7 @@ set_zone_override:
         object:
 
 clear_zone_override:
-  fields:
-    entity_id:
-      required: true
-      selector:
-        entity:
-          integration: evohome
-          domain: climate
+  target:
+    entity:
+      integration: evohome
+      domain: climate

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -1,13 +1,12 @@
 {
+  "exceptions": {
+    "zone_only_service": {
+      "message": "Only zones support the `{service}` service"
+    }
+  },
   "services": {
     "clear_zone_override": {
       "description": "Sets a zone to follow its schedule.",
-      "fields": {
-        "entity_id": {
-          "description": "[%key:component::evohome::services::set_zone_override::fields::entity_id::description%]",
-          "name": "[%key:component::evohome::services::set_zone_override::fields::entity_id::name%]"
-        }
-      },
       "name": "Clear zone override"
     },
     "refresh_system": {
@@ -42,10 +41,6 @@
         "duration": {
           "description": "The zone will revert to its schedule after this time. If 0 the change is until the next scheduled setpoint.",
           "name": "Duration"
-        },
-        "entity_id": {
-          "description": "The entity ID of the Evohome zone.",
-          "name": "Entity"
         },
         "setpoint": {
           "description": "The temperature to be used instead of the scheduled setpoint.",

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -192,7 +192,7 @@ async def test_zone_services_with_ctl_id(
     service: EvoService,
     service_data: dict[str, Any],
 ) -> None:
-    """Test calling zone-only service with a non-zone entity_id fails."""
+    """Test calling zone-only services with a non-zone entity_id fail."""
 
     with pytest.raises(ServiceValidationError) as excinfo:
         await hass.services.async_call(

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -194,3 +194,22 @@ async def test_zone_clear_zone_override_with_ctl_id(  # ServiceValidationError
         )
 
     assert excinfo.value.translation_key == "zone_only_service"
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_set_zone_override_with_ctl_id(
+    hass: HomeAssistant,
+    ctl_id: str,
+) -> None:
+    """Test calling a zone service with a non-zone entity_id fails."""
+
+    with pytest.raises(ServiceValidationError) as excinfo:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_ZONE_OVERRIDE,
+            {ATTR_SETPOINT: 19.5},
+            target={ATTR_ENTITY_ID: ctl_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_key == "zone_only_service"

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -18,6 +18,7 @@ from homeassistant.components.evohome.const import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 
 @pytest.mark.parametrize("install", ["default"])
@@ -126,9 +127,8 @@ async def test_zone_clear_zone_override(
         await hass.services.async_call(
             DOMAIN,
             EvoService.CLEAR_ZONE_OVERRIDE,
-            {
-                ATTR_ENTITY_ID: zone_id,
-            },
+            {},
+            target={ATTR_ENTITY_ID: zone_id},
             blocking=True,
         )
 
@@ -151,9 +151,9 @@ async def test_zone_set_zone_override(
             DOMAIN,
             EvoService.SET_ZONE_OVERRIDE,
             {
-                ATTR_ENTITY_ID: zone_id,
                 ATTR_SETPOINT: 19.5,
             },
+            target={ATTR_ENTITY_ID: zone_id},
             blocking=True,
         )
 
@@ -165,13 +165,32 @@ async def test_zone_set_zone_override(
             DOMAIN,
             EvoService.SET_ZONE_OVERRIDE,
             {
-                ATTR_ENTITY_ID: zone_id,
                 ATTR_SETPOINT: 19.5,
                 ATTR_DURATION: {"minutes": 135},
             },
+            target={ATTR_ENTITY_ID: zone_id},
             blocking=True,
         )
 
         mock_fcn.assert_awaited_once_with(
             19.5, until=datetime(2024, 7, 10, 14, 15, tzinfo=UTC)
         )
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_zone_clear_zone_override_with_ctl_id(  # ServiceValidationError
+    hass: HomeAssistant,
+    ctl_id: str,
+) -> None:
+    """Test calling a zone service with a non-zone entity_id fails."""
+
+    with pytest.raises(ServiceValidationError) as excinfo:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.CLEAR_ZONE_OVERRIDE,
+            {},
+            target={ATTR_ENTITY_ID: ctl_id},
+            blocking=True,
+        )
+
+    assert excinfo.value.translation_key == "zone_only_service"

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+from voluptuous import Any
 
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,
@@ -178,38 +179,26 @@ async def test_set_zone_override(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_clear_zone_override_with_ctl_id(
+@pytest.mark.parametrize(
+    ("service", "service_data"),
+    [
+        (EvoService.CLEAR_ZONE_OVERRIDE, {}),
+        (EvoService.SET_ZONE_OVERRIDE, {ATTR_SETPOINT: 19.5}),
+    ],
+)
+async def test_zone_services_with_ctl_id(
     hass: HomeAssistant,
     ctl_id: str,
+    service: EvoService,
+    service_data: dict[str, Any],
 ) -> None:
-    """Test calling clear_zone_override service with a non-zone entity_id fails."""
+    """Test calling zone-only service with a non-zone entity_id fails."""
 
     with pytest.raises(ServiceValidationError) as excinfo:
         await hass.services.async_call(
             DOMAIN,
-            EvoService.CLEAR_ZONE_OVERRIDE,
-            {},
-            target={ATTR_ENTITY_ID: ctl_id},
-            blocking=True,
-        )
-
-    assert excinfo.value.translation_key == "zone_only_service"
-
-
-@pytest.mark.parametrize("install", ["default"])
-async def test_set_zone_override_with_ctl_id(
-    hass: HomeAssistant,
-    ctl_id: str,
-) -> None:
-    """Test calling set_zone_override service with a non-zone entity_id fails."""
-
-    with pytest.raises(ServiceValidationError) as excinfo:
-        await hass.services.async_call(
-            DOMAIN,
-            EvoService.SET_ZONE_OVERRIDE,
-            {
-                ATTR_SETPOINT: 19.5,
-            },
+            service,
+            service_data,
             target={ATTR_ENTITY_ID: ctl_id},
             blocking=True,
         )

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -207,7 +207,9 @@ async def test_set_zone_override_with_ctl_id(
         await hass.services.async_call(
             DOMAIN,
             EvoService.SET_ZONE_OVERRIDE,
-            {ATTR_SETPOINT: 19.5},
+            {
+                ATTR_SETPOINT: 19.5,
+            },
             target={ATTR_ENTITY_ID: ctl_id},
             blocking=True,
         )

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -22,7 +22,7 @@ from homeassistant.exceptions import ServiceValidationError
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_service_refresh_system(
+async def test_refresh_system(
     hass: HomeAssistant,
     evohome: EvohomeClient,
 ) -> None:
@@ -41,7 +41,7 @@ async def test_service_refresh_system(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_service_reset_system(
+async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,
 ) -> None:
@@ -60,7 +60,7 @@ async def test_service_reset_system(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_ctl_set_system_mode(
+async def test_set_system_mode(
     hass: HomeAssistant,
     ctl_id: str,
     freezer: FrozenDateTimeFactory,
@@ -116,7 +116,7 @@ async def test_ctl_set_system_mode(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_zone_clear_zone_override(
+async def test_clear_zone_override(
     hass: HomeAssistant,
     zone_id: str,
 ) -> None:
@@ -136,7 +136,7 @@ async def test_zone_clear_zone_override(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_zone_set_zone_override(
+async def test_set_zone_override(
     hass: HomeAssistant,
     zone_id: str,
     freezer: FrozenDateTimeFactory,
@@ -178,7 +178,7 @@ async def test_zone_set_zone_override(
 
 
 @pytest.mark.parametrize("install", ["default"])
-async def test_zone_clear_zone_override_with_ctl_id(  # ServiceValidationError
+async def test_clear_zone_override_with_ctl_id(
     hass: HomeAssistant,
     ctl_id: str,
 ) -> None:

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import patch
 
 from evohomeasync2 import EvohomeClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from voluptuous import Any
 
 from homeassistant.components.evohome.const import (
     ATTR_DURATION,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -182,7 +182,7 @@ async def test_clear_zone_override_with_ctl_id(
     hass: HomeAssistant,
     ctl_id: str,
 ) -> None:
-    """Test calling a zone service with a non-zone entity_id fails."""
+    """Test calling clear_zone_override service with a non-zone entity_id fails."""
 
     with pytest.raises(ServiceValidationError) as excinfo:
         await hass.services.async_call(
@@ -201,7 +201,7 @@ async def test_set_zone_override_with_ctl_id(
     hass: HomeAssistant,
     ctl_id: str,
 ) -> None:
-    """Test calling a zone service with a non-zone entity_id fails."""
+    """Test calling set_zone_override service with a non-zone entity_id fails."""
 
     with pytest.raises(ServiceValidationError) as excinfo:
         await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> This PR prepares evohome for an upcoming PR that will add config flow.

Migrate evohome's zone services (`set_zone_override`, `clear_zone_override`) to entity-level services, removing the old dispatcher/signal routing pattern from those entities.

Since both controllers & zones are implemented as **Climate** entities, `EvoClimateEntity` now has stub methods for entity-level services that raise `ServiceValidationError` with clear messages when called on the wrong entity type. 

The existing tests of native service pass essentially unchanged, and additional test have been added.

A subsequent PR will migrate the remaining services, although that will require a deprecation.

The PR is related to #162700

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
