### PR TITLE
Firefly III add client in init

### DIFF
--- a/homeassistant/components/firefly_iii/__init__.py
+++ b/homeassistant/components/firefly_iii/__init__.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from homeassistant.const import Platform
+from aiohttp import CookieJar
+from pyfirefly import Firefly
+
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .coordinator import FireflyConfigEntry, FireflyDataUpdateCoordinator
 
@@ -13,7 +17,17 @@ _PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: FireflyConfigEntry) -> bool:
     """Set up Firefly III from a config entry."""
 
-    coordinator = FireflyDataUpdateCoordinator(hass, entry)
+    client = Firefly(
+        api_url=entry.data[CONF_URL],
+        api_key=entry.data[CONF_API_KEY],
+        session=async_create_clientsession(
+            hass,
+            entry.data[CONF_VERIFY_SSL],
+            cookie_jar=CookieJar(unsafe=True),
+        ),
+    )
+
+    coordinator = FireflyDataUpdateCoordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator

--- a/homeassistant/components/firefly_iii/coordinator.py
+++ b/homeassistant/components/firefly_iii/coordinator.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 
-from aiohttp import CookieJar
 from pyfirefly import (
     Firefly,
     FireflyAuthenticationError,
@@ -17,10 +16,8 @@ from pyfirefly import (
 from pyfirefly.models import Account, Bill, Budget, Category, Currency
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -49,7 +46,12 @@ class FireflyDataUpdateCoordinator(DataUpdateCoordinator[FireflyCoordinatorData]
 
     config_entry: FireflyConfigEntry
 
-    def __init__(self, hass: HomeAssistant, config_entry: FireflyConfigEntry) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: FireflyConfigEntry,
+        firefly: Firefly,
+    ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
@@ -58,15 +60,7 @@ class FireflyDataUpdateCoordinator(DataUpdateCoordinator[FireflyCoordinatorData]
             name=DOMAIN,
             update_interval=DEFAULT_SCAN_INTERVAL,
         )
-        self.firefly = Firefly(
-            api_url=self.config_entry.data[CONF_URL],
-            api_key=self.config_entry.data[CONF_API_KEY],
-            session=async_create_clientsession(
-                self.hass,
-                self.config_entry.data[CONF_VERIFY_SSL],
-                cookie_jar=CookieJar(unsafe=True),
-            ),
-        )
+        self.firefly = firefly
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""

--- a/tests/components/firefly_iii/conftest.py
+++ b/tests/components/firefly_iii/conftest.py
@@ -38,6 +38,7 @@ def mock_firefly_client() -> Generator[AsyncMock]:
         patch(
             "homeassistant.components.firefly_iii.config_flow.Firefly"
         ) as mock_client,
+        patch("homeassistant.components.firefly_iii.Firefly", new=mock_client),
         patch(
             "homeassistant.components.firefly_iii.coordinator.Firefly", new=mock_client
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Optimizing a bit to put it more in line with other integrations to put the client ini in the in the __init__.py and not directly in the coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
