### PR TITLE
Add authentication error handling to Tibber sensor

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -10,7 +10,12 @@ from random import randrange
 from typing import Any
 
 import aiohttp
-from tibber import FatalHttpExceptionError, RetryableHttpExceptionError, TibberHome
+from tibber import (
+    FatalHttpExceptionError,
+    InvalidLoginError,
+    RetryableHttpExceptionError,
+    TibberHome,
+)
 from tibber.data_api import TibberDevice
 
 from homeassistant.components.sensor import (
@@ -33,7 +38,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, PlatformNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -626,7 +631,7 @@ async def _async_setup_graphql_sensors(
             raise PlatformNotReady from err
 
         if home.has_active_subscription:
-            entities.append(TibberSensorElPrice(home))
+            entities.append(TibberSensorElPrice(home, entry))
             if coordinator is None:
                 coordinator = TibberDataCoordinator(hass, entry, tibber_connection)
             entities.extend(
@@ -743,9 +748,10 @@ class TibberSensorElPrice(TibberSensor):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_translation_key = "electricity_price"
 
-    def __init__(self, tibber_home: TibberHome) -> None:
+    def __init__(self, tibber_home: TibberHome, entry: TibberConfigEntry) -> None:
         """Initialize the sensor."""
         super().__init__(tibber_home=tibber_home)
+        self._entry = entry
         self._last_updated: datetime.datetime | None = None
         self._spread_load_constant = randrange(TWENTY_MINUTES)
 
@@ -802,9 +808,12 @@ class TibberSensorElPrice(TibberSensor):
     async def _fetch_data(self) -> None:
         _LOGGER.debug("Fetching data")
         try:
+            await self._entry.runtime_data.async_get_client(self.hass)
             await self._tibber_home.update_info_and_price_info()
-        except TimeoutError, aiohttp.ClientError:
+        except (TimeoutError, aiohttp.ClientError):
             return
+        except InvalidLoginError as err:
+            raise ConfigEntryAuthFailed from err
         data = self._tibber_home.info["viewer"]["home"]
         self._attr_extra_state_attributes["app_nickname"] = data["appNickname"]
         self._attr_extra_state_attributes["grid_company"] = data["meteringPointData"][


### PR DESCRIPTION
> This PR was developed with the assistance of Claude AI. The changes have been tested and have been running stably for over 6 hours. I updated just the `sensor.py` file of the main repository and installed the whole `tibber` directory as a custom component on my Home Assistant server. I only get `rt_subscribe` errors now when the network connection is lost, for example.

## Summary
This PR enhances error handling in the Tibber sensor integration by properly catching and propagating authentication failures, and ensures the API client is refreshed before data fetches.

## Key Changes
- **Import additions**: Added `InvalidLoginError` from tibber library and `ConfigEntryAuthFailed` from Home Assistant exceptions
- **TibberSensorElPrice initialization**: Now accepts and stores a `TibberConfigEntry` parameter to access runtime data
- **Authentication error handling**: Added explicit catch for `InvalidLoginError` exceptions, converting them to `ConfigEntryAuthFailed` to properly signal authentication issues to Home Assistant
- **Client refresh**: Added call to `async_get_client()` before fetching data to ensure the API client is up-to-date
- **Exception syntax fix**: Corrected exception tuple syntax from `TimeoutError, aiohttp.ClientError` to `(TimeoutError, aiohttp.ClientError)`

## Implementation Details
The changes ensure that when authentication fails during data fetching, Home Assistant is properly notified via `ConfigEntryAuthFailed`, which will trigger appropriate UI notifications and config entry state updates. The client refresh call helps maintain a valid authentication state before attempting API operations.