### PR TITLE
Handle missing Daikin zone temperature keys

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -115,7 +115,7 @@ def _zone_temperature_lists(device: Appliance) -> tuple[list[str], list[str]]:
     try:
         heating = device.represent(DAIKIN_ZONE_TEMP_HEAT)[1]
         cooling = device.represent(DAIKIN_ZONE_TEMP_COOL)[1]
-    except (AttributeError, KeyError):
+    except AttributeError, KeyError:
         return ([], [])
     return (list(heating or []), list(cooling or []))
 
@@ -141,7 +141,7 @@ def _system_target_temperature(device: Appliance) -> float | None:
         return None
     try:
         return float(target)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
 

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -115,7 +115,7 @@ def _zone_temperature_lists(device: Appliance) -> tuple[list[str], list[str]]:
     try:
         heating = device.represent(DAIKIN_ZONE_TEMP_HEAT)[1]
         cooling = device.represent(DAIKIN_ZONE_TEMP_COOL)[1]
-    except AttributeError:
+    except (AttributeError, KeyError):
         return ([], [])
     return (list(heating or []), list(cooling or []))
 
@@ -141,7 +141,7 @@ def _system_target_temperature(device: Appliance) -> float | None:
         return None
     try:
         return float(target)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 

--- a/tests/components/daikin/test_zone_climate.py
+++ b/tests/components/daikin/test_zone_climate.py
@@ -112,6 +112,27 @@ async def test_setup_entry_skips_zone_climates_without_support(
     assert _zone_entity_id(entity_registry, zone_device, 0) is None
 
 
+async def test_setup_entry_handles_missing_zone_temperature_key(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    zone_device: ZoneDevice,
+) -> None:
+    """Missing zone temperature keys do not break climate setup."""
+    configure_zone_device(zone_device, zones=[["Living", "1", 22]])
+    zone_device.values.pop("lztemp_h")
+
+    await _async_setup_daikin(hass, zone_device)
+
+    assert _zone_entity_id(entity_registry, zone_device, 0) is None
+    main_entity_id = entity_registry.async_get_entity_id(
+        CLIMATE_DOMAIN,
+        DOMAIN,
+        zone_device.mac,
+    )
+    assert main_entity_id is not None
+    assert hass.states.get(main_entity_id) is not None
+
+
 @pytest.mark.parametrize(
     ("mode", "expected_zone_key"),
     [("hot", "lztemp_h"), ("cool", "lztemp_c")],


### PR DESCRIPTION
## Breaking change
None

## Proposed change
Handle Daikin devices that expose zones but omit one or both zone temperature keys (`lztemp_h`/`lztemp_c`) in API values.

Before this change, setup could fail with `KeyError: 'lztemp_h'` during `_supports_zone_temperature_control()`, which aborted climate platform setup.

This change updates zone temperature decoding to treat missing keys as unsupported zone temperature control instead of raising, so the main Daikin climate entity still sets up.

A regression test is added to verify setup does not fail when `lztemp_h` is missing.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/164125
- This PR is related to issue: User report on 2026.3b0 with traceback `KeyError: 'lztemp_h'` in Daikin climate setup
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


