### PR TITLE
Ensure future is marked as retrieved in frontend storage

### DIFF
--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -42,13 +42,16 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
         store = UserStore(hass, user_id)
         try:
             await store.async_load()
-        except BaseException as ex:  # noqa: BLE001
-            # Note: we don't re-raise here, to avoid never-retrieved future exception
-            # (occurs if there are no simulteanous callers)
+        except BaseException as ex:
             del stores[user_id]
             future.set_exception(ex)
-        else:
-            future.set_result(store)
+            # Ensure the future is marked as retrieved
+            # since if there is no concurrent call it
+            # will otherwise never be retrieved.
+            future.exception()
+            raise
+
+        future.set_result(store)
 
     return await future
 

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -50,7 +50,6 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
             # will otherwise never be retrieved.
             future.exception()
             raise
-
         future.set_result(store)
 
     return await future

--- a/homeassistant/components/frontend/storage.py
+++ b/homeassistant/components/frontend/storage.py
@@ -42,11 +42,13 @@ async def async_user_store(hass: HomeAssistant, user_id: str) -> UserStore:
         store = UserStore(hass, user_id)
         try:
             await store.async_load()
-        except BaseException as ex:
+        except BaseException as ex:  # noqa: BLE001
+            # Note: we don't re-raise here, to avoid never-retrieved future exception
+            # (occurs if there are no simulteanous callers)
             del stores[user_id]
             future.set_exception(ex)
-            raise
-        future.set_result(store)
+        else:
+            future.set_result(store)
 
     return await future
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes warnings in test
`pytest tests/components/frontend/test_storage.py::test_user_store_load_error`

```
ERROR:homeassistant:Error doing job: Future exception was never retrieved (task: None):   File "/home/vscode/.local/ha-venv/bin/pytest", line 10, in <module>
    sys.exit(console_main())
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/config/__init__.py", line 221, in console_main
    code = main()
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/config/__init__.py", line 197, in main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/main.py", line 365, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/main.py", line 318, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/main.py", line 372, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/main.py", line 396, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 118, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 137, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 244, in call_and_report
    call = CallInfo.from_call(
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 353, in from_call
    result: TResult | None = func()
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/runner.py", line 179, in pytest_runtest_call
    item.runtest()
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_asyncio/plugin.py", line 469, in runtest
    super().runtest()
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_asyncio/plugin.py", line 716, in inner
    runner.run(coro, context=context)
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete
    self.run_forever()
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/base_events.py", line 677, in run_forever
    self._run_once()
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/base_events.py", line 2038, in _run_once
    handle._run()
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
  File "/workspaces/core/tests/components/frontend/test_storage.py", line 632, in test_user_store_load_error
    await async_user_store(hass, hass_admin_user.id)
  File "/workspaces/core/homeassistant/components/frontend/storage.py", line 41, in async_user_store
    future = stores[user_id] = hass.loop.create_future()
  File "/home/vscode/.local/share/uv/python/cpython-3.14.3-linux-x86_64-gnu/lib/python3.14/asyncio/base_events.py", line 459, in create_future
    return futures.Future(loop=self)
Traceback (most recent call last):
  File "/workspaces/core/tests/components/frontend/test_storage.py", line 632, in test_user_store_load_error
    await async_user_store(hass, hass_admin_user.id)
  File "/workspaces/core/homeassistant/components/frontend/storage.py", line 44, in async_user_store
    await store.async_load()
  File "/workspaces/core/homeassistant/components/frontend/storage.py", line 65, in async_load
    self.data = await self._store.async_load() or {}
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/tests/components/frontend/test_storage.py", line 626, in failing_async_load
    raise OSError("Storage read error")
OSError: Storage read error
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
