### PR TITLE
Add Trinnov Altitude integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1753,6 +1753,8 @@ build.json @home-assistant/supervisor
 /tests/components/trend/ @jpbede
 /homeassistant/components/triggercmd/ @rvmey
 /tests/components/triggercmd/ @rvmey
+/homeassistant/components/trinnov_altitude/ @binarylogic
+/tests/components/trinnov_altitude/ @binarylogic
 /homeassistant/components/tts/ @home-assistant/core
 /tests/components/tts/ @home-assistant/core
 /homeassistant/components/tuya/ @Tuya @zlinoliver

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -1,0 +1,53 @@
+"""The Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
+from trinnov_altitude.trinnov_altitude import TrinnovAltitude
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN
+
+PLATFORMS: list[str] = [Platform.REMOTE]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry for Trinnov Altitude."""
+
+    host = entry.data[CONF_HOST]
+    client = TrinnovAltitude(host=host)
+
+    try:
+        await client.connect()
+    except (ConnectionFailedError, ConnectionTimeoutError) as err:
+        await client.disconnect()
+        raise ConfigEntryNotReady(f"Unable to connect to {host}: {err}") from err
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
+    async def disconnect(event: Event) -> None:
+        await client.disconnect()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, disconnect)
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Trinnov Altitude config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        client = hass.data[DOMAIN].pop(entry.entry_id)
+        await client.disconnect()
+
+    return unload_ok

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import Event, HomeAssistant
 
 from .const import CLIENT_ID, DOMAIN
 
-PLATFORMS: list[str] = [Platform.REMOTE]
+PLATFORMS: list[str] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import Event, HomeAssistant
 
 from .const import CLIENT_ID, DOMAIN
 
-PLATFORMS: list[str] = [Platform.MEDIA_PLAYER, Platform.REMOTE]
+PLATFORMS: list[str] = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.REMOTE]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -14,7 +14,9 @@ PLATFORMS: list[str] = [
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.REMOTE,
+    Platform.SENSOR,
     Platform.SELECT,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -17,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for Trinnov Altitude."""
 
     host = entry.data[CONF_HOST].strip()
-    mac = entry.data[CONF_MAC].strip()
+    mac = entry.data.get(CONF_MAC, "").strip()
     device = TrinnovAltitude(host=host, mac=mac, client_id=CLIENT_ID)
 
     # Spawn a task to start listening for events from the device
@@ -46,5 +46,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         client = hass.data[DOMAIN].pop(entry.entry_id)
         await client.disconnect()
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN)
 
     return unload_ok

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -10,7 +10,12 @@ from homeassistant.core import Event, HomeAssistant
 
 from .const import CLIENT_ID, DOMAIN
 
-PLATFORMS: list[str] = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.REMOTE]
+PLATFORMS: list[str] = [
+    Platform.MEDIA_PLAYER,
+    Platform.NUMBER,
+    Platform.REMOTE,
+    Platform.SELECT,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from trinnov_altitude.client import TrinnovAltitudeClient
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import CLIENT_ID, DOMAIN
 
-PLATFORMS: list[str] = [
+PLATFORMS: list[Platform] = [
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.REMOTE,
@@ -26,11 +28,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     host = entry.data[CONF_HOST].strip()
     mac = entry.data.get(CONF_MAC, "").strip() or None
     device = TrinnovAltitudeClient(host=host, mac=mac, client_id=CLIENT_ID)
-    device.state.id = entry.unique_id
 
-    await device.start()
+    try:
+        await device.start()
+        await device.wait_synced()
+    except (ConnectionFailedError, ConnectionTimeoutError, TimeoutError) as err:
+        await device.stop()
+        raise ConfigEntryNotReady(
+            f"Could not connect to Trinnov Altitude at {host}"
+        ) from err
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = device
+    entry.runtime_data = device
 
     async def stop(_event: Event) -> None:
         await device.stop()
@@ -48,9 +56,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        client = hass.data[DOMAIN].pop(entry.entry_id)
-        await client.stop()
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
+        await entry.runtime_data.stop()
 
     return unload_ok

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from trinnov_altitude.trinnov_altitude import TrinnovAltitude
+from trinnov_altitude.client import TrinnovAltitudeClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_MAC, EVENT_HOMEASSISTANT_STOP, Platform
@@ -17,21 +17,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for Trinnov Altitude."""
 
     host = entry.data[CONF_HOST].strip()
-    mac = entry.data.get(CONF_MAC, "").strip()
-    device = TrinnovAltitude(host=host, mac=mac, client_id=CLIENT_ID)
+    mac = entry.data.get(CONF_MAC, "").strip() or None
+    device = TrinnovAltitudeClient(host=host, mac=mac, client_id=CLIENT_ID)
+    device.state.id = entry.unique_id
 
-    # Spawn a task to start listening for events from the device
-    device.start_listening()
+    await device.start()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = device
 
-    # If the device is connected, ensure that we disconnect when Home Assistant is stopped
-    async def disconnect(event: Event) -> None:
-        await device.disconnect()
+    async def stop(_event: Event) -> None:
+        await device.stop()
 
-    entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, disconnect)
-    )
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -45,7 +42,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         client = hass.data[DOMAIN].pop(entry.entry_id)
-        await client.disconnect()
+        await client.stop()
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)
 

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -1,0 +1,83 @@
+"""Config flow for Hello World integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
+import voluptuous as vol
+
+from homeassistant import exceptions
+from homeassistant.config_entries import (
+    CONN_CLASS_LOCAL_PUSH,
+    ConfigFlow,
+    ConfigFlowResult,
+)
+from homeassistant.const import CONF_HOST
+
+from . import TrinnovAltitude
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
+
+
+async def validate_input(data: dict) -> dict[str, Any]:
+    """Validate the user input allows us to connect."""
+
+    host = data[CONF_HOST].strip()
+    device = TrinnovAltitude(host=host)
+    device_id = None
+
+    try:
+        await device.connect()
+        device_id = device.id
+    except ConnectionFailedError as exc:
+        raise ConnectionFailed from exc
+    except ConnectionTimeoutError as exc:
+        raise ConnectionTimeout from exc
+    finally:
+        await device.disconnect()
+
+    return {"host": host, "id": device_id, "title": f"Trinnov Altitude ({device_id})"}
+
+
+class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Trinnov Altitude."""
+
+    VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(user_input)
+            except ConnectionFailed:
+                errors["host"] = "invalid_host"
+            except ConnectionTimeout:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(info["id"], raise_on_progress=False)
+                self._abort_if_unique_id_configured(updates={CONF_HOST: info["host"]})
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+
+class ConnectionFailed(exceptions.HomeAssistantError):
+    """Error to indicate that we could not connect to the provided host."""
+
+
+class ConnectionTimeout(exceptions.HomeAssistantError):
+    """Error to indicate that we timed out trying to connect to the provided host."""

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from trinnov_altitude.client import TrinnovAltitudeClient
 from trinnov_altitude.exceptions import (
     ConnectionFailedError,
     ConnectionTimeoutError,
-    InvalidMacAddressOUIError,
     MalformedMacAddressError,
 )
 import voluptuous as vol
@@ -20,7 +20,6 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_MAC
 
-from trinnov_altitude.trinnov_altitude import TrinnovAltitude
 from .const import DOMAIN, NAME  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,29 +42,30 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             host = user_input[CONF_HOST].strip()
-            mac = user_input.get(CONF_MAC, "").strip()
+            mac = user_input.get(CONF_MAC, "").strip() or None
 
+            device = TrinnovAltitudeClient(host=host, mac=mac)
             try:
-                device = TrinnovAltitude(host=host, mac=mac)
-                await device.connect()
+                await device.start()
+                await device.wait_synced()
             except MalformedMacAddressError:
-                errors[CONF_MAC] = "invalid_mac"
-            except InvalidMacAddressOUIError:
                 errors[CONF_MAC] = "invalid_mac"
             except ConnectionFailedError:
                 errors[CONF_HOST] = "invalid_host"
-            except ConnectionTimeoutError:
+            except (ConnectionTimeoutError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception while setting up Trinnov")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(device.id, raise_on_progress=False)
+                await self.async_set_unique_id(device.state.id, raise_on_progress=False)
                 processed_input = {CONF_HOST: host, CONF_MAC: mac}
                 self._abort_if_unique_id_configured(processed_input)
                 return self.async_create_entry(
-                    title=f"{NAME} ({device.id})", data=processed_input
+                    title=f"{NAME} ({device.state.id})", data=processed_input
                 )
+            finally:
+                await device.stop()
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_MAC
 
-from .const import DOMAIN, NAME  # pylint:disable=unused-import
+from .const import DOMAIN, NAME
 
 _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema(
@@ -32,6 +32,7 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Trinnov Altitude."""
 
     VERSION = 1
+    MINOR_VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(
@@ -55,7 +56,7 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
             except (ConnectionTimeoutError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception while setting up Trinnov")
+                _LOGGER.exception("Unexpected exception while setting up device")
                 errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(device.state.id, raise_on_progress=False)

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow for Hello World integration."""
+"""Config flow for Trinnov Altitude integration."""
 
 from __future__ import annotations
 
@@ -20,11 +20,13 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_HOST, CONF_MAC
 
-from . import TrinnovAltitude
+from trinnov_altitude.trinnov_altitude import TrinnovAltitude
 from .const import DOMAIN, NAME  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
-DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str, vol.Optional(CONF_MAC): str})
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_HOST): str, vol.Optional(CONF_MAC, default=""): str}
+)
 
 
 class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -41,7 +43,7 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             host = user_input[CONF_HOST].strip()
-            mac = user_input[CONF_MAC]
+            mac = user_input.get(CONF_MAC, "").strip()
 
             try:
                 device = TrinnovAltitude(host=host, mac=mac)
@@ -55,7 +57,7 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
             except ConnectionTimeoutError:
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception: {e}")
+                _LOGGER.exception("Unexpected exception while setting up Trinnov")
                 errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(device.id, raise_on_progress=False)

--- a/homeassistant/components/trinnov_altitude/const.py
+++ b/homeassistant/components/trinnov_altitude/const.py
@@ -1,8 +1,8 @@
 """Constants for the Trinnov Altitude integration."""
 
 AREA = "Media Room"
+CLIENT_ID = "Home Assistant Trinnov Altitude Integration"
 MANUFACTURER = "Trinnov"
 MODEL = "Altitude"
 NAME = f"{MANUFACTURER} {MODEL}"
 DOMAIN = "trinnov_altitude"
-DEFAULT_HOST = "my-kaleidescape.local"

--- a/homeassistant/components/trinnov_altitude/const.py
+++ b/homeassistant/components/trinnov_altitude/const.py
@@ -1,0 +1,8 @@
+"""Constants for the Trinnov Altitude integration."""
+
+AREA = "Media Room"
+MANUFACTURER = "Trinnov"
+MODEL = "Altitude"
+NAME = f"{MANUFACTURER} {MODEL}"
+DOMAIN = "trinnov_altitude"
+DEFAULT_HOST = "my-kaleidescape.local"

--- a/homeassistant/components/trinnov_altitude/const.py
+++ b/homeassistant/components/trinnov_altitude/const.py
@@ -1,6 +1,5 @@
 """Constants for the Trinnov Altitude integration."""
 
-AREA = "Media Room"
 CLIENT_ID = "Home Assistant Trinnov Altitude Integration"
 MANUFACTURER = "Trinnov"
 MODEL = "Altitude"

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -1,0 +1,53 @@
+"""Base Entity for Trinnov Altitude."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import AREA, DOMAIN, MANUFACTURER, MODEL, NAME
+
+if TYPE_CHECKING:
+    from trinnov_altitude.messages import Message
+    from trinnov_altitude.trinnov_altitude import TrinnovAltitude
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TrinnovAltitudeEntity(Entity):
+    """Defines a base Trinnov Altitude entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, device: TrinnovAltitude) -> None:
+        """Initialize entity."""
+        self._device = device
+
+        self._attr_unique_id = device.id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            # Instead of setting the device name to the entity name,
+            # this should be updated to set has_entity_name = True
+            name=f"{NAME} ({device.id})",
+            model=MODEL,
+            manufacturer=MANUFACTURER,
+            sw_version=f"{device.version}",
+            suggested_area=AREA,
+            configuration_url=f"http://{device.host}",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register update listener."""
+
+        @callback
+        def _update(event: Message) -> None:
+            """Handle device state changes."""
+            self.async_write_ha_state()
+
+        self._device.register_callback(_update)
+        self.async_on_remove(self._device.disconnect)

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    from trinnov_altitude.messages import Message
-    from trinnov_altitude.trinnov_altitude import TrinnovAltitude
+    from trinnov_altitude.client import TrinnovAltitudeClient
+    from trinnov_altitude.protocol import Message
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,21 +27,21 @@ class TrinnovAltitudeEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, device: TrinnovAltitude) -> None:
+    def __init__(self, device: TrinnovAltitudeClient) -> None:
         """Initialize entity."""
 
         self._device = device
         self._callback: Callable[[Any], None] | None = None
 
-        self._attr_unique_id = device.id
+        self._attr_unique_id = str(device.state.id)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(device.id))},
+            identifiers={(DOMAIN, str(device.state.id))},
             # Instead of setting the device name to the entity name,
             # this should be updated to set has_entity_name = True
-            name=f"{NAME} ({device.id})",
+            name=f"{NAME} ({device.state.id})",
             model=MODEL,
             manufacturer=MANUFACTURER,
-            sw_version=f"{device.version}",
+            sw_version=device.state.version,
             configuration_url=f"http://{device.host}",
         )
 
@@ -49,7 +49,7 @@ class TrinnovAltitudeEntity(Entity):
         """Register update listener."""
 
         @callback
-        def _update(event: Message) -> None:
+        def _update(_event: str, _message: Message | None) -> None:
             """Handle device state changes."""
             self.async_write_ha_state()
 

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 from typing import TYPE_CHECKING
 
@@ -12,7 +13,6 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN, MANUFACTURER, MODEL, NAME
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
     from typing import Any
 
     from trinnov_altitude.client import TrinnovAltitudeClient
@@ -36,8 +36,6 @@ class TrinnovAltitudeEntity(Entity):
         self._attr_unique_id = str(device.state.id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(device.state.id))},
-            # Instead of setting the device name to the entity name,
-            # this should be updated to set has_entity_name = True
             name=f"{NAME} ({device.state.id})",
             model=MODEL,
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -9,7 +9,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
-from .const import AREA, DOMAIN, MANUFACTURER, MODEL, NAME
+from .const import DOMAIN, MANUFACTURER, MODEL, NAME
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -42,7 +42,6 @@ class TrinnovAltitudeEntity(Entity):
             model=MODEL,
             manufacturer=MANUFACTURER,
             sw_version=f"{device.version}",
-            suggested_area=AREA,
             configuration_url=f"http://{device.host}",
         )
 
@@ -57,7 +56,7 @@ class TrinnovAltitudeEntity(Entity):
         self._callback = _update
         self._device.register_callback(self._callback)
 
-    async def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Deregister update listener."""
 
         if self._callback is not None:

--- a/homeassistant/components/trinnov_altitude/manifest.json
+++ b/homeassistant/components/trinnov_altitude/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "trinnov_altitude",
+  "name": "Trinnov Altitude",
+  "codeowners": ["@binarylogic"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/trinnov_altitude",
+  "iot_class": "local_push",
+  "loggers": ["trinnov_altitude"],
+  "requirements": ["trinnov_altitude==0.1"]
+}

--- a/homeassistant/components/trinnov_altitude/manifest.json
+++ b/homeassistant/components/trinnov_altitude/manifest.json
@@ -4,7 +4,8 @@
   "codeowners": ["@binarylogic"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/trinnov_altitude",
+  "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["trinnov_altitude"],
-  "requirements": ["trinnov_altitude==0.1"]
+  "requirements": ["trinnov-altitude==3.0.0"]
 }

--- a/homeassistant/components/trinnov_altitude/manifest.json
+++ b/homeassistant/components/trinnov_altitude/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["trinnov_altitude"],
-  "requirements": ["trinnov-altitude==3.0.0"]
+  "requirements": ["trinnov-altitude==3.1.0"]
 }

--- a/homeassistant/components/trinnov_altitude/manifest.json
+++ b/homeassistant/components/trinnov_altitude/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["trinnov_altitude"],
-  "requirements": ["trinnov-altitude==3.1.0"]
+  "requirements": ["trinnov-altitude==3.1.0"],
+  "quality_scale": "bronze"
 }

--- a/homeassistant/components/trinnov_altitude/media_player.py
+++ b/homeassistant/components/trinnov_altitude/media_player.py
@@ -11,8 +11,8 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
 )
 from homeassistant.exceptions import HomeAssistantError
+from trinnov_altitude.exceptions import NoMacAddressError
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the media player platform from a config entry."""
-    async_add_entities([TrinnovAltitudeMediaPlayer(hass.data[DOMAIN][entry.entry_id])])
+    async_add_entities([TrinnovAltitudeMediaPlayer(entry.runtime_data)])
 
 
 class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
@@ -55,7 +55,12 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
 
     async def async_turn_on(self) -> None:
         """Power on."""
-        self._device.power_on()
+        try:
+            self._device.power_on()
+        except NoMacAddressError as exc:
+            raise HomeAssistantError(
+                "Device is not configured with a MAC address. Add the MAC address in the integration configuration to power it on"
+            ) from exc
 
     async def async_turn_off(self) -> None:
         """Power off."""

--- a/homeassistant/components/trinnov_altitude/media_player.py
+++ b/homeassistant/components/trinnov_altitude/media_player.py
@@ -1,0 +1,111 @@
+"""Media player for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the media player platform from a config entry."""
+    async_add_entities([TrinnovAltitudeMediaPlayer(hass.data[DOMAIN][entry.entry_id])])
+
+
+class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
+    """Representation of a Trinnov Altitude device."""
+
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
+    _attr_name = None
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+    )
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        """Mute/unmute volume."""
+        await self._device.mute_set(mute)
+
+    async def async_select_source(self, source: str) -> None:
+        """Select source."""
+        try:
+            await self._device.source_set_by_name(source)
+        except ValueError as exc:
+            raise HomeAssistantError(str(exc)) from exc
+
+    async def async_turn_on(self) -> None:
+        """Power on."""
+        self._device.power_on()
+
+    async def async_turn_off(self) -> None:
+        """Power off."""
+        await self._device.power_off()
+
+    async def async_volume_up(self) -> None:
+        """Volume up."""
+        await self._device.volume_up()
+
+    async def async_volume_down(self) -> None:
+        """Volume down."""
+        await self._device.volume_down()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level (0..1)."""
+        await self._device.volume_percentage_set(volume * 100.0)
+
+    @property
+    def available(self) -> bool:
+        """Return if device is available."""
+        return self._device.power_on_available() or self._device.connected
+
+    @property
+    def input_source(self) -> str | None:
+        """Current source."""
+        return self._device.state.source
+
+    @property
+    def input_source_list(self) -> list[str] | None:
+        """Available source list."""
+        return list(self._device.state.sources.values())
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Boolean if volume is currently muted."""
+        return self._device.state.mute
+
+    @property
+    def state(self) -> MediaPlayerState:
+        """State of device."""
+        if not self._device.connected or not self._device.state.synced:
+            return MediaPlayerState.OFF
+        if self._device.state.source_format:
+            return MediaPlayerState.PLAYING
+        return MediaPlayerState.IDLE
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level (0..1)."""
+        percentage = self._device.volume_percentage
+        if percentage is None:
+            return None
+        return percentage / 100.0

--- a/homeassistant/components/trinnov_altitude/number.py
+++ b/homeassistant/components/trinnov_altitude/number.py
@@ -1,0 +1,42 @@
+"""Number entities for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.number import NumberEntity, NumberMode
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up number entities from config entry."""
+    async_add_entities([TrinnovAltitudeVolumeNumber(hass.data[DOMAIN][entry.entry_id])])
+
+
+class TrinnovAltitudeVolumeNumber(TrinnovAltitudeEntity, NumberEntity):
+    """Volume number entity."""
+
+    _attr_name = None
+    _attr_native_min_value = -120.0
+    _attr_native_max_value = 20.0
+    _attr_native_step = 0.5
+    _attr_mode = NumberMode.SLIDER
+    _attr_translation_key = "volume"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return current volume."""
+        return self._device.state.volume
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set volume value."""
+        await self._device.volume_set(value)

--- a/homeassistant/components/trinnov_altitude/number.py
+++ b/homeassistant/components/trinnov_altitude/number.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from homeassistant.components.number import NumberEntity, NumberMode
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -19,7 +18,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up number entities from config entry."""
-    async_add_entities([TrinnovAltitudeVolumeNumber(hass.data[DOMAIN][entry.entry_id])])
+    async_add_entities([TrinnovAltitudeVolumeNumber(entry.runtime_data)])
 
 
 class TrinnovAltitudeVolumeNumber(TrinnovAltitudeEntity, NumberEntity):

--- a/homeassistant/components/trinnov_altitude/quality_scale.yaml
+++ b/homeassistant/components/trinnov_altitude/quality_scale.yaml
@@ -1,0 +1,24 @@
+rules:
+  # Bronze
+  config-flow: done
+  test-before-configure: done
+  unique-config-entry: done
+  config-flow-test-coverage: done
+  runtime-data: done
+  test-before-setup: done
+  appropriate-polling: done
+  entity-unique-id: done
+  has-entity-name: done
+  entity-event-setup:
+    status: exempt
+    comment: The integration does not use event entities.
+  dependency-transparency: done
+  action-setup:
+    status: exempt
+    comment: The integration only uses platform services.
+  common-modules: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-actions: done
+  brands: done

--- a/homeassistant/components/trinnov_altitude/remote.py
+++ b/homeassistant/components/trinnov_altitude/remote.py
@@ -1,0 +1,58 @@
+"""Remote for Trinnov integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.remote import RemoteEntity
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the platform from a config entry."""
+    entities = [TrinnovAltitudeRemote(hass.data[DOMAIN][entry.entry_id])]
+    async_add_entities(entities)
+
+
+VALID_COMMANDS = {
+    "select",
+}
+
+
+class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
+    """Representation of a Trinnov Altitude device."""
+
+    _attr_name = None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return True
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the device on."""
+        await self._device.leave_standby()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the device off."""
+        await self._device.enter_standby()
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send a command to a device."""
+        for cmd in command:
+            if cmd not in VALID_COMMANDS:
+                raise HomeAssistantError(f"{cmd} is not a known command")
+            await getattr(self._device, cmd)()

--- a/homeassistant/components/trinnov_altitude/remote.py
+++ b/homeassistant/components/trinnov_altitude/remote.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from trinnov_altitude.exceptions import NoMacAddressError, NotConnectedError
+
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.exceptions import HomeAssistantError
 
@@ -28,7 +30,40 @@ async def async_setup_entry(
 
 
 VALID_COMMANDS = {
-    "select",
+    "acoustic_correction_off",
+    "acoustic_correction_on",
+    "acoustic_correction_toggle",
+    "bypass_off",
+    "bypass_on",
+    "bypass_toggle",
+    "dim_off",
+    "dim_on",
+    "dim_toggle",
+    "front_display_off",
+    "front_display_on",
+    "front_display_toggle",
+    "level_alignment_off",
+    "level_alignment_on",
+    "level_alignment_toggle",
+    "mute_off",
+    "mute_on",
+    "mute_toggle",
+    "page_down",
+    "page_up",
+    "preset_load",
+    "quick_optimized_off",
+    "quick_optimized_on",
+    "quick_optimized_toggle",
+    "remapping_mode_set",
+    "source_set",
+    "time_alignment_off",
+    "time_alignment_on",
+    "time_alignment_toggle",
+    "upmixer_set",
+    "volume_down",
+    "volume_ramp",
+    "volume_set",
+    "volume_up",
 }
 
 
@@ -40,19 +75,67 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return True
+        return self._device.connected()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
-        await self._device.leave_standby()
+        try:
+            self._device.power_on()
+        except NoMacAddressError as exc:
+            raise HomeAssistantError(
+                "Trinnov Altitude is not configured with a mac address, which is required to power it on."
+            ) from exc
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
-        await self._device.enter_standby()
+        await self._device.power_off()
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to a device."""
         for cmd in command:
-            if cmd not in VALID_COMMANDS:
-                raise HomeAssistantError(f"{cmd} is not a known command")
-            await getattr(self._device, cmd)()
+            try:
+                cmd_parts = cmd.split()  # Split the cmd string by spaces
+                method_name = cmd_parts[0]  # The first token is the method name
+                args_strings = cmd_parts[1:]  # The rest of the tokens are the arguments
+                typed_args = [self._cast_to_primitive_type(arg) for arg in args_strings]
+
+                if method_name not in VALID_COMMANDS:
+                    raise HomeAssistantError(
+                        f"{cmd} is not a known Trinnov Altitude command"
+                    )
+
+                await getattr(self._device, method_name)(*typed_args)
+            except NotConnectedError as exc:
+                raise HomeAssistantError(
+                    "Trinnov Altitude must be powered on before sending commands"
+                ) from exc
+            except TypeError as exc:
+                raise HomeAssistantError(
+                    f"Command arguments are invalid: {exc}"
+                ) from exc
+
+    def _cast_to_primitive_type(self, arg: str) -> bool | int | float | str:
+        """Casts command arguments to primitive types that the device expects."""
+
+        # Convert to lowercase for boolean checks
+        arg_lower = arg.lower()
+
+        if arg_lower == "true":
+            return True
+
+        if arg_lower == "false":
+            return False
+
+        # Attempt to convert to int or float
+        try:
+            return int(arg)
+        except ValueError:
+            pass
+
+        try:
+            return float(arg)
+        except ValueError:
+            pass
+
+        # Return as string if all else fails
+        return arg

--- a/homeassistant/components/trinnov_altitude/remote.py
+++ b/homeassistant/components/trinnov_altitude/remote.py
@@ -1,6 +1,7 @@
 """Remote for Trinnov integration."""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from trinnov_altitude.command_bridge import (
@@ -13,7 +14,6 @@ from trinnov_altitude.exceptions import NoMacAddressError, NotConnectedError
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -29,7 +29,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the platform from a config entry."""
-    entities = [TrinnovAltitudeRemote(hass.data[DOMAIN][entry.entry_id])]
+    entities = [TrinnovAltitudeRemote(entry.runtime_data)]
     async_add_entities(entities)
 
 
@@ -49,7 +49,7 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
             self._device.power_on()
         except NoMacAddressError as exc:
             raise HomeAssistantError(
-                "Trinnov Altitude is not configured with a mac address, which is required to power it on."
+                "Device is not configured with a MAC address. Add the MAC address in the integration configuration to power it on"
             ) from exc
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/trinnov_altitude/remote.py
+++ b/homeassistant/components/trinnov_altitude/remote.py
@@ -1,10 +1,13 @@
 """Remote for Trinnov integration."""
 
 from __future__ import annotations
-
-import shlex
 from typing import TYPE_CHECKING
 
+from trinnov_altitude.command_bridge import (
+    VALID_COMMANDS,
+    normalize_args,
+    parse_command,
+)
 from trinnov_altitude.exceptions import NoMacAddressError, NotConnectedError
 
 from homeassistant.components.remote import RemoteEntity
@@ -30,44 +33,6 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-VALID_COMMANDS = {
-    "acoustic_correction_off",
-    "acoustic_correction_on",
-    "acoustic_correction_toggle",
-    "bypass_off",
-    "bypass_on",
-    "bypass_toggle",
-    "dim_off",
-    "dim_on",
-    "dim_toggle",
-    "front_display_off",
-    "front_display_on",
-    "front_display_toggle",
-    "level_alignment_off",
-    "level_alignment_on",
-    "level_alignment_toggle",
-    "mute_off",
-    "mute_on",
-    "mute_toggle",
-    "page_down",
-    "page_up",
-    "preset_load",
-    "quick_optimized_off",
-    "quick_optimized_on",
-    "quick_optimized_toggle",
-    "remapping_mode_set",
-    "source_set",
-    "time_alignment_off",
-    "time_alignment_on",
-    "time_alignment_toggle",
-    "upmixer_set",
-    "volume_down",
-    "volume_ramp",
-    "volume_set",
-    "volume_up",
-}
-
-
 class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
     """Representation of a Trinnov Altitude device."""
 
@@ -76,7 +41,7 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return self._device.connected()
+        return self._device.connected and self._device.state.synced
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
@@ -94,19 +59,17 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to a device."""
         for cmd in command:
+            method_name: str | None = None
             try:
-                cmd_parts = shlex.split(cmd)
-                if not cmd_parts:
-                    raise HomeAssistantError("Command cannot be empty")
-                method_name = cmd_parts[0]
-                args_strings = cmd_parts[1:]
-                typed_args = [self._cast_to_primitive_type(arg) for arg in args_strings]
+                parsed = parse_command(cmd)
+                method_name = parsed.method_name
 
                 if method_name not in VALID_COMMANDS:
                     raise HomeAssistantError(
-                        f"{cmd} is not a known Trinnov Altitude command"
+                        f"'{method_name}' is not a valid Trinnov Altitude command"
                     )
 
+                typed_args = normalize_args(method_name, parsed.args)
                 await getattr(self._device, method_name)(*typed_args)
             except NotConnectedError as exc:
                 raise HomeAssistantError(
@@ -114,31 +77,7 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
                 ) from exc
             except TypeError as exc:
                 raise HomeAssistantError(
-                    f"Command arguments are invalid: {exc}"
+                    f"Invalid arguments for command '{method_name or cmd}'. Expected format: <command> <arg1> <arg2> ..."
                 ) from exc
-
-    def _cast_to_primitive_type(self, arg: str) -> bool | int | float | str:
-        """Casts command arguments to primitive types that the device expects."""
-
-        # Convert to lowercase for boolean checks
-        arg_lower = arg.lower()
-
-        if arg_lower == "true":
-            return True
-
-        if arg_lower == "false":
-            return False
-
-        # Attempt to convert to int or float
-        try:
-            return int(arg)
-        except ValueError:
-            pass
-
-        try:
-            return float(arg)
-        except ValueError:
-            pass
-
-        # Return as string if all else fails
-        return arg
+            except ValueError as exc:
+                raise HomeAssistantError(str(exc)) from exc

--- a/homeassistant/components/trinnov_altitude/remote.py
+++ b/homeassistant/components/trinnov_altitude/remote.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import TYPE_CHECKING
 
 from trinnov_altitude.exceptions import NoMacAddressError, NotConnectedError
@@ -94,9 +95,11 @@ class TrinnovAltitudeRemote(TrinnovAltitudeEntity, RemoteEntity):
         """Send a command to a device."""
         for cmd in command:
             try:
-                cmd_parts = cmd.split()  # Split the cmd string by spaces
-                method_name = cmd_parts[0]  # The first token is the method name
-                args_strings = cmd_parts[1:]  # The rest of the tokens are the arguments
+                cmd_parts = shlex.split(cmd)
+                if not cmd_parts:
+                    raise HomeAssistantError("Command cannot be empty")
+                method_name = cmd_parts[0]
+                args_strings = cmd_parts[1:]
                 typed_args = [self._cast_to_primitive_type(arg) for arg in args_strings]
 
                 if method_name not in VALID_COMMANDS:

--- a/homeassistant/components/trinnov_altitude/select.py
+++ b/homeassistant/components/trinnov_altitude/select.py
@@ -10,7 +10,6 @@ from trinnov_altitude.const import UpmixerMode
 from homeassistant.components.select import SelectEntity
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -23,7 +22,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up select entities from config entry."""
-    device = hass.data[DOMAIN][entry.entry_id]
+    device = entry.runtime_data
     async_add_entities(
         [
             TrinnovAltitudeSourceSelect(device),
@@ -89,6 +88,7 @@ class TrinnovAltitudePresetSelect(TrinnovAltitudeEntity, SelectEntity):
             if name == option:
                 await self._device.preset_set(preset_id)
                 return
+        raise HomeAssistantError(f"Invalid preset option: {option}")
 
 
 class TrinnovAltitudeUpmixerSelect(TrinnovAltitudeEntity, SelectEntity):

--- a/homeassistant/components/trinnov_altitude/select.py
+++ b/homeassistant/components/trinnov_altitude/select.py
@@ -1,0 +1,127 @@
+"""Select entities for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from trinnov_altitude.command_bridge import parse_upmixer_mode
+from trinnov_altitude.const import UpmixerMode
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up select entities from config entry."""
+    device = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            TrinnovAltitudeSourceSelect(device),
+            TrinnovAltitudePresetSelect(device),
+            TrinnovAltitudeUpmixerSelect(device),
+        ]
+    )
+
+
+class TrinnovAltitudeSourceSelect(TrinnovAltitudeEntity, SelectEntity):
+    """Representation of a Trinnov Altitude source select entity."""
+
+    _attr_translation_key = "source"
+    _attr_name = "Source"
+
+    def __init__(self, device) -> None:
+        """Initialize source select entity."""
+        super().__init__(device)
+        self._attr_unique_id = f"{self._attr_unique_id}-source-select"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current source."""
+        return self._device.state.source
+
+    @property
+    def options(self) -> list[str]:
+        """Return available source options."""
+        return list(self._device.state.sources.values())
+
+    async def async_select_option(self, option: str) -> None:
+        """Change selected source."""
+        try:
+            await self._device.source_set_by_name(option)
+        except ValueError as exc:
+            raise HomeAssistantError(str(exc)) from exc
+
+
+class TrinnovAltitudePresetSelect(TrinnovAltitudeEntity, SelectEntity):
+    """Representation of a Trinnov Altitude preset select entity."""
+
+    _attr_translation_key = "preset"
+    _attr_name = "Preset"
+
+    def __init__(self, device) -> None:
+        """Initialize preset select entity."""
+        super().__init__(device)
+        self._attr_unique_id = f"{self._attr_unique_id}-preset-select"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current preset."""
+        return self._device.state.preset
+
+    @property
+    def options(self) -> list[str]:
+        """Return available preset options."""
+        return list(self._device.state.presets.values())
+
+    async def async_select_option(self, option: str) -> None:
+        """Change selected preset."""
+        for preset_id, name in self._device.state.presets.items():
+            if name == option:
+                await self._device.preset_set(preset_id)
+                return
+
+
+class TrinnovAltitudeUpmixerSelect(TrinnovAltitudeEntity, SelectEntity):
+    """Representation of a Trinnov Altitude upmixer select entity."""
+
+    _attr_translation_key = "upmixer"
+    _attr_name = "Upmixer"
+
+    def __init__(self, device) -> None:
+        """Initialize upmixer select entity."""
+        super().__init__(device)
+        self._attr_unique_id = f"{self._attr_unique_id}-upmixer-select"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current upmixer."""
+        upmixer = self._device.state.upmixer
+        if upmixer is None:
+            return None
+        try:
+            return parse_upmixer_mode(upmixer).value
+        except ValueError:
+            return None
+
+    @property
+    def options(self) -> list[str]:
+        """Return available upmixer options."""
+        return [mode.value for mode in UpmixerMode]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change selected upmixer."""
+        try:
+            mode = parse_upmixer_mode(option)
+        except ValueError as exc:
+            raise HomeAssistantError(str(exc)) from exc
+        await self._device.upmixer_set(mode)

--- a/homeassistant/components/trinnov_altitude/sensor.py
+++ b/homeassistant/components/trinnov_altitude/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import EntityCategory
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -123,7 +122,7 @@ async def async_setup_entry(
     """Set up sensor entities from config entry."""
     async_add_entities(
         [
-            TrinnovAltitudeSensor(hass.data[DOMAIN][entry.entry_id], description)
+            TrinnovAltitudeSensor(entry.runtime_data, description)
             for description in SENSORS
         ]
     )

--- a/homeassistant/components/trinnov_altitude/sensor.py
+++ b/homeassistant/components/trinnov_altitude/sensor.py
@@ -1,0 +1,167 @@
+"""Sensor entities for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.typing import StateType
+    from trinnov_altitude.state import AltitudeState
+
+
+class PowerStatus(StrEnum):
+    """Power status states."""
+
+    OFF = "off"
+    BOOTING = "booting"
+    READY = "ready"
+
+
+class ConnectionStatus(StrEnum):
+    """Connection status states."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTED = "connected"
+
+
+class SyncStatus(StrEnum):
+    """Sync status states."""
+
+    SYNCING = "syncing"
+    SYNCED = "synced"
+
+
+@dataclass(frozen=True, kw_only=True)
+class TrinnovAltitudeSensorEntityDescription(SensorEntityDescription):
+    """Describes Trinnov Altitude sensor entity."""
+
+    value_fn: Callable[[AltitudeState], StateType]
+
+
+POWER_STATUS_ICONS = {
+    PowerStatus.OFF: "mdi:power-off",
+    PowerStatus.BOOTING: "mdi:power-settings",
+    PowerStatus.READY: "mdi:power-on",
+}
+
+
+SENSORS: tuple[TrinnovAltitudeSensorEntityDescription, ...] = (
+    TrinnovAltitudeSensorEntityDescription(
+        key="power_status",
+        translation_key="power_status",
+        name="Power Status",
+        device_class=SensorDeviceClass.ENUM,
+        options=[status.value for status in PowerStatus],
+        value_fn=lambda _state: PowerStatus.READY,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="connection_status",
+        translation_key="connection_status",
+        name="Connection Status",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[status.value for status in ConnectionStatus],
+        value_fn=lambda _state: ConnectionStatus.CONNECTED,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="sync_status",
+        translation_key="sync_status",
+        name="Sync Status",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[status.value for status in SyncStatus],
+        value_fn=lambda state: SyncStatus.SYNCED if state.synced else SyncStatus.SYNCING,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="version",
+        translation_key="version",
+        name="Version",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: state.version,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="decoder",
+        translation_key="decoder",
+        name="Decoder",
+        value_fn=lambda state: state.decoder,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="source_format",
+        translation_key="source_format",
+        name="Source Format",
+        value_fn=lambda state: state.source_format,
+    ),
+    TrinnovAltitudeSensorEntityDescription(
+        key="audiosync",
+        translation_key="audiosync",
+        name="Audiosync",
+        value_fn=lambda state: state.audiosync,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up sensor entities from config entry."""
+    async_add_entities(
+        [
+            TrinnovAltitudeSensor(hass.data[DOMAIN][entry.entry_id], description)
+            for description in SENSORS
+        ]
+    )
+
+
+class TrinnovAltitudeSensor(TrinnovAltitudeEntity, SensorEntity):
+    """Representation of a Trinnov Altitude sensor."""
+
+    entity_description: TrinnovAltitudeSensorEntityDescription
+
+    def __init__(self, device, entity_description) -> None:
+        """Initialize sensor."""
+        super().__init__(device)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{self._attr_unique_id}-{entity_description.key}"
+
+    @property
+    def native_value(self) -> StateType:
+        """Return value of sensor."""
+        if self.entity_description.key == "power_status":
+            if not self._device.connected:
+                return PowerStatus.OFF
+            if not self._device.state.synced:
+                return PowerStatus.BOOTING
+            return PowerStatus.READY
+
+        if self.entity_description.key == "connection_status":
+            return (
+                ConnectionStatus.CONNECTED
+                if self._device.connected
+                else ConnectionStatus.DISCONNECTED
+            )
+
+        return self.entity_description.value_fn(self._device.state)
+
+    @property
+    def icon(self) -> str | None:
+        """Return dynamic icon for power status sensor."""
+        if self.entity_description.key == "power_status":
+            return POWER_STATUS_ICONS.get(self.native_value)
+        return None

--- a/homeassistant/components/trinnov_altitude/strings.json
+++ b/homeassistant/components/trinnov_altitude/strings.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/trinnov_altitude/strings.json
+++ b/homeassistant/components/trinnov_altitude/strings.json
@@ -1,18 +1,21 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]"
-        }
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "invalid_mac": "Invalid MAC address",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "mac": "MAC address"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/trinnov_altitude/strings.json
+++ b/homeassistant/components/trinnov_altitude/strings.json
@@ -17,5 +17,70 @@
         }
       }
     }
+  },
+  "entity": {
+    "number": {
+      "volume": {
+        "name": "Volume"
+      }
+    },
+    "select": {
+      "preset": {
+        "name": "Preset"
+      },
+      "source": {
+        "name": "Source"
+      },
+      "upmixer": {
+        "name": "Upmixer"
+      }
+    },
+    "sensor": {
+      "audiosync": {
+        "name": "Audiosync"
+      },
+      "connection_status": {
+        "name": "Connection Status",
+        "state": {
+          "connected": "Connected",
+          "disconnected": "Disconnected"
+        }
+      },
+      "decoder": {
+        "name": "Decoder"
+      },
+      "power_status": {
+        "name": "Power Status",
+        "state": {
+          "booting": "Booting",
+          "off": "Off",
+          "ready": "Ready"
+        }
+      },
+      "source_format": {
+        "name": "Source Format"
+      },
+      "sync_status": {
+        "name": "Sync Status",
+        "state": {
+          "synced": "Synced",
+          "syncing": "Syncing"
+        }
+      },
+      "version": {
+        "name": "Version"
+      }
+    },
+    "switch": {
+      "bypass": {
+        "name": "Bypass"
+      },
+      "dim": {
+        "name": "Dim"
+      },
+      "mute": {
+        "name": "Mute"
+      }
+    }
   }
 }

--- a/homeassistant/components/trinnov_altitude/switch.py
+++ b/homeassistant/components/trinnov_altitude/switch.py
@@ -1,0 +1,95 @@
+"""Switch entities for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+
+from .const import DOMAIN
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+@dataclass(frozen=True, kw_only=True)
+class TrinnovAltitudeSwitchEntityDescription(SwitchEntityDescription):
+    """Describes Trinnov Altitude switch entity."""
+
+    value_fn: Callable[[Any], bool]
+    turn_on_fn: Callable[[Any], Awaitable[None]]
+    turn_off_fn: Callable[[Any], Awaitable[None]]
+
+
+SWITCHES: tuple[TrinnovAltitudeSwitchEntityDescription, ...] = (
+    TrinnovAltitudeSwitchEntityDescription(
+        key="mute",
+        translation_key="mute",
+        name="Mute",
+        value_fn=lambda state: bool(state.mute),
+        turn_on_fn=lambda device: device.mute_set(True),
+        turn_off_fn=lambda device: device.mute_set(False),
+    ),
+    TrinnovAltitudeSwitchEntityDescription(
+        key="dim",
+        translation_key="dim",
+        name="Dim",
+        value_fn=lambda state: bool(state.dim),
+        turn_on_fn=lambda device: device.dim_set(True),
+        turn_off_fn=lambda device: device.dim_set(False),
+    ),
+    TrinnovAltitudeSwitchEntityDescription(
+        key="bypass",
+        translation_key="bypass",
+        name="Bypass",
+        value_fn=lambda state: bool(state.bypass),
+        turn_on_fn=lambda device: device.bypass_set(True),
+        turn_off_fn=lambda device: device.bypass_set(False),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up switch entities from config entry."""
+    async_add_entities(
+        [
+            TrinnovAltitudeSwitch(hass.data[DOMAIN][entry.entry_id], description)
+            for description in SWITCHES
+        ]
+    )
+
+
+class TrinnovAltitudeSwitch(TrinnovAltitudeEntity, SwitchEntity):
+    """Representation of a Trinnov Altitude switch."""
+
+    entity_description: TrinnovAltitudeSwitchEntityDescription
+
+    def __init__(
+        self, device, entity_description: TrinnovAltitudeSwitchEntityDescription
+    ) -> None:
+        """Initialize switch."""
+        super().__init__(device)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{self._attr_unique_id}-{entity_description.key}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if switch is on."""
+        return self.entity_description.value_fn(self._device.state)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn switch on."""
+        await self.entity_description.turn_on_fn(self._device)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn switch off."""
+        await self.entity_description.turn_off_fn(self._device)

--- a/homeassistant/components/trinnov_altitude/switch.py
+++ b/homeassistant/components/trinnov_altitude/switch.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 
-from .const import DOMAIN
 from .entity import TrinnovAltitudeEntity
 
 if TYPE_CHECKING:
@@ -62,7 +61,7 @@ async def async_setup_entry(
     """Set up switch entities from config entry."""
     async_add_entities(
         [
-            TrinnovAltitudeSwitch(hass.data[DOMAIN][entry.entry_id], description)
+            TrinnovAltitudeSwitch(entry.runtime_data, description)
             for description in SWITCHES
         ]
     )

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -740,6 +740,7 @@ FLOWS = {
         "trane",
         "transmission",
         "triggercmd",
+        "trinnov_altitude",
         "tuya",
         "twentemilieu",
         "twilio",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7237,6 +7237,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "trinnov_altitude": {
+      "name": "Trinnov Altitude",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "tuya": {
       "name": "Tuya",
       "integration_type": "hub",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7239,7 +7239,7 @@
     },
     "trinnov_altitude": {
       "name": "Trinnov Altitude",
-      "integration_type": "hub",
+      "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3115,7 +3115,7 @@ transmission-rpc==7.0.3
 triggercmd==0.0.36
 
 # homeassistant.components.trinnov_altitude
-trinnov_altitude==0.1
+trinnov-altitude==3.0.0
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3115,7 +3115,7 @@ transmission-rpc==7.0.3
 triggercmd==0.0.36
 
 # homeassistant.components.trinnov_altitude
-trinnov-altitude==3.0.0
+trinnov-altitude==3.1.0
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3114,6 +3114,9 @@ transmission-rpc==7.0.3
 # homeassistant.components.triggercmd
 triggercmd==0.0.36
 
+# homeassistant.components.trinnov_altitude
+trinnov_altitude==0.1
+
 # homeassistant.components.twinkly
 ttls==1.8.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2618,7 +2618,7 @@ transmission-rpc==7.0.3
 triggercmd==0.0.36
 
 # homeassistant.components.trinnov_altitude
-trinnov_altitude==0.1
+trinnov-altitude==3.0.0
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2618,7 +2618,7 @@ transmission-rpc==7.0.3
 triggercmd==0.0.36
 
 # homeassistant.components.trinnov_altitude
-trinnov-altitude==3.0.0
+trinnov-altitude==3.1.0
 
 # homeassistant.components.twinkly
 ttls==1.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2617,6 +2617,9 @@ transmission-rpc==7.0.3
 # homeassistant.components.triggercmd
 triggercmd==0.0.36
 
+# homeassistant.components.trinnov_altitude
+trinnov_altitude==0.1
+
 # homeassistant.components.twinkly
 ttls==1.8.3
 

--- a/tests/components/trinnov_altitude/__init__.py
+++ b/tests/components/trinnov_altitude/__init__.py
@@ -1,0 +1,4 @@
+"""Tests for Trinnov Altitude."""
+
+MOCK_HOST = "127.0.0.1"
+MOCK_ID = "123456"

--- a/tests/components/trinnov_altitude/__init__.py
+++ b/tests/components/trinnov_altitude/__init__.py
@@ -1,4 +1,5 @@
 """Tests for Trinnov Altitude."""
 
+MOCK_MAC = "c8:7f:54:7a:eb:c2"
 MOCK_HOST = "127.0.0.1"
 MOCK_ID = "123456"

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -1,0 +1,52 @@
+"""Fixtures for Trinnov Altitude integration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.trinnov_altitude.const import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_HOST, MOCK_ID
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="mock_device")
+def fixture_mock_device() -> Generator[None, AsyncMock, None]:
+    """Return a mocked TrinnovAltitude."""
+    with patch(
+        "homeassistant.components.trinnov_altitude.TrinnovAltitude", autospec=True
+    ) as mock:
+        altitude = mock.return_value
+        altitude.connect = AsyncMock(return_value=None)
+        altitude.disconnect = AsyncMock(return_value=None)
+        altitude.host = MOCK_HOST
+        altitude.id = MOCK_ID
+        altitude.version = "VERSION"
+        yield altitude
+
+
+@pytest.fixture(name="mock_config_entry")
+def fixture_mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_ID,
+        version=1,
+        data={CONF_HOST: MOCK_HOST},
+    )
+
+
+@pytest.fixture(name="mock_integration")
+async def fixture_mock_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Return a mock ConfigEntry setup for Kaleidescape integration."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -6,10 +6,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.trinnov_altitude.const import DOMAIN
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_MAC
 from homeassistant.core import HomeAssistant
 
-from . import MOCK_HOST, MOCK_ID
+from . import MOCK_HOST, MOCK_ID, MOCK_MAC
 
 from tests.common import MockConfigEntry
 
@@ -36,7 +36,7 @@ def fixture_mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=MOCK_ID,
         version=1,
-        data={CONF_HOST: MOCK_HOST},
+        data={CONF_HOST: MOCK_HOST, CONF_MAC: MOCK_MAC},
     )
 
 

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -33,9 +33,26 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
         altitude.start = AsyncMock(return_value=None)
         altitude.wait_synced = AsyncMock(return_value=None)
         altitude.stop = AsyncMock(return_value=None)
+        altitude.power_off = AsyncMock(return_value=None)
+        altitude.mute_set = AsyncMock(return_value=None)
+        altitude.source_set_by_name = AsyncMock(return_value=None)
+        altitude.volume_up = AsyncMock(return_value=None)
+        altitude.volume_down = AsyncMock(return_value=None)
+        altitude.volume_percentage_set = AsyncMock(return_value=None)
+        altitude.power_on_available.return_value = True
+        altitude.power_on.return_value = None
+        altitude.volume_percentage = 50.0
         altitude.host = MOCK_HOST
         altitude.connected = True
-        altitude.state = SimpleNamespace(id=MOCK_ID, version="VERSION", synced=True)
+        altitude.state = SimpleNamespace(
+            id=MOCK_ID,
+            version="VERSION",
+            synced=True,
+            source="Apple TV",
+            sources={0: "Apple TV", 1: "Blu-ray"},
+            source_format="PCM",
+            mute=False,
+        )
         yield altitude
 
 

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -15,7 +15,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="mock_device")
-def fixture_mock_device() -> Generator[None, AsyncMock, None]:
+def fixture_mock_device() -> Generator[AsyncMock, None, None]:
     """Return a mocked TrinnovAltitude."""
     with patch(
         "homeassistant.components.trinnov_altitude.TrinnovAltitude", autospec=True
@@ -45,7 +45,7 @@ async def fixture_mock_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
 ) -> MockConfigEntry:
-    """Return a mock ConfigEntry setup for Kaleidescape integration."""
+    """Return a mock ConfigEntry setup for Trinnov Altitude integration."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -36,6 +36,8 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
         altitude.power_off = AsyncMock(return_value=None)
         altitude.mute_set = AsyncMock(return_value=None)
         altitude.source_set_by_name = AsyncMock(return_value=None)
+        altitude.preset_set = AsyncMock(return_value=None)
+        altitude.upmixer_set = AsyncMock(return_value=None)
         altitude.volume_up = AsyncMock(return_value=None)
         altitude.volume_down = AsyncMock(return_value=None)
         altitude.volume_set = AsyncMock(return_value=None)
@@ -54,6 +56,9 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
             source_format="PCM",
             mute=False,
             volume=-35.0,
+            preset="Movie",
+            presets={0: "Movie", 1: "Music"},
+            upmixer="native",
         )
         yield altitude
 

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -38,6 +38,7 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
         altitude.source_set_by_name = AsyncMock(return_value=None)
         altitude.volume_up = AsyncMock(return_value=None)
         altitude.volume_down = AsyncMock(return_value=None)
+        altitude.volume_set = AsyncMock(return_value=None)
         altitude.volume_percentage_set = AsyncMock(return_value=None)
         altitude.power_on_available.return_value = True
         altitude.power_on.return_value = None
@@ -52,6 +53,7 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
             sources={0: "Apple TV", 1: "Blu-ray"},
             source_format="PCM",
             mute=False,
+            volume=-35.0,
         )
         yield altitude
 

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for Trinnov Altitude integration."""
 
 from collections.abc import Generator
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -17,15 +18,24 @@ from tests.common import MockConfigEntry
 @pytest.fixture(name="mock_device")
 def fixture_mock_device() -> Generator[AsyncMock, None, None]:
     """Return a mocked TrinnovAltitude."""
-    with patch(
-        "homeassistant.components.trinnov_altitude.TrinnovAltitude", autospec=True
-    ) as mock:
-        altitude = mock.return_value
-        altitude.connect = AsyncMock(return_value=None)
-        altitude.disconnect = AsyncMock(return_value=None)
+    with (
+        patch(
+            "homeassistant.components.trinnov_altitude.TrinnovAltitudeClient",
+            autospec=True,
+        ) as init_mock,
+        patch(
+            "homeassistant.components.trinnov_altitude.config_flow.TrinnovAltitudeClient",
+            autospec=True,
+        ) as flow_mock,
+    ):
+        altitude = init_mock.return_value
+        flow_mock.return_value = altitude
+        altitude.start = AsyncMock(return_value=None)
+        altitude.wait_synced = AsyncMock(return_value=None)
+        altitude.stop = AsyncMock(return_value=None)
         altitude.host = MOCK_HOST
-        altitude.id = MOCK_ID
-        altitude.version = "VERSION"
+        altitude.connected = True
+        altitude.state = SimpleNamespace(id=MOCK_ID, version="VERSION", synced=True)
         yield altitude
 
 

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -35,6 +35,8 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
         altitude.stop = AsyncMock(return_value=None)
         altitude.power_off = AsyncMock(return_value=None)
         altitude.mute_set = AsyncMock(return_value=None)
+        altitude.dim_set = AsyncMock(return_value=None)
+        altitude.bypass_set = AsyncMock(return_value=None)
         altitude.source_set_by_name = AsyncMock(return_value=None)
         altitude.preset_set = AsyncMock(return_value=None)
         altitude.upmixer_set = AsyncMock(return_value=None)
@@ -54,7 +56,11 @@ def fixture_mock_device() -> Generator[AsyncMock, None, None]:
             source="Apple TV",
             sources={0: "Apple TV", 1: "Blu-ray"},
             source_format="PCM",
+            decoder="Dolby Atmos",
+            audiosync=42,
             mute=False,
+            dim=False,
+            bypass=False,
             volume=-35.0,
             preset="Movie",
             presets={0: "Movie", 1: "Music"},

--- a/tests/components/trinnov_altitude/test_config_flow.py
+++ b/tests/components/trinnov_altitude/test_config_flow.py
@@ -1,0 +1,77 @@
+"""Tests for Trinnov Altitude config flow."""
+
+from unittest.mock import AsyncMock
+
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
+
+from homeassistant.components.trinnov_altitude.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> None:
+    """Test user config flow."""
+
+    # Test connection failed
+    #
+    # Note: I could not get this test to pass when isolating in a separate test.
+    # There appears to be a race condition with mocking that I could not resolve
+    # despite other tests having the same pattern.
+
+    mock_device.connect.side_effect = ConnectionFailedError("message")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: MOCK_HOST}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"host": "invalid_host"}
+
+    # Test connection timeout
+
+    mock_device.connect.side_effect = ConnectionTimeoutError("message")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: MOCK_HOST}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    # Test success
+
+    mock_device.connect.side_effect = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"][CONF_HOST] == MOCK_HOST
+
+
+async def test_user_config_flow_device_exists_abort(
+    hass: HomeAssistant, mock_device: AsyncMock, mock_integration: MockConfigEntry
+) -> None:
+    """Test flow aborts when device already configured."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}, data={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/trinnov_altitude/test_config_flow.py
+++ b/tests/components/trinnov_altitude/test_config_flow.py
@@ -18,15 +18,10 @@ CONTEXT = {"source": SOURCE_USER}
 DATA = {CONF_HOST: MOCK_HOST, CONF_MAC: MOCK_MAC}
 
 
-async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> None:
-    """Test user config flow."""
-
-    # Note: I could not get this test to pass when isolating each failure in
-    # separate tests. There appears to be a race condition with mocking that
-    # I could not resolve despite other tests having the same pattern.
-
-    # Test connection failed
-
+async def test_user_config_flow_connection_failed(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow connection failed."""
     mock_device.start.side_effect = ConnectionFailedError(OSError("message"))
 
     result = await hass.config_entries.flow.async_init(
@@ -37,8 +32,11 @@ async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> 
     assert result["step_id"] == "user"
     assert result["errors"] == {"host": "invalid_host"}
 
-    # Test connection timeout
 
+async def test_user_config_flow_connection_timeout(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow connection timeout."""
     mock_device.start.side_effect = ConnectionTimeoutError("message")
 
     result = await hass.config_entries.flow.async_init(
@@ -49,8 +47,11 @@ async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> 
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
 
-    # Test success
 
+async def test_user_config_flow_success(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow success."""
     mock_device.start.side_effect = None
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context=CONTEXT)

--- a/tests/components/trinnov_altitude/test_config_flow.py
+++ b/tests/components/trinnov_altitude/test_config_flow.py
@@ -78,3 +78,19 @@ async def test_user_config_flow_device_exists_abort(
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_user_config_flow_without_mac(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow without MAC address."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context=CONTEXT)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == MOCK_HOST
+    assert result["data"][CONF_MAC] == ""

--- a/tests/components/trinnov_altitude/test_config_flow.py
+++ b/tests/components/trinnov_altitude/test_config_flow.py
@@ -27,7 +27,7 @@ async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> 
 
     # Test connection failed
 
-    mock_device.connect.side_effect = ConnectionFailedError("message")
+    mock_device.start.side_effect = ConnectionFailedError(OSError("message"))
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context=CONTEXT, data=DATA
@@ -39,7 +39,7 @@ async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> 
 
     # Test connection timeout
 
-    mock_device.connect.side_effect = ConnectionTimeoutError("message")
+    mock_device.start.side_effect = ConnectionTimeoutError("message")
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context=CONTEXT, data=DATA
@@ -51,7 +51,7 @@ async def test_user_config_flow(hass: HomeAssistant, mock_device: AsyncMock) -> 
 
     # Test success
 
-    mock_device.connect.side_effect = None
+    mock_device.start.side_effect = None
 
     result = await hass.config_entries.flow.async_init(DOMAIN, context=CONTEXT)
     assert result["type"] is FlowResultType.FORM
@@ -93,4 +93,4 @@ async def test_user_config_flow_without_mac(
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_HOST] == MOCK_HOST
-    assert result["data"][CONF_MAC] == ""
+    assert result["data"][CONF_MAC] is None

--- a/tests/components/trinnov_altitude/test_init.py
+++ b/tests/components/trinnov_altitude/test_init.py
@@ -1,0 +1,63 @@
+"""Tests for Trinnov Altitude config entry."""
+
+from unittest.mock import AsyncMock
+
+from trinnov_altitude.exceptions import ConnectionFailedError
+
+from homeassistant.components.trinnov_altitude.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_config_entry(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test config entry loading and unloading."""
+    mock_config_entry = mock_integration
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_device.connect.call_count == 1
+    assert mock_device.disconnect.call_count == 0
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Called twice, both from `async_listen_once(EVENT_HOMEASSISTANT_STOP)` and `async_on_remove`
+    # This is fine as disconnect is idempotent
+    assert mock_device.disconnect.call_count == 2
+    assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_config_entry_not_ready(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test config entry not ready."""
+    mock_device.connect.side_effect = ConnectionFailedError("message")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test device."""
+    device = device_registry.async_get_device(
+        identifiers={("trinnov_altitude", MOCK_ID)}
+    )
+    assert device is not None
+    assert device.identifiers == {("trinnov_altitude", MOCK_ID)}

--- a/tests/components/trinnov_altitude/test_init.py
+++ b/tests/components/trinnov_altitude/test_init.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import AsyncMock
 
-from trinnov_altitude.exceptions import ConnectionFailedError
-
 from homeassistant.components.trinnov_altitude.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -14,7 +12,7 @@ from . import MOCK_ID
 from tests.common import MockConfigEntry
 
 
-async def test_unload_config_entry(
+async def test_setup_entry(
     hass: HomeAssistant,
     mock_device: AsyncMock,
     mock_integration: MockConfigEntry,
@@ -22,31 +20,14 @@ async def test_unload_config_entry(
     """Test config entry loading and unloading."""
     mock_config_entry = mock_integration
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_device.connect.call_count == 1
+    assert mock_device.start_listening.call_count == 1
     assert mock_device.disconnect.call_count == 0
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Called twice, both from `async_listen_once(EVENT_HOMEASSISTANT_STOP)` and `async_on_remove`
-    # This is fine as disconnect is idempotent
-    assert mock_device.disconnect.call_count == 2
+    assert mock_device.disconnect.call_count == 1
     assert mock_config_entry.entry_id not in hass.data[DOMAIN]
-
-
-async def test_config_entry_not_ready(
-    hass: HomeAssistant,
-    mock_device: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test config entry not ready."""
-    mock_device.connect.side_effect = ConnectionFailedError("message")
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_device(

--- a/tests/components/trinnov_altitude/test_init.py
+++ b/tests/components/trinnov_altitude/test_init.py
@@ -20,13 +20,13 @@ async def test_setup_entry(
     """Test config entry loading and unloading."""
     mock_config_entry = mock_integration
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_device.start_listening.call_count == 1
-    assert mock_device.disconnect.call_count == 0
+    assert mock_device.start.call_count == 1
+    assert mock_device.stop.call_count == 0
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_device.disconnect.call_count == 1
+    assert mock_device.stop.call_count == 1
     assert mock_config_entry.entry_id not in hass.data[DOMAIN]
 
 

--- a/tests/components/trinnov_altitude/test_media_player.py
+++ b/tests/components/trinnov_altitude/test_media_player.py
@@ -1,0 +1,115 @@
+"""Tests for Trinnov Altitude media player platform."""
+
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_VOLUME_LEVEL,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
+    MediaPlayerState,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = f"media_player.trinnov_altitude_{MOCK_ID}"
+
+
+async def test_entity(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test entity attributes and state."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == MediaPlayerState.PLAYING
+
+
+async def test_commands(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test media player service calls."""
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.power_on.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.power_off.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: ENTITY_ID, "is_volume_muted": True},
+        blocking=True,
+    )
+    mock_device.mute_set.assert_called_once_with(True)
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.35},
+        blocking=True,
+    )
+    mock_device.volume_percentage_set.assert_called_once_with(35.0)
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_UP,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.volume_up.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_DOWN,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.volume_down.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, "source": "Apple TV"},
+        blocking=True,
+    )
+    mock_device.source_set_by_name.assert_called_once_with("Apple TV")
+
+
+async def test_state_off_when_not_synced(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test state is OFF when disconnected/unsynced."""
+    mock_device.connected = False
+    mock_device.state.synced = False
+
+    callback = mock_device.register_callback.call_args[0][0]
+    callback("received_message", None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == MediaPlayerState.OFF

--- a/tests/components/trinnov_altitude/test_number.py
+++ b/tests/components/trinnov_altitude/test_number.py
@@ -1,0 +1,36 @@
+"""Tests for Trinnov Altitude number platform."""
+
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = f"number.trinnov_altitude_{MOCK_ID}_volume"
+
+
+async def test_entity(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test volume number entity exists."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+
+
+async def test_set_value(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test setting volume number value."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: ENTITY_ID, "value": -40.5},
+        blocking=True,
+    )
+    mock_device.volume_set.assert_called_once_with(-40.5)

--- a/tests/components/trinnov_altitude/test_remote.py
+++ b/tests/components/trinnov_altitude/test_remote.py
@@ -2,8 +2,12 @@
 
 from unittest.mock import MagicMock
 
-from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
 
 from . import MOCK_ID
@@ -19,6 +23,7 @@ async def test_entity(
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test entity attributes."""
+
     assert hass.states.get(ENTITY_ID)
 
 
@@ -28,10 +33,51 @@ async def test_commands(
     mock_integration: MockConfigEntry,
 ) -> None:
     """Test service calls."""
+
     await hass.services.async_call(
         REMOTE_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: ENTITY_ID},
         blocking=True,
     )
-    assert mock_device.leave_standby.call_count == 1
+    assert mock_device.power_on.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    assert mock_device.power_off.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["source_set 1"]},
+        blocking=True,
+    )
+    mock_device.source_set.assert_called_once_with(1)
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["volume_down"]},
+        blocking=True,
+    )
+    assert mock_device.volume_down.call_count == 1
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["volume_ramp -42.5 10"]},
+        blocking=True,
+    )
+    mock_device.volume_ramp.assert_called_once_with(-42.5, 10)
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["volume_set -40.5"]},
+        blocking=True,
+    )
+    mock_device.volume_set.assert_called_once_with(-40.5)

--- a/tests/components/trinnov_altitude/test_remote.py
+++ b/tests/components/trinnov_altitude/test_remote.py
@@ -1,0 +1,37 @@
+"""Tests for Trinnov Altitude remote platform."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = f"remote.trinnov_altitude_{MOCK_ID}"
+
+
+async def test_entity(
+    hass: HomeAssistant,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test entity attributes."""
+    assert hass.states.get(ENTITY_ID)
+
+
+async def test_commands(
+    hass: HomeAssistant,
+    mock_device: MagicMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test service calls."""
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    assert mock_device.leave_standby.call_count == 1

--- a/tests/components/trinnov_altitude/test_select.py
+++ b/tests/components/trinnov_altitude/test_select.py
@@ -1,0 +1,87 @@
+"""Tests for Trinnov Altitude select platform."""
+
+import pytest
+
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN, SERVICE_SELECT_OPTION
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+SOURCE_ENTITY_ID = f"select.trinnov_altitude_{MOCK_ID}_source"
+PRESET_ENTITY_ID = f"select.trinnov_altitude_{MOCK_ID}_preset"
+UPMIXER_ENTITY_ID = f"select.trinnov_altitude_{MOCK_ID}_upmixer"
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test select entities are created."""
+    assert hass.states.get(SOURCE_ENTITY_ID) is not None
+    assert hass.states.get(PRESET_ENTITY_ID) is not None
+    assert hass.states.get(UPMIXER_ENTITY_ID) is not None
+
+
+async def test_source_select_option(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test source select service call."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: SOURCE_ENTITY_ID, "option": "Apple TV"},
+        blocking=True,
+    )
+    mock_device.source_set_by_name.assert_called_once_with("Apple TV")
+
+
+async def test_preset_select_option(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test preset select service call."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: PRESET_ENTITY_ID, "option": "Music"},
+        blocking=True,
+    )
+    mock_device.preset_set.assert_called_once_with(1)
+
+
+async def test_upmixer_select_option(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test upmixer select service call."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: UPMIXER_ENTITY_ID, "option": "dolby"},
+        blocking=True,
+    )
+    assert mock_device.upmixer_set.call_count == 1
+
+
+async def test_upmixer_select_option_invalid(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test invalid upmixer option raises HomeAssistantError."""
+    with pytest.raises(HomeAssistantError, match="Invalid upmixer mode"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: UPMIXER_ENTITY_ID, "option": "invalid_mode"},
+            blocking=True,
+        )

--- a/tests/components/trinnov_altitude/test_sensor.py
+++ b/tests/components/trinnov_altitude/test_sensor.py
@@ -1,0 +1,46 @@
+"""Tests for Trinnov Altitude sensor platform."""
+
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+POWER_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_power_status"
+CONNECTION_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_connection_status"
+SYNC_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_sync_status"
+DECODER_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_decoder"
+SOURCE_FORMAT_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_source_format"
+AUDIOSYNC_ENTITY_ID = f"sensor.trinnov_altitude_{MOCK_ID}_audiosync"
+
+
+async def test_entities_and_values(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test sensor entities and default values."""
+    assert hass.states.get(POWER_ENTITY_ID).state == "ready"
+    assert hass.states.get(CONNECTION_ENTITY_ID).state == "connected"
+    assert hass.states.get(SYNC_ENTITY_ID).state == "synced"
+    assert hass.states.get(DECODER_ENTITY_ID).state == "Dolby Atmos"
+    assert hass.states.get(SOURCE_FORMAT_ENTITY_ID).state == "PCM"
+    assert hass.states.get(AUDIOSYNC_ENTITY_ID).state == "42"
+
+
+async def test_power_and_connection_when_disconnected(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test sensor values when device is disconnected."""
+    mock_device.connected = False
+    mock_device.state.synced = False
+
+    callback = mock_device.register_callback.call_args[0][0]
+    callback("received_message", None)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(POWER_ENTITY_ID).state == "off"
+    assert hass.states.get(CONNECTION_ENTITY_ID).state == "disconnected"
+    assert hass.states.get(SYNC_ENTITY_ID).state == "syncing"

--- a/tests/components/trinnov_altitude/test_switch.py
+++ b/tests/components/trinnov_altitude/test_switch.py
@@ -67,8 +67,24 @@ async def test_dim_and_bypass_commands(
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: DIM_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.dim_set.assert_called_with(False)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
         SERVICE_TURN_ON,
         {ATTR_ENTITY_ID: BYPASS_ENTITY_ID},
         blocking=True,
     )
     mock_device.bypass_set.assert_called_once_with(True)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: BYPASS_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.bypass_set.assert_called_with(False)

--- a/tests/components/trinnov_altitude/test_switch.py
+++ b/tests/components/trinnov_altitude/test_switch.py
@@ -1,0 +1,74 @@
+"""Tests for Trinnov Altitude switch platform."""
+
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+MUTE_ENTITY_ID = f"switch.trinnov_altitude_{MOCK_ID}_mute"
+DIM_ENTITY_ID = f"switch.trinnov_altitude_{MOCK_ID}_dim"
+BYPASS_ENTITY_ID = f"switch.trinnov_altitude_{MOCK_ID}_bypass"
+
+
+async def test_entities(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test switch entities are created."""
+    assert hass.states.get(MUTE_ENTITY_ID) is not None
+    assert hass.states.get(DIM_ENTITY_ID) is not None
+    assert hass.states.get(BYPASS_ENTITY_ID) is not None
+
+
+async def test_mute_commands(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test mute switch service calls."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: MUTE_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.mute_set.assert_called_once_with(True)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: MUTE_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.mute_set.assert_called_with(False)
+
+
+async def test_dim_and_bypass_commands(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test dim and bypass switch service calls."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: DIM_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.dim_set.assert_called_once_with(True)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: BYPASS_ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.bypass_set.assert_called_once_with(True)


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
Add a new `trinnov_altitude` integration for Trinnov Altitude processors.

This initial core submission includes:
- Config flow for host + optional MAC input
- Config entry setup/unload lifecycle
- Remote platform support (`turn_on`, `turn_off`, `send_command`)
- Media player platform support (power, source select, mute, and volume controls)
- Number platform support for native dB volume control
- Select platform support for source, preset, and upmixer
- Switch platform support for mute, dim, and bypass
- Sensor platform support for power/connection/sync and key diagnostics
- Integration tests for setup, config flow, remote commands, number/select/switch/sensor platforms
- Required generated-file updates (`config_flows`, `integrations.json`, requirements files, CODEOWNERS)

## Type of change
- [x] New integration (thank you!)

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43819
- Link to developer documentation pull request:
- Link to frontend pull request:
- Brands PR (already merged): https://github.com/home-assistant/brands/pull/8455

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] New dependencies have been added to `requirements_all.txt`.
- [x] For the new dependency, release reference: https://pypi.org/project/trinnov-altitude/

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Source snapshot
- Source-of-truth repo: https://github.com/binarylogic/trinnov-altitude-homeassistant
- Source commit: `1e8c682`
- Sync workflow notes: https://github.com/binarylogic/trinnov-altitude-homeassistant/blob/master/SYNC_NOTES.md
- Python library release for this sync: https://github.com/binarylogic/py-trinnov-altitude/releases/tag/v3.1.0
