### PR TITLE
Disable code interpreter with minimal reasoning for OpenAI

### DIFF
--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -512,6 +512,11 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
                     options.pop(CONF_WEB_SEARCH_REGION, None)
                     options.pop(CONF_WEB_SEARCH_COUNTRY, None)
                     options.pop(CONF_WEB_SEARCH_TIMEZONE, None)
+            if (
+                user_input.get(CONF_CODE_INTERPRETER)
+                and user_input.get(CONF_REASONING_EFFORT) == "minimal"
+            ):
+                errors[CONF_CODE_INTERPRETER] = "code_interpreter_minimal_reasoning"
 
             options.update(user_input)
             if not errors:

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -38,6 +38,7 @@
       },
       "entry_type": "AI task",
       "error": {
+        "code_interpreter_minimal_reasoning": "[%key:component::openai_conversation::config_subentries::conversation::error::code_interpreter_minimal_reasoning%]",
         "model_not_supported": "[%key:component::openai_conversation::config_subentries::conversation::error::model_not_supported%]",
         "web_search_minimal_reasoning": "[%key:component::openai_conversation::config_subentries::conversation::error::web_search_minimal_reasoning%]"
       },
@@ -93,6 +94,7 @@
       },
       "entry_type": "Conversation agent",
       "error": {
+        "code_interpreter_minimal_reasoning": "Code interpreter is not supported with minimal reasoning effort",
         "model_not_supported": "This model is not supported, please select a different model",
         "web_search_minimal_reasoning": "Web search is currently not supported with minimal reasoning effort"
       },

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -311,8 +311,15 @@ async def test_subentry_reasoning_effort_list(
     )
 
 
-async def test_subentry_websearch_unsupported_reasoning_effort(
-    hass: HomeAssistant, mock_config_entry, mock_init_component
+@pytest.mark.parametrize(
+    ("parameter", "error"),
+    [
+        (CONF_WEB_SEARCH, "web_search_minimal_reasoning"),
+        (CONF_CODE_INTERPRETER, "code_interpreter_minimal_reasoning"),
+    ],
+)
+async def test_subentry_unsupported_reasoning_effort(
+    hass: HomeAssistant, mock_config_entry, mock_init_component, parameter, error
 ) -> None:
     """Test the subentry form giving error about unsupported minimal reasoning effort."""
     subentry = next(iter(mock_config_entry.subentries.values()))
@@ -349,18 +356,18 @@ async def test_subentry_websearch_unsupported_reasoning_effort(
         subentry_flow["flow_id"],
         {
             CONF_REASONING_EFFORT: "minimal",
-            CONF_WEB_SEARCH: True,
+            parameter: True,
         },
     )
     assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["errors"] == {"web_search": "web_search_minimal_reasoning"}
+    assert subentry_flow["errors"] == {parameter: error}
 
     # Reconfigure model step
     subentry_flow = await hass.config_entries.subentries.async_configure(
         subentry_flow["flow_id"],
         {
             CONF_REASONING_EFFORT: "low",
-            CONF_WEB_SEARCH: True,
+            parameter: True,
         },
     )
     assert subentry_flow["type"] is FlowResultType.ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've noticed that enabling the code interpreter tool with minimal reason effort gives an error.
Even though minimal reasoning effort is only supported by gpt-5 versions only (it was introduced with gpt-5 and removed with gpt-5.1), it is still nice to have the error in our config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
