### PR TITLE
Drop single-use service name constants in bsblan

### DIFF
--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -31,10 +31,6 @@ ATTR_FRIDAY_SLOTS = "friday_slots"
 ATTR_SATURDAY_SLOTS = "saturday_slots"
 ATTR_SUNDAY_SLOTS = "sunday_slots"
 
-# Service names
-SERVICE_SET_HOT_WATER_SCHEDULE = "set_hot_water_schedule"
-SERVICE_SYNC_TIME = "sync_time"
-
 
 # Schema for a single time slot
 _SLOT_SCHEMA = vol.Schema(
@@ -260,14 +256,14 @@ def async_setup_services(hass: HomeAssistant) -> None:
     """Register the BSB-LAN services."""
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
+        "set_hot_water_schedule",
         set_hot_water_schedule,
         schema=SERVICE_SET_HOT_WATER_SCHEDULE_SCHEMA,
     )
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_SYNC_TIME,
+        "sync_time",
         async_sync_time,
         schema=SYNC_TIME_SCHEMA,
     )

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -10,10 +10,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.bsblan.const import DOMAIN
-from homeassistant.components.bsblan.services import (
-    SERVICE_SET_HOT_WATER_SCHEDULE,
-    async_setup_services,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -134,7 +130,7 @@ async def test_set_hot_water_schedule(
 
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
+        "set_hot_water_schedule",
         service_call_data,
         blocking=True,
     )
@@ -163,7 +159,7 @@ async def test_invalid_device_id(
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {
                 "device_id": "invalid_device_id",
                 "monday_slots": [
@@ -176,11 +172,12 @@ async def test_invalid_device_id(
     assert exc_info.value.translation_key == "invalid_device_id"
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     ("service_name", "service_data"),
     [
         (
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {"monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}]},
         ),
         ("sync_time", {}),
@@ -205,9 +202,6 @@ async def test_no_config_entry_for_device(
         name="Other Device",
     )
 
-    # Register the bsblan service without setting up any bsblan config entry
-    async_setup_services(hass)
-
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
@@ -222,26 +216,15 @@ async def test_no_config_entry_for_device(
 async def test_config_entry_not_loaded(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
+    device_entry: dr.DeviceEntry,
 ) -> None:
     """Test error when config entry is not loaded."""
-    # Add the config entry but don't set it up (so it stays in NOT_LOADED state)
-    mock_config_entry.add_to_hass(hass)
-
-    # Create the device manually since setup won't run
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry.entry_id,
-        identifiers={(DOMAIN, TEST_DEVICE_MAC)},
-        name="BSB-LAN Device",
-    )
-
-    # Register the service
-    async_setup_services(hass)
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
 
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {
                 "device_id": device_entry.id,
                 "monday_slots": [
@@ -266,7 +249,7 @@ async def test_api_error(
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {
                 "device_id": device_entry.id,
                 "monday_slots": [
@@ -302,7 +285,7 @@ async def test_time_validation_errors(
     with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {
                 "device_id": device_entry.id,
                 "monday_slots": [
@@ -325,7 +308,7 @@ async def test_unprovided_days_are_none(
     # Only provide Monday and Tuesday, leave other days unprovided
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
+        "set_hot_water_schedule",
         {
             "device_id": device_entry.id,
             "monday_slots": [
@@ -369,7 +352,7 @@ async def test_string_time_formats(
     # Test with string time formats
     await hass.services.async_call(
         DOMAIN,
-        SERVICE_SET_HOT_WATER_SCHEDULE,
+        "set_hot_water_schedule",
         {
             "device_id": device_entry.id,
             "monday_slots": [
@@ -406,7 +389,7 @@ async def test_non_standard_time_types(
     with pytest.raises(vol.MultipleInvalid):
         await hass.services.async_call(
             DOMAIN,
-            SERVICE_SET_HOT_WATER_SCHEDULE,
+            "set_hot_water_schedule",
             {
                 "device_id": device_entry.id,
                 "monday_slots": [
@@ -424,7 +407,7 @@ async def test_async_setup_services(
 ) -> None:
     """Test service registration."""
     # Verify service doesn't exist initially
-    assert not hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+    assert not hass.services.has_service(DOMAIN, "set_hot_water_schedule")
 
     # Set up the integration
     mock_config_entry.add_to_hass(hass)
@@ -432,7 +415,7 @@ async def test_async_setup_services(
     await hass.async_block_till_done()
 
     # Verify service is now registered
-    assert hass.services.has_service(DOMAIN, SERVICE_SET_HOT_WATER_SCHEDULE)
+    assert hass.services.has_service(DOMAIN, "set_hot_water_schedule")
 
 
 async def test_sync_time_service(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It's a pattern we want to move away from: if the constant is only used once in the code (tests do not count) then it is pointless to declare it as a constant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
