### PR TITLE
Fix int vs float template sensor issue

### DIFF
--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -257,7 +257,7 @@ class AbstractTemplateSensor(AbstractTemplateEntity, RestoreSensor):
     ) -> StateType | date | datetime | Decimal | None:
         """Validate the state."""
         if self._numeric_state_expected:
-            if isinstance(result, (int, float)):
+            if not isinstance(result, bool) and isinstance(result, (int, float)):
                 return result
 
             if isinstance(result, str) and "." not in result:

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -257,6 +257,14 @@ class AbstractTemplateSensor(AbstractTemplateEntity, RestoreSensor):
     ) -> StateType | date | datetime | Decimal | None:
         """Validate the state."""
         if self._numeric_state_expected:
+            if isinstance(result, (int, float)):
+                return result
+
+            if isinstance(result, str) and "." not in result:
+                return template_validators.number(self, CONF_STATE, return_type=int)(
+                    result
+                )
+
             return template_validators.number(self, CONF_STATE)(result)
 
         if result is None or self.device_class not in (

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -260,11 +260,6 @@ class AbstractTemplateSensor(AbstractTemplateEntity, RestoreSensor):
             if not isinstance(result, bool) and isinstance(result, (int, float)):
                 return result
 
-            if isinstance(result, str) and "." not in result:
-                return template_validators.number(self, CONF_STATE, return_type=int)(
-                    result
-                )
-
             return template_validators.number(self, CONF_STATE)(result)
 
         if result is None or self.device_class not in (

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -684,7 +684,7 @@ async def test_sun_renders_once_per_sensor(hass: HomeAssistant) -> None:
     def _record_async_render(self, *args, **kwargs):
         """Catch async_render."""
         async_render_calls.append(self.template)
-        return "75"
+        return 75
 
     later = dt_util.utcnow()
 

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -692,7 +692,7 @@ async def test_sun_renders_once_per_sensor(hass: HomeAssistant) -> None:
         hass.states.async_set("sun.sun", {"elevation": 50, "next_rising": later})
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.solar_angle").state == "75.0"
+    assert hass.states.get("sensor.solar_angle").state == "75"
     assert hass.states.get("sensor.sunrise").state == "75"
 
     assert len(async_render_calls) == 2
@@ -1524,7 +1524,7 @@ async def test_last_reset(hass: HomeAssistant, expected: str) -> None:
 
     state = hass.states.get(TEST_SENSOR.entity_id)
     assert state is not None
-    assert state.state == "0.0"
+    assert state.state == "0"
     assert state.attributes["state_class"] == "total"
     assert state.attributes["last_reset"] == expected
 
@@ -1553,7 +1553,7 @@ async def test_invalid_last_reset(
 
     state = hass.states.get(TEST_SENSOR.entity_id)
     assert state is not None
-    assert state.state == "0.0"
+    assert state.state == "0"
     assert state.attributes.get("last_reset") is None
 
     err = "Received invalid sensor last_reset: not a datetime for entity"
@@ -1993,3 +1993,45 @@ async def test_numeric_sensor_recovers_from_exception(hass: HomeAssistant) -> No
     ):
         await async_trigger(hass, TEST_STATE_SENSOR, set_state)
         assert hass.states.get(TEST_SENSOR.entity_id).state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("count", "config"),
+    [
+        (
+            1,
+            {
+                "device_class": "temperature",
+                "state_class": "measurement",
+                "unit_of_measurement": "°C",
+            },
+        )
+    ],
+)
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    ("state_template", "expected_state"),
+    [
+        ("{{ '1.0' }}", "1.0"),
+        ("{{ '1' }}", "1"),
+        ("{{ 1.0 }}", "1.0"),
+        ("{{ 1 }}", "1"),
+        ("{{ '0.0' }}", "0.0"),
+        ("{{ '0' }}", "0"),
+        ("{{ 0.0 }}", "0.0"),
+        ("{{ 0 }}", "0"),
+        ("{{ '10021452' }}", "10021452"),
+        ("{{ 10021452 }}", "10021452"),
+        ("{{ '1002.1452' }}", "1002.1452"),
+        ("{{ 1002.1452 }}", "1002.1452"),
+    ],
+)
+@pytest.mark.usefixtures("setup_state_sensor")
+async def test_numeric_sensor_int_float(
+    hass: HomeAssistant, expected_state: str
+) -> None:
+    """Test sensor properly stores int or float for state."""
+    await async_trigger(hass, TEST_STATE_SENSOR, "anything")
+    assert hass.states.get(TEST_SENSOR.entity_id).state == expected_state

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -2026,6 +2026,8 @@ async def test_numeric_sensor_recovers_from_exception(hass: HomeAssistant) -> No
         ("{{ 10021452 }}", "10021452"),
         ("{{ '1002.1452' }}", "1002.1452"),
         ("{{ 1002.1452 }}", "1002.1452"),
+        ("{{ True }}", STATE_UNKNOWN),
+        ("{{ False }}", STATE_UNKNOWN),
     ],
 )
 @pytest.mark.usefixtures("setup_state_sensor")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix an issue found in 2026.3 beta where template sensors do not honor int/float values from template.

e.g. Templates outputting `0` should remain `0`, not `0.0`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
