### PR TITLE
Add sensor entity for total swing time

### DIFF
--- a/homeassistant/components/smarla/icons.json
+++ b/homeassistant/components/smarla/icons.json
@@ -19,7 +19,7 @@
         "default": "mdi:counter"
       },
       "total_swing_time": {
-        "default": "mdi:counter"
+        "default": "mdi:history"
       }
     },
     "switch": {

--- a/homeassistant/components/smarla/icons.json
+++ b/homeassistant/components/smarla/icons.json
@@ -17,6 +17,9 @@
       },
       "swing_count": {
         "default": "mdi:counter"
+      },
+      "total_swing_time": {
+        "default": "mdi:counter"
       }
     },
     "switch": {

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -62,6 +62,14 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         property="swing_count",
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
+    SmarlaSensorEntityDescription(
+        key="total_swing_time",
+        translation_key="total_swing_time",
+        service="info",
+        property="total_swing_time",
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
 ]
 
 

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pysmarlaapi.federwiege.services.classes import Property
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -67,7 +68,9 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         translation_key="total_swing_time",
         service="info",
         property="total_swing_time",
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_unit_of_measurement=UnitOfTime.HOURS,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 ]

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -48,6 +48,9 @@
       "swing_count": {
         "name": "Swing count",
         "unit_of_measurement": "swings"
+      },
+      "total_swing_time": {
+        "name": "Total swing time"
       }
     },
     "switch": {

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -93,9 +93,11 @@ def _mock_info_service() -> MagicMock:
     mock_info_service = MagicMock(spec=Service)
     mock_info_service.props = {
         "version": MagicMock(spec=Property),
+        "total_swing_time": MagicMock(spec=Property),
     }
 
     mock_info_service.props["version"].get.return_value = "1.0.0"
+    mock_info_service.props["total_swing_time"].get.return_value = 0
 
     return mock_info_service
 

--- a/tests/components/smarla/snapshots/test_sensor.ambr
+++ b/tests/components/smarla/snapshots/test_sensor.ambr
@@ -210,3 +210,56 @@
     'state': '0',
   })
 # ---
+# name: test_entities[sensor.smarla_total_swing_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.smarla_total_swing_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Total swing time',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total swing time',
+    'platform': 'smarla',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_swing_time',
+    'unique_id': 'ABCD-total_swing_time',
+    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+  })
+# ---
+# name: test_entities[sensor.smarla_total_swing_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smarla Total swing time',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smarla_total_swing_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---

--- a/tests/components/smarla/snapshots/test_sensor.ambr
+++ b/tests/components/smarla/snapshots/test_sensor.ambr
@@ -235,8 +235,14 @@
     'name': None,
     'object_id_base': 'Total swing time',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
     'original_name': 'Total swing time',
     'platform': 'smarla',
@@ -245,21 +251,22 @@
     'supported_features': 0,
     'translation_key': 'total_swing_time',
     'unique_id': 'ABCD-total_swing_time',
-    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
   })
 # ---
 # name: test_entities[sensor.smarla_total_swing_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'duration',
       'friendly_name': 'Smarla Total swing time',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
+      'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.smarla_total_swing_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': '0.0',
   })
 # ---

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -1,5 +1,6 @@
 """Test sensor platform for Swing2Sleep Smarla integration."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -75,7 +76,7 @@ async def test_sensor_state_update(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_federwiege: MagicMock,
-    entity_info: dict[str, str],
+    entity_info: dict[str, Any],
 ) -> None:
     """Test Smarla Sensor callback."""
     assert await setup_integration(hass, mock_config_entry)

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -18,31 +18,36 @@ SENSOR_ENTITIES = [
         "entity_id": "sensor.smarla_amplitude",
         "service": "analyser",
         "property": "oscillation",
-        "test_value": [1, 0],
+        "initial_state": "0",
+        "test": ([1, 0], "1"),
     },
     {
         "entity_id": "sensor.smarla_period",
         "service": "analyser",
         "property": "oscillation",
-        "test_value": [0, 1],
+        "initial_state": "0",
+        "test": ([0, 1], "1"),
     },
     {
         "entity_id": "sensor.smarla_activity",
         "service": "analyser",
         "property": "activity",
-        "test_value": 1,
+        "initial_state": "0",
+        "test": (1, "1"),
     },
     {
         "entity_id": "sensor.smarla_swing_count",
         "service": "analyser",
         "property": "swing_count",
-        "test_value": 1,
+        "initial_state": "0",
+        "test": (1, "1"),
     },
     {
         "entity_id": "sensor.smarla_total_swing_time",
         "service": "info",
         "property": "total_swing_time",
-        "test_value": 1,
+        "initial_state": "0.0",
+        "test": (3600, "1.0"),
     },
 ]
 
@@ -83,13 +88,15 @@ async def test_sensor_state_update(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "0"
+    assert state.state == entity_info["initial_state"]
 
-    mock_sensor_property.get.return_value = entity_info["test_value"]
+    test_value, expected_state = entity_info["test"]
+
+    mock_sensor_property.get.return_value = test_value
 
     await update_property_listeners(mock_sensor_property)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "1"
+    assert state.state == expected_state

--- a/tests/components/smarla/test_sensor.py
+++ b/tests/components/smarla/test_sensor.py
@@ -38,6 +38,12 @@ SENSOR_ENTITIES = [
         "property": "swing_count",
         "test_value": 1,
     },
+    {
+        "entity_id": "sensor.smarla_total_swing_time",
+        "service": "info",
+        "property": "total_swing_time",
+        "test_value": 1,
+    },
 ]
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add new sensor entity to display the total swing time in seconds.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43817
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
