### PR TITLE
Fix ZHA update entities not working after reload

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -281,6 +281,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         await ha_zha_data.gateway_proxy.shutdown()
         ha_zha_data.gateway_proxy = None
 
+    ha_zha_data.update_coordinator = None
+
     # clean up any remaining entity metadata
     # (entities that have been discovered but not yet added to HA)
     # suppress KeyError because we don't know what state we may

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -274,6 +274,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload ZHA config entry."""
+    if not await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS):
+        return False
+
     ha_zha_data = get_zha_data(hass)
     ha_zha_data.config_entry = None
 
@@ -293,7 +296,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     websocket_api.async_unload_api(hass)
 
-    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+    return True
 
 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -33,6 +33,7 @@ from homeassistant.components.update import (
 from homeassistant.components.zha.helpers import (
     ZHADeviceProxy,
     ZHAGatewayProxy,
+    get_zha_data,
     get_zha_gateway,
     get_zha_gateway_proxy,
 )
@@ -55,6 +56,7 @@ from homeassistant.setup import async_setup_component
 from .common import find_entity_id, update_attribute_cache
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 
@@ -265,6 +267,43 @@ async def test_firmware_update_notification_from_service_call(
             attrs[ATTR_LATEST_VERSION]
             == f"0x{fw_image.firmware.header.file_version:08x}"
         )
+
+
+async def test_firmware_update_poll_after_reload(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    config_entry: MockConfigEntry,
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test polling a ZHA update entity still works after reloading ZHA."""
+    await setup_zha()
+    await async_setup_component(hass, HA_DOMAIN, {})
+
+    zha_data = get_zha_data(hass)
+    coordinator_before = zha_data.update_coordinator
+    assert coordinator_before is not None
+
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator_after = get_zha_data(hass).update_coordinator
+    assert coordinator_after is not None
+    assert coordinator_after is not coordinator_before
+
+    zha_device, _, _, _ = await setup_test_data(hass, zigpy_device_mock)
+    entity_id = find_entity_id(Platform.UPDATE, zha_device, hass)
+    assert entity_id is not None
+
+    with patch("zigpy.ota.OTA.broadcast_notify") as mock_broadcast_notify:
+        await hass.services.async_call(
+            HA_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            service_data={ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+        assert mock_broadcast_notify.await_count == 1
+        assert mock_broadcast_notify.call_args_list[0] == call(jitter=100)
 
 
 def make_packet(zigpy_device, cluster, cmd_name: str, **kwargs):


### PR DESCRIPTION
## Proposed change
This fixes an issue where ZHA update entities do not work after the integration is reloaded (with `Debouncer call ignored as shutdown has been requested` being logged).

This is fixed by explicitly setting the `update_coordinator` in `ha_zha_data` to `None`, so a new one can be created by the update platform [here](https://github.com/home-assistant/core/blob/e8a35ea69de70f2d98f1996ac6eef0242314b635/homeassistant/components/zha/update.py#L58-L63). A regression test is also added.

Further, the HA `async_unload_platforms` call is moved to the top, so we unload HA platforms before tearing down ZHA internals. This hasn't caused any observable issues in practice but it's the correct order for unloading and also works as expected. For details, see this review comment: https://github.com/home-assistant/core/pull/164290#discussion_r2863355850

### Future work: `runtime_data`

This problem could have been avoided by using `runtime_data`, so a future PR will refactor ZHA to use that for the update coordinator. For a beta bugfix PR, I think a smaller fix like this is better.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
