### PR TITLE
Mock ConnectionContextBuilder in homematicip_cloud tests

### DIFF
--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from homematicip.async_home import AsyncHome
 from homematicip.auth import Auth
 from homematicip.base.enums import WeatherCondition, WeatherDayTime
+from homematicip.connection.connection_context import ConnectionContext
 from homematicip.connection.rest_connection import RestConnection
 import pytest
 
@@ -131,10 +132,16 @@ def simple_mock_home_fixture():
         get_current_state_async=AsyncMock(),
     )
 
-    with patch(
-        "homeassistant.components.homematicip_cloud.hap.AsyncHome",
-        autospec=True,
-        return_value=mock_home,
+    with (
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.AsyncHome",
+            autospec=True,
+            return_value=mock_home,
+        ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
+            return_value=ConnectionContext(),
+        ),
     ):
         yield
 

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -1,11 +1,10 @@
 """Initializer helpers for HomematicIP fake server."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.async_home import AsyncHome
 from homematicip.auth import Auth
 from homematicip.base.enums import WeatherCondition, WeatherDayTime
-from homematicip.connection.connection_context import ConnectionContext
 from homematicip.connection.rest_connection import RestConnection
 import pytest
 
@@ -140,7 +139,7 @@ def simple_mock_home_fixture():
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=ConnectionContext(),
+            return_value=MagicMock(),
         ),
     ):
         yield

--- a/tests/components/homematicip_cloud/conftest.py
+++ b/tests/components/homematicip_cloud/conftest.py
@@ -1,6 +1,6 @@
 """Initializer helpers for HomematicIP fake server."""
 
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.async_home import AsyncHome
 from homematicip.auth import Auth
@@ -139,7 +139,6 @@ def simple_mock_home_fixture():
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=MagicMock(),
         ),
     ):
         yield

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,6 +1,6 @@
 """Test HomematicIP Cloud setup process."""
 
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 
@@ -106,7 +106,6 @@ async def test_load_entry_fails_due_to_connection_error(
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=MagicMock(),
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
@@ -128,7 +127,6 @@ async def test_load_entry_fails_due_to_generic_exception(
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=MagicMock(),
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -127,6 +127,10 @@ async def test_load_entry_fails_due_to_generic_exception(
             "homeassistant.components.homematicip_cloud.hap.AsyncHome.get_current_state_async",
             side_effect=Exception,
         ),
+        patch(
+            "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
+            return_value=ConnectionContext(),
+        ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
 

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,8 +1,7 @@
 """Test HomematicIP Cloud setup process."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from homematicip.connection.connection_context import ConnectionContext
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 
 from homeassistant.components.homematicip_cloud.const import (
@@ -107,7 +106,7 @@ async def test_load_entry_fails_due_to_connection_error(
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=ConnectionContext(),
+            return_value=MagicMock(),
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
@@ -129,7 +128,7 @@ async def test_load_entry_fails_due_to_generic_exception(
         ),
         patch(
             "homeassistant.components.homematicip_cloud.hap.ConnectionContextBuilder.build_context_async",
-            return_value=ConnectionContext(),
+            return_value=MagicMock(),
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Patch `ConnectionContextBuilder.build_context_async` in the `simple_mock_home` fixture and the generic-exception init test to prevent a real connection context from being built during setup.

Without this mock, the builder attempts to resolve and connect to the Homematic IP cloud service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
