### PR TITLE
Add Casper Glow integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -138,6 +138,7 @@ homeassistant.components.calendar.*
 homeassistant.components.cambridge_audio.*
 homeassistant.components.camera.*
 homeassistant.components.canary.*
+homeassistant.components.casper_glow.*
 homeassistant.components.cert_expiry.*
 homeassistant.components.clickatell.*
 homeassistant.components.clicksend.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -273,6 +273,8 @@ build.json @home-assistant/supervisor
 /tests/components/cambridge_audio/ @noahhusby
 /homeassistant/components/camera/ @home-assistant/core
 /tests/components/camera/ @home-assistant/core
+/homeassistant/components/casper_glow/ @mikeodr
+/tests/components/casper_glow/ @mikeodr
 /homeassistant/components/cast/ @emontnemery
 /tests/components/cast/ @emontnemery
 /homeassistant/components/ccm15/ @ocalvo

--- a/homeassistant/components/casper_glow/__init__.py
+++ b/homeassistant/components/casper_glow/__init__.py
@@ -1,0 +1,79 @@
+"""The Casper Glow integration."""
+
+from __future__ import annotations
+
+from pycasperglow import CasperGlow
+
+from homeassistant.components import bluetooth
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.const import CONF_ADDRESS, Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, SERVICE_PAUSE, SERVICE_RESUME
+from .coordinator import CasperGlowCoordinator
+from .models import CasperGlowConfigEntry, CasperGlowData
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up Casper Glow services."""
+    for service_name, method in (
+        (SERVICE_PAUSE, "async_pause"),
+        (SERVICE_RESUME, "async_resume"),
+    ):
+        service.async_register_platform_entity_service(
+            hass,
+            DOMAIN,
+            service_name,
+            entity_domain=LIGHT_DOMAIN,
+            schema={},
+            func=method,
+        )
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Casper Glow integration."""
+    async_setup_services(hass)
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: CasperGlowConfigEntry) -> bool:
+    """Set up Casper Glow from a config entry."""
+    address: str = entry.data[CONF_ADDRESS]
+    ble_device = bluetooth.async_ble_device_from_address(hass, address.upper(), True)
+    if not ble_device:
+        raise ConfigEntryNotReady(
+            f"Could not find Casper Glow device with address {address}"
+        )
+
+    glow = CasperGlow(ble_device)
+    coordinator = CasperGlowCoordinator(hass, glow, entry.title)
+    entry.runtime_data = CasperGlowData(coordinator)
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(coordinator.async_start())
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: CasperGlowConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: CasperGlowConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    """Remove a config entry from a device."""
+    return True

--- a/homeassistant/components/casper_glow/config_flow.py
+++ b/homeassistant/components/casper_glow/config_flow.py
@@ -1,0 +1,115 @@
+"""Config flow for Casper Glow integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bluetooth_data_tools import human_readable_name
+from pycasperglow import CasperGlow, CasperGlowError
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_ADDRESS
+
+from .const import DOMAIN, LOCAL_NAMES
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasperGlowConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Casper Glow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+        self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle the bluetooth discovery step."""
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+        self._discovery_info = discovery_info
+        self.context["title_placeholders"] = {
+            "name": human_readable_name(
+                None, discovery_info.name, discovery_info.address
+            )
+        }
+        return await self.async_step_user()
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the user step to pick discovered device."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            discovery_info = self._discovered_devices[address]
+            await self.async_set_unique_id(
+                discovery_info.address, raise_on_progress=False
+            )
+            self._abort_if_unique_id_configured()
+            glow = CasperGlow(discovery_info.device)
+            try:
+                await glow.handshake()
+            except CasperGlowError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title=human_readable_name(
+                        None, discovery_info.name, discovery_info.address
+                    ),
+                    data={
+                        CONF_ADDRESS: discovery_info.address,
+                    },
+                )
+
+        if discovery := self._discovery_info:
+            self._discovered_devices[discovery.address] = discovery
+        else:
+            current_addresses = self._async_current_ids(include_ignore=False)
+            for discovery in async_discovered_service_info(self.hass):
+                if (
+                    discovery.address in current_addresses
+                    or discovery.address in self._discovered_devices
+                    or discovery.name is None
+                    or not any(
+                        discovery.name.startswith(local_name)
+                        for local_name in LOCAL_NAMES
+                    )
+                ):
+                    continue
+                self._discovered_devices[discovery.address] = discovery
+
+        if not self._discovered_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_ADDRESS): vol.In(
+                    {
+                        service_info.address: human_readable_name(
+                            None, service_info.name, service_info.address
+                        )
+                        for service_info in self._discovered_devices.values()
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )

--- a/homeassistant/components/casper_glow/const.py
+++ b/homeassistant/components/casper_glow/const.py
@@ -1,0 +1,27 @@
+"""Constants for the Casper Glow integration."""
+
+from datetime import timedelta
+
+from pycasperglow import BRIGHTNESS_LEVELS, DEVICE_NAME_PREFIX, DIMMING_TIME_MINUTES
+
+DOMAIN = "casper_glow"
+
+LOCAL_NAMES = {DEVICE_NAME_PREFIX}
+
+SERVICE_PAUSE = "pause"
+SERVICE_RESUME = "resume"
+
+# Map device brightness percentages (60-100) to HA's 0-255 scale.
+# The device only supports 5 fixed levels, so we spread them evenly
+# across HA's 1-255 range (0 is reserved for off) rather than
+# mapping them proportionally, which would cluster all steps in the
+# top 40% of the slider.
+_LEVELS = sorted(BRIGHTNESS_LEVELS)
+BRIGHTNESS_PCT_TO_HA: dict[int, int] = {
+    pct: round(1 + (i / (len(_LEVELS) - 1)) * 254) for i, pct in enumerate(_LEVELS)
+}
+
+DEFAULT_DIMMING_TIME_MINUTES: int = DIMMING_TIME_MINUTES[0]
+
+# Interval between periodic state polls to catch externally-triggered changes.
+STATE_POLL_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/casper_glow/coordinator.py
+++ b/homeassistant/components/casper_glow/coordinator.py
@@ -1,0 +1,101 @@
+"""Coordinator for the Casper Glow integration."""
+
+from __future__ import annotations
+
+import logging
+
+from bleak import BleakError
+from bluetooth_data_tools import monotonic_time_coarse
+from pycasperglow import CasperGlow
+
+from homeassistant.components.bluetooth import (
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
+from homeassistant.components.bluetooth.active_update_coordinator import (
+    ActiveBluetoothDataUpdateCoordinator,
+)
+from homeassistant.core import HomeAssistant, callback
+
+from .const import STATE_POLL_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasperGlowCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
+    """Coordinator for Casper Glow BLE devices."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: CasperGlow,
+        title: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            address=device.address,
+            mode=BluetoothScanningMode.PASSIVE,
+            needs_poll_method=self._needs_poll,
+            poll_method=self._async_update,
+            connectable=True,
+        )
+        self.device = device
+        self.last_dimming_time_minutes: int | None = (
+            device.state.configured_dimming_time_minutes
+        )
+        self.command_unavailable_logged: bool = False
+        self.title = title
+
+    @callback
+    def _needs_poll(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        seconds_since_last_poll: float | None,
+    ) -> bool:
+        """Return True if a poll is needed."""
+        return (
+            seconds_since_last_poll is None
+            or seconds_since_last_poll >= STATE_POLL_INTERVAL.total_seconds()
+        )
+
+    async def _async_update(self, service_info: BluetoothServiceInfoBleak) -> None:
+        """Poll device state."""
+        await self.device.query_state()
+
+    async def _async_poll(self) -> None:
+        """Poll the device and log availability changes at info level."""
+        assert self._last_service_info
+
+        try:
+            await self._async_poll_data(self._last_service_info)
+        except BleakError as exc:
+            if self.last_poll_successful:
+                _LOGGER.info("%s is unavailable: %s", self.title, exc)
+                self.last_poll_successful = False
+            return
+        except Exception:
+            if self.last_poll_successful:
+                _LOGGER.exception("%s: unexpected error while polling", self.title)
+                self.last_poll_successful = False
+            return
+        finally:
+            self._last_poll = monotonic_time_coarse()
+
+        if not self.last_poll_successful:
+            _LOGGER.info("%s is back online", self.title)
+            self.last_poll_successful = True
+
+        self._async_handle_bluetooth_poll()
+
+    @callback
+    def _async_handle_bluetooth_event(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Update BLE device reference on each advertisement."""
+        self.device.set_ble_device(service_info.device)
+        super()._async_handle_bluetooth_event(service_info, change)

--- a/homeassistant/components/casper_glow/entity.py
+++ b/homeassistant/components/casper_glow/entity.py
@@ -1,0 +1,60 @@
+"""Base entity for the Casper Glow integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+import logging
+
+from pycasperglow import CasperGlowError
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+)
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+from .coordinator import CasperGlowCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasperGlowEntity(PassiveBluetoothCoordinatorEntity[CasperGlowCoordinator]):
+    """Base class for Casper Glow entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: CasperGlowCoordinator) -> None:
+        """Initialize a Casper Glow entity."""
+        super().__init__(coordinator)
+        self._device = coordinator.device
+        self._attr_device_info = DeviceInfo(
+            name=coordinator.title,
+            manufacturer="Casper",
+            model="Glow",
+            connections={(dr.CONNECTION_BLUETOOTH, coordinator.device.address)},
+        )
+
+    async def _async_command(self, coro: Awaitable[None]) -> None:
+        """Execute a device command, handling errors and availability logging."""
+        try:
+            await coro
+        except CasperGlowError as err:
+            if not self.coordinator.command_unavailable_logged:
+                _LOGGER.info("Device is unavailable")
+                self.coordinator.command_unavailable_logged = True
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        if self.coordinator.command_unavailable_logged:
+            _LOGGER.info("Device is back online")
+            self.coordinator.command_unavailable_logged = False
+
+    def _log_back_online_if_needed(self) -> None:
+        """Log recovery and clear the unavailability flag if previously set."""
+        if self.coordinator.command_unavailable_logged:
+            _LOGGER.info("Device is back online")
+            self.coordinator.command_unavailable_logged = False

--- a/homeassistant/components/casper_glow/icons.json
+++ b/homeassistant/components/casper_glow/icons.json
@@ -1,0 +1,10 @@
+{
+  "services": {
+    "pause": {
+      "service": "mdi:pause"
+    },
+    "resume": {
+      "service": "mdi:play"
+    }
+  }
+}

--- a/homeassistant/components/casper_glow/light.py
+++ b/homeassistant/components/casper_glow/light.py
@@ -1,0 +1,111 @@
+"""Casper Glow integration light platform."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pycasperglow import GlowState
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import BRIGHTNESS_PCT_TO_HA, DEFAULT_DIMMING_TIME_MINUTES
+from .coordinator import CasperGlowCoordinator
+from .entity import CasperGlowEntity
+from .models import CasperGlowConfigEntry
+
+PARALLEL_UPDATES = 0
+
+
+def _ha_brightness_to_device_pct(brightness: int) -> int:
+    """Convert HA brightness (1-255) to device percentage by snapping to nearest."""
+    closest_pct = 60
+    closest_dist = abs(brightness - BRIGHTNESS_PCT_TO_HA[60])
+    for pct, ha_val in BRIGHTNESS_PCT_TO_HA.items():
+        dist = abs(brightness - ha_val)
+        if dist < closest_dist:
+            closest_dist = dist
+            closest_pct = pct
+    return closest_pct
+
+
+def _device_pct_to_ha_brightness(pct: int) -> int:
+    """Convert device brightness percentage (60-100) to HA brightness (0-255)."""
+    return BRIGHTNESS_PCT_TO_HA[pct]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CasperGlowConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the light platform for Casper Glow."""
+    async_add_entities([CasperGlowLight(entry.runtime_data.coordinator)])
+
+
+class CasperGlowLight(CasperGlowEntity, LightEntity):
+    """Representation of a Casper Glow light."""
+
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_name = None
+
+    def __init__(self, coordinator: CasperGlowCoordinator) -> None:
+        """Initialize a Casper Glow light."""
+        super().__init__(coordinator)
+        self._attr_unique_id = coordinator.device.address
+        self._attr_is_on = coordinator.device.is_on
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback when entity is added."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._device.register_callback(self._async_handle_state_update)
+        )
+
+    @callback
+    def _async_handle_state_update(self, state: GlowState) -> None:
+        """Handle a state update from the device."""
+        if state.is_on is not None:
+            self._attr_is_on = state.is_on
+        if state.brightness_level is not None:
+            self._attr_brightness = _device_pct_to_ha_brightness(state.brightness_level)
+        self._log_back_online_if_needed()
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        brightness_pct: int | None = None
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness_pct = _ha_brightness_to_device_pct(kwargs[ATTR_BRIGHTNESS])
+
+        await self._async_command(self._device.turn_on())
+        if brightness_pct is not None:
+            await self._async_command(
+                self._device.set_brightness_and_dimming_time(
+                    brightness_pct,
+                    self.coordinator.last_dimming_time_minutes
+                    if self.coordinator.last_dimming_time_minutes is not None
+                    else DEFAULT_DIMMING_TIME_MINUTES,
+                )
+            )
+
+        self._attr_is_on = True
+        if brightness_pct is not None:
+            self._attr_brightness = _device_pct_to_ha_brightness(brightness_pct)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._async_command(self._device.turn_off())
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    async def async_pause(self) -> None:
+        """Pause an active dimming sequence."""
+        await self._async_command(self._device.pause())
+
+    async def async_resume(self) -> None:
+        """Resume a paused dimming sequence."""
+        await self._async_command(self._device.resume())

--- a/homeassistant/components/casper_glow/manifest.json
+++ b/homeassistant/components/casper_glow/manifest.json
@@ -1,0 +1,19 @@
+{
+  "domain": "casper_glow",
+  "name": "Casper Glow",
+  "bluetooth": [
+    {
+      "connectable": true,
+      "service_uuid": "9bb30001-fee9-4c24-8361-443b5b7c88f6"
+    }
+  ],
+  "codeowners": ["@mikeodr"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters"],
+  "documentation": "https://www.home-assistant.io/integrations/casper_glow",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "loggers": ["pycasperglow"],
+  "quality_scale": "bronze",
+  "requirements": ["pycasperglow==1.0.1"]
+}

--- a/homeassistant/components/casper_glow/models.py
+++ b/homeassistant/components/casper_glow/models.py
@@ -1,0 +1,25 @@
+"""The Casper Glow integration models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pycasperglow import CasperGlow
+
+from homeassistant.config_entries import ConfigEntry
+
+from .coordinator import CasperGlowCoordinator
+
+type CasperGlowConfigEntry = ConfigEntry[CasperGlowData]
+
+
+@dataclass(frozen=True)
+class CasperGlowData:
+    """Data for the Casper Glow integration."""
+
+    coordinator: CasperGlowCoordinator
+
+    @property
+    def device(self) -> CasperGlow:
+        """Return the CasperGlow device."""
+        return self.coordinator.device

--- a/homeassistant/components/casper_glow/quality_scale.yaml
+++ b/homeassistant/components/casper_glow/quality_scale.yaml
@@ -1,0 +1,24 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Gold (implemented and explicitly desired)
+  entity-translations: done
+  icon-translations: done

--- a/homeassistant/components/casper_glow/services.yaml
+++ b/homeassistant/components/casper_glow/services.yaml
@@ -1,0 +1,10 @@
+pause:
+  target:
+    entity:
+      integration: casper_glow
+      domain: light
+resume:
+  target:
+    entity:
+      integration: casper_glow
+      domain: light

--- a/homeassistant/components/casper_glow/strings.json
+++ b/homeassistant/components/casper_glow/strings.json
@@ -1,0 +1,39 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "data": {
+          "address": "Bluetooth address"
+        },
+        "data_description": {
+          "address": "The Bluetooth address of the Casper Glow light"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Casper Glow: {error}"
+    }
+  },
+  "services": {
+    "pause": {
+      "description": "Pause an active dimming sequence.",
+      "name": "Pause"
+    },
+    "resume": {
+      "description": "Resume a paused dimming sequence.",
+      "name": "Resume"
+    }
+  }
+}

--- a/homeassistant/components/casper_glow/translations/en.json
+++ b/homeassistant/components/casper_glow/translations/en.json
@@ -1,0 +1,39 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured",
+            "already_in_progress": "Configuration flow is already in progress",
+            "no_devices_found": "No devices found on the network"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "user": {
+                "data": {
+                    "address": "Bluetooth address"
+                },
+                "data_description": {
+                    "address": "The Bluetooth address of the Casper Glow light"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "communication_error": {
+            "message": "An error occurred while communicating with the Casper Glow: {error}"
+        }
+    },
+    "services": {
+        "pause": {
+            "description": "Pause an active dimming sequence.",
+            "name": "Pause"
+        },
+        "resume": {
+            "description": "Resume a paused dimming sequence.",
+            "name": "Resume"
+        }
+    }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -86,6 +86,11 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "service_data_uuid": "0000fcd2-0000-1000-8000-00805f9b34fb",
     },
     {
+        "connectable": True,
+        "domain": "casper_glow",
+        "service_uuid": "9bb30001-fee9-4c24-8361-443b5b7c88f6",
+    },
+    {
         "domain": "dormakaba_dkey",
         "service_uuid": "e7a60000-6639-429f-94fd-86de8ea26897",
     },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -117,6 +117,7 @@ FLOWS = {
         "caldav",
         "cambridge_audio",
         "canary",
+        "casper_glow",
         "cast",
         "ccm15",
         "cert_expiry",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -973,6 +973,12 @@
       "iot_class": "cloud_polling",
       "single_config_entry": true
     },
+    "casper_glow": {
+      "name": "Casper Glow",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "ccm15": {
       "name": "Midea ccm15 AC Controller",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1135,6 +1135,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.casper_glow.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.cert_expiry.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1979,6 +1979,9 @@ pybravia==0.4.1
 # homeassistant.components.nissan_leaf
 pycarwings2==2.14
 
+# homeassistant.components.casper_glow
+pycasperglow==1.0.1
+
 # homeassistant.components.cloudflare
 pycfdns==3.0.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1707,6 +1707,9 @@ pybotvac==0.0.28
 # homeassistant.components.braviatv
 pybravia==0.4.1
 
+# homeassistant.components.casper_glow
+pycasperglow==1.0.1
+
 # homeassistant.components.cloudflare
 pycfdns==3.0.0
 

--- a/tests/components/casper_glow/__init__.py
+++ b/tests/components/casper_glow/__init__.py
@@ -1,0 +1,55 @@
+"""Tests for the Casper Glow integration."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import (
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_bluetooth_service_info,
+)
+
+CASPER_GLOW_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="Jar",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    manufacturer_data={},
+    service_uuids=["9bb30001-fee9-4c24-8361-443b5b7c88f6"],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Jar"),
+    advertisement=generate_advertisement_data(
+        service_uuids=["9bb30001-fee9-4c24-8361-443b5b7c88f6"],
+    ),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+
+async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up the Casper Glow integration."""
+    entry.add_to_hass(hass)
+    inject_bluetooth_service_info(hass, CASPER_GLOW_DISCOVERY_INFO)
+    with patch("pycasperglow.CasperGlow.query_state", new_callable=AsyncMock):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+
+NOT_CASPER_GLOW_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="NotGlow",
+    address="AA:BB:CC:DD:EE:00",
+    rssi=-60,
+    manufacturer_data={},
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:00", name="NotGlow"),
+    advertisement=generate_advertisement_data(),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)

--- a/tests/components/casper_glow/conftest.py
+++ b/tests/components/casper_glow/conftest.py
@@ -1,0 +1,36 @@
+"""Casper Glow session fixtures."""
+
+import pytest
+
+from homeassistant.components.casper_glow.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+
+from . import CASPER_GLOW_DISCOVERY_INFO, setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth(enable_bluetooth: None) -> None:
+    """Auto mock bluetooth."""
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a Casper Glow config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Jar",
+        data={CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address},
+        unique_id=CASPER_GLOW_DISCOVERY_INFO.address,
+    )
+
+
+@pytest.fixture
+async def config_entry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> MockConfigEntry:
+    """Set up a Casper Glow config entry."""
+    await setup_integration(hass, mock_config_entry)
+    return mock_config_entry

--- a/tests/components/casper_glow/snapshots/test_light.ambr
+++ b/tests/components/casper_glow/snapshots/test_light.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_entities[light.jar-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.jar',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'casper_glow',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:DD:EE:FF',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[light.jar-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Jar',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.jar',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/casper_glow/test_config_flow.py
+++ b/tests/components/casper_glow/test_config_flow.py
@@ -1,0 +1,272 @@
+"""Test the Casper Glow config flow."""
+
+from unittest.mock import patch
+
+from bluetooth_data_tools import human_readable_name
+from pycasperglow import CasperGlowError
+
+from homeassistant import config_entries
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.casper_glow.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import CASPER_GLOW_DISCOVERY_INFO, NOT_CASPER_GLOW_DISCOVERY_INFO
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
+
+
+async def test_bluetooth_step_success(hass: HomeAssistant) -> None:
+    """Test bluetooth discovery step success."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=CASPER_GLOW_DISCOVERY_INFO,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        ),
+        patch(
+            "homeassistant.components.casper_glow.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result2["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert result2["result"].unique_id == CASPER_GLOW_DISCOVERY_INFO.address
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_step_success(hass: HomeAssistant) -> None:
+    """Test user step success path."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[NOT_CASPER_GLOW_DISCOVERY_INFO, CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        ),
+        patch(
+            "homeassistant.components.casper_glow.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result2["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert result2["result"].unique_id == CASPER_GLOW_DISCOVERY_INFO.address
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_step_no_devices(hass: HomeAssistant) -> None:
+    """Test user step with no devices found."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[NOT_CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_user_step_cannot_connect(hass: HomeAssistant) -> None:
+    """Test user step when device cannot connect."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        side_effect=CasperGlowError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+    with (
+        patch(
+            "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        ),
+        patch(
+            "homeassistant.components.casper_glow.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result3["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_user_step_unknown_error(hass: HomeAssistant) -> None:
+    """Test user step with an unknown exception."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        side_effect=RuntimeError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "unknown"}
+
+    with (
+        patch(
+            "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        ),
+        patch(
+            "homeassistant.components.casper_glow.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result3["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test already configured device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+        },
+        unique_id=CASPER_GLOW_DISCOVERY_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=CASPER_GLOW_DISCOVERY_INFO,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_step_skips_nameless_device(hass: HomeAssistant) -> None:
+    """Test that devices with no local name are not shown in user discovery."""
+    nameless_discovery = BluetoothServiceInfoBleak(
+        name=None,
+        address="AA:BB:CC:DD:EE:11",
+        rssi=-60,
+        manufacturer_data={},
+        service_uuids=["9bb30001-fee9-4c24-8361-443b5b7c88f6"],
+        service_data={},
+        source="local",
+        device=generate_ble_device(address="AA:BB:CC:DD:EE:11", name=None),
+        advertisement=generate_advertisement_data(
+            service_uuids=["9bb30001-fee9-4c24-8361-443b5b7c88f6"],
+        ),
+        time=0,
+        connectable=True,
+        tx_power=-127,
+    )
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[nameless_discovery],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"

--- a/tests/components/casper_glow/test_coordinator.py
+++ b/tests/components/casper_glow/test_coordinator.py
@@ -1,0 +1,91 @@
+"""Test the Casper Glow coordinator."""
+
+from unittest.mock import AsyncMock, patch
+
+from bleak import BleakError
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_poll_bleak_error_logs_unavailable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a BleakError during polling logs unavailable at info level once."""
+    coordinator = config_entry.runtime_data.coordinator
+
+    with patch.object(
+        coordinator.device,
+        "query_state",
+        side_effect=BleakError("connection failed"),
+    ):
+        await coordinator._async_poll()
+
+    assert "Jar is unavailable" in caplog.text
+    assert caplog.text.count("Jar is unavailable") == 1
+    assert not coordinator.last_poll_successful
+
+    # A second poll failure must not log again
+    caplog.clear()
+    with patch.object(
+        coordinator.device,
+        "query_state",
+        side_effect=BleakError("still down"),
+    ):
+        await coordinator._async_poll()
+
+    assert "Jar is unavailable" not in caplog.text
+
+
+async def test_poll_generic_exception_logs_unavailable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a generic exception during polling logs unavailable at info level once."""
+    coordinator = config_entry.runtime_data.coordinator
+
+    with patch.object(
+        coordinator.device,
+        "query_state",
+        side_effect=Exception("unexpected"),
+    ):
+        await coordinator._async_poll()
+
+    assert "unexpected error while polling" in caplog.text
+    assert not coordinator.last_poll_successful
+
+
+async def test_poll_recovery_logs_back_online(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that recovery after a failed poll logs back online at info level."""
+    coordinator = config_entry.runtime_data.coordinator
+
+    # First make a poll fail
+    with patch.object(
+        coordinator.device,
+        "query_state",
+        side_effect=BleakError("gone"),
+    ):
+        await coordinator._async_poll()
+
+    assert not coordinator.last_poll_successful
+    caplog.clear()
+
+    # Now recover
+    with patch.object(
+        coordinator.device,
+        "query_state",
+        new_callable=AsyncMock,
+    ):
+        await coordinator._async_poll()
+
+    assert "Jar is back online" in caplog.text
+    assert coordinator.last_poll_successful

--- a/tests/components/casper_glow/test_init.py
+++ b/tests/components/casper_glow/test_init.py
@@ -1,0 +1,137 @@
+"""Test the Casper Glow integration init."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.bluetooth import BluetoothChange
+from homeassistant.components.casper_glow import async_remove_config_entry_device
+from homeassistant.components.casper_glow.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import CASPER_GLOW_DISCOVERY_INFO
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import inject_bluetooth_service_info
+
+
+async def test_async_setup_entry_success(hass: HomeAssistant) -> None:
+    """Test successful setup of a config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Jar",
+        data={CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address},
+        unique_id=CASPER_GLOW_DISCOVERY_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    inject_bluetooth_service_info(hass, CASPER_GLOW_DISCOVERY_INFO)
+
+    with patch(
+        "pycasperglow.CasperGlow.query_state",
+        new_callable=AsyncMock,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.device is not None
+
+
+async def test_async_setup_entry_device_not_found(hass: HomeAssistant) -> None:
+    """Test setup raises ConfigEntryNotReady when BLE device is not found."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Jar",
+        data={CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address},
+        unique_id=CASPER_GLOW_DISCOVERY_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    # Do not inject BLE info — device is not in the cache
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_async_unload_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test unloading a config entry."""
+    result = await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert result is True
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_async_remove_config_entry_device_active(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that removing an active device is allowed."""
+    device = device_registry.async_get_device(
+        connections={(dr.CONNECTION_BLUETOOTH, CASPER_GLOW_DISCOVERY_INFO.address)}
+    )
+    assert device is not None
+
+    result = await async_remove_config_entry_device(hass, config_entry, device)
+    assert result is True
+
+
+async def test_async_remove_config_entry_device_stale(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that removing a stale device returns True."""
+    # Create a stale device with a different address
+    stale_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_BLUETOOTH, "FF:FF:FF:FF:FF:FF")},
+    )
+    assert stale_device is not None
+
+    result = await async_remove_config_entry_device(hass, config_entry, stale_device)
+    assert result is True
+
+
+async def test_ble_device_update_callback(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that BLE device updates are forwarded to the CasperGlow instance."""
+    device = config_entry.runtime_data.device
+    coordinator = config_entry.runtime_data.coordinator
+
+    with patch.object(device, "set_ble_device") as mock_set_ble:
+        # Directly call the coordinator's BLE event handler to verify it
+        # forwards the updated BLE device to the CasperGlow instance.
+        coordinator._async_handle_bluetooth_event(
+            CASPER_GLOW_DISCOVERY_INFO, BluetoothChange.ADVERTISEMENT
+        )
+
+        mock_set_ble.assert_called_once()
+        assert (
+            mock_set_ble.call_args[0][0].address == CASPER_GLOW_DISCOVERY_INFO.address
+        )
+
+
+async def test_coordinator_polls_on_advertisement(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that the coordinator polls device state when an advertisement is received."""
+    # Reload the entry with a fresh query_state mock so we can count exactly how
+    # many polls the coordinator fires when an advertisement is received at startup.
+    with patch(
+        "pycasperglow.CasperGlow.query_state",
+        new_callable=AsyncMock,
+    ) as mock_query_state:
+        await hass.config_entries.async_reload(config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    mock_query_state.assert_called_once()

--- a/tests/components/casper_glow/test_light.py
+++ b/tests/components/casper_glow/test_light.py
@@ -1,0 +1,596 @@
+"""Test the Casper Glow light platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from pycasperglow import CasperGlowError, GlowState
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.casper_glow.const import (
+    DEFAULT_DIMMING_TIME_MINUTES,
+    DOMAIN,
+)
+from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_MODE, ColorMode
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import CASPER_GLOW_DISCOVERY_INFO, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "light.jar"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test all light entities match the snapshot."""
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.LIGHT]):
+        await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_turn_on(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test turning on the light."""
+    with patch(
+        "pycasperglow.CasperGlow.turn_on",
+    ) as mock_turn_on:
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_turn_on.assert_called_once()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_turn_off(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test turning off the light."""
+    # First turn on
+    with patch(
+        "pycasperglow.CasperGlow.turn_on",
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    # Then turn off
+    with patch(
+        "pycasperglow.CasperGlow.turn_off",
+    ) as mock_turn_off:
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_turn_off.assert_called_once()
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_state_update_via_callback(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that the entity updates state when the device fires a callback."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Simulate device pushing a state update
+    device = config_entry.runtime_data.device
+    device._state = GlowState(is_on=True)
+    device._fire_callbacks()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    # Push state off
+    device._state = GlowState(is_on=False)
+    device._fire_callbacks()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_color_mode(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test that the light reports BRIGHTNESS color mode."""
+    # Turn on the light to verify color_mode is set
+    with patch(
+        "pycasperglow.CasperGlow.turn_on",
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get(ATTR_COLOR_MODE) == ColorMode.BRIGHTNESS
+
+
+async def test_turn_on_with_brightness(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test turning on the light with brightness."""
+    with (
+        patch("pycasperglow.CasperGlow.turn_on") as mock_turn_on,
+        patch(
+            "pycasperglow.CasperGlow.set_brightness_and_dimming_time",
+            new_callable=AsyncMock,
+        ) as mock_set,
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_BRIGHTNESS: 255},
+            blocking=True,
+        )
+
+    mock_turn_on.assert_called_once_with()
+    mock_set.assert_called_once_with(100, DEFAULT_DIMMING_TIME_MINUTES)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 255
+
+
+@pytest.mark.parametrize(
+    ("ha_brightness", "device_pct", "expected_ha_brightness"),
+    [
+        (1, 60, 1),
+        (64, 70, 64),
+        (128, 80, 128),
+        (192, 90, 192),
+        (255, 100, 255),
+    ],
+)
+async def test_brightness_snap_to_nearest(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    ha_brightness: int,
+    device_pct: int,
+    expected_ha_brightness: int,
+) -> None:
+    """Test that brightness values map correctly to device percentages and back."""
+    with (
+        patch("pycasperglow.CasperGlow.turn_on") as mock_turn_on,
+        patch(
+            "pycasperglow.CasperGlow.set_brightness_and_dimming_time",
+            new_callable=AsyncMock,
+        ) as mock_set,
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_BRIGHTNESS: ha_brightness},
+            blocking=True,
+        )
+
+    mock_turn_on.assert_called_once_with()
+    mock_set.assert_called_once_with(device_pct, DEFAULT_DIMMING_TIME_MINUTES)
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes.get(ATTR_BRIGHTNESS) == expected_ha_brightness
+
+
+async def test_brightness_update_via_callback(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that brightness updates via device callback."""
+    device = config_entry.runtime_data.device
+    device._state = GlowState(is_on=True, brightness_level=80)
+    device._fire_callbacks()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 128
+
+
+async def test_turn_on_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that a turn on error raises HomeAssistantError without marking entity unavailable."""
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_on",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_turn_off_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that a turn off error raises HomeAssistantError and leaves the light on."""
+    # First turn on
+    with patch(
+        "pycasperglow.CasperGlow.turn_on",
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_off",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_pause_error(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test that a pause error raises HomeAssistantError without marking entity unavailable."""
+    with (
+        patch(
+            "pycasperglow.CasperGlow.pause",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_resume_error(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Test that a resume error raises HomeAssistantError without marking entity unavailable."""
+    with (
+        patch(
+            "pycasperglow.CasperGlow.resume",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "resume",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test device info is correctly populated."""
+    device = device_registry.async_get_device(
+        connections={(dr.CONNECTION_BLUETOOTH, CASPER_GLOW_DISCOVERY_INFO.address)}
+    )
+    assert device is not None
+    assert device.manufacturer == "Casper"
+    assert device.model == "Glow"
+
+
+async def test_pause_service(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test the pause entity service."""
+    with patch(
+        "pycasperglow.CasperGlow.pause",
+    ) as mock_pause:
+        await hass.services.async_call(
+            DOMAIN,
+            "pause",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_pause.assert_called_once()
+
+
+async def test_resume_service(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test the resume entity service."""
+    with patch(
+        "pycasperglow.CasperGlow.resume",
+    ) as mock_resume:
+        await hass.services.async_call(
+            DOMAIN,
+            "resume",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_resume.assert_called_once()
+
+
+async def test_state_update_via_callback_after_command_failure(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that device callbacks correctly update state even after a command failure."""
+    # Fail a command — entity remains in last known state (unknown), not unavailable
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_on",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Device sends a push state update — entity reflects true device state
+    device = config_entry.runtime_data.device
+    device._state = GlowState(is_on=True)
+    device._fire_callbacks()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+async def test_unavailable_logged_only_once(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that unavailability is logged only once across multiple failures."""
+    with patch(
+        "pycasperglow.CasperGlow.turn_on",
+        side_effect=CasperGlowError("Connection failed"),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                "light",
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: ENTITY_ID},
+                blocking=True,
+            )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                "light",
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: ENTITY_ID},
+                blocking=True,
+            )
+
+    assert caplog.text.count("Device is unavailable") == 1
+
+
+async def test_back_online_logged_on_recovery(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that recovery is logged when the device comes back online via callback."""
+    # Fail first
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_on",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is unavailable" in caplog.text
+
+    # Recover via callback
+    device = config_entry.runtime_data.device
+    device._state = GlowState(is_on=True)
+    device._fire_callbacks()
+    await hass.async_block_till_done()
+
+    assert "Device is back online" in caplog.text
+
+
+async def test_back_online_logged_after_successful_command(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that recovery is logged when a command succeeds after a prior failure."""
+    # Fail first to set _unavailable_logged
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_on",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is unavailable" in caplog.text
+
+    # Succeed next command — recovery should be logged immediately, not waiting for callback
+    with patch("pycasperglow.CasperGlow.turn_on"):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is back online" in caplog.text
+
+
+async def test_back_online_logged_after_successful_turn_off(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that recovery is logged when turn_off succeeds after a prior failure."""
+    # First turn on so there is something to turn off
+    with patch("pycasperglow.CasperGlow.turn_on"):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    # Fail turn_off to set _unavailable_logged
+    with (
+        patch(
+            "pycasperglow.CasperGlow.turn_off",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is unavailable" in caplog.text
+
+    # Succeed next turn_off — recovery should be logged immediately
+    with patch("pycasperglow.CasperGlow.turn_off"):
+        await hass.services.async_call(
+            "light",
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is back online" in caplog.text
+
+
+async def test_back_online_logged_after_successful_pause(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that recovery is logged when pause succeeds after a prior failure."""
+    # Fail pause to set _unavailable_logged
+    with (
+        patch(
+            "pycasperglow.CasperGlow.pause",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is unavailable" in caplog.text
+
+    # Succeed next pause — recovery should be logged immediately
+    with patch("pycasperglow.CasperGlow.pause"):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is back online" in caplog.text
+
+
+async def test_back_online_logged_after_successful_resume(
+    hass: HomeAssistant, config_entry: MockConfigEntry, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that recovery is logged when resume succeeds after a prior failure."""
+    # Fail resume to set _unavailable_logged
+    with (
+        patch(
+            "pycasperglow.CasperGlow.resume",
+            side_effect=CasperGlowError("Connection failed"),
+        ),
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "resume",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is unavailable" in caplog.text
+
+    # Succeed next resume — recovery should be logged immediately
+    with patch("pycasperglow.CasperGlow.resume"):
+        await hass.services.async_call(
+            DOMAIN,
+            "resume",
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert "Device is back online" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new integration for [Casper Glow](https://casper.com/products/glow) Bluetooth controllable lights.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43793
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


## Quality Checklist

## Bronze
- [x] `action-setup` - Service actions are registered in [async_setup](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/__init__.py#L47-L50)
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval - [`STATE_POLL_INTERVAL = timedelta(seconds=30)`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/const.py#L29) used in [`coordinator._needs_poll()`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/coordinator.py#L63-L70)
- [x] `brands` - Has branding assets available for the integration - https://github.com/home-assistant/brands/pull/9878
- [x] `common-modules` - Place common patterns in common modules - [entity.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/entity.py), [models.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/models.py), [coordinator.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/coordinator.py), [const.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/const.py)
- [x] `config-flow-test-coverage` - Full test coverage for the config flow - [test_config_flow.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/tests/components/casper_glow/test_config_flow.py)
- [x] `config-flow` - Integration needs to be able to be set up via the UI - [config_flow.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/config_flow.py)
    - [x] Uses `data_description` to give context to fields - [strings.json#L17-L19](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/strings.json#L17-L19)
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly - [__init__.py#L66](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/__init__.py#L66), [models.py](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/models.py)
- [x] `dependency-transparency` - Dependency transparency - [`"requirements": ["pycasperglow==1.0.1"]`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/manifest.json#L20) [pypi](https://pypi.org/project/pycasperglow/) [OSI License](https://github.com/mikeodr/pycasperglow/blob/main/LICENSE) [CI Pipeline](https://github.com/mikeodr/pycasperglow/blob/main/.github/workflows/publish.yml#L38)
- [x] `docs-actions` - The documentation describes the provided service actions that can be used - [services.yaml](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/services.yaml), https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-removal-instructions` - The documentation provides removal instructions - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods - callbacks registered via `async_on_remove` in `async_added_to_hass` in [light.py#L60-L65](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/light.py#L60-L65) and all other platform files
- [x] `entity-unique-id` - Entities have a unique ID - [light.py#L57](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/light.py#L57) (MAC address), all others use `f"{address}_{key}"`
- [x] `has-entity-name` - Entities use has_entity_name = True - [`_attr_has_entity_name = True`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/entity.py#L25), light uses [`_attr_name = None`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/light.py#L50)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data - [`type CasperGlowConfigEntry = ConfigEntry[CasperGlowData]`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/models.py), set at [__init__.py#L66](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/__init__.py#L66)
- [x] `test-before-configure` - Test a connection in the config flow - [`await glow.handshake()`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/config_flow.py#L62-L69), tested in [test_config_flow.py#L107](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/tests/components/casper_glow/test_config_flow.py#L107)
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly - [`ConfigEntryNotReady`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/__init__.py#L58-L60) if BLE device not found, tested in [test_init.py#L43](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/tests/components/casper_glow/test_init.py#L43)
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice - [`_abort_if_unique_id_configured()`](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/homeassistant/components/casper_glow/config_flow.py#L38), tested in [test_config_flow.py#L215](https://github.com/home-assistant/core/blob/dcbe5d06f4f1a471c0752913ae49739c85cae8d1/tests/components/casper_glow/test_config_flow.py#L215)