### PR TITLE
Check Daikin zone temp keys before represent

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -112,6 +112,14 @@ def _zone_is_configured(zone: DaikinZone) -> bool:
 
 def _zone_temperature_lists(device: Appliance) -> tuple[list[str], list[str]]:
     """Return the decoded zone temperature lists."""
+    values = getattr(device, "values", None)
+    if (
+        values is None
+        or values.get(DAIKIN_ZONE_TEMP_HEAT) is None
+        or values.get(DAIKIN_ZONE_TEMP_COOL) is None
+    ):
+        return ([], [])
+
     try:
         heating = device.represent(DAIKIN_ZONE_TEMP_HEAT)[1]
         cooling = device.represent(DAIKIN_ZONE_TEMP_COOL)[1]

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -112,19 +112,12 @@ def _zone_is_configured(zone: DaikinZone) -> bool:
 
 def _zone_temperature_lists(device: Appliance) -> tuple[list[str], list[str]]:
     """Return the decoded zone temperature lists."""
-    values = getattr(device, "values", None)
-    if (
-        values is None
-        or values.get(DAIKIN_ZONE_TEMP_HEAT) is None
-        or values.get(DAIKIN_ZONE_TEMP_COOL) is None
-    ):
+    values = device.values
+    if DAIKIN_ZONE_TEMP_HEAT not in values or DAIKIN_ZONE_TEMP_COOL not in values:
         return ([], [])
 
-    try:
-        heating = device.represent(DAIKIN_ZONE_TEMP_HEAT)[1]
-        cooling = device.represent(DAIKIN_ZONE_TEMP_COOL)[1]
-    except AttributeError, KeyError:
-        return ([], [])
+    heating = device.represent(DAIKIN_ZONE_TEMP_HEAT)[1]
+    cooling = device.represent(DAIKIN_ZONE_TEMP_COOL)[1]
     return (list(heating or []), list(cooling or []))
 
 


### PR DESCRIPTION
## Breaking change
None

## Proposed change
Follow up on review feedback for the Daikin zone temperature fix by checking
for `lztemp_h` and `lztemp_c` in `device.values` before calling
`device.represent(...)`.

This keeps the previous defensive behavior (no setup crash if keys are missing)
while making capability detection explicit instead of depending on a `KeyError`
path.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/164125
- This PR is related to issue: Follow-up to https://github.com/home-assistant/core/pull/164170
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
