### PR TITLE
Add diagnostics to aladdin_connect for easier troubleshooting

### DIFF
--- a/homeassistant/components/aladdin_connect/diagnostics.py
+++ b/homeassistant/components/aladdin_connect/diagnostics.py
@@ -1,0 +1,32 @@
+"""Diagnostics support for Aladdin Connect."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .coordinator import AladdinConnectConfigEntry
+
+TO_REDACT = {"access_token", "refresh_token"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: AladdinConnectConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return {
+        "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT),
+        "doors": {
+            uid: {
+                "device_id": coordinator.data.device_id,
+                "door_number": coordinator.data.door_number,
+                "name": coordinator.data.name,
+                "status": coordinator.data.status,
+                "link_status": coordinator.data.link_status,
+                "battery_level": coordinator.data.battery_level,
+            }
+            for uid, coordinator in config_entry.runtime_data.items()
+        },
+    }

--- a/homeassistant/components/aladdin_connect/quality_scale.yaml
+++ b/homeassistant/components/aladdin_connect/quality_scale.yaml
@@ -45,7 +45,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery: done
   discovery-update-info:
     status: exempt

--- a/tests/components/aladdin_connect/snapshots/test_diagnostics.ambr
+++ b/tests/components/aladdin_connect/snapshots/test_diagnostics.ambr
@@ -1,0 +1,40 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'config_entry': dict({
+      'data': dict({
+        'auth_implementation': 'aladdin_connect',
+        'token': dict({
+          'access_token': '**REDACTED**',
+          'expires_in': 3600,
+          'refresh_token': '**REDACTED**',
+        }),
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'aladdin_connect',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'Aladdin Connect',
+      'unique_id': 'test_user_123',
+      'version': 2,
+    }),
+    'doors': dict({
+      'test_device_id-1': dict({
+        'battery_level': 100,
+        'device_id': 'test_device_id',
+        'door_number': 1,
+        'link_status': 'connected',
+        'name': 'Test Door',
+        'status': 'closed',
+      }),
+    }),
+  })
+# ---

--- a/tests/components/aladdin_connect/test_diagnostics.py
+++ b/tests/components/aladdin_connect/test_diagnostics.py
@@ -1,0 +1,28 @@
+"""Tests for the Aladdin Connect diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.core import HomeAssistant
+
+from . import init_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics."""
+    await init_integration(hass, mock_config_entry)
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+    assert result == snapshot(
+        exclude=props("created_at", "modified_at", "entry_id", "expires_at")
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There's no way to export `aladdin_connect` state when troubleshooting issues. This adds config entry diagnostics so users can download door status, battery levels, and connection info to share in bug reports. OAuth tokens are redacted.

Moves the `diagnostics` quality scale rule from `todo` to `done`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
