### PR TITLE
Improve descriptions of `schlage` actions

### DIFF
--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -77,11 +77,11 @@
       "description": "Adds a PIN code to a lock.",
       "fields": {
         "code": {
-          "description": "The PIN code to add. Must be unique to lock and be between 4 and 8 digits long.",
+          "description": "The PIN code to add. Must be unique to the lock and be between 4 and 8 digits long.",
           "name": "PIN code"
         },
         "name": {
-          "description": "Name for PIN code. Must be case insensitively unique to lock.",
+          "description": "Name for PIN code. Must be case insensitively unique to the lock.",
           "name": "PIN name"
         }
       },

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -74,7 +74,7 @@
   },
   "services": {
     "add_code": {
-      "description": "Add a PIN code to a lock.",
+      "description": "Adds a PIN code to a lock.",
       "fields": {
         "code": {
           "description": "The PIN code to add. Must be unique to lock and be between 4 and 8 digits long.",
@@ -88,17 +88,17 @@
       "name": "Add PIN code"
     },
     "delete_code": {
-      "description": "Delete a PIN code from a lock.",
+      "description": "Deletes a PIN code from a lock.",
       "fields": {
         "name": {
           "description": "Name of PIN code to delete.",
-          "name": "PIN name"
+          "name": "[%key:component::schlage::services::add_code::fields::name::name%]"
         }
       },
       "name": "Delete PIN code"
     },
     "get_codes": {
-      "description": "Retrieve all PIN codes from the lock.",
+      "description": "Retrieves all PIN codes from a lock.",
       "name": "Get PIN codes"
     }
   }

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -175,7 +175,7 @@ async def test_add_code_service_duplicate_name(
 
     with pytest.raises(
         ServiceValidationError,
-        match='A PIN code with the name "test_user" already exists on the lock.',
+        match='A PIN code with the name "test_user" already exists on the lock',
     ) as exc_info:
         await hass.services.async_call(
             DOMAIN,
@@ -206,7 +206,7 @@ async def test_add_code_service_duplicate_code(
 
     with pytest.raises(
         ServiceValidationError,
-        match="A PIN code with this value already exists on the lock.",
+        match="A PIN code with this value already exists on the lock",
     ) as exc_info:
         await hass.services.async_call(
             DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Address my post-merge comments in https://github.com/home-assistant/core/pull/151014
- change all action descriptions to third-person singular
- consistently use "a lock" as it's not chosen, yet
- deduplicate the "PIN name" field via reference

Also change "unique to lock" to "unique to the lock" to ensure proper (machine) translations.
Without the article the word "lock" is interpreted as a verb by Google Translate & Co.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
