### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -235,7 +235,7 @@ class FFmpegConvertResponse(web.StreamResponse):
             if request.transport:
                 request.transport.abort()
             raise  # don't log error
-        except:
+        except Exception:
             _LOGGER.exception("Unexpected error during ffmpeg conversion")
             raise
         finally:

--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -138,7 +138,7 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
                 await device.open()
                 await device.synchronize()
                 self._device_info = await device.get_device_info()
-        except:
+        except Exception:
             await device.abort()
             raise
 

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -1085,7 +1085,7 @@ async def test_name(hass: HomeAssistant) -> None:
 
 def test_device_class_units(hass: HomeAssistant) -> None:
     """Test all numeric device classes have unit."""
-    # DEVICE_CLASS_UNITS should include all device classes except:
+    # DEVICE_CLASS_UNITS should include all device classes except Exception:
     # - NumberDeviceClass.MONETARY
     # - Device classes enumerated in NON_NUMERIC_DEVICE_CLASSES
     assert set(NUMBER_DEVICE_CLASS_UNITS) == set(

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2953,7 +2953,7 @@ def test_async_rounded_state_registered_entity_with_display_precision(
 
 def test_device_class_units_state_classes(hass: HomeAssistant) -> None:
     """Test all numeric device classes have unit and state class."""
-    # DEVICE_CLASS_UNITS should include all device classes except:
+    # DEVICE_CLASS_UNITS should include all device classes except Exception:
     # - SensorDeviceClass.MONETARY
     # - Device classes enumerated in NON_NUMERIC_DEVICE_CLASSES
     assert set(DEVICE_CLASS_UNITS) == set(


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.