### PR TITLE
Reject relative paths in SFTP storage backup location config flow

### DIFF
--- a/homeassistant/components/sftp_storage/config_flow.py
+++ b/homeassistant/components/sftp_storage/config_flow.py
@@ -124,6 +124,17 @@ class SFTPFlowHandler(ConfigFlow, domain=DOMAIN):
                 }
             )
 
+            if not user_input[CONF_BACKUP_LOCATION].startswith("/"):
+                errors[CONF_BACKUP_LOCATION] = "backup_location_relative"
+                return self.async_show_form(
+                    step_id=step_id,
+                    data_schema=self.add_suggested_values_to_schema(
+                        DATA_SCHEMA, user_input
+                    ),
+                    description_placeholders=placeholders,
+                    errors=errors,
+                )
+
             try:
                 # Validate auth input and save uploaded key file if provided
                 user_input = await self._validate_auth_and_save_keyfile(user_input)

--- a/homeassistant/components/sftp_storage/strings.json
+++ b/homeassistant/components/sftp_storage/strings.json
@@ -4,6 +4,7 @@
       "already_configured": "Integration already configured. Host with same address, port and backup location already exists."
     },
     "error": {
+      "backup_location_relative": "The remote path must be an absolute path (starting with `/`).",
       "invalid_key": "Invalid key uploaded. Please make sure key corresponds to valid SSH key algorithm.",
       "key_or_password_needed": "Please configure password or private key file location for SFTP Storage.",
       "os_error": "{error_message}. Please check if host and/or port are correct.",

--- a/tests/components/sftp_storage/conftest.py
+++ b/tests/components/sftp_storage/conftest.py
@@ -31,7 +31,7 @@ from tests.common import MockConfigEntry
 type ComponentSetup = Callable[[], Awaitable[None]]
 
 BACKUP_METADATA = {
-    "file_path": "backup_location/backup.tar",
+    "file_path": "/backup_location/backup.tar",
     "metadata": {
         "addons": [{"name": "Test", "slug": "test", "version": "1.0.0"}],
         "backup_id": "test-backup",
@@ -60,7 +60,7 @@ USER_INPUT = {
     CONF_USERNAME: "username",
     CONF_PASSWORD: "password",
     CONF_PRIVATE_KEY_FILE: PRIVATE_KEY_FILE_UUID,
-    CONF_BACKUP_LOCATION: "backup_location",
+    CONF_BACKUP_LOCATION: "/backup_location",
 }
 TEST_AGENT_ID = ulid()
 
@@ -118,7 +118,7 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_USERNAME: "username",
             CONF_PASSWORD: "password",
             CONF_PRIVATE_KEY_FILE: str(private_key),
-            CONF_BACKUP_LOCATION: "backup_location",
+            CONF_BACKUP_LOCATION: "/backup_location",
         },
     )
 

--- a/tests/components/sftp_storage/test_backup.py
+++ b/tests/components/sftp_storage/test_backup.py
@@ -151,7 +151,7 @@ async def test_agents_list_backups_include_bad_metadata(
     # Called two times, one for bad backup metadata and once for good
     assert mock_ssh_connection._sftp._mock_open._mock_read.call_count == 2
     assert (
-        "Failed to load backup metadata from file: backup_location/invalid.metadata.json. Expecting value: line 1 column 1 (char 0)"
+        "Failed to load backup metadata from file: /backup_location/invalid.metadata.json. Expecting value: line 1 column 1 (char 0)"
         in caplog.messages
     )
 

--- a/tests/components/sftp_storage/test_config_flow.py
+++ b/tests/components/sftp_storage/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.sftp_storage.config_flow import (
     SFTPStorageMissingPasswordOrPkey,
 )
 from homeassistant.components.sftp_storage.const import (
+    CONF_BACKUP_LOCATION,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_PRIVATE_KEY_FILE,
@@ -194,3 +195,35 @@ async def test_config_entry_error(hass: HomeAssistant) -> None:
         result["flow_id"], user_input
     )
     assert "errors" in result and result["errors"]["base"] == "key_or_password_needed"
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("mock_process_uploaded_file")
+@pytest.mark.usefixtures("mock_ssh_connection")
+async def test_relative_backup_location_rejected(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a relative backup location path is rejected."""
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+
+    user_input = USER_INPUT.copy()
+    user_input[CONF_BACKUP_LOCATION] = "backups"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_BACKUP_LOCATION: "backup_location_relative"}
+
+    # Fix the path and verify the flow succeeds
+    user_input[CONF_BACKUP_LOCATION] = "/backups"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The SFTP storage integration config flow accepted relative paths (e.g., `backups` instead of `/backups` for the backup location field. These relative paths were saved successfully but later caused `SFTPNoSuchFile` errors when the integration tried to upload, list, or download backups.

This PR adds an early validation in the config flow to reject backup location paths that don't start with `/`. A field-specific error is shown on the backup location input, guiding the user to provide an absolute path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164285
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
