### PR TITLE
Add spring status sensor entity

### DIFF
--- a/homeassistant/components/smarla/icons.json
+++ b/homeassistant/components/smarla/icons.json
@@ -15,6 +15,9 @@
       "period": {
         "default": "mdi:sine-wave"
       },
+      "spring_status": {
+        "default": "mdi:feather"
+      },
       "swing_count": {
         "default": "mdi:counter"
       },

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
+    StateType,
 )
 from homeassistant.const import UnitOfLength, UnitOfTime
 from homeassistant.core import HomeAssistant
@@ -27,7 +28,7 @@ PARALLEL_UPDATES = 0
 class SmarlaSensorEntityDescription(SmarlaEntityDescription, SensorEntityDescription):
     """Class describing Swing2Sleep Smarla sensor entities."""
 
-    value_fn: Callable[[Any], Any] = lambda value: value
+    value_fn: Callable[[Any], StateType] = lambda value: value
     multiple: bool = False
     value_pos: int = 0
 
@@ -86,7 +87,9 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         property="spring_status",
         device_class=SensorDeviceClass.ENUM,
         options=[status.name.lower() for status in SpringStatus],
-        value_fn=lambda value: SpringStatus(value).name.lower() if value else None,
+        value_fn=lambda value: (
+            SpringStatus(value).name.lower() if value is not None else None
+        ),
     ),
 ]
 
@@ -116,7 +119,7 @@ class SmarlaSensor(SmarlaBaseEntity, SensorEntity):
     _property: Property[int]
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> StateType:
         """Return the entity value to represent the entity state."""
         value = self._property.get()
         return self.entity_description.value_fn(value)
@@ -130,7 +133,7 @@ class SmarlaSensorMultiple(SmarlaBaseEntity, SensorEntity):
     _property: Property[list[int]]
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> StateType:
         """Return the entity value to represent the entity state."""
         raw = self._property.get()
         value = raw[self.entity_description.value_pos] if raw is not None else None

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -86,10 +86,12 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         service="analyser",
         property="spring_status",
         device_class=SensorDeviceClass.ENUM,
-        options=[status.name.lower() for status in SpringStatus],
-        value_fn=lambda value: (
-            SpringStatus(value).name.lower() if value is not None else None
-        ),
+        options=[
+            status.name.lower()
+            for status in SpringStatus
+            if status != SpringStatus.UNKNOWN
+        ],
+        value_fn=lambda value: SpringStatus(value).name.lower() if value else None,
     ),
 ]
 

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -1,8 +1,11 @@
 """Support for the Swing2Sleep Smarla sensor entities."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from pysmarlaapi.federwiege.services.classes import Property
+from pysmarlaapi.federwiege.services.types import SpringStatus
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -24,6 +27,7 @@ PARALLEL_UPDATES = 0
 class SmarlaSensorEntityDescription(SmarlaEntityDescription, SensorEntityDescription):
     """Class describing Swing2Sleep Smarla sensor entities."""
 
+    value_fn: Callable[[Any], Any] = lambda value: value
     multiple: bool = False
     value_pos: int = 0
 
@@ -75,6 +79,15 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         suggested_unit_of_measurement=UnitOfTime.HOURS,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
+    SmarlaSensorEntityDescription(
+        key="spring_status",
+        translation_key="spring_status",
+        service="analyser",
+        property="spring_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[status.name.lower() for status in SpringStatus],
+        value_fn=lambda value: SpringStatus(value).name.lower() if value else None,
+    ),
 ]
 
 
@@ -105,7 +118,8 @@ class SmarlaSensor(SmarlaBaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the entity value to represent the entity state."""
-        return self._property.get()
+        value = self._property.get()
+        return self.entity_description.value_fn(value)
 
 
 class SmarlaSensorMultiple(SmarlaBaseEntity, SensorEntity):
@@ -118,5 +132,6 @@ class SmarlaSensorMultiple(SmarlaBaseEntity, SensorEntity):
     @property
     def native_value(self) -> int | None:
         """Return the entity value to represent the entity state."""
-        v = self._property.get()
-        return v[self.entity_description.value_pos] if v is not None else None
+        raw = self._property.get()
+        value = raw[self.entity_description.value_pos] if raw is not None else None
+        return self.entity_description.value_fn(value)

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from pysmarlaapi.federwiege.services.classes import Property
 from pysmarlaapi.federwiege.services.types import SpringStatus
@@ -23,54 +23,56 @@ from .entity import SmarlaBaseEntity, SmarlaEntityDescription
 
 PARALLEL_UPDATES = 0
 
+_VT = TypeVar("_VT")
+
 
 @dataclass(frozen=True, kw_only=True)
-class SmarlaSensorEntityDescription(SmarlaEntityDescription, SensorEntityDescription):
+class SmarlaSensorEntityDescription(
+    SmarlaEntityDescription, SensorEntityDescription, Generic[_VT]
+):
     """Class describing Swing2Sleep Smarla sensor entities."""
 
-    value_fn: Callable[[Any], StateType] = lambda value: value
-    multiple: bool = False
-    value_pos: int = 0
+    value_fn: Callable[[_VT | None], StateType] = lambda value: (
+        value if isinstance(value, (str, int, float)) else None
+    )
 
 
-SENSORS: list[SmarlaSensorEntityDescription] = [
-    SmarlaSensorEntityDescription(
+SENSORS: list[SmarlaSensorEntityDescription[Any]] = [
+    SmarlaSensorEntityDescription[list[int]](
         key="amplitude",
         translation_key="amplitude",
         service="analyser",
         property="oscillation",
-        multiple=True,
-        value_pos=0,
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda value: value[0] if value else None,
     ),
-    SmarlaSensorEntityDescription(
+    SmarlaSensorEntityDescription[list[int]](
         key="period",
         translation_key="period",
         service="analyser",
         property="oscillation",
-        multiple=True,
-        value_pos=1,
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda value: value[1] if value else None,
     ),
-    SmarlaSensorEntityDescription(
+    SmarlaSensorEntityDescription[int](
         key="activity",
         translation_key="activity",
         service="analyser",
         property="activity",
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SmarlaSensorEntityDescription(
+    SmarlaSensorEntityDescription[int](
         key="swing_count",
         translation_key="swing_count",
         service="analyser",
         property="swing_count",
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SmarlaSensorEntityDescription(
+    SmarlaSensorEntityDescription[int](
         key="total_swing_time",
         translation_key="total_swing_time",
         service="info",
@@ -80,7 +82,7 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         suggested_unit_of_measurement=UnitOfTime.HOURS,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SmarlaSensorEntityDescription(
+    SmarlaSensorEntityDescription[SpringStatus](
         key="spring_status",
         translation_key="spring_status",
         service="analyser",
@@ -91,7 +93,9 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
             for status in SpringStatus
             if status != SpringStatus.UNKNOWN
         ],
-        value_fn=lambda value: SpringStatus(value).name.lower() if value else None,
+        value_fn=lambda value: (
+            value.name.lower() if value and value != SpringStatus.UNKNOWN else None
+        ),
     ),
 ]
 
@@ -103,40 +107,18 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Smarla sensors from config entry."""
     federwiege = config_entry.runtime_data
-    async_add_entities(
-        (
-            SmarlaSensor(federwiege, desc)
-            if not desc.multiple
-            else SmarlaSensorMultiple(federwiege, desc)
-        )
-        for desc in SENSORS
-    )
+    async_add_entities(SmarlaSensor(federwiege, desc) for desc in SENSORS)
 
 
-class SmarlaSensor(SmarlaBaseEntity, SensorEntity):
+class SmarlaSensor(SmarlaBaseEntity, SensorEntity, Generic[_VT]):
     """Representation of Smarla sensor."""
 
-    entity_description: SmarlaSensorEntityDescription
+    entity_description: SmarlaSensorEntityDescription[_VT]
 
-    _property: Property[int]
+    _property: Property[_VT]
 
     @property
     def native_value(self) -> StateType:
         """Return the entity value to represent the entity state."""
         value = self._property.get()
-        return self.entity_description.value_fn(value)
-
-
-class SmarlaSensorMultiple(SmarlaBaseEntity, SensorEntity):
-    """Representation of Smarla sensor with multiple values inside property."""
-
-    entity_description: SmarlaSensorEntityDescription
-
-    _property: Property[list[int]]
-
-    @property
-    def native_value(self) -> StateType:
-        """Return the entity value to represent the entity state."""
-        raw = self._property.get()
-        value = raw[self.entity_description.value_pos] if raw is not None else None
         return self.entity_description.value_fn(value)

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -57,8 +57,7 @@
           "constellation_critical_too_low": "Critically too weak",
           "constellation_too_high": "Too strong",
           "constellation_too_low": "Too weak",
-          "normal": "Normal",
-          "unknown": "Unknown"
+          "normal": "Normal"
         }
       },
       "swing_count": {

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -50,6 +50,17 @@
       "period": {
         "name": "Period"
       },
+      "spring_status": {
+        "name": "Spring status",
+        "state": {
+          "constellation_critical_too_high": "Critically too strong",
+          "constellation_critical_too_low": "Critically too weak",
+          "constellation_too_high": "Too strong",
+          "constellation_too_low": "Too weak",
+          "normal": "Normal",
+          "unknown": "Unknown"
+        }
+      },
       "swing_count": {
         "name": "Swing count",
         "unit_of_measurement": "swings"

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -80,11 +80,13 @@ def _mock_analyser_service() -> MagicMock:
         "oscillation": MagicMock(spec=Property),
         "activity": MagicMock(spec=Property),
         "swing_count": MagicMock(spec=Property),
+        "spring_status": MagicMock(spec=Property),
     }
 
     mock_analyser_service.props["oscillation"].get.return_value = [0, 0]
     mock_analyser_service.props["activity"].get.return_value = 0
     mock_analyser_service.props["swing_count"].get.return_value = 0
+    mock_analyser_service.props["spring_status"].get.return_value = 0
 
     return mock_analyser_service
 

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pysmarlaapi import AuthToken
 from pysmarlaapi.federwiege.services.classes import Property, Service
-from pysmarlaapi.federwiege.services.types import UpdateStatus
+from pysmarlaapi.federwiege.services.types import SpringStatus, UpdateStatus
 import pytest
 
 from homeassistant.components.smarla.const import DOMAIN
@@ -86,7 +86,7 @@ def _mock_analyser_service() -> MagicMock:
     mock_analyser_service.props["oscillation"].get.return_value = [0, 0]
     mock_analyser_service.props["activity"].get.return_value = 0
     mock_analyser_service.props["swing_count"].get.return_value = 0
-    mock_analyser_service.props["spring_status"].get.return_value = 0
+    mock_analyser_service.props["spring_status"].get.return_value = SpringStatus.UNKNOWN
 
     return mock_analyser_service
 

--- a/tests/components/smarla/snapshots/test_sensor.ambr
+++ b/tests/components/smarla/snapshots/test_sensor.ambr
@@ -165,6 +165,73 @@
     'state': '0',
   })
 # ---
+# name: test_entities[sensor.smarla_spring_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'unknown',
+        'normal',
+        'constellation_too_high',
+        'constellation_too_low',
+        'constellation_critical_too_high',
+        'constellation_critical_too_low',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.smarla_spring_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Spring status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Spring status',
+    'platform': 'smarla',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'spring_status',
+    'unique_id': 'ABCD-spring_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.smarla_spring_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Smarla Spring status',
+      'options': list([
+        'unknown',
+        'normal',
+        'constellation_too_high',
+        'constellation_too_low',
+        'constellation_critical_too_high',
+        'constellation_critical_too_low',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smarla_spring_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_entities[sensor.smarla_swing_count-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smarla/snapshots/test_sensor.ambr
+++ b/tests/components/smarla/snapshots/test_sensor.ambr
@@ -172,7 +172,6 @@
     'area_id': None,
     'capabilities': dict({
       'options': list([
-        'unknown',
         'normal',
         'constellation_too_high',
         'constellation_too_low',
@@ -216,7 +215,6 @@
       'device_class': 'enum',
       'friendly_name': 'Smarla Spring status',
       'options': list([
-        'unknown',
         'normal',
         'constellation_too_high',
         'constellation_too_low',

--- a/tests/components/smarla/test_number.py
+++ b/tests/components/smarla/test_number.py
@@ -67,7 +67,6 @@ async def test_number_action(
 
     entity_id = entity_info["entity_id"]
 
-    # Turn on
     await hass.services.async_call(
         NUMBER_DOMAIN,
         service,

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -101,8 +101,6 @@ async def test_sensor_state_update(
 
     test_value, expected_state = entity_info["test"]
 
-    mock_sensor_property.get.return_value = test_value
-
     # Set new value and trigger update
     mock_sensor_property.get.return_value = test_value
     await update_property_listeners(mock_sensor_property)

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -50,6 +50,13 @@ SENSOR_ENTITIES = [
         "initial_state": "0.0",
         "test": (3600, "1.0"),
     },
+    {
+        "entity_id": "sensor.smarla_spring_status",
+        "service": "analyser",
+        "property": "spring_status",
+        "initial_state": "unknown",
+        "test": (1, "normal"),
+    },
 ]
 
 
@@ -87,6 +94,7 @@ async def test_sensor_state_update(
 
     entity_id = entity_info["entity_id"]
 
+    # Verify initial state
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == entity_info["initial_state"]
@@ -95,9 +103,12 @@ async def test_sensor_state_update(
 
     mock_sensor_property.get.return_value = test_value
 
+    # Set new value and trigger update
+    mock_sensor_property.get.return_value = test_value
     await update_property_listeners(mock_sensor_property)
     await hass.async_block_till_done()
 
+    # Verify updated state
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == expected_state

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -54,7 +54,7 @@ SENSOR_ENTITIES = [
         "entity_id": "sensor.smarla_spring_status",
         "service": "analyser",
         "property": "spring_status",
-        "initial_state": "unknown",
+        "initial_state": STATE_UNKNOWN,
         "test": (1, "normal"),
     },
 ]

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from pysmarlaapi.federwiege.services.types import SpringStatus
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -55,7 +56,7 @@ SENSOR_ENTITIES = [
         "service": "analyser",
         "property": "spring_status",
         "initial_state": STATE_UNKNOWN,
-        "test": (1, "normal"),
+        "test": (SpringStatus.NORMAL, "normal"),
     },
 ]
 

--- a/tests/components/smarla/test_switch.py
+++ b/tests/components/smarla/test_switch.py
@@ -78,7 +78,6 @@ async def test_switch_action(
 
     entity_id = entity_info["entity_id"]
 
-    # Turn on
     await hass.services.async_call(
         SWITCH_DOMAIN,
         service,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new sensor entity to show the status of the used spring constellation.
It presents this information as Enum values and can be used to identify if the correct springs are used.

Tests were adjusted to support enum values for the new sensor entity.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43813
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
