### PR TITLE
Add send diagnostics button to smarla

### DIFF
--- a/homeassistant/components/smarla/button.py
+++ b/homeassistant/components/smarla/button.py
@@ -1,0 +1,53 @@
+"""Support for the Swing2Sleep Smarla button entities."""
+
+from dataclasses import dataclass
+
+from pysmarlaapi.federwiege.services.classes import Property
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import FederwiegeConfigEntry
+from .entity import SmarlaBaseEntity, SmarlaEntityDescription
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class SmarlaButtonEntityDescription(SmarlaEntityDescription, ButtonEntityDescription):
+    """Class describing Swing2Sleep Smarla button entity."""
+
+
+BUTTONS: list[SmarlaButtonEntityDescription] = [
+    SmarlaButtonEntityDescription(
+        key="send_diagnostics",
+        translation_key="send_diagnostics",
+        service="system",
+        property="send_diagnostic_data",
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FederwiegeConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Smarla buttons from config entry."""
+    federwiege = config_entry.runtime_data
+    async_add_entities(SmarlaButton(federwiege, desc) for desc in BUTTONS)
+
+
+class SmarlaButton(SmarlaBaseEntity, ButtonEntity):
+    """Representation of a Smarla button."""
+
+    entity_description: SmarlaButtonEntityDescription
+
+    _property: Property[str]
+
+    def press(self) -> None:
+        """Press the button."""
+        self._property.set("Sent from Home Assistant")

--- a/homeassistant/components/smarla/const.py
+++ b/homeassistant/components/smarla/const.py
@@ -6,7 +6,13 @@ DOMAIN = "smarla"
 
 HOST = "https://devices.swing2sleep.de"
 
-PLATFORMS = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH, Platform.UPDATE]
+PLATFORMS = [
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.UPDATE,
+]
 
 DEVICE_MODEL_NAME = "Smarla"
 MANUFACTURER_NAME = "Swing2Sleep"

--- a/homeassistant/components/smarla/strings.json
+++ b/homeassistant/components/smarla/strings.json
@@ -30,6 +30,11 @@
     }
   },
   "entity": {
+    "button": {
+      "send_diagnostics": {
+        "name": "Send diagnostics"
+      }
+    },
     "number": {
       "intensity": {
         "name": "Intensity"

--- a/tests/components/smarla/conftest.py
+++ b/tests/components/smarla/conftest.py
@@ -105,6 +105,7 @@ def _mock_system_service() -> MagicMock:
     mock_system_service.props = {
         "firmware_update": MagicMock(spec=Property),
         "firmware_update_status": MagicMock(spec=Property),
+        "send_diagnostic_data": MagicMock(spec=Property),
     }
 
     mock_system_service.props["firmware_update"].get.return_value = 0

--- a/tests/components/smarla/snapshots/test_button.ambr
+++ b/tests/components/smarla/snapshots/test_button.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_entities[button.smarla_send_diagnostics-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.smarla_send_diagnostics',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Send diagnostics',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Send diagnostics',
+    'platform': 'smarla',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'send_diagnostics',
+    'unique_id': 'ABCD-send_diagnostics',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.smarla_send_diagnostics-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smarla Send diagnostics',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.smarla_send_diagnostics',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/smarla/test_button.py
+++ b/tests/components/smarla/test_button.py
@@ -1,0 +1,67 @@
+"""Test button platform for Swing2Sleep Smarla integration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+BUTTON_ENTITIES = [
+    {
+        "entity_id": "button.smarla_send_diagnostics",
+        "service": "system",
+        "property": "send_diagnostic_data",
+    },
+]
+
+
+@pytest.mark.usefixtures("mock_federwiege")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the Smarla entities."""
+    with (
+        patch("homeassistant.components.smarla.PLATFORMS", [Platform.BUTTON]),
+    ):
+        assert await setup_integration(hass, mock_config_entry)
+
+        await snapshot_platform(
+            hass, entity_registry, snapshot, mock_config_entry.entry_id
+        )
+
+
+@pytest.mark.parametrize("entity_info", BUTTON_ENTITIES)
+async def test_button_action(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_federwiege: MagicMock,
+    entity_info: dict[str, str],
+) -> None:
+    """Test Smarla Button press behavior."""
+    assert await setup_integration(hass, mock_config_entry)
+
+    mock_button_property = mock_federwiege.get_property(
+        entity_info["service"], entity_info["property"]
+    )
+
+    entity_id = entity_info["entity_id"]
+
+    # Turn on
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock_button_property.set.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add button platform and an entity, which allows to trigger a one-time event to send diagnostic data.

Tests were added accordingly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43815
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
