### PR TITLE
Add device_id and satellite_id to conversation HTTP/websocket APIs

### DIFF
--- a/homeassistant/components/conversation/http.py
+++ b/homeassistant/components/conversation/http.py
@@ -48,6 +48,8 @@ def async_setup(hass: HomeAssistant) -> None:
         vol.Optional("conversation_id"): vol.Any(str, None),
         vol.Optional("language"): str,
         vol.Optional("agent_id"): agent_id_validator,
+        vol.Optional("device_id"): vol.Any(str, None),
+        vol.Optional("satellite_id"): vol.Any(str, None),
     }
 )
 @websocket_api.async_response
@@ -64,6 +66,8 @@ async def websocket_process(
         context=connection.context(msg),
         language=msg.get("language"),
         agent_id=msg.get("agent_id"),
+        device_id=msg.get("device_id"),
+        satellite_id=msg.get("satellite_id"),
     )
     connection.send_result(msg["id"], result.as_dict())
 
@@ -248,6 +252,8 @@ class ConversationProcessView(http.HomeAssistantView):
                 vol.Optional("conversation_id"): str,
                 vol.Optional("language"): str,
                 vol.Optional("agent_id"): agent_id_validator,
+                vol.Optional("device_id"): vol.Any(str, None),
+                vol.Optional("satellite_id"): vol.Any(str, None),
             }
         )
     )
@@ -262,6 +268,8 @@ class ConversationProcessView(http.HomeAssistantView):
             context=self.context(request),
             language=data.get("language"),
             agent_id=data.get("agent_id"),
+            device_id=data.get("device_id"),
+            satellite_id=data.get("satellite_id"),
         )
 
         return self.json(result.as_dict())

--- a/tests/components/conversation/test_http.py
+++ b/tests/components/conversation/test_http.py
@@ -173,6 +173,36 @@ async def test_http_api_wrong_data(
     assert resp.status == HTTPStatus.BAD_REQUEST
 
 
+async def test_http_processing_intent_with_device_satellite_ids(
+    hass: HomeAssistant,
+    init_components,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test processing intent via HTTP API with both device_id and satellite_id."""
+    client = await hass_client()
+    mock_result = intent.IntentResponse(language=hass.config.language)
+    mock_result.async_set_speech("test")
+
+    with patch(
+        "homeassistant.components.conversation.http.async_converse",
+        return_value=mock_result,
+    ) as mock_converse:
+        resp = await client.post(
+            "/api/conversation/process",
+            json={
+                "text": "test",
+                "device_id": "test-device-id",
+                "satellite_id": "test-satellite-id",
+            },
+        )
+
+        assert resp.status == HTTPStatus.OK
+        mock_converse.assert_called_once()
+        call_kwargs = mock_converse.call_args[1]
+        assert call_kwargs["device_id"] == "test-device-id"
+        assert call_kwargs["satellite_id"] == "test-satellite-id"
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -219,6 +249,38 @@ async def test_ws_api(
     assert msg["success"]
     assert msg["result"] == snapshot
     assert msg["result"]["response"]["data"]["code"] == "no_intent_match"
+
+
+async def test_ws_api_with_device_satellite_ids(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the Websocket conversation API with both device_id and satellite_id."""
+    client = await hass_ws_client(hass)
+    mock_result = intent.IntentResponse(language=hass.config.language)
+    mock_result.async_set_speech("test")
+
+    with patch(
+        "homeassistant.components.conversation.http.async_converse",
+        return_value=mock_result,
+    ) as mock_converse:
+        await client.send_json_auto_id(
+            {
+                "type": "conversation/process",
+                "text": "test",
+                "device_id": "test-device-id",
+                "satellite_id": "test-satellite-id",
+            }
+        )
+
+        msg = await client.receive_json()
+
+        assert msg["success"]
+        mock_converse.assert_called_once()
+        call_kwargs = mock_converse.call_args[1]
+        assert call_kwargs["device_id"] == "test-device-id"
+        assert call_kwargs["satellite_id"] == "test-satellite-id"
 
 
 @pytest.mark.parametrize("agent_id", AGENT_ID_OPTIONS)

--- a/tests/components/conversation/test_http.py
+++ b/tests/components/conversation/test_http.py
@@ -16,6 +16,7 @@ from homeassistant.components.conversation import (
     async_get_chat_log,
 )
 from homeassistant.components.conversation.const import HOME_ASSISTANT_AGENT
+from homeassistant.components.conversation.models import ConversationResult
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
@@ -185,7 +186,7 @@ async def test_http_processing_intent_with_device_satellite_ids(
 
     with patch(
         "homeassistant.components.conversation.http.async_converse",
-        return_value=mock_result,
+        return_value=ConversationResult(response=mock_result),
     ) as mock_converse:
         resp = await client.post(
             "/api/conversation/process",
@@ -263,7 +264,7 @@ async def test_ws_api_with_device_satellite_ids(
 
     with patch(
         "homeassistant.components.conversation.http.async_converse",
-        return_value=mock_result,
+        return_value=ConversationResult(response=mock_result),
     ) as mock_converse:
         await client.send_json_auto_id(
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow `device_id` and `satellite_id` to be passed through the `conversation` HTTP and websocket APIs. These ids are required for voice commands that affect the current area.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
