### PR TITLE
Handle serial port close race condition in rfxtrx during shutdown

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -127,6 +127,26 @@ def _create_rfx(
     else:
         transport = rfxtrxmod.PySerialTransport(config[CONF_DEVICE])
 
+        # Work around a race condition in pyRFXtrx during shutdown.
+        # When close_connection() closes the serial port, the background read
+        # thread may still be inside serial.read(), which calls
+        # os.read(self.fd, ...). Since closing sets fd=None, this raises
+        # TypeError. The library's transport_errors decorator only catches
+        # socket.error, SerialException, and OSError — not TypeError.
+        # https://github.com/Danielhiversen/pyRFXtrx/pull/155
+        original_receive = transport.receive_blocking
+
+        def _receive_blocking_wrapper() -> rfxtrxmod.RFXtrxEvent | None:
+            try:
+                return original_receive()
+            except TypeError:
+                if getattr(transport.serial, "fd", ...) is None:
+                    _LOGGER.debug("Serial port closed during read")
+                    return None
+                raise
+
+        transport.receive_blocking = _receive_blocking_wrapper
+
     rfx = rfxtrxmod.Connect(
         transport,
         event_callback,

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import ANY, call
+from unittest.mock import ANY, MagicMock, call
 
+import pytest
 import RFXtrx as rfxtrxmod
 
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
@@ -17,6 +18,47 @@ from .conftest import setup_rfx_test_cfg
 from tests.typing import WebSocketGenerator
 
 SOME_PROTOCOLS = ["ac", "arc"]
+
+
+async def test_serial_receive_blocking_type_error_on_shutdown(
+    hass: HomeAssistant, rfxtrx, transport_mock
+) -> None:
+    """Test that TypeError during serial shutdown is suppressed.
+
+    pyRFXtrx has a race condition where closing the serial port sets fd=None
+    while the read thread is still inside os.read(), causing a TypeError.
+    """
+    original_receive = MagicMock(
+        side_effect=TypeError("'NoneType' object cannot be interpreted as an integer")
+    )
+    serial_mock = MagicMock(fd=None)
+    transport_mock.return_value.receive_blocking = original_receive
+    transport_mock.return_value.serial = serial_mock
+
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # After setup, the transport's receive_blocking should have been wrapped.
+    # Calling the wrapper should suppress the TypeError when serial.fd is None.
+    wrapped_receive = transport_mock.return_value.receive_blocking
+    assert wrapped_receive() is None
+
+
+async def test_serial_receive_blocking_type_error_reraised(
+    hass: HomeAssistant, rfxtrx, transport_mock
+) -> None:
+    """Test that unrelated TypeErrors still propagate."""
+    original_receive = MagicMock(side_effect=TypeError("unexpected"))
+    serial_mock = MagicMock(fd=1)
+    transport_mock.return_value.receive_blocking = original_receive
+    transport_mock.return_value.serial = serial_mock
+
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    wrapped_receive = transport_mock.return_value.receive_blocking
+    with pytest.raises(TypeError, match="unexpected"):
+        wrapped_receive()
 
 
 async def test_fire_event(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Work around a race condition in `pyRFXtrx` where stopping Home Assistant causes an uncaught `TypeError` in the serial read thread.

During shutdown, `close_connection()` closes the serial port (setting `fd=None`) while the background read thread may still be inside `serial.read()` → `os.read(self.fd, ...)`. Since `fd` is `None`, a `TypeError` is raised. The library's `transport_errors` decorator only catches `socket.error`, `SerialException`, and `OSError` — not `TypeError` — so it becomes an uncaught thread exception logged on every restart.

Changes:

- Wrap `receive_blocking` on `PySerialTransport` to catch `TypeError` when
  `serial.fd` is `None` (i.e., port was closed), suppressing the spurious error
  during shutdown while re-raising unrelated `TypeError`s.
- Add integration-level tests that set up the config entry via
  `setup_rfx_test_cfg` and verify the wrapper behavior.


The proper fix belongs upstream in `pyRFXtrx` (https://github.com/Danielhiversen/pyRFXtrx/pull/155), but that PR has been
stale since May 2025.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #136368
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
