### PR TITLE
Allow installing minimal dependencies in bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,12 +6,47 @@ set -e
 
 cd "$(realpath "$(dirname "$0")/..")"
 
+INSTALL_ALL=false
+INSTALL_BASE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --all)
+      INSTALL_ALL=true
+      shift
+      ;;
+    --base)
+      INSTALL_BASE=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: ./script/[setup | bootstrap] [--all | --base]"
+      echo "  Defaults to --all"
+      exit 1
+      ;;
+  esac
+done
+
 echo "Installing development dependencies..."
-uv pip install \
-  -e . \
-  -r requirements_test_all.txt \
-  colorlog \
-  --upgrade \
-  --config-settings editable_mode=compat
+if [ "$INSTALL_BASE" = true ]; then
+  echo "BASE BASE BASE"; exit 0
+  uv pip install \
+    -e . \
+    -r requirements_test.txt \
+    colorlog \
+    --constraint homeassistant/package_constraints.txt \
+    --upgrade \
+    --config-settings editable_mode=compat
+else
+  echo "ALL ALL ALL"; exit 0
+  uv pip install \
+    -e . \
+    -r requirements_test_all.txt \
+    colorlog \
+    --upgrade \
+    --config-settings editable_mode=compat
+fi
 
 python3 -m script.translations develop --all

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,7 +9,7 @@ cd "$(realpath "$(dirname "$0")/..")"
 INSTALL_PARMS="-r requirements_test_all.txt"
 
 # Parse arguments
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   case $1 in
     --all)
       shift

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -36,11 +36,11 @@ case "$#" in
 esac
 
 echo "Installing development dependencies..."
-echo uv pip install \
+uv pip install \
   -e . \
   -r requirements_test$MODE.txt \
   colorlog \
   --upgrade \
   --config-settings editable_mode=compat
 
-echo python3 -m script.translations develop --all
+python3 -m script.translations develop --all

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,35 +4,43 @@
 # Stop on errors
 set -e
 
+usage() {
+    echo "Usage: ./script/setup [--all | --base]"
+    exit 1
+}
+
 cd "$(realpath "$(dirname "$0")/..")"
 
-INSTALL_PARMS="-r requirements_test_all.txt"
-
-# Parse arguments
-while [ $# -gt 0 ]; do
-  case $1 in
-    --all)
-      shift
-      ;;
-    --base)
-      INSTALL_PARMS="-r requirements_test.txt --constraint homeassistant/package_constraints.txt"
-      shift
-      ;;
+case "$#" in
+    0)
+        MODE="_all"
+        ;;
+    1)
+        case "$1" in
+            --all)
+                MODE="_all"
+                ;;
+            --base)
+                MODE=""
+                ;;
+            *)
+                echo "Error: unknown option '$1'" >&2
+                usage
+                ;;
+        esac
+        ;;
     *)
-      echo "Unknown option: $1"
-      echo "Usage: ./script/[setup | bootstrap] [--all | --base]"
-      echo "  Defaults to --all"
-      exit 1
-      ;;
-  esac
-done
+        echo "Error: too many arguments" >&2
+        usage
+        ;;
+esac
 
 echo "Installing development dependencies..."
-uv pip install \
+echo uv pip install \
   -e . \
-  $INSTALL_PARMS \
+  -r requirements_test$MODE.txt \
   colorlog \
   --upgrade \
   --config-settings editable_mode=compat
 
-python3 -m script.translations develop --all
+echo python3 -m script.translations develop --all

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,18 +6,16 @@ set -e
 
 cd "$(realpath "$(dirname "$0")/..")"
 
-INSTALL_ALL=false
-INSTALL_BASE=false
+INSTALL_PARMS="-r requirements_test_all.txt"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
     --all)
-      INSTALL_ALL=true
       shift
       ;;
     --base)
-      INSTALL_BASE=true
+      INSTALL_PARMS="-r requirements_test.txt --constraint homeassistant/package_constraints.txt"
       shift
       ;;
     *)
@@ -30,23 +28,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Installing development dependencies..."
-if [ "$INSTALL_BASE" = true ]; then
-  echo "BASE BASE BASE"; exit 0
-  uv pip install \
-    -e . \
-    -r requirements_test.txt \
-    colorlog \
-    --constraint homeassistant/package_constraints.txt \
-    --upgrade \
-    --config-settings editable_mode=compat
-else
-  echo "ALL ALL ALL"; exit 0
-  uv pip install \
-    -e . \
-    -r requirements_test_all.txt \
-    colorlog \
-    --upgrade \
-    --config-settings editable_mode=compat
-fi
+uv pip install \
+  -e . \
+  $INSTALL_PARMS \
+  colorlog \
+  --upgrade \
+  --config-settings editable_mode=compat
 
 python3 -m script.translations develop --all

--- a/script/setup
+++ b/script/setup
@@ -29,7 +29,7 @@ if ! [ -x "$(command -v uv)" ]; then
   python3 -m pip install uv
 fi
 
-script/bootstrap
+script/bootstrap $*
 
 prek install
 

--- a/script/setup
+++ b/script/setup
@@ -29,7 +29,7 @@ if ! [ -x "$(command -v uv)" ]; then
   python3 -m pip install uv
 fi
 
-script/bootstrap $*
+script/bootstrap "$@"
 
 prek install
 


### PR DESCRIPTION



## Proposed change
There was a recent change to `script/setup` such that all requirements are installed all the time. This caused two problems. `uv pip install` would fail with the error `no more FDs available` (error text from my memory as I don't have it the actual text). This is fixable with `ulimit -n 2048`. Then `uv pip install` would fail trying to build one of the requirements as the rust compiler is not installed. Installing the rust compiler fixed that.

The reason to allow users to install the minimum required is to avoid those problems and to keep a simpler setup such that only required requirements are installed.

For reference, there is a discussion thread on Discord here: https://discord.com/channels/330944238910963714/554842238073700352/1476323132758429921

Note: claude.ai used on latest commit to improve parsing of arguments. I fully tested and reviewed every line.

I am on MacOS 15.7

## Type of change


- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
