### PR TITLE
Debounce Matter cover state writes

### DIFF
--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 from enum import IntEnum
 from math import floor
 from typing import Any
@@ -22,8 +20,8 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 
 from .const import LOGGER
 from .entity import MatterEntity, MatterEntityDescription
@@ -32,6 +30,7 @@ from .models import MatterDiscoverySchema
 
 # The MASK used for extracting bits 0 to 1 of the byte.
 OPERATIONAL_STATUS_MASK = 0b11
+WRITE_STATE_DEBOUNCE_SECONDS = 0.1
 
 # map Matter window cover types to HA device class
 TYPE_MAP = {
@@ -73,8 +72,19 @@ class MatterCoverEntityDescription(CoverEntityDescription, MatterEntityDescripti
 class MatterCover(MatterEntity, CoverEntity):
     """Representation of a Matter Cover."""
 
-    _cancel_write_state: Callable[[], None] | None = None
+    _write_state_debouncer: Debouncer[None] | None = None
     entity_description: MatterCoverEntityDescription
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity has been added to Home Assistant."""
+        await super().async_added_to_hass()
+        self._write_state_debouncer = Debouncer(
+            self.hass,
+            LOGGER,
+            cooldown=WRITE_STATE_DEBOUNCE_SECONDS,
+            immediate=False,
+            function=self.async_write_ha_state,
+        )
 
     @property
     def is_closed(self) -> bool | None:
@@ -123,24 +133,15 @@ class MatterCover(MatterEntity, CoverEntity):
         """Handle updates from the device."""
         self._attr_available = self._endpoint.node.available
         self._update_from_device()
-        if self._cancel_write_state is not None:
-            self._cancel_write_state()
-        self._cancel_write_state = async_call_later(
-            self.hass, 0.1, self._async_write_state_later
-        )
-
-    @callback
-    def _async_write_state_later(self, now: datetime) -> None:
-        """Write the Home Assistant state after debouncing attribute updates."""
-        self._cancel_write_state = None
-        self.async_write_ha_state()
+        assert self._write_state_debouncer is not None
+        self._write_state_debouncer.async_schedule_call()
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from Home Assistant."""
         await super().async_will_remove_from_hass()
-        if self._cancel_write_state is not None:
-            self._cancel_write_state()
-            self._cancel_write_state = None
+        if self._write_state_debouncer is not None:
+            self._write_state_debouncer.async_shutdown()
+            self._write_state_debouncer = None
 
     @callback
     def _update_from_device(self) -> None:

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from enum import IntEnum
 from math import floor
 from typing import Any
@@ -21,6 +23,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .const import LOGGER
 from .entity import MatterEntity, MatterEntityDescription
@@ -70,6 +73,7 @@ class MatterCoverEntityDescription(CoverEntityDescription, MatterEntityDescripti
 class MatterCover(MatterEntity, CoverEntity):
     """Representation of a Matter Cover."""
 
+    _cancel_write_state: Callable[[], None] | None = None
     entity_description: MatterCoverEntityDescription
 
     @property
@@ -113,6 +117,30 @@ class MatterCover(MatterEntity, CoverEntity):
             # value needs to be inverted and is sent in 100ths
             clusters.WindowCovering.Commands.GoToTiltPercentage((100 - position) * 100)
         )
+
+    @callback
+    def _on_matter_event(self, event: Any, data: Any = None) -> None:
+        """Handle updates from the device."""
+        self._attr_available = self._endpoint.node.available
+        self._update_from_device()
+        if self._cancel_write_state is not None:
+            self._cancel_write_state()
+        self._cancel_write_state = async_call_later(
+            self.hass, 0.1, self._async_write_state_later
+        )
+
+    @callback
+    def _async_write_state_later(self, now: datetime) -> None:
+        """Write the Home Assistant state after debouncing attribute updates."""
+        self._cancel_write_state = None
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from Home Assistant."""
+        await super().async_will_remove_from_hass()
+        if self._cancel_write_state is not None:
+            self._cancel_write_state()
+            self._cancel_write_state = None
 
     @callback
     def _update_from_device(self) -> None:

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -1,5 +1,6 @@
 """Test Matter covers."""
 
+import asyncio
 from math import floor
 from unittest.mock import MagicMock, call
 
@@ -226,6 +227,49 @@ async def test_cover_position_aware_lift(
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["current_position"] == 0
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
+        ("mock_window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+    ],
+)
+async def test_cover_position_aware_lift_debounce(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+) -> None:
+    """Test cover state update is debounced for split attribute updates."""
+
+    set_node_attribute(matter_node, 1, 258, 14, 9900)
+    set_node_attribute(matter_node, 1, 258, 10, 0b001010)
+    await trigger_subscription_callback(hass, matter_client)
+
+    await asyncio.sleep(0.11)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+    set_node_attribute(matter_node, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+    set_node_attribute(matter_node, 1, 258, 14, 10000)
+    await trigger_subscription_callback(hass, matter_client)
+
+    await asyncio.sleep(0.11)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
     assert state.state == CoverState.CLOSED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Debounce Matter cover state writes to avoid intermittent state changes when attribute updates arrive in the wrong order.

<img width="294" height="435" alt="image" src="https://github.com/user-attachments/assets/3b66598f-8716-4f25-a324-75d1a2ef3593" />


This has been observed using Eve MotionBlinds with Firmware 3.5.1 and Matter.js based Matter Server (0.4.3). The Matter.js server sends the attribute updates in different order:

```
2026-02-25 15:51:26.840 DEBUG (MainThread) [matter_server.client] Attribute updated: Node: 103 - Attribute: 1/258/10 - New value: 0
2026-02-25 15:51:26.840 DEBUG (MainThread) [homeassistant.components.matter] Operational status 0b00000000 for cover.eve_motionblinds_20caa9901
2026-02-25 15:51:26.840 DEBUG (MainThread) [homeassistant.components.matter] Current position for cover.eve_motionblinds_20caa9901 - raw: 9900 - corrected: 1
2026-02-25 15:51:26.841 INFO (MainThread) 
2026-02-25 15:51:26.848 DEBUG (MainThread) [matter_server.client] Attribute updated: Node: 103 - Attribute: 1/258/14 - New value: 10000
2026-02-25 15:51:26.849 DEBUG (MainThread) [homeassistant.components.matter] Operational status 0b00000000 for cover.eve_motionblinds_20caa9901
2026-02-25 15:51:26.849 DEBUG (MainThread) [homeassistant.components.matter] Current position for cover.eve_motionblinds_20caa9901 - raw: 10000 - corrected: 0
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
