### PR TITLE
Fix handling of several thermostat QuickApp's in fibaro

### DIFF
--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -275,8 +275,11 @@ class FibaroController:
                 # otherwise add the first visible device in the group
                 # which is a hack, but solves a problem with FGT having
                 # hidden compatibility devices before the real device
-                if last_climate_parent != device.parent_fibaro_id or (
-                    device.has_endpoint_id and last_endpoint != device.endpoint_id
+                # Second hack is for quickapps which have parent id 0 and no children
+                if (
+                    last_climate_parent != device.parent_fibaro_id
+                    or (device.has_endpoint_id and last_endpoint != device.endpoint_id)
+                    or device.parent_fibaro_id == 0
                 ):
                     _LOGGER.debug("Handle separately")
                     self.fibaro_devices[platform].append(device)

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -287,6 +287,68 @@ def mock_thermostat_with_operating_mode() -> Mock:
 
 
 @pytest.fixture
+def mock_thermostat_quickapp_1() -> Mock:
+    """Fixture for a thermostat."""
+    climate = Mock()
+    climate.fibaro_id = 6
+    climate.parent_fibaro_id = 0
+    climate.has_endpoint_id = False
+    climate.name = "Test climate"
+    climate.room_id = 1
+    climate.dead = False
+    climate.visible = True
+    climate.enabled = True
+    climate.type = "com.fibaro.hvacSystemHeat"
+    climate.base_type = "com.fibaro.hvacSystem"
+    climate.properties = {"manufacturer": ""}
+    climate.actions = {"setHeatingThermostatSetpoint": 1, "setThermostatMode": 1}
+    climate.supported_features = {}
+    climate.has_supported_operating_modes = False
+    climate.has_supported_thermostat_modes = True
+    climate.supported_thermostat_modes = ["Off", "Heat"]
+    climate.has_thermostat_mode = True
+    climate.thermostat_mode = "Heat"
+    climate.has_unit = False
+    climate.has_heating_thermostat_setpoint = False
+    climate.has_heating_thermostat_setpoint_future = False
+    value_mock = Mock()
+    value_mock.has_value = False
+    climate.value = value_mock
+    return climate
+
+
+@pytest.fixture
+def mock_thermostat_quickapp_2() -> Mock:
+    """Fixture for a thermostat."""
+    climate = Mock()
+    climate.fibaro_id = 7
+    climate.parent_fibaro_id = 0
+    climate.has_endpoint_id = False
+    climate.name = "Test climate 2"
+    climate.room_id = 1
+    climate.dead = False
+    climate.visible = True
+    climate.enabled = True
+    climate.type = "com.fibaro.hvacSystemHeat"
+    climate.base_type = "com.fibaro.hvacSystem"
+    climate.properties = {"manufacturer": ""}
+    climate.actions = {"setHeatingThermostatSetpoint": 1, "setThermostatMode": 1}
+    climate.supported_features = {}
+    climate.has_supported_operating_modes = False
+    climate.has_supported_thermostat_modes = True
+    climate.supported_thermostat_modes = ["Off", "Heat"]
+    climate.has_thermostat_mode = True
+    climate.thermostat_mode = "Heat"
+    climate.has_unit = False
+    climate.has_heating_thermostat_setpoint = False
+    climate.has_heating_thermostat_setpoint_future = False
+    value_mock = Mock()
+    value_mock.has_value = False
+    climate.value = value_mock
+    return climate
+
+
+@pytest.fixture
 def mock_fan_device() -> Mock:
     """Fixture for a fan endpoint of a thermostat device."""
     climate = Mock()

--- a/tests/components/fibaro/test_climate.py
+++ b/tests/components/fibaro/test_climate.py
@@ -50,7 +50,7 @@ async def test_climate_setup_2_quickapps(
     mock_thermostat_quickapp_2: Mock,
     mock_room: Mock,
 ) -> None:
-    """Test that the climate creates entities for more then one QuickApp."""
+    """Test that the climate creates entities for more than one QuickApp."""
 
     # Arrange
     mock_fibaro_client.read_rooms.return_value = [mock_room]

--- a/tests/components/fibaro/test_climate.py
+++ b/tests/components/fibaro/test_climate.py
@@ -41,6 +41,34 @@ async def test_climate_setup(
         )
 
 
+async def test_climate_setup_2_quickapps(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_thermostat_quickapp_1: Mock,
+    mock_thermostat_quickapp_2: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test that the climate creates entities for more then one QuickApp."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [
+        mock_thermostat_quickapp_1,
+        mock_thermostat_quickapp_2,
+    ]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.CLIMATE]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        entry1 = entity_registry.async_get("climate.room_1_test_climate_6")
+        assert entry1
+        entry2 = entity_registry.async_get("climate.room_1_test_climate_2_7")
+        assert entry2
+
+
 async def test_hvac_mode_preset(
     hass: HomeAssistant,
     mock_fibaro_client: Mock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Thermostat devices in Fibaro are different when they are created as QuickApp instead of beeing a hardware device.
Therefore only one thermostat was detected.
This fixes the behaviour and created correctly a climate device per thermostat.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164169
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
