### PR TITLE
Availability check for Anthropic integration

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -75,7 +75,7 @@ class AnthropicRuntimeData:
         """Mark the config entry entities as unavailable."""
         if not self.is_available:
             return
-        LOGGER.info("Claude API become unavailable")
+        LOGGER.info("Claude API is unavailable")
         self.is_available = False
         async_dispatcher_send(
             self._hass, f"{DOMAIN}_availability_{self._entry.entry_id}"
@@ -92,7 +92,7 @@ class AnthropicRuntimeData:
         """Mark the config entry entities as available."""
         if self.is_available:
             return
-        LOGGER.info("Claude API become available")
+        LOGGER.info("Claude API is back online")
         self.is_available = True
         async_dispatcher_send(
             self._hass, f"{DOMAIN}_availability_{self._entry.entry_id}"

--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -44,7 +44,7 @@ class AnthropicRuntimeData:
     client: anthropic.AsyncClient
     is_available: bool = True
 
-    async def _check_availability(self, time: datetime) -> None:
+    async def _check_availability(self, _time: datetime) -> None:
         """Check if the API is still unavailable."""
         if self.is_available:
             return

--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from datetime import datetime
+
 import anthropic
 
 from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import CONF_API_KEY, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
@@ -14,10 +17,13 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    AVAILABILITY_CHECK_PERIOD,
     CONF_CHAT_MODEL,
     DEFAULT_CONVERSATION_NAME,
     DEPRECATED_MODELS,
@@ -28,7 +34,72 @@ from .const import (
 PLATFORMS = (Platform.AI_TASK, Platform.CONVERSATION)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-type AnthropicConfigEntry = ConfigEntry[anthropic.AsyncClient]
+
+@dataclass(slots=True)
+class AnthropicRuntimeData:
+    """Config entry runtime data for Anthropic integration."""
+
+    _hass: HomeAssistant
+    _entry: AnthropicConfigEntry
+    client: anthropic.AsyncClient
+    is_available: bool = True
+
+    async def _check_availability(self, time: datetime) -> None:
+        """Check if the API is still unavailable."""
+        if self.is_available:
+            return
+
+        try:
+            await self.client.models.list(timeout=10.0)
+        except anthropic.APIConnectionError:
+            # Schedule another check
+            self._entry.async_on_unload(
+                async_call_later(
+                    self._hass, AVAILABILITY_CHECK_PERIOD, self._check_availability
+                )
+            )
+            return
+        except anthropic.AuthenticationError:
+            # Leave unavailable until the entry is reloaded after reauth, no schedule
+            self._entry.async_start_reauth(self._hass)
+            return
+        except anthropic.AnthropicError as err:
+            # Any other error means the API is available,
+            # everything else is not availability issue
+            LOGGER.debug("Error while checking Claude API availability: %s", err)
+
+        self.mark_available()
+
+    @callback
+    def mark_unavailable(self, check_later: bool = True) -> None:
+        """Mark the config entry entities as unavailable."""
+        if not self.is_available:
+            return
+        LOGGER.info("Claude API become unavailable")
+        self.is_available = False
+        async_dispatcher_send(
+            self._hass, f"{DOMAIN}_availability_{self._entry.entry_id}"
+        )
+        if check_later:
+            self._entry.async_on_unload(
+                async_call_later(
+                    self._hass, AVAILABILITY_CHECK_PERIOD, self._check_availability
+                )
+            )
+
+    @callback
+    def mark_available(self) -> None:
+        """Mark the config entry entities as available."""
+        if self.is_available:
+            return
+        LOGGER.info("Claude API become available")
+        self.is_available = True
+        async_dispatcher_send(
+            self._hass, f"{DOMAIN}_availability_{self._entry.entry_id}"
+        )
+
+
+type AnthropicConfigEntry = ConfigEntry[AnthropicRuntimeData]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -61,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) ->
             },
         ) from err
 
-    entry.runtime_data = client
+    entry.runtime_data = AnthropicRuntimeData(hass, entry, client)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/anthropic/const.py
+++ b/homeassistant/components/anthropic/const.py
@@ -5,6 +5,8 @@ import logging
 DOMAIN = "anthropic"
 LOGGER = logging.getLogger(__package__)
 
+AVAILABILITY_CHECK_PERIOD = 60
+
 DEFAULT_CONVERSATION_NAME = "Claude conversation"
 DEFAULT_AI_TASK_NAME = "Claude AI Task"
 

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -899,7 +899,9 @@ class AnthropicBaseLLMEntity(Entity):
             except anthropic.APIConnectionError as err:
                 self.entry.runtime_data.mark_unavailable()
                 raise HomeAssistantError(
-                    f"Connection error while talking to Anthropic: {err}"
+                    translation_domain=DOMAIN,
+                    translation_key="api_error",
+                    translation_placeholders={"message": err.message},
                 ) from err
             except anthropic.AnthropicError as err:
                 self.entry.runtime_data.mark_available()

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -76,9 +76,10 @@ from voluptuous_openapi import convert
 
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigSubentry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.json import json_dumps
 from homeassistant.util import slugify
@@ -660,6 +661,27 @@ class AnthropicBaseLLMEntity(Entity):
             entry_type=dr.DeviceEntryType.SERVICE,
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Register availability dispatcher listener."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{DOMAIN}_availability_{self.entry.entry_id}",
+                self._handle_availability_update,
+            )
+        )
+
+    @callback
+    def _handle_availability_update(self) -> None:
+        """Handle availability update from dispatcher."""
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.entry.runtime_data.is_available
+
     async def _async_handle_chat_log(
         self,
         chat_log: conversation.ChatLog,
@@ -845,7 +867,7 @@ class AnthropicBaseLLMEntity(Entity):
         if tools:
             model_args["tools"] = tools
 
-        client = self.entry.runtime_data
+        client = self.entry.runtime_data.client
 
         # To prevent infinite loops, we limit the number of iterations
         for _iteration in range(max_iterations):
@@ -868,12 +890,19 @@ class AnthropicBaseLLMEntity(Entity):
                 messages.extend(new_messages)
             except anthropic.AuthenticationError as err:
                 self.entry.async_start_reauth(self.hass)
+                self.entry.runtime_data.mark_unavailable(False)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_authentication_error",
                     translation_placeholders={"message": err.message},
                 ) from err
+            except anthropic.APIConnectionError as err:
+                self.entry.runtime_data.mark_unavailable()
+                raise HomeAssistantError(
+                    f"Connection error while talking to Anthropic: {err}"
+                ) from err
             except anthropic.AnthropicError as err:
+                self.entry.runtime_data.mark_available()
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_error",
@@ -883,6 +912,8 @@ class AnthropicBaseLLMEntity(Entity):
                         else str(err)
                     },
                 ) from err
+            else:
+                self.entry.runtime_data.mark_available()
 
             if not chat_log.unresponded_tool_results:
                 break

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -23,7 +23,7 @@ rules:
   entity-event-setup:
     status: exempt
     comment: |
-      Integration does not subscribe to events.
+      Integration entities do not subscribe to events.
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
@@ -35,9 +35,9 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates:
     status: exempt
     comment: |

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -20,10 +20,7 @@ rules:
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
-  entity-event-setup:
-    status: exempt
-    comment: |
-      Integration entities do not subscribe to events.
+  entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done

--- a/homeassistant/components/anthropic/repairs.py
+++ b/homeassistant/components/anthropic/repairs.py
@@ -58,7 +58,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
         if entry.entry_id in self._model_list_cache:
             model_list = self._model_list_cache[entry.entry_id]
         else:
-            client = entry.runtime_data
+            client = entry.runtime_data.client
             model_list = [
                 model_option
                 for model_option in await get_model_list(client)

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -4,7 +4,7 @@ import datetime
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
-from anthropic import AuthenticationError, RateLimitError
+from anthropic import APITimeoutError, AuthenticationError, RateLimitError
 from anthropic.types import (
     CitationsWebSearchResultLocation,
     CitationWebSearchResultLocationParam,
@@ -28,6 +28,7 @@ import voluptuous as vol
 
 from homeassistant.components import conversation
 from homeassistant.components.anthropic.const import (
+    AVAILABILITY_CHECK_PERIOD,
     CONF_CHAT_MODEL,
     CONF_CODE_EXECUTION,
     CONF_THINKING_BUDGET,
@@ -63,7 +64,7 @@ from . import (
     create_web_search_result_block,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_entity(
@@ -148,6 +149,11 @@ async def test_auth_error_handling(
     assert result.response.error_code == "unknown", result
 
     await hass.async_block_till_done()
+
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
 
@@ -157,6 +163,212 @@ async def test_auth_error_handling(
     assert "context" in flow
     assert flow["context"]["source"] == SOURCE_REAUTH
     assert flow["context"]["entry_id"] == mock_config_entry.entry_id
+
+
+@freeze_time("2026-02-27 12:00:00")
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_error_handling(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test making entity unavailable on connection error."""
+    mock_create_stream.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    result = await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == "unknown", result
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Try again
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_create_stream.side_effect = RateLimitError(
+        message=None,
+        response=Response(status_code=429, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+
+    # Get a different error meaning the connection is restored
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check state is back to normal
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "2026-02-27T12:00:00+00:00"
+
+    # Check that the background check is not running
+    async_fire_time_changed(
+        hass,
+        datetime.datetime.now(datetime.UTC)
+        + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD),
+    )
+    await hass.async_block_till_done()
+    mock_model_list.assert_not_awaited()
+
+
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_check_reauth(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test authentication error during background availability check."""
+    mock_create_stream.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_model_list.side_effect = AuthenticationError(
+        message="Invalid API key",
+        response=Response(status_code=403, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+
+    # Wait for background check to run and fail
+    assert mock_model_list.await_count == 0
+    test_time = datetime.datetime.now(datetime.UTC)
+    async_fire_time_changed(
+        hass, test_time + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD)
+    )
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Check that the background check is not running anymore
+    async_fire_time_changed(
+        hass, test_time + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD * 2)
+    )
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    # Check that a reauth flow has been created
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert "context" in flow
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id
+
+
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_restore_non_connectivity(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test background availability check restore on non-connectivity error."""
+    mock_create_stream.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_model_list.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Wait for background check to run and fail
+    assert mock_model_list.await_count == 0
+    test_time = datetime.datetime.now(datetime.UTC)
+    async_fire_time_changed(
+        hass, test_time + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD)
+    )
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Now make the background check fail with non-connectivity error
+    mock_model_list.side_effect = RateLimitError(
+        message=None,
+        response=Response(status_code=429, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+    async_fire_time_changed(
+        hass, test_time + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD * 2)
+    )
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    # Check that state is back to normal since the error is not connectivity related
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state != "unavailable"
+
+    # Check that the background check is not running anymore
+    async_fire_time_changed(
+        hass, test_time + datetime.timedelta(seconds=AVAILABILITY_CHECK_PERIOD * 3)
+    )
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
 
 
 async def test_template_error(

--- a/tests/components/anthropic/test_repairs.py
+++ b/tests/components/anthropic/test_repairs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.components.anthropic import AnthropicRuntimeData
 from homeassistant.components.anthropic.const import CONF_CHAT_MODEL, DOMAIN
 from homeassistant.config_entries import ConfigEntryState, ConfigSubentry
 from homeassistant.core import HomeAssistant
@@ -38,7 +39,7 @@ def _make_entry(
     )
     entry.add_to_hass(hass)
     object.__setattr__(entry, "state", ConfigEntryState.LOADED)
-    entry.runtime_data = MagicMock()
+    entry.runtime_data = AnthropicRuntimeData(hass, entry, MagicMock())
     return entry
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set the entity states to 'unavailable' when there is a reasonable doubt request would succeed.

If during conversation or AI Task data generation we get a connectivity issue, we will make all entities that belong to the same config entry as unavailable. When this happens, we start checking the availability every minute. If the entity is available, there is no periodic availability check. Once we receive a successful response or non-connectivity error, the entity states are restored.
However if we receive an auth error, we make the entities unavailable, but don't run background availability checks, waiting for the user to complete the reauth flow and reload the config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
