### PR TITLE
Drop single-use service name constants in blink

### DIFF
--- a/homeassistant/components/blink/services.py
+++ b/homeassistant/components/blink/services.py
@@ -17,14 +17,7 @@ from homeassistant.helpers import config_validation as cv, issue_registry as ir,
 
 from .const import DOMAIN
 
-SERVICE_RECORD = "record"
-SERVICE_TRIGGER = "trigger_camera"
-SERVICE_SAVE_VIDEO = "save_video"
-SERVICE_SAVE_RECENT_CLIPS = "save_recent_clips"
-
-
 # Deprecated
-SERVICE_SEND_PIN = "send_pin"
 SERVICE_SEND_PIN_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): vol.All(cv.ensure_list, [cv.string]),
@@ -45,14 +38,14 @@ async def _send_pin(call: ServiceCall) -> None:
         severity=ir.IssueSeverity.ERROR,
         breaks_in_ha_version="2026.5.0",
         translation_key="service_send_pin_deprecation",
-        translation_placeholders={"service_name": f"{DOMAIN}.{SERVICE_SEND_PIN}"},
+        translation_placeholders={"service_name": f"{call.domain}.{call.service}"},
     )
 
     # Service has been removed - raise exception
     raise HomeAssistantError(
         translation_domain=DOMAIN,
         translation_key="service_removed",
-        translation_placeholders={"service_name": f"{DOMAIN}.{SERVICE_SEND_PIN}"},
+        translation_placeholders={"service_name": f"{call.domain}.{call.service}"},
     )
 
 
@@ -62,7 +55,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SEND_PIN,
+        "send_pin",
         _send_pin,
         schema=SERVICE_SEND_PIN_SCHEMA,
     )
@@ -70,7 +63,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_RECORD,
+        "record",
         entity_domain=CAMERA_DOMAIN,
         schema=None,
         func="record",
@@ -78,7 +71,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_TRIGGER,
+        "trigger_camera",
         entity_domain=CAMERA_DOMAIN,
         schema=None,
         func="trigger_camera",
@@ -86,7 +79,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_SAVE_RECENT_CLIPS,
+        "save_recent_clips",
         entity_domain=CAMERA_DOMAIN,
         schema={vol.Required(CONF_FILE_PATH): cv.string},
         func="save_recent_clips",
@@ -94,7 +87,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
-        SERVICE_SAVE_VIDEO,
+        "save_video",
         entity_domain=CAMERA_DOMAIN,
         schema={vol.Required(CONF_FILENAME): cv.string},
         func="save_video",

--- a/tests/components/blink/test_init.py
+++ b/tests/components/blink/test_init.py
@@ -7,7 +7,6 @@ from blinkpy.auth import LoginError
 import pytest
 
 from homeassistant.components.blink.const import DOMAIN
-from homeassistant.components.blink.services import SERVICE_SAVE_VIDEO
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -73,7 +72,7 @@ async def test_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
-    assert hass.services.has_service(DOMAIN, SERVICE_SAVE_VIDEO)
+    assert hass.services.has_service(DOMAIN, "save_video")
 
 
 async def test_migrate_V0(

--- a/tests/components/blink/test_services.py
+++ b/tests/components/blink/test_services.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from homeassistant.components.blink.const import DOMAIN
-from homeassistant.components.blink.services import SERVICE_SEND_PIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_PIN
 from homeassistant.core import HomeAssistant
@@ -42,7 +41,7 @@ async def test_pin_service_calls(
     ):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SEND_PIN,
+            "send_pin",
             {ATTR_CONFIG_ENTRY_ID: [mock_config_entry.entry_id], CONF_PIN: PIN},
             blocking=True,
         )
@@ -60,7 +59,7 @@ async def test_pin_service_calls(
     ):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SEND_PIN,
+            "send_pin",
             {ATTR_CONFIG_ENTRY_ID: ["bad-config_id"], CONF_PIN: PIN},
             blocking=True,
         )
@@ -89,7 +88,7 @@ async def test_service_pin_creates_repair_issue(
     ):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SEND_PIN,
+            "send_pin",
             {ATTR_CONFIG_ENTRY_ID: [mock_config_entry.entry_id], CONF_PIN: PIN},
             blocking=True,
         )
@@ -109,7 +108,7 @@ async def test_service_pin_creates_repair_issue(
     ):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SEND_PIN,
+            "send_pin",
             {ATTR_CONFIG_ENTRY_ID: [mock_config_entry.entry_id], CONF_PIN: PIN},
             blocking=True,
         )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It's a pattern we want to move away from: if the constant is only used once in the code (tests do not count) then it is pointless to declare it as a constant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
