### PR TITLE
Add missing features to Wyoming conversation agent

### DIFF
--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -1,6 +1,7 @@
 """Support for Wyoming intent recognition services."""
 
 import logging
+from typing import Literal
 
 from wyoming.asr import Transcript
 from wyoming.client import AsyncTcpClient
@@ -10,6 +11,7 @@ from wyoming.intent import Intent, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import MATCH_ALL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -89,8 +91,11 @@ class WyomingConversationEntity(
         self._attr_unique_id = f"{config_entry.entry_id}-conversation"
 
     @property
-    def supported_languages(self) -> list[str]:
+    def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
+        if not self._supported_languages:
+            return MATCH_ALL
+
         return self._supported_languages
 
     async def async_process(
@@ -100,11 +105,17 @@ class WyomingConversationEntity(
         conversation_id = user_input.conversation_id or ulid_util.ulid_now()
         intent_response = intent.IntentResponse(language=user_input.language)
 
+        context = {"conversation_id": conversation_id}
+        if user_input.satellite_id:
+            context["satellite_id"] = user_input.satellite_id
+
         try:
             async with AsyncTcpClient(self.service.host, self.service.port) as client:
                 await client.write_event(
                     Transcript(
-                        user_input.text, context={"conversation_id": conversation_id}
+                        user_input.text,
+                        context=context,
+                        language=user_input.language,
                     ).event()
                 )
 

--- a/homeassistant/components/wyoming/conversation.py
+++ b/homeassistant/components/wyoming/conversation.py
@@ -149,6 +149,8 @@ class WyomingConversationEntity(
                             intent_slots,
                             text_input=user_input.text,
                             language=user_input.language,
+                            satellite_id=user_input.satellite_id,
+                            device_id=user_input.device_id,
                         )
 
                         if (not intent_response.speech) and recognized_intent.text:

--- a/tests/components/wyoming/__init__.py
+++ b/tests/components/wyoming/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from unittest.mock import patch
 
+from wyoming.asr import Transcript
 from wyoming.event import Event
 from wyoming.info import (
     AsrModel,
@@ -172,13 +173,14 @@ EMPTY_INFO = Info()
 class MockAsyncTcpClient:
     """Mock AsyncTcpClient."""
 
-    def __init__(self, responses: list[Event]) -> None:
+    def __init__(self, responses: list[Event | None]) -> None:
         """Initialize."""
         self.host: str | None = None
         self.port: int | None = None
         self.written: list[Event] = []
         self.responses = responses
         self.is_connected: bool | None = None
+        self.transcript: Transcript | None = None
 
     async def connect(self) -> None:
         """Connect."""
@@ -191,6 +193,9 @@ class MockAsyncTcpClient:
     async def write_event(self, event: Event):
         """Send."""
         self.written.append(event)
+
+        if Transcript.is_type(event.type):
+            self.transcript = Transcript.from_event(event)
 
     async def read_event(self) -> Event | None:
         """Receive."""

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -7,21 +7,24 @@ from unittest.mock import patch
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
 from wyoming.handle import Handled, NotHandled
+from wyoming.info import Info
 from wyoming.intent import Entity, Intent, NotRecognized
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import MATCH_ALL
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import intent
 
-from . import MockAsyncTcpClient
+from . import HANDLE_INFO, INTENT_INFO, MockAsyncTcpClient
 
 
 async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> None:
     """Test when an intent is recognized."""
     agent_id = "conversation.test_intent"
-
     conversation_id = "conversation-1234"
+    satellite_id = "satellite-1234"
+
     test_intent = Intent(
         name="TestIntent",
         entities=[Entity(name="entity", value="value")],
@@ -40,9 +43,10 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
 
     intent.async_register(hass, TestIntentHandler())
 
+    client = MockAsyncTcpClient([test_intent.event()])
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
-        MockAsyncTcpClient([test_intent.event()]),
+        client,
     ):
         result = await conversation.async_converse(
             hass=hass,
@@ -51,7 +55,16 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
             context=Context(),
             language=hass.config.language,
             agent_id=agent_id,
+            satellite_id=satellite_id,
         )
+
+    # Ensure language and context are sent
+    assert client.transcript is not None
+    assert client.transcript.language == hass.config.language
+    assert client.transcript.context == {
+        "conversation_id": conversation_id,
+        "satellite_id": satellite_id,
+    }
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
@@ -123,12 +136,13 @@ async def test_not_recognized(
 async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> None:
     """Test when an intent is handled."""
     agent_id = "conversation.test_handle"
-
     conversation_id = "conversation-1234"
+    satellite_id = "satellite-1234"
 
+    client = MockAsyncTcpClient([Handled(text="success").event()])
     with patch(
         "homeassistant.components.wyoming.conversation.AsyncTcpClient",
-        MockAsyncTcpClient([Handled(text="success").event()]),
+        client,
     ):
         result = await conversation.async_converse(
             hass=hass,
@@ -137,7 +151,16 @@ async def test_handle(hass: HomeAssistant, init_wyoming_handle: ConfigEntry) -> 
             context=Context(),
             language=hass.config.language,
             agent_id=agent_id,
+            satellite_id=satellite_id,
         )
+
+    # Ensure language and context are sent
+    assert client.transcript is not None
+    assert client.transcript.language == hass.config.language
+    assert client.transcript.context == {
+        "conversation_id": conversation_id,
+        "satellite_id": satellite_id,
+    }
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert result.response.speech, "No speech"
@@ -222,3 +245,39 @@ async def test_oserror(
     assert result.response.error_code == intent.IntentResponseErrorCode.UNKNOWN
     assert result.response.speech, "No speech"
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
+
+
+async def test_intent_all_languages(
+    hass: HomeAssistant, intent_config_entry: ConfigEntry
+) -> None:
+    """Tests that an empty list of supported languages means the intent recognizer supports all languages."""
+    with (
+        patch.object(INTENT_INFO.intent[0].models[0], "languages", []),
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=Info(intent=INTENT_INFO.intent),
+        ),
+    ):
+        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, "conversation.test_intent")
+    assert agent is not None
+    assert agent.supported_languages == MATCH_ALL
+
+
+async def test_handle_all_languages(
+    hass: HomeAssistant, handle_config_entry: ConfigEntry
+) -> None:
+    """Tests that an empty list of supported languages means the intent handler supports all languages."""
+    with (
+        patch.object(HANDLE_INFO.handle[0].models[0], "languages", []),
+        patch(
+            "homeassistant.components.wyoming.data.load_wyoming_info",
+            return_value=Info(handle=HANDLE_INFO.handle),
+        ),
+    ):
+        await hass.config_entries.async_setup(handle_config_entry.entry_id)
+
+    agent = conversation.async_get_agent(hass, "conversation.test_handle")
+    assert agent is not None
+    assert agent.supported_languages == MATCH_ALL

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
 from wyoming.handle import Handled, NotHandled
@@ -251,37 +252,43 @@ async def test_oserror(
     assert result.response.speech.get("plain", {}).get("speech") == snapshot
 
 
-async def test_intent_all_languages(
-    hass: HomeAssistant, intent_config_entry: ConfigEntry
+@pytest.mark.parametrize(
+    ("config_entry_fixture", "info_obj", "info_kwargs", "agent_id"),
+    [
+        (
+            "intent_config_entry",
+            INTENT_INFO.intent[0].models[0],
+            {"intent": INTENT_INFO.intent},
+            "conversation.test_intent",
+        ),
+        (
+            "handle_config_entry",
+            HANDLE_INFO.handle[0].models[0],
+            {"handle": HANDLE_INFO.handle},
+            "conversation.test_handle",
+        ),
+    ],
+)
+async def test_supported_languages_empty_means_all(
+    hass: HomeAssistant,
+    request: pytest.FixtureRequest,
+    config_entry_fixture: str,
+    info_obj,
+    info_kwargs: dict,
+    agent_id: str,
 ) -> None:
-    """Tests that an empty list of supported languages means the intent recognizer supports all languages."""
+    """Test that an empty list of supported languages means the agent supports all languages."""
+    config_entry: ConfigEntry = request.getfixturevalue(config_entry_fixture)
+
     with (
-        patch.object(INTENT_INFO.intent[0].models[0], "languages", []),
+        patch.object(info_obj, "languages", []),
         patch(
             "homeassistant.components.wyoming.data.load_wyoming_info",
-            return_value=Info(intent=INTENT_INFO.intent),
+            return_value=Info(**info_kwargs),
         ),
     ):
-        await hass.config_entries.async_setup(intent_config_entry.entry_id)
+        await hass.config_entries.async_setup(config_entry.entry_id)
 
-    agent = conversation.async_get_agent(hass, "conversation.test_intent")
-    assert agent is not None
-    assert agent.supported_languages == MATCH_ALL
-
-
-async def test_handle_all_languages(
-    hass: HomeAssistant, handle_config_entry: ConfigEntry
-) -> None:
-    """Tests that an empty list of supported languages means the intent handler supports all languages."""
-    with (
-        patch.object(HANDLE_INFO.handle[0].models[0], "languages", []),
-        patch(
-            "homeassistant.components.wyoming.data.load_wyoming_info",
-            return_value=Info(handle=HANDLE_INFO.handle),
-        ),
-    ):
-        await hass.config_entries.async_setup(handle_config_entry.entry_id)
-
-    agent = conversation.async_get_agent(hass, "conversation.test_handle")
+    agent = conversation.async_get_agent(hass, agent_id)
     assert agent is not None
     assert agent.supported_languages == MATCH_ALL

--- a/tests/components/wyoming/test_conversation.py
+++ b/tests/components/wyoming/test_conversation.py
@@ -24,6 +24,7 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
     agent_id = "conversation.test_intent"
     conversation_id = "conversation-1234"
     satellite_id = "satellite-1234"
+    device_id = "device-1234"
 
     test_intent = Intent(
         name="TestIntent",
@@ -39,6 +40,8 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
         async def async_handle(self, intent_obj: intent.Intent):
             """Handle the intent."""
             assert intent_obj.slots.get("entity", {}).get("value") == "value"
+            assert intent_obj.satellite_id == satellite_id
+            assert intent_obj.device_id == device_id
             return intent_obj.create_response()
 
     intent.async_register(hass, TestIntentHandler())
@@ -56,6 +59,7 @@ async def test_intent(hass: HomeAssistant, init_wyoming_intent: ConfigEntry) -> 
             language=hass.config.language,
             agent_id=agent_id,
             satellite_id=satellite_id,
+            device_id=device_id,
         )
 
     # Ensure language and context are sent


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a few small missing features from Wyoming conversation agents:
* Pass `satellite_id` and `device_id` around so area-specific commands work properly
* Support `MATCH_ALL` for supported languages so LLMs can be used

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
