### PR TITLE
Trigger recovery mode on registry major version downgrade

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -70,7 +70,7 @@ from .const import (
     SIGNAL_BOOTSTRAP_INTEGRATIONS,
 )
 from .core_config import async_process_ha_core_config
-from .exceptions import HomeAssistantError
+from .exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from .helpers import (
     area_registry,
     category_registry,
@@ -442,19 +442,20 @@ async def async_load_base_functionality(hass: core.HomeAssistant) -> None:
     frame.async_setup(hass)
     template.async_setup(hass)
     translation.async_setup(hass)
+    load_empty = hass.config.recovery_mode
     await asyncio.gather(
         create_eager_task(get_internal_store_manager(hass).async_initialize()),
-        create_eager_task(area_registry.async_load(hass)),
-        create_eager_task(category_registry.async_load(hass)),
-        create_eager_task(device_registry.async_load(hass)),
-        create_eager_task(entity_registry.async_load(hass)),
-        create_eager_task(floor_registry.async_load(hass)),
-        create_eager_task(issue_registry.async_load(hass)),
-        create_eager_task(label_registry.async_load(hass)),
+        create_eager_task(area_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(category_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(device_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(entity_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(floor_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(issue_registry.async_load(hass, load_empty=load_empty)),
+        create_eager_task(label_registry.async_load(hass, load_empty=load_empty)),
         hass.async_add_executor_job(_init_blocking_io_modules_in_executor),
         create_eager_task(template.async_load_custom_templates(hass)),
-        create_eager_task(restore_state.async_load(hass)),
-        create_eager_task(hass.config_entries.async_initialize()),
+        create_eager_task(restore_state.async_load(hass, load_empty=load_empty)),
+        create_eager_task(hass.config_entries.async_initialize(load_empty=load_empty)),
         create_eager_task(async_get_system_info(hass)),
         create_eager_task(condition.async_setup(hass)),
         create_eager_task(trigger.async_setup(hass)),
@@ -475,7 +476,18 @@ async def async_from_config_dict(
     # Prime custom component cache early so we know if registry entries are tied
     # to a custom integration
     await loader.async_get_custom_components(hass)
-    await async_load_base_functionality(hass)
+    try:
+        await async_load_base_functionality(hass)
+    except UnsupportedStorageVersionError as err:
+        _LOGGER.error(
+            "Storage file %s was created by a newer version of Home Assistant"
+            " (storage version %s > %s); activating recovery mode; on-disk data"
+            " is preserved; upgrade Home Assistant or restore from a backup",
+            err.storage_key,
+            err.found_version,
+            err.expected_version,
+        )
+        return None
 
     # Set up core.
     _LOGGER.debug("Setting up %s", CORE_INTEGRATIONS)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -467,7 +467,7 @@ async def async_load_base_functionality(hass: core.HomeAssistant) -> bool:
             create_eager_task(trigger.async_setup(hass)),
         )
     except UnsupportedStorageVersionError as err:
-        # Uf we're already in recovery mode, we don't want to handle the exception
+        # If we're already in recovery mode, we don't want to handle the exception
         # and activate recovery mode again, as that would lead to an infinite loop.
         if recovery:
             raise

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -478,7 +478,7 @@ async def async_load_base_functionality(hass: core.HomeAssistant) -> bool:
             " is preserved; upgrade Home Assistant or restore from a backup",
             err.storage_key,
             err.found_version,
-            err.expected_version,
+            err.max_supported_version,
         )
         return False
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -433,33 +433,56 @@ def _init_blocking_io_modules_in_executor() -> None:
     is_docker_env()
 
 
-async def async_load_base_functionality(hass: core.HomeAssistant) -> None:
-    """Load the registries and modules that will do blocking I/O."""
+async def async_load_base_functionality(hass: core.HomeAssistant) -> bool:
+    """Load the registries and modules that will do blocking I/O.
+
+    Return whether loading succeeded.
+    """
     if DATA_REGISTRIES_LOADED in hass.data:
-        return
+        return True
+
     hass.data[DATA_REGISTRIES_LOADED] = None
     entity.async_setup(hass)
     frame.async_setup(hass)
     template.async_setup(hass)
     translation.async_setup(hass)
-    load_empty = hass.config.recovery_mode
-    await asyncio.gather(
-        create_eager_task(get_internal_store_manager(hass).async_initialize()),
-        create_eager_task(area_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(category_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(device_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(entity_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(floor_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(issue_registry.async_load(hass, load_empty=load_empty)),
-        create_eager_task(label_registry.async_load(hass, load_empty=load_empty)),
-        hass.async_add_executor_job(_init_blocking_io_modules_in_executor),
-        create_eager_task(template.async_load_custom_templates(hass)),
-        create_eager_task(restore_state.async_load(hass, load_empty=load_empty)),
-        create_eager_task(hass.config_entries.async_initialize(load_empty=load_empty)),
-        create_eager_task(async_get_system_info(hass)),
-        create_eager_task(condition.async_setup(hass)),
-        create_eager_task(trigger.async_setup(hass)),
-    )
+
+    recovery = hass.config.recovery_mode
+    try:
+        await asyncio.gather(
+            create_eager_task(get_internal_store_manager(hass).async_initialize()),
+            create_eager_task(area_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(category_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(device_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(entity_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(floor_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(issue_registry.async_load(hass, load_empty=recovery)),
+            create_eager_task(label_registry.async_load(hass, load_empty=recovery)),
+            hass.async_add_executor_job(_init_blocking_io_modules_in_executor),
+            create_eager_task(template.async_load_custom_templates(hass)),
+            create_eager_task(restore_state.async_load(hass, load_empty=recovery)),
+            create_eager_task(hass.config_entries.async_initialize()),
+            create_eager_task(async_get_system_info(hass)),
+            create_eager_task(condition.async_setup(hass)),
+            create_eager_task(trigger.async_setup(hass)),
+        )
+    except UnsupportedStorageVersionError as err:
+        # Uf we're already in recovery mode, we don't want to handle the exception
+        # and activate recovery mode again, as that would lead to an infinite loop.
+        if recovery:
+            raise
+
+        _LOGGER.error(
+            "Storage file %s was created by a newer version of Home Assistant"
+            " (storage version %s > %s); activating recovery mode; on-disk data"
+            " is preserved; upgrade Home Assistant or restore from a backup",
+            err.storage_key,
+            err.found_version,
+            err.expected_version,
+        )
+        return False
+
+    return True
 
 
 async def async_from_config_dict(
@@ -476,17 +499,8 @@ async def async_from_config_dict(
     # Prime custom component cache early so we know if registry entries are tied
     # to a custom integration
     await loader.async_get_custom_components(hass)
-    try:
-        await async_load_base_functionality(hass)
-    except UnsupportedStorageVersionError as err:
-        _LOGGER.error(
-            "Storage file %s was created by a newer version of Home Assistant"
-            " (storage version %s > %s); activating recovery mode; on-disk data"
-            " is preserved; upgrade Home Assistant or restore from a backup",
-            err.storage_key,
-            err.found_version,
-            err.expected_version,
-        )
+
+    if not await async_load_base_functionality(hass):
         return None
 
     # Set up core.

--- a/homeassistant/components/backup/store.py
+++ b/homeassistant/components/backup/store.py
@@ -29,12 +29,17 @@ class StoredBackupData(TypedDict):
 class _BackupStore(Store[StoredBackupData]):
     """Class to help storing backup data."""
 
+    # Maximum version we support reading for forward compatibility.
+    # This allows reading data written by a newer HA version after downgrade.
+    _MAX_READABLE_VERSION = 2
+
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize storage class."""
         super().__init__(
             hass,
             STORAGE_VERSION,
             STORAGE_KEY,
+            max_readable_version=self._MAX_READABLE_VERSION,
             minor_version=STORAGE_VERSION_MINOR,
         )
 
@@ -86,8 +91,8 @@ class _BackupStore(Store[StoredBackupData]):
         # data["config"]["schedule"]["state"] will be removed. The bump to 2 is
         # planned to happen after a 6 month quiet period with no minor version
         # changes.
-        # Reject if major version is higher than 2.
-        if old_major_version > 2:
+        # Reject if major version is higher than _MAX_READABLE_VERSION.
+        if old_major_version > self._MAX_READABLE_VERSION:
             raise NotImplementedError
         return data
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2203,10 +2203,8 @@ class ConfigEntries:
             entry.async_shutdown()
         self.flow.async_shutdown()
 
-    async def async_initialize(self, *, load_empty: bool = False) -> None:
+    async def async_initialize(self) -> None:
         """Initialize config entry config."""
-        if load_empty:
-            self._store.set_load_empty()
         config = await self._store.async_load()
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2203,8 +2203,10 @@ class ConfigEntries:
             entry.async_shutdown()
         self.flow.async_shutdown()
 
-    async def async_initialize(self) -> None:
+    async def async_initialize(self, *, load_empty: bool = False) -> None:
         """Initialize config entry config."""
+        if load_empty:
+            self._store.set_load_empty()
         config = await self._store.async_load()
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -387,14 +387,14 @@ class UnsupportedStorageVersionError(HomeAssistantError):
     """Raised when a storage file has a newer major version than expected."""
 
     def __init__(
-        self, storage_key: str, found_version: int, expected_version: int
+        self, storage_key: str, found_version: int, max_supported_version: int
     ) -> None:
         """Initialize error."""
         super().__init__(
             f"Storage file {storage_key} has version {found_version}"
-            f" which is newer than the expected version {expected_version};"
+            f" which is newer than the max supported version {max_supported_version};"
             " upgrade Home Assistant or restore from a backup",
         )
         self.storage_key = storage_key
         self.found_version = found_version
-        self.expected_version = expected_version
+        self.max_supported_version = max_supported_version

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -381,3 +381,20 @@ class DependencyError(HomeAssistantError):
             f"Could not setup dependencies: {', '.join(failed_dependencies)}",
         )
         self.failed_dependencies = failed_dependencies
+
+
+class UnsupportedStorageVersionError(HomeAssistantError):
+    """Raised when a storage file has a newer major version than expected."""
+
+    def __init__(
+        self, storage_key: str, found_version: int, expected_version: int
+    ) -> None:
+        """Initialize error."""
+        super().__init__(
+            f"Storage file {storage_key} has version {found_version}"
+            f" which is newer than the expected version {expected_version};"
+            " upgrade Home Assistant or restore from a backup",
+        )
+        self.storage_key = storage_key
+        self.found_version = found_version
+        self.expected_version = expected_version

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -549,10 +549,13 @@ def async_get(hass: HomeAssistant) -> AreaRegistry:
     return AreaRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load area registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()
 
 
 @callback

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -447,9 +447,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             EventAreaRegistryUpdatedData(action="reorder", area_id=None),
         )
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the area registry."""
-        await super().async_load(load_empty=load_empty)
         self._async_setup_cleanup()
 
         data = await self._store.async_load()

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -447,8 +447,9 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             EventAreaRegistryUpdatedData(action="reorder", area_id=None),
         )
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the area registry."""
+        await super().async_load(load_empty=load_empty)
         self._async_setup_cleanup()
 
         data = await self._store.async_load()
@@ -552,10 +553,7 @@ def async_get(hass: HomeAssistant) -> AreaRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load area registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)
 
 
 @callback

--- a/homeassistant/helpers/category_registry.py
+++ b/homeassistant/helpers/category_registry.py
@@ -204,8 +204,9 @@ class CategoryRegistry(BaseRegistry[CategoryRegistryStoreData]):
 
         return new
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the category registry."""
+        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         category_entries: dict[str, dict[str, CategoryEntry]] = {}
 
@@ -268,7 +269,4 @@ def async_get(hass: HomeAssistant) -> CategoryRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load category registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)

--- a/homeassistant/helpers/category_registry.py
+++ b/homeassistant/helpers/category_registry.py
@@ -77,7 +77,7 @@ class CategoryRegistryStore(Store[CategoryRegistryStoreData]):
     ) -> CategoryRegistryStoreData:
         """Migrate to the new version."""
         if old_major_version > STORAGE_VERSION_MAJOR:
-            raise ValueError("Can't migrate to future version")
+            raise NotImplementedError
 
         if old_major_version == 1:
             if old_minor_version < 2:
@@ -265,7 +265,10 @@ def async_get(hass: HomeAssistant) -> CategoryRegistry:
     return CategoryRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load category registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()

--- a/homeassistant/helpers/category_registry.py
+++ b/homeassistant/helpers/category_registry.py
@@ -204,9 +204,8 @@ class CategoryRegistry(BaseRegistry[CategoryRegistryStoreData]):
 
         return new
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the category registry."""
-        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         category_entries: dict[str, dict[str, CategoryEntry]] = {}
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1461,8 +1461,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         )
         self.async_schedule_save()
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the device registry."""
+        await super().async_load(load_empty=load_empty)
         async_setup_cleanup(self.hass, self)
 
         data = await self._store.async_load()
@@ -1709,10 +1710,7 @@ def async_get(hass: HomeAssistant) -> DeviceRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load device registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)
 
 
 @callback

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1461,9 +1461,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         )
         self.async_schedule_save()
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the device registry."""
-        await super().async_load(load_empty=load_empty)
         async_setup_cleanup(self.hass, self)
 
         data = await self._store.async_load()

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1706,10 +1706,13 @@ def async_get(hass: HomeAssistant) -> DeviceRegistry:
     return DeviceRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load device registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1945,10 +1945,13 @@ def async_get(hass: HomeAssistant) -> EntityRegistry:
     return EntityRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load entity registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1678,8 +1678,9 @@ class EntityRegistry(BaseRegistry):
             new_options[domain] = options
         return self._async_update_entity(entity_id, options=new_options)
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the entity registry."""
+        await super().async_load(load_empty=load_empty)
         _async_setup_cleanup(self.hass, self)
         _async_setup_entity_restore(self.hass, self)
 
@@ -1948,10 +1949,7 @@ def async_get(hass: HomeAssistant) -> EntityRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load entity registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1678,9 +1678,8 @@ class EntityRegistry(BaseRegistry):
             new_options[domain] = options
         return self._async_update_entity(entity_id, options=new_options)
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the entity registry."""
-        await super().async_load(load_empty=load_empty)
         _async_setup_cleanup(self.hass, self)
         _async_setup_entity_restore(self.hass, self)
 

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -94,7 +94,7 @@ class FloorRegistryStore(Store[FloorRegistryStoreData]):
     ) -> FloorRegistryStoreData:
         """Migrate to the new version."""
         if old_major_version > STORAGE_VERSION_MAJOR:
-            raise ValueError("Can't migrate to future version")
+            raise NotImplementedError
 
         if old_major_version == 1:
             if old_minor_version < 2:
@@ -353,7 +353,10 @@ def async_get(hass: HomeAssistant) -> FloorRegistry:
     return FloorRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load floor registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -307,9 +307,8 @@ class FloorRegistry(BaseRegistry[FloorRegistryStoreData]):
             _EventFloorRegistryUpdatedData_Reorder(action="reorder"),
         )
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the floor registry."""
-        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         floors = FloorRegistryItems()
 

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -307,8 +307,9 @@ class FloorRegistry(BaseRegistry[FloorRegistryStoreData]):
             _EventFloorRegistryUpdatedData_Reorder(action="reorder"),
         )
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the floor registry."""
+        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         floors = FloorRegistryItems()
 
@@ -356,7 +357,4 @@ def async_get(hass: HomeAssistant) -> FloorRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load floor registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)

--- a/homeassistant/helpers/issue_registry.py
+++ b/homeassistant/helpers/issue_registry.py
@@ -251,8 +251,9 @@ class IssueRegistry(BaseRegistry):
         """
         self._store.make_read_only()
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the issue registry."""
+        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
 
         issues: dict[tuple[str, str], IssueEntry] = {}
@@ -324,9 +325,7 @@ async def async_load(
     ir = async_get(hass)
     if read_only:  # only used in for check config script
         ir.make_read_only()
-    if load_empty:
-        ir.set_load_empty()
-    return await ir.async_load()
+    await ir.async_load(load_empty=load_empty)
 
 
 @callback

--- a/homeassistant/helpers/issue_registry.py
+++ b/homeassistant/helpers/issue_registry.py
@@ -314,11 +314,18 @@ def async_get(hass: HomeAssistant) -> IssueRegistry:
     return IssueRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant, *, read_only: bool = False) -> None:
+async def async_load(
+    hass: HomeAssistant,
+    *,
+    read_only: bool = False,
+    load_empty: bool = False,
+) -> None:
     """Load issue registry."""
     ir = async_get(hass)
     if read_only:  # only used in for check config script
         ir.make_read_only()
+    if load_empty:
+        ir.set_load_empty()
     return await ir.async_load()
 
 

--- a/homeassistant/helpers/issue_registry.py
+++ b/homeassistant/helpers/issue_registry.py
@@ -251,9 +251,8 @@ class IssueRegistry(BaseRegistry):
         """
         self._store.make_read_only()
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the issue registry."""
-        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
 
         issues: dict[tuple[str, str], IssueEntry] = {}

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -80,7 +80,7 @@ class LabelRegistryStore(Store[LabelRegistryStoreData]):
     ) -> LabelRegistryStoreData:
         """Migrate to the new version."""
         if old_major_version > STORAGE_VERSION_MAJOR:
-            raise ValueError("Can't migrate to future version")
+            raise NotImplementedError
 
         if old_major_version == 1:
             if old_minor_version < 2:
@@ -270,7 +270,10 @@ def async_get(hass: HomeAssistant) -> LabelRegistry:
     return LabelRegistry(hass)
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load label registry."""
     assert DATA_REGISTRY not in hass.data
-    await async_get(hass).async_load()
+    registry = async_get(hass)
+    if load_empty:
+        registry.set_load_empty()
+    await registry.async_load()

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -224,8 +224,9 @@ class LabelRegistry(BaseRegistry[LabelRegistryStoreData]):
 
         return new
 
-    async def async_load(self) -> None:
+    async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the label registry."""
+        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         labels = NormalizedNameBaseRegistryItems[LabelEntry]()
 
@@ -273,7 +274,4 @@ def async_get(hass: HomeAssistant) -> LabelRegistry:
 async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load label registry."""
     assert DATA_REGISTRY not in hass.data
-    registry = async_get(hass)
-    if load_empty:
-        registry.set_load_empty()
-    await registry.async_load()
+    await async_get(hass).async_load(load_empty=load_empty)

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -224,9 +224,8 @@ class LabelRegistry(BaseRegistry[LabelRegistryStoreData]):
 
         return new
 
-    async def async_load(self, *, load_empty: bool = False) -> None:
+    async def _async_load(self) -> None:
         """Load the label registry."""
-        await super().async_load(load_empty=load_empty)
         data = await self._store.async_load()
         labels = NormalizedNameBaseRegistryItems[LabelEntry]()
 

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -81,6 +81,14 @@ class BaseRegistry[_StoreDataT: Mapping[str, Any] | Sequence[Any]](ABC):
         """Set the store to load empty and become read-only."""
         self._store.set_load_empty()
 
+    async def async_load(self, *, load_empty: bool = False) -> None:
+        """Load the registry.
+
+        Optionally set the store to load empty and become read-only.
+        """
+        if load_empty:
+            self.set_load_empty()
+
     @abstractmethod
     def _data_to_save(self) -> _StoreDataT:
         """Return data of registry to store in a file."""

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -77,6 +77,10 @@ class BaseRegistry[_StoreDataT: Mapping[str, Any] | Sequence[Any]](ABC):
         delay = SAVE_DELAY if self.hass.state is CoreState.running else SAVE_DELAY_LONG
         self._store.async_delay_save(self._data_to_save, delay)
 
+    def set_load_empty(self) -> None:
+        """Set the store to load empty and become read-only."""
+        self._store.set_load_empty()
+
     @abstractmethod
     def _data_to_save(self) -> _StoreDataT:
         """Return data of registry to store in a file."""

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -84,6 +84,11 @@ class BaseRegistry[_StoreDataT: Mapping[str, Any] | Sequence[Any]](ABC):
         """
         if load_empty:
             self._store.set_load_empty()
+        await self._async_load()
+
+    @abstractmethod
+    async def _async_load(self) -> None:
+        """Load the registry."""
 
     @abstractmethod
     def _data_to_save(self) -> _StoreDataT:

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -77,17 +77,13 @@ class BaseRegistry[_StoreDataT: Mapping[str, Any] | Sequence[Any]](ABC):
         delay = SAVE_DELAY if self.hass.state is CoreState.running else SAVE_DELAY_LONG
         self._store.async_delay_save(self._data_to_save, delay)
 
-    def set_load_empty(self) -> None:
-        """Set the store to load empty and become read-only."""
-        self._store.set_load_empty()
-
     async def async_load(self, *, load_empty: bool = False) -> None:
         """Load the registry.
 
         Optionally set the store to load empty and become read-only.
         """
         if load_empty:
-            self.set_load_empty()
+            self._store.set_load_empty()
 
     @abstractmethod
     def _data_to_save(self) -> _StoreDataT:

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -95,9 +95,12 @@ class StoredState:
         )
 
 
-async def async_load(hass: HomeAssistant) -> None:
+async def async_load(hass: HomeAssistant, *, load_empty: bool = False) -> None:
     """Load the restore state task."""
-    await async_get(hass).async_setup()
+    data = async_get(hass)
+    if load_empty:
+        data.set_load_empty()
+    await data.async_setup()
 
 
 @callback
@@ -123,6 +126,10 @@ class RestoreStateData:
         )
         self.last_states: dict[str, StoredState] = {}
         self.entities: dict[str, RestoreEntity] = {}
+
+    def set_load_empty(self) -> None:
+        """Set the store to load empty and become read-only."""
+        self.store.set_load_empty()
 
     async def async_setup(self) -> None:
         """Set up up the instance of this data helper."""

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -9,7 +9,7 @@ from typing import Any, Self, cast
 
 from homeassistant.const import ATTR_RESTORED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, State, callback, valid_entity_id
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.util import dt as dt_util
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import json_loads
@@ -146,6 +146,8 @@ class RestoreStateData:
         """Load the instance of this data helper."""
         try:
             stored_states = await self.store.async_load()
+        except UnsupportedStorageVersionError:
+            raise
         except HomeAssistantError as exc:
             _LOGGER.error("Error loading last states", exc_info=exc)
             stored_states = None

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -239,6 +239,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         *,
         atomic_writes: bool = False,
         encoder: type[JSONEncoder] | None = None,
+        max_readable_version: int | None = None,
         minor_version: int = 1,
         read_only: bool = False,
         serialize_in_event_loop: bool = True,
@@ -246,6 +247,10 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         """Initialize storage class.
 
         Args:
+            max_readable_version: Maximum major version that can be read. Defaults
+            to version. Set higher than version to support forward compatibility,
+            allowing reading data written by newer versions (e.g., after downgrade).
+
             serialize_in_event_loop: Whether to serialize data in the event loop.
             Set to True (default) if data passed to async_save and data produced by
             data_func passed to async_delay_save needs to be serialized in the event
@@ -274,6 +279,9 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         self._atomic_writes = atomic_writes
         self._read_only = read_only
         self._load_empty = False
+        self._max_readable_version = (
+            max_readable_version if max_readable_version is not None else version
+        )
         self._next_write_time = 0.0
         self._manager = get_internal_store_manager(hass)
         self._serialize_in_event_loop = serialize_in_event_loop
@@ -430,9 +438,9 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         ):
             stored = data["data"]
         else:
-            if data["version"] > self.version:
+            if data["version"] > self._max_readable_version:
                 raise UnsupportedStorageVersionError(
-                    self.key, data["version"], self.version
+                    self.key, data["version"], self._max_readable_version
                 )
             _LOGGER.info(
                 "Migrating %s storage from %s.%s to %s.%s",

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -28,7 +28,7 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util, json as json_util
 from homeassistant.util.file import WriteError, write_utf8_file, write_utf8_file_atomic
@@ -273,6 +273,7 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         self._encoder = encoder
         self._atomic_writes = atomic_writes
         self._read_only = read_only
+        self._load_empty = False
         self._next_write_time = 0.0
         self._manager = get_internal_store_manager(hass)
         self._serialize_in_event_loop = serialize_in_event_loop
@@ -288,6 +289,14 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         This method is irreversible.
         """
         self._read_only = True
+
+    def set_load_empty(self) -> None:
+        """Set the store to load empty data and become read-only.
+
+        When set, the store will skip loading data from disk and return None,
+        while also becoming read-only to preserve on-disk data untouched.
+        """
+        self._load_empty = True
 
     async def async_load(self) -> _T | None:
         """Load data.
@@ -328,6 +337,12 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
 
     async def _async_load_data(self):
         """Load the data."""
+        # When load_empty is set, skip loading storage files and use empty
+        # data while preserving the on-disk files untouched.
+        if self._load_empty:
+            self.make_read_only()
+            return None
+
         # Check if we have a pending write
         if self._data is not None:
             data = self._data
@@ -415,6 +430,10 @@ class Store[_T: Mapping[str, Any] | Sequence[Any]]:
         ):
             stored = data["data"]
         else:
+            if data["version"] > self.version:
+                raise UnsupportedStorageVersionError(
+                    self.key, data["version"], self.version
+                )
             _LOGGER.info(
                 "Migrating %s storage from %s.%s to %s.%s",
                 self.key,

--- a/tests/helpers/test_registry.py
+++ b/tests/helpers/test_registry.py
@@ -21,6 +21,9 @@ class SampleRegistry(BaseRegistry):
         self._store = storage.Store(hass, 1, "test")
         self.save_calls = 0
 
+    async def _async_load(self) -> None:
+        """Load the registry."""
+
     def _data_to_save(self) -> dict[str, Any]:
         """Return data of registry to save."""
         self.save_calls += 1

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -669,7 +669,7 @@ async def test_loading_newer_major_version_raises(
         await store.async_load()
     assert exc_info.value.storage_key == MOCK_KEY
     assert exc_info.value.found_version == MOCK_VERSION_2
-    assert exc_info.value.expected_version == MOCK_VERSION
+    assert exc_info.value.max_supported_version == MOCK_VERSION
     # Verify on-disk data is not modified
     assert hass_storage[MOCK_KEY]["version"] == MOCK_VERSION_2
     assert hass_storage[MOCK_KEY]["minor_version"] == MOCK_MINOR_VERSION_1

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -25,7 +25,7 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.helpers import issue_registry as ir, storage
 from homeassistant.helpers.json import json_bytes, prepare_save_json
 from homeassistant.util import dt as dt_util
@@ -657,14 +657,23 @@ async def test_minor_version(
     assert hass_storage[store_v_1_2.key]["minor_version"] == MOCK_MINOR_VERSION_2
 
 
-async def test_migrate_major_not_implemented_raises(
-    hass: HomeAssistant, store: storage.Store, store_v_2_1: storage.Store
+async def test_loading_newer_major_version_raises(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    store: storage.Store,
+    store_v_2_1: storage.Store,
 ) -> None:
-    """Test migrating between major versions fails if not implemented."""
-
+    """Test loading storage with a newer major version raises and preserves data."""
     await store_v_2_1.async_save(MOCK_DATA)
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(UnsupportedStorageVersionError) as exc_info:
         await store.async_load()
+    assert exc_info.value.storage_key == MOCK_KEY
+    assert exc_info.value.found_version == MOCK_VERSION_2
+    assert exc_info.value.expected_version == MOCK_VERSION
+    # Verify on-disk data is not modified
+    assert hass_storage[MOCK_KEY]["version"] == MOCK_VERSION_2
+    assert hass_storage[MOCK_KEY]["minor_version"] == MOCK_MINOR_VERSION_1
+    assert hass_storage[MOCK_KEY]["data"] == MOCK_DATA
 
 
 async def test_migrate_minor_not_implemented(
@@ -1349,3 +1358,27 @@ async def test_storage_concurrent_load(hass: HomeAssistant) -> None:
         )
         for load in loads:
             assert load == "data"
+
+
+async def test_load_empty_returns_none_and_read_only(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Test store with load_empty returns None, becomes read-only, and skips version checks."""
+    # Use a future version to also verify no version error is raised
+    hass_storage[MOCK_KEY] = {
+        "version": 99,
+        "minor_version": 1,
+        "key": MOCK_KEY,
+        "data": MOCK_DATA,
+    }
+
+    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+    store.set_load_empty()
+
+    data = await store.async_load()
+    assert data is None
+    assert store._read_only is True
+
+    await store.async_save({"new": "data"})
+    assert hass_storage[MOCK_KEY]["data"] == MOCK_DATA
+    assert hass_storage[MOCK_KEY]["version"] == 99

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     SIGNAL_BOOTSTRAP_INTEGRATIONS,
 )
 from homeassistant.core import CoreState, HomeAssistant, async_get_hass, callback
-from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.translation import async_translations_loaded
 from homeassistant.helpers.typing import ConfigType
@@ -968,6 +968,7 @@ async def test_setup_hass_recovery_mode_and_safe_mode(
 @pytest.mark.parametrize("hass_config", [{"frontend": {}}])
 @pytest.mark.usefixtures("mock_hass_config")
 async def test_storage_version_too_new_triggers_recovery_mode(
+    hass_storage: dict[str, Any],
     mock_enable_logging: AsyncMock,
     mock_is_virtual_env: Mock,
     mock_mount_local_lib_path: AsyncMock,
@@ -976,36 +977,32 @@ async def test_storage_version_too_new_triggers_recovery_mode(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that a storage file with a newer major version triggers recovery mode."""
-    call_count = 0
+    hass_storage["core.entity_registry"] = {
+        "version": 99,
+        "minor_version": 1,
+        "key": "core.entity_registry",
+        "data": {},
+    }
 
-    async def _raise_first_call(
-        hass: HomeAssistant, *, load_empty: bool = False
-    ) -> None:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise UnsupportedStorageVersionError("core.entity_registry", 2, 1)
-
-    with patch(
-        "homeassistant.bootstrap.entity_registry.async_load",
-        side_effect=_raise_first_call,
-    ):
-        hass = await bootstrap.async_setup_hass(
-            runner.RuntimeConfig(
-                config_dir=get_test_config_dir(),
-                verbose=False,
-                log_rotate_days=10,
-                log_file="",
-                log_no_color=False,
-                skip_pip=True,
-                recovery_mode=False,
-            ),
-        )
+    hass = await bootstrap.async_setup_hass(
+        runner.RuntimeConfig(
+            config_dir=get_test_config_dir(),
+            verbose=False,
+            log_rotate_days=10,
+            log_file="",
+            log_no_color=False,
+            skip_pip=True,
+            recovery_mode=False,
+        ),
+    )
 
     assert hass is not None
     assert hass.config.recovery_mode is True
     assert "recovery_mode" in hass.config.components
-    assert "storage version 2 > 1" in caplog.text
+    assert (
+        "Storage file core.entity_registry was created"
+        " by a newer version of Home Assistant" in caplog.text
+    )
 
 
 @pytest.mark.parametrize("hass_config", [{"homeassistant": {"non-existing": 1}}])

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -976,18 +976,18 @@ async def test_storage_version_too_new_triggers_recovery_mode(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that a storage file with a newer major version triggers recovery mode."""
-    original_load = bootstrap.async_load_base_functionality
     call_count = 0
 
-    async def _raise_first_call(hass: HomeAssistant) -> None:
+    async def _raise_first_call(
+        hass: HomeAssistant, *, load_empty: bool = False
+    ) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
             raise UnsupportedStorageVersionError("core.entity_registry", 2, 1)
-        return await original_load(hass)
 
     with patch(
-        "homeassistant.bootstrap.async_load_base_functionality",
+        "homeassistant.bootstrap.entity_registry.async_load",
         side_effect=_raise_first_call,
     ):
         hass = await bootstrap.async_setup_hass(
@@ -1771,19 +1771,3 @@ async def test_recorder_not_promoted(hass: HomeAssistant) -> None:
     )
 
     assert "recorder" not in all_integrations
-
-
-async def test_async_from_config_dict_returns_none_on_storage_version_error(
-    hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test async_from_config_dict returns None on UnsupportedStorageVersionError."""
-    with patch(
-        "homeassistant.bootstrap.async_load_base_functionality",
-        side_effect=UnsupportedStorageVersionError("core.entity_registry", 99, 1),
-    ):
-        result = await bootstrap.async_from_config_dict({}, hass)
-
-    assert result is None
-    assert "core.entity_registry" in caplog.text
-    assert "storage version 99 > 1" in caplog.text

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     SIGNAL_BOOTSTRAP_INTEGRATIONS,
 )
 from homeassistant.core import CoreState, HomeAssistant, async_get_hass, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.translation import async_translations_loaded
 from homeassistant.helpers.typing import ConfigType
@@ -965,6 +965,49 @@ async def test_setup_hass_recovery_mode_and_safe_mode(
     assert "Starting in safe mode" not in caplog.text
 
 
+@pytest.mark.parametrize("hass_config", [{"frontend": {}}])
+@pytest.mark.usefixtures("mock_hass_config")
+async def test_storage_version_too_new_triggers_recovery_mode(
+    mock_enable_logging: AsyncMock,
+    mock_is_virtual_env: Mock,
+    mock_mount_local_lib_path: AsyncMock,
+    mock_ensure_config_exists: AsyncMock,
+    mock_process_ha_config_upgrade: Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a storage file with a newer major version triggers recovery mode."""
+    original_load = bootstrap.async_load_base_functionality
+    call_count = 0
+
+    async def _raise_first_call(hass: HomeAssistant) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise UnsupportedStorageVersionError("core.entity_registry", 2, 1)
+        return await original_load(hass)
+
+    with patch(
+        "homeassistant.bootstrap.async_load_base_functionality",
+        side_effect=_raise_first_call,
+    ):
+        hass = await bootstrap.async_setup_hass(
+            runner.RuntimeConfig(
+                config_dir=get_test_config_dir(),
+                verbose=False,
+                log_rotate_days=10,
+                log_file="",
+                log_no_color=False,
+                skip_pip=True,
+                recovery_mode=False,
+            ),
+        )
+
+    assert hass is not None
+    assert hass.config.recovery_mode is True
+    assert "recovery_mode" in hass.config.components
+    assert "storage version 2 > 1" in caplog.text
+
+
 @pytest.mark.parametrize("hass_config", [{"homeassistant": {"non-existing": 1}}])
 @pytest.mark.usefixtures("mock_hass_config")
 async def test_setup_hass_invalid_core_config(
@@ -1728,3 +1771,19 @@ async def test_recorder_not_promoted(hass: HomeAssistant) -> None:
     )
 
     assert "recorder" not in all_integrations
+
+
+async def test_async_from_config_dict_returns_none_on_storage_version_error(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test async_from_config_dict returns None on UnsupportedStorageVersionError."""
+    with patch(
+        "homeassistant.bootstrap.async_load_base_functionality",
+        side_effect=UnsupportedStorageVersionError("core.entity_registry", 99, 1),
+    ):
+        result = await bootstrap.async_from_config_dict({}, hass)
+
+    assert result is None
+    assert "core.entity_registry" in caplog.text
+    assert "storage version 99 > 1" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trigger recovery mode on registry major version downgrade.

The overall goal of this PR is to improve how we handle major version bumps in the registries in the context of rollbacks.

The specific changes in this PR:
- The base store class will now raise `UnsupportedStorageVersionError` if the major version in the file is higher than the one supported by the code.
  - Registries will now all always raise `NotImplementedError` in the same conditions, as a few of them used to raise a different exception. That code should never actually be hit, as it's handled above anyway, so we could remove it completely, but it doesn't hurt for it to be there.
- The bootstrap code will now catch `UnsupportedStorageVersionError` and launch recovery mode in response.
- In recovery mode the relevant registries will now behave differently - they will work in-memory only starting with empty contents. In this way the contents of underlying files will always be preserved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
