### PR TITLE
Add HDFury audio offset numbers

### DIFF
--- a/homeassistant/components/hdfury/icons.json
+++ b/homeassistant/components/hdfury/icons.json
@@ -6,6 +6,12 @@
       }
     },
     "number": {
+      "audio_unmute": {
+        "default": "mdi:volume-high"
+      },
+      "earc_unmute": {
+        "default": "mdi:volume-high"
+      },
       "oled_fade": {
         "default": "mdi:cellphone-information"
       },

--- a/homeassistant/components/hdfury/number.py
+++ b/homeassistant/components/hdfury/number.py
@@ -32,6 +32,32 @@ class HDFuryNumberEntityDescription(NumberEntityDescription):
 
 NUMBERS: tuple[HDFuryNumberEntityDescription, ...] = (
     HDFuryNumberEntityDescription(
+        key="unmutecnt",
+        translation_key="audio_unmute",
+        entity_registry_enabled_default=False,
+        mode=NumberMode.BOX,
+        native_min_value=50,
+        native_max_value=1000,
+        native_step=1,
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        entity_category=EntityCategory.CONFIG,
+        set_value_fn=lambda client, value: client.set_audio_unmute(value),
+    ),
+    HDFuryNumberEntityDescription(
+        key="earcunmutecnt",
+        translation_key="earc_unmute",
+        entity_registry_enabled_default=False,
+        mode=NumberMode.BOX,
+        native_min_value=0,
+        native_max_value=1000,
+        native_step=1,
+        device_class=NumberDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        entity_category=EntityCategory.CONFIG,
+        set_value_fn=lambda client, value: client.set_earc_unmute(value),
+    ),
+    HDFuryNumberEntityDescription(
         key="oledfade",
         translation_key="oled_fade",
         mode=NumberMode.BOX,

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -41,6 +41,12 @@
       }
     },
     "number": {
+      "audio_unmute": {
+        "name": "Audio unmute offset"
+      },
+      "earc_unmute": {
+        "name": "eARC unmute offset"
+      },
       "oled_fade": {
         "name": "OLED fade timer"
       },

--- a/homeassistant/components/hdfury/strings.json
+++ b/homeassistant/components/hdfury/strings.json
@@ -42,10 +42,10 @@
     },
     "number": {
       "audio_unmute": {
-        "name": "Audio unmute offset"
+        "name": "Unmute delay"
       },
       "earc_unmute": {
-        "name": "eARC unmute offset"
+        "name": "eARC unmute delay"
       },
       "oled_fade": {
         "name": "OLED fade timer"

--- a/tests/components/hdfury/conftest.py
+++ b/tests/components/hdfury/conftest.py
@@ -104,6 +104,8 @@ def mock_hdfury_client() -> Generator[AsyncMock]:
                 "relay": "0",
                 "macaddr": "c7:1c:df:9d:f6:40",
                 "reboottimer": "0",
+                "unmutecnt": "500",
+                "earcunmutecnt": "0",
                 "oled": "1",
                 "oledfade": "30",
             }

--- a/tests/components/hdfury/snapshots/test_diagnostics.ambr
+++ b/tests/components/hdfury/snapshots/test_diagnostics.ambr
@@ -15,6 +15,7 @@
       'cec1en': '1',
       'cec2en': '1',
       'cec3en': '1',
+      'earcunmutecnt': '0',
       'htpcmode0': '0',
       'htpcmode1': '0',
       'htpcmode2': '0',
@@ -29,6 +30,7 @@
       'relay': '0',
       'tx0plus5': '1',
       'tx1plus5': '1',
+      'unmutecnt': '500',
     }),
     'info': dict({
       'AUD0': 'bitstream 48kHz',

--- a/tests/components/hdfury/snapshots/test_number.ambr
+++ b/tests/components/hdfury/snapshots/test_number.ambr
@@ -1,65 +1,5 @@
 # serializer version: 1
-# name: test_number_entities[number.hdfury_vrroom_02_audio_unmute_offset-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'max': 1000,
-      'min': 50,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'number',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'number.hdfury_vrroom_02_audio_unmute_offset',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Audio unmute offset',
-    'options': dict({
-    }),
-    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
-    'original_icon': None,
-    'original_name': 'Audio unmute offset',
-    'platform': 'hdfury',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'audio_unmute',
-    'unique_id': '000123456789_unmutecnt',
-    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
-  })
-# ---
-# name: test_number_entities[number.hdfury_vrroom_02_audio_unmute_offset-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'HDFury VRROOM-02 Audio unmute offset',
-      'max': 1000,
-      'min': 50,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1,
-      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.hdfury_vrroom_02_audio_unmute_offset',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '500.0',
-  })
-# ---
-# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_offset-entry]
+# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_delay-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -77,7 +17,7 @@
     'disabled_by': None,
     'domain': 'number',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_offset',
+    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_delay',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -85,12 +25,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'eARC unmute offset',
+    'object_id_base': 'eARC unmute delay',
     'options': dict({
     }),
     'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
-    'original_name': 'eARC unmute offset',
+    'original_name': 'eARC unmute delay',
     'platform': 'hdfury',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -100,11 +40,11 @@
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_offset-state]
+# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_delay-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
-      'friendly_name': 'HDFury VRROOM-02 eARC unmute offset',
+      'friendly_name': 'HDFury VRROOM-02 eARC unmute delay',
       'max': 1000,
       'min': 0,
       'mode': <NumberMode.BOX: 'box'>,
@@ -112,7 +52,7 @@
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_offset',
+    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_delay',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -237,5 +177,65 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
+  })
+# ---
+# name: test_number_entities[number.hdfury_vrroom_02_unmute_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1000,
+      'min': 50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.hdfury_vrroom_02_unmute_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Unmute delay',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Unmute delay',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_unmute',
+    'unique_id': '000123456789_unmutecnt',
+    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+  })
+# ---
+# name: test_number_entities[number.hdfury_vrroom_02_unmute_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'HDFury VRROOM-02 Unmute delay',
+      'max': 1000,
+      'min': 50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hdfury_vrroom_02_unmute_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '500.0',
   })
 # ---

--- a/tests/components/hdfury/snapshots/test_number.ambr
+++ b/tests/components/hdfury/snapshots/test_number.ambr
@@ -1,4 +1,124 @@
 # serializer version: 1
+# name: test_number_entities[number.hdfury_vrroom_02_audio_unmute_offset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1000,
+      'min': 50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.hdfury_vrroom_02_audio_unmute_offset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Audio unmute offset',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Audio unmute offset',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'audio_unmute',
+    'unique_id': '000123456789_unmutecnt',
+    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+  })
+# ---
+# name: test_number_entities[number.hdfury_vrroom_02_audio_unmute_offset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'HDFury VRROOM-02 Audio unmute offset',
+      'max': 1000,
+      'min': 50,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hdfury_vrroom_02_audio_unmute_offset',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '500.0',
+  })
+# ---
+# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_offset-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 1000,
+      'min': 0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_offset',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'eARC unmute offset',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'eARC unmute offset',
+    'platform': 'hdfury',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'earc_unmute',
+    'unique_id': '000123456789_earcunmutecnt',
+    'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+  })
+# ---
+# name: test_number_entities[number.hdfury_vrroom_02_earc_unmute_offset-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'HDFury VRROOM-02 eARC unmute offset',
+      'max': 1000,
+      'min': 0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1,
+      'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.hdfury_vrroom_02_earc_unmute_offset',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_number_entities[number.hdfury_vrroom_02_oled_fade_timer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/hdfury/test_number.py
+++ b/tests/components/hdfury/test_number.py
@@ -41,8 +41,8 @@ async def test_number_entities(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer", "set_oled_fade"),
         ("number.hdfury_vrroom_02_restart_timer", "set_reboot_timer"),
-        ("number.hdfury_vrroom_02_audio_unmute_offset", "set_audio_unmute"),
-        ("number.hdfury_vrroom_02_earc_unmute_offset", "set_earc_unmute"),
+        ("number.hdfury_vrroom_02_unmute_delay", "set_audio_unmute"),
+        ("number.hdfury_vrroom_02_earc_unmute_delay", "set_earc_unmute"),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -72,8 +72,8 @@ async def test_number_set_value(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer", "set_oled_fade"),
         ("number.hdfury_vrroom_02_restart_timer", "set_reboot_timer"),
-        ("number.hdfury_vrroom_02_audio_unmute_offset", "set_audio_unmute"),
-        ("number.hdfury_vrroom_02_earc_unmute_offset", "set_earc_unmute"),
+        ("number.hdfury_vrroom_02_unmute_delay", "set_audio_unmute"),
+        ("number.hdfury_vrroom_02_earc_unmute_delay", "set_earc_unmute"),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -107,8 +107,8 @@ async def test_number_error(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer"),
         ("number.hdfury_vrroom_02_restart_timer"),
-        ("number.hdfury_vrroom_02_audio_unmute_offset"),
-        ("number.hdfury_vrroom_02_earc_unmute_offset"),
+        ("number.hdfury_vrroom_02_unmute_delay"),
+        ("number.hdfury_vrroom_02_earc_unmute_delay"),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/hdfury/test_number.py
+++ b/tests/components/hdfury/test_number.py
@@ -72,8 +72,11 @@ async def test_number_set_value(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer", "set_oled_fade"),
         ("number.hdfury_vrroom_02_restart_timer", "set_reboot_timer"),
+        ("number.hdfury_vrroom_02_audio_unmute_offset", "set_audio_unmute"),
+        ("number.hdfury_vrroom_02_earc_unmute_offset", "set_earc_unmute"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_error(
     hass: HomeAssistant,
     mock_hdfury_client: AsyncMock,
@@ -104,8 +107,11 @@ async def test_number_error(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer"),
         ("number.hdfury_vrroom_02_restart_timer"),
+        ("number.hdfury_vrroom_02_audio_unmute_offset"),
+        ("number.hdfury_vrroom_02_earc_unmute_offset"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_entities_unavailable_on_error(
     hass: HomeAssistant,
     mock_hdfury_client: AsyncMock,

--- a/tests/components/hdfury/test_number.py
+++ b/tests/components/hdfury/test_number.py
@@ -23,6 +23,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -40,8 +41,11 @@ async def test_number_entities(
     [
         ("number.hdfury_vrroom_02_oled_fade_timer", "set_oled_fade"),
         ("number.hdfury_vrroom_02_restart_timer", "set_reboot_timer"),
+        ("number.hdfury_vrroom_02_audio_unmute_offset", "set_audio_unmute"),
+        ("number.hdfury_vrroom_02_earc_unmute_offset", "set_earc_unmute"),
     ],
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_number_set_value(
     hass: HomeAssistant,
     mock_hdfury_client: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds audio offset number entities to the HDFury integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43804
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.