### PR TITLE
madvr: migrate runtime to madvr-envy while keeping legacy entity IDs

### DIFF
--- a/homeassistant/components/madvr/__init__.py
+++ b/homeassistant/components/madvr/__init__.py
@@ -1,65 +1,116 @@
-"""The madvr-envy integration."""
+"""The madVR Envy integration."""
 
 from __future__ import annotations
 
-import logging
+from typing import Any
 
-from madvr.madvr import Madvr
-
-from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.REMOTE, Platform.SENSOR]
+from .const import (
+    DEFAULT_COMMAND_TIMEOUT,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+    DEFAULT_RECONNECT_JITTER,
+    DEFAULT_RECONNECT_MAX_BACKOFF,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    OPT_COMMAND_TIMEOUT,
+    OPT_CONNECT_TIMEOUT,
+    OPT_READ_TIMEOUT,
+    OPT_RECONNECT_INITIAL_BACKOFF,
+    OPT_RECONNECT_JITTER,
+    OPT_RECONNECT_MAX_BACKOFF,
+    OPT_SYNC_TIMEOUT,
+    PLATFORMS,
+)
+from .coordinator import MadvrEnvyCoordinator
+from .models import MadvrEnvyRuntimeData
 
-_LOGGER = logging.getLogger(__name__)
+MadvrEnvyConfigEntry = ConfigEntry
 
 
-async def async_handle_unload(coordinator: MadVRCoordinator) -> None:
-    """Handle unload."""
-    _LOGGER.debug("Integration unloading")
-    coordinator.client.stop()
-    await coordinator.client.async_cancel_tasks()
-    _LOGGER.debug("Integration closing connection")
-    await coordinator.client.close_connection()
-    _LOGGER.debug("Unloaded")
+async def async_setup_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> bool:
+    """Set up madVR Envy from a config entry."""
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
 
-
-async def async_setup_entry(hass: HomeAssistant, entry: MadVRConfigEntry) -> bool:
-    """Set up the integration from a config entry."""
-    assert entry.unique_id
-    madVRClient = Madvr(
-        host=entry.data[CONF_HOST],
-        logger=_LOGGER,
-        port=entry.data[CONF_PORT],
-        mac=entry.unique_id,
-        connect_timeout=10,
-        loop=hass.loop,
+    client = MadvrEnvyClient(
+        host=host,
+        port=port,
+        connect_timeout=_get_float_option(entry, OPT_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+        command_timeout=_get_float_option(entry, OPT_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+        read_timeout=_get_float_option(entry, OPT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT),
+        reconnect_initial_backoff=_get_float_option(
+            entry,
+            OPT_RECONNECT_INITIAL_BACKOFF,
+            DEFAULT_RECONNECT_INITIAL_BACKOFF,
+        ),
+        reconnect_max_backoff=_get_float_option(
+            entry,
+            OPT_RECONNECT_MAX_BACKOFF,
+            DEFAULT_RECONNECT_MAX_BACKOFF,
+        ),
+        reconnect_jitter=_get_float_option(
+            entry,
+            OPT_RECONNECT_JITTER,
+            DEFAULT_RECONNECT_JITTER,
+        ),
+        auto_reconnect=True,
     )
-    coordinator = MadVRCoordinator(hass, entry, madVRClient)
+    coordinator = MadvrEnvyCoordinator(
+        hass,
+        client,
+        sync_timeout=_get_float_option(entry, OPT_SYNC_TIMEOUT, DEFAULT_SYNC_TIMEOUT),
+    )
 
-    entry.runtime_data = coordinator
+    try:
+        await coordinator.async_start()
+    except (
+        envy_exceptions.ConnectionFailedError,
+        envy_exceptions.ConnectionTimeoutError,
+        TimeoutError,
+    ) as err:
+        await coordinator.async_shutdown()
+        raise ConfigEntryNotReady(f"Could not connect to madVR Envy at {host}:{port}") from err
+    except Exception:
+        await coordinator.async_shutdown()
+        raise
 
+    runtime_data = MadvrEnvyRuntimeData(client=client, coordinator=coordinator, last_data={})
+    entry.runtime_data = runtime_data
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
+
+    async def _handle_hass_stop(_event: Event) -> None:
+        await coordinator.async_shutdown()
+
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _handle_hass_stop))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    async def handle_unload(event: Event) -> None:
-        """Handle unload."""
-        await async_handle_unload(coordinator=coordinator)
-
-    # listen for core stop event
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, handle_unload)
-
-    # handle loading operations
-    await coordinator.handle_coordinator_load()
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: MadVRConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        coordinator: MadVRCoordinator = entry.runtime_data
-        await async_handle_unload(coordinator=coordinator)
-
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await entry.runtime_data.coordinator.async_shutdown()
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN, None)
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> None:
+    """Handle reload request."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+def _get_float_option(entry: ConfigEntry, key: str, default: float) -> float:
+    value: Any = entry.options.get(key, default)
+    return float(value)

--- a/homeassistant/components/madvr/binary_sensor.py
+++ b/homeassistant/components/madvr/binary_sensor.py
@@ -9,11 +9,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from .coordinator import MadvrEnvyCoordinator
+from .entity import MadvrEnvyEntity
 
 _HDR_FLAG = "hdr_flag"
 _OUTGOING_HDR_FLAG = "outgoing_hdr_flag"
@@ -25,7 +26,7 @@ _SIGNAL_STATE = "signal_state"
 class MadvrBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describe madVR binary sensor entity."""
 
-    value_fn: Callable[[MadVRCoordinator], bool]
+    value_fn: Callable[[MadvrEnvyCoordinator], bool]
 
 
 BINARY_SENSORS: tuple[MadvrBinarySensorEntityDescription, ...] = (
@@ -54,28 +55,28 @@ BINARY_SENSORS: tuple[MadvrBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the binary sensor entities."""
-    coordinator = entry.runtime_data
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(
         MadvrBinarySensor(coordinator, description) for description in BINARY_SENSORS
     )
 
 
-class MadvrBinarySensor(MadVREntity, BinarySensorEntity):
+class MadvrBinarySensor(MadvrEnvyEntity, BinarySensorEntity):
     """Base class for madVR binary sensors."""
 
     entity_description: MadvrBinarySensorEntityDescription
 
     def __init__(
         self,
-        coordinator: MadVRCoordinator,
+        coordinator: MadvrEnvyCoordinator,
         description: MadvrBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, description.key)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.mac}_{description.key}"
 

--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -1,139 +1,235 @@
-"""Config flow for the integration."""
+"""Config flow for madVR Envy integration."""
 
-import asyncio
+from __future__ import annotations
+
 import logging
 from typing import Any
 
-import aiohttp
-from madvr.madvr import HeartBeatError, Madvr
 import voluptuous as vol
-
-from homeassistant.config_entries import (
-    SOURCE_RECONFIGURE,
-    ConfigFlow,
-    ConfigFlowResult,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
 
-from .const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
-from .errors import CannotConnect
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
+
+from .const import (
+    DEFAULT_COMMAND_TIMEOUT,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_NAME,
+    DEFAULT_ENABLE_ADVANCED_ENTITIES,
+    DEFAULT_PORT,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+    DEFAULT_RECONNECT_JITTER,
+    DEFAULT_RECONNECT_MAX_BACKOFF,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    OPT_COMMAND_TIMEOUT,
+    OPT_CONNECT_TIMEOUT,
+    OPT_ENABLE_ADVANCED_ENTITIES,
+    OPT_READ_TIMEOUT,
+    OPT_RECONNECT_INITIAL_BACKOFF,
+    OPT_RECONNECT_JITTER,
+    OPT_RECONNECT_MAX_BACKOFF,
+    OPT_SYNC_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=65535)
+        ),
     }
 )
 
-RETRY_INTERVAL = 1
 
-
-class MadVRConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for the integration."""
+class MadvrEnvyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for madVR Envy."""
 
     VERSION = 1
+    _reauth_entry: ConfigEntry | None = None
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        return await self._handle_config_step(user_input)
-
-    async def async_step_reconfigure(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
-        return await self._handle_config_step(user_input, step_id="reconfigure")
-
-    async def _handle_config_step(
-        self, user_input: dict[str, Any] | None = None, step_id: str = "user"
-    ) -> ConfigFlowResult:
-        """Handle the configuration step for both initial setup and reconfiguration."""
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            _LOGGER.debug("User input: %s", user_input)
-            host = user_input[CONF_HOST]
-            port = user_input[CONF_PORT]
+            host = user_input[CONF_HOST].strip()
+            port = int(user_input[CONF_PORT])
+            self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
 
-            try:
-                mac = await test_connection(self.hass, host, port)
-            except CannotConnect:
-                _LOGGER.error("CannotConnect error caught")
+            unique_id, _mac_address = await _validate_connection(host, port)
+            if unique_id is None:
                 errors["base"] = "cannot_connect"
             else:
-                if not mac:
-                    errors["base"] = "no_mac"
-                else:
-                    _LOGGER.debug("MAC address found: %s", mac)
-                    # abort if the detected mac differs from the one in the entry
-                    await self.async_set_unique_id(mac)
-                    if self.source == SOURCE_RECONFIGURE:
-                        self._abort_if_unique_id_mismatch(reason="set_up_new_device")
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
+                title = DEFAULT_NAME
+                return self.async_create_entry(
+                    title=title,
+                    data={CONF_HOST: host, CONF_PORT: port},
+                )
 
-                        _LOGGER.debug("Reconfiguration done")
-                        return self.async_update_reload_and_abort(
-                            entry=self._get_reconfigure_entry(),
-                            data={**user_input, CONF_HOST: host, CONF_PORT: port},
-                        )
-                    # abort if already configured with same mac
-                    self._abort_if_unique_id_configured(updates={CONF_HOST: host})
-
-                    _LOGGER.debug("Configuration successful")
-                    return self.async_create_entry(
-                        title=DEFAULT_NAME,
-                        data=user_input,
-                    )
-        _LOGGER.debug("Showing form with errors: %s", errors)
         return self.async_show_form(
-            step_id=step_id,
-            data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, user_input
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Handle reauth flow."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm(entry_data)
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if self._reauth_entry is None:
+            return self.async_abort(reason="unknown")
+
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            port = int(user_input[CONF_PORT])
+
+            unique_id, _ = await _validate_connection(host, port)
+            if unique_id is None:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_mismatch()
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={**self._reauth_entry.data, CONF_HOST: host, CONF_PORT: port},
+                )
+                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=self._reauth_entry.data.get(CONF_HOST, "")
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=self._reauth_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+                }
             ),
             errors=errors,
         )
 
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        return MadvrEnvyOptionsFlowHandler(config_entry)
 
-async def test_connection(hass: HomeAssistant, host: str, port: int) -> str:
-    """Test if we can connect to the device and grab the mac."""
-    madvr_client = Madvr(host=host, port=port, loop=hass.loop)
-    _LOGGER.debug("Testing connection to madVR at %s:%s", host, port)
-    # try to connect
+
+class MadvrEnvyOptionsFlowHandler(OptionsFlow):
+    """Handle madVR Envy options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        if user_input is not None:
+            initial_backoff = float(user_input[OPT_RECONNECT_INITIAL_BACKOFF])
+            max_backoff = float(user_input[OPT_RECONNECT_MAX_BACKOFF])
+            jitter = float(user_input[OPT_RECONNECT_JITTER])
+            if initial_backoff > max_backoff:
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=_build_options_schema(self._config_entry),
+                    errors={"base": "invalid_backoff"},
+                )
+            if jitter < 0.0 or jitter > 1.0:
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=_build_options_schema(self._config_entry),
+                    errors={"base": "invalid_jitter"},
+                )
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_build_options_schema(self._config_entry),
+        )
+
+
+async def _validate_connection(host: str, port: int) -> tuple[str | None, str | None]:
+    client = MadvrEnvyClient(host=host, port=port)
     try:
-        await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
-    # connection can raise HeartBeatError if the device is not available or connection does not work
-    except (TimeoutError, aiohttp.ClientError, OSError, HeartBeatError) as err:
-        _LOGGER.error("Error connecting to madVR: %s", err)
-        raise CannotConnect from err
+        await client.start()
+        await client.wait_synced(timeout=DEFAULT_SYNC_TIMEOUT)
+    except (
+        envy_exceptions.ConnectionFailedError,
+        envy_exceptions.ConnectionTimeoutError,
+        envy_exceptions.NotConnectedError,
+        TimeoutError,
+    ):
+        return None, None
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Unexpected error during madVR Envy connection validation")
+        return None, None
+    finally:
+        await client.stop()
 
-    # check if we are connected
-    if not madvr_client.connected:
-        raise CannotConnect("Connection failed")
-
-    # background tasks needed to capture realtime info
-    await madvr_client.async_add_tasks()
-
-    # wait for client to capture device info
-    retry_time = 15
-    while not madvr_client.mac_address and retry_time > 0:
-        await asyncio.sleep(RETRY_INTERVAL)
-        retry_time -= 1
-
-    mac_address = madvr_client.mac_address
+    mac_address = client.state.mac_address
     if mac_address:
-        _LOGGER.debug("Connected to madVR with MAC: %s", mac_address)
-    # close this connection because this client object will not be reused
-    await close_test_connection(madvr_client)
-    _LOGGER.debug("Connection test successful")
-    return mac_address
+        return mac_address.lower().replace(":", ""), mac_address
+
+    return f"{host}_{port}", None
 
 
-async def close_test_connection(madvr_client: Madvr) -> None:
-    """Close the test connection."""
-    _LOGGER.debug("Closing test connection")
-    madvr_client.stop()
-    await madvr_client.async_cancel_tasks()
-    await madvr_client.close_connection()
+def _build_options_schema(config_entry: ConfigEntry) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(
+                OPT_SYNC_TIMEOUT,
+                default=config_entry.options.get(OPT_SYNC_TIMEOUT, DEFAULT_SYNC_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_CONNECT_TIMEOUT,
+                default=config_entry.options.get(OPT_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_COMMAND_TIMEOUT,
+                default=config_entry.options.get(OPT_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_READ_TIMEOUT,
+                default=config_entry.options.get(OPT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_RECONNECT_INITIAL_BACKOFF,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_INITIAL_BACKOFF,
+                    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0)),
+            vol.Required(
+                OPT_RECONNECT_MAX_BACKOFF,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_MAX_BACKOFF,
+                    DEFAULT_RECONNECT_MAX_BACKOFF,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0)),
+            vol.Required(
+                OPT_RECONNECT_JITTER,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_JITTER,
+                    DEFAULT_RECONNECT_JITTER,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
+            vol.Required(
+                OPT_ENABLE_ADVANCED_ENTITIES,
+                default=config_entry.options.get(
+                    OPT_ENABLE_ADVANCED_ENTITIES,
+                    DEFAULT_ENABLE_ADVANCED_ENTITIES,
+                ),
+            ): bool,
+        }
+    )

--- a/homeassistant/components/madvr/const.py
+++ b/homeassistant/components/madvr/const.py
@@ -1,11 +1,50 @@
-"""Constants for the madvr-envy integration."""
+"""Constants for the madVR Envy integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
 
 DOMAIN = "madvr"
-
+NAME = "madVR Envy"
 DEFAULT_NAME = "envy"
-DEFAULT_PORT = 44077
+MANUFACTURER = "madVR Labs"
+MODEL = "Envy"
 
-# Sensor keys
+DEFAULT_PORT = 44077
+DEFAULT_SYNC_TIMEOUT = 10.0
+DEFAULT_CONNECT_TIMEOUT = 3.0
+DEFAULT_COMMAND_TIMEOUT = 2.0
+DEFAULT_READ_TIMEOUT = 30.0
+DEFAULT_RECONNECT_INITIAL_BACKOFF = 1.0
+DEFAULT_RECONNECT_MAX_BACKOFF = 30.0
+DEFAULT_RECONNECT_JITTER = 0.2
+DEFAULT_ENABLE_ADVANCED_ENTITIES = True
+
+OPT_SYNC_TIMEOUT = "sync_timeout"
+OPT_CONNECT_TIMEOUT = "connect_timeout"
+OPT_COMMAND_TIMEOUT = "command_timeout"
+OPT_READ_TIMEOUT = "read_timeout"
+OPT_RECONNECT_INITIAL_BACKOFF = "reconnect_initial_backoff"
+OPT_RECONNECT_MAX_BACKOFF = "reconnect_max_backoff"
+OPT_RECONNECT_JITTER = "reconnect_jitter"
+OPT_ENABLE_ADVANCED_ENTITIES = "enable_advanced_entities"
+
+EVENT_PREFIX = f"{DOMAIN}."
+
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.REMOTE,
+]
+
+SENSITIVE_DIAGNOSTIC_KEYS = {
+    "host",
+    "mac",
+    "mac_address",
+    "configuration_url",
+}
+
+# Legacy sensor keys retained for entity ID/unique ID compatibility.
 TEMP_GPU = "temp_gpu"
 TEMP_HDMI = "temp_hdmi"
 TEMP_CPU = "temp_cpu"

--- a/homeassistant/components/madvr/coordinator.py
+++ b/homeassistant/components/madvr/coordinator.py
@@ -1,54 +1,215 @@
-"""Coordinator for handling data fetching and updates."""
+"""Push coordinator for madVR Envy integration."""
 
 from __future__ import annotations
 
-import logging
+from copy import deepcopy
 from typing import Any
 
-from madvr.madvr import Madvr
-
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
+from madvr_envy.adapter import EnvyStateAdapter
+from madvr_envy.ha_bridge import HABridgeDispatcher, coordinator_payload
 
-_LOGGER = logging.getLogger(__name__)
+from .const import (
+    ASPECT_DEC,
+    ASPECT_INT,
+    ASPECT_NAME,
+    ASPECT_RES,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    INCOMING_ASPECT_RATIO,
+    INCOMING_BIT_DEPTH,
+    INCOMING_BLACK_LEVELS,
+    INCOMING_COLORIMETRY,
+    INCOMING_COLOR_SPACE,
+    INCOMING_FRAME_RATE,
+    INCOMING_RES,
+    INCOMING_SIGNAL_TYPE,
+    MASKING_DEC,
+    MASKING_INT,
+    MASKING_RES,
+    OUTGOING_BIT_DEPTH,
+    OUTGOING_BLACK_LEVELS,
+    OUTGOING_COLORIMETRY,
+    OUTGOING_COLOR_SPACE,
+    OUTGOING_FRAME_RATE,
+    OUTGOING_RES,
+    OUTGOING_SIGNAL_TYPE,
+    TEMP_CPU,
+    TEMP_GPU,
+    TEMP_HDMI,
+    TEMP_MAINBOARD,
+)
 
-type MadVRConfigEntry = ConfigEntry[MadVRCoordinator]
 
-
-class MadVRCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Madvr coordinator for Envy (push-based API)."""
-
-    config_entry: MadVRConfigEntry
+class MadvrEnvyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Bridge madvr_envy push updates into Home Assistant entities."""
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: MadVRConfigEntry,
-        client: Madvr,
+        client: MadvrEnvyClient,
+        *,
+        sync_timeout: float = DEFAULT_SYNC_TIMEOUT,
     ) -> None:
-        """Initialize madvr coordinator."""
-        super().__init__(hass, _LOGGER, config_entry=config_entry, name=DOMAIN)
-        assert self.config_entry.unique_id
-        self.mac = self.config_entry.unique_id
+        super().__init__(hass, logger=client.logger, name=DOMAIN)
         self.client = client
-        # this does not use poll/refresh, so we need to set this to not None on init
-        self.data = {}
-        # this passes a callback to the client to push new data to the coordinator
-        self.client.set_update_callback(self.handle_push_data)
-        _LOGGER.debug("MadVRCoordinator initialized with mac: %s", self.mac)
+        self._sync_timeout = sync_timeout
 
-    def handle_push_data(self, data: dict[str, Any]) -> None:
-        """Handle new data pushed from the API."""
-        _LOGGER.debug("Received push data: %s", data)
-        # inform HA that we have new data
-        self.async_set_updated_data(data)
+        self._adapter = EnvyStateAdapter()
+        self._dispatcher = HABridgeDispatcher(event_emitter=self._emit_bus_event)
 
-    async def handle_coordinator_load(self) -> None:
-        """Handle operations on integration load."""
-        _LOGGER.debug("Using loop: %s", self.client.loop)
-        # tell the library to start background tasks
-        await self.client.async_add_tasks()
-        _LOGGER.debug("Added %s tasks to client", len(self.client.tasks))
+        self._adapter_callback_handle: Any | None = None
+        self._client_callback_registered = False
+        self._started = False
+        self.mac = f"{self.client.host}_{self.client.port}"
+
+    async def async_start(self) -> None:
+        """Start client and register callbacks once."""
+        if self._started:
+            return
+
+        if self._adapter_callback_handle is None:
+            self._adapter_callback_handle = self.client.register_adapter_callback(
+                self._adapter,
+                self._handle_adapter_update,
+            )
+
+        if not self._client_callback_registered:
+            self.client.register_callback(self._handle_client_event)
+            self._client_callback_registered = True
+
+        await self.client.start()
+        await self.client.wait_synced(timeout=self._sync_timeout)
+        await self._prime_state()
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        self.async_set_updated_data(self._legacy_payload(coordinator_payload(snapshot)))
+        self._started = True
+
+    async def async_shutdown(self) -> None:
+        """Stop runtime and clean callbacks."""
+        if self._adapter_callback_handle is not None:
+            self.client.deregister_adapter_callback(self._adapter_callback_handle)
+            self._adapter_callback_handle = None
+
+        if self._client_callback_registered:
+            self.client.deregister_callback(self._handle_client_event)
+            self._client_callback_registered = False
+
+        await self.client.stop()
+        self._started = False
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Return latest known data for manual refresh calls."""
+        if self.data is not None:
+            return deepcopy(self.data)
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        return self._legacy_payload(coordinator_payload(snapshot))
+
+    def _emit_bus_event(self, event_type: str, event_data: dict[str, object]) -> None:
+        self.hass.bus.async_fire(event_type, event_data)
+
+    def _handle_adapter_update(self, snapshot, deltas, events) -> None:  # noqa: ANN001
+        update = self._dispatcher.handle_adapter_update(snapshot, deltas, events)
+        self.async_set_updated_data(self._legacy_payload(update.coordinator_data))
+
+    def _handle_client_event(self, event: str, _message: object | None = None) -> None:
+        if event == "disconnected":
+            self.async_set_updated_data(self._with_available(False))
+        elif event == "connected":
+            self.async_set_updated_data(self._with_available(True))
+
+    def _with_available(self, available: bool) -> dict[str, Any]:
+        if self.data is not None:
+            data = dict(self.data)
+            data["available"] = available
+            return data
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        data = self._legacy_payload(coordinator_payload(snapshot))
+        data["available"] = available
+        return data
+
+    async def _prime_state(self) -> None:
+        """Best-effort startup priming for richer initial entity state."""
+        try:
+            await self.client.get_mac_address()
+            await self.client.get_temperatures()
+
+            groups = await self.client.enum_profile_groups_collect()
+            for group in groups:
+                await self.client.enum_profiles_collect(group.group_id)
+        except (
+            TimeoutError,
+            envy_exceptions.MadvrEnvyError,
+            OSError,
+        ) as err:
+            self.logger.debug("Startup priming skipped due to command failure: %s", err)
+
+    def _legacy_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Map adapter payload to legacy madVR keys for entity compatibility."""
+        data = dict(payload)
+
+        mac_address = data.get("mac_address")
+        if isinstance(mac_address, str) and mac_address:
+            self.mac = mac_address.lower().replace(":", "")
+
+        temperatures = data.get("temperatures")
+        if isinstance(temperatures, (list, tuple)):
+            if len(temperatures) > 0:
+                data[TEMP_GPU] = temperatures[0]
+            if len(temperatures) > 1:
+                data[TEMP_HDMI] = temperatures[1]
+            if len(temperatures) > 2:
+                data[TEMP_CPU] = temperatures[2]
+            if len(temperatures) > 3:
+                data[TEMP_MAINBOARD] = temperatures[3]
+
+        incoming = data.get("incoming_signal")
+        if isinstance(incoming, dict):
+            data[INCOMING_RES] = incoming.get("resolution")
+            data[INCOMING_SIGNAL_TYPE] = incoming.get("signal_type")
+            data[INCOMING_FRAME_RATE] = incoming.get("frame_rate")
+            data[INCOMING_COLOR_SPACE] = incoming.get("color_space")
+            data[INCOMING_BIT_DEPTH] = incoming.get("bit_depth")
+            data[INCOMING_COLORIMETRY] = incoming.get("colorimetry")
+            data[INCOMING_BLACK_LEVELS] = incoming.get("black_levels")
+            data[INCOMING_ASPECT_RATIO] = incoming.get("aspect_ratio")
+            hdr_mode = incoming.get("hdr_mode")
+            data["hdr_flag"] = isinstance(hdr_mode, str) and hdr_mode.upper() != "SDR"
+
+        outgoing = data.get("outgoing_signal")
+        if isinstance(outgoing, dict):
+            data[OUTGOING_RES] = outgoing.get("resolution")
+            data[OUTGOING_SIGNAL_TYPE] = outgoing.get("signal_type")
+            data[OUTGOING_FRAME_RATE] = outgoing.get("frame_rate")
+            data[OUTGOING_COLOR_SPACE] = outgoing.get("color_space")
+            data[OUTGOING_BIT_DEPTH] = outgoing.get("bit_depth")
+            data[OUTGOING_COLORIMETRY] = outgoing.get("colorimetry")
+            data[OUTGOING_BLACK_LEVELS] = outgoing.get("black_levels")
+            hdr_mode = outgoing.get("hdr_mode")
+            data["outgoing_hdr_flag"] = (
+                isinstance(hdr_mode, str) and hdr_mode.upper() != "SDR"
+            )
+
+        aspect_ratio = data.get("aspect_ratio")
+        if isinstance(aspect_ratio, dict):
+            data[ASPECT_RES] = aspect_ratio.get("resolution")
+            data[ASPECT_DEC] = aspect_ratio.get("decimal_ratio")
+            data[ASPECT_INT] = aspect_ratio.get("integer_ratio")
+            data[ASPECT_NAME] = aspect_ratio.get("name")
+
+        masking_ratio = data.get("masking_ratio")
+        if isinstance(masking_ratio, dict):
+            data[MASKING_RES] = masking_ratio.get("resolution")
+            data[MASKING_DEC] = masking_ratio.get("decimal_ratio")
+            data[MASKING_INT] = masking_ratio.get("integer_ratio")
+
+        data["is_on"] = data.get("power_state") != "off"
+        data["is_signal"] = bool(data.get("signal_present"))
+        return data

--- a/homeassistant/components/madvr/diagnostics.py
+++ b/homeassistant/components/madvr/diagnostics.py
@@ -5,19 +5,18 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-
-from .coordinator import MadVRConfigEntry
 
 TO_REDACT = [CONF_HOST]
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: MadVRConfigEntry
+    hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data = config_entry.runtime_data.data
+    data = config_entry.runtime_data.coordinator.data
 
     return {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT),

--- a/homeassistant/components/madvr/entity.py
+++ b/homeassistant/components/madvr/entity.py
@@ -1,24 +1,74 @@
-"""Base class for madVR entities."""
+"""Entity base classes for madVR Envy."""
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-from .coordinator import MadVRCoordinator
+from madvr_envy import exceptions
+
+from .const import DOMAIN, MANUFACTURER, MODEL, NAME
+from .coordinator import MadvrEnvyCoordinator
 
 
-class MadVREntity(CoordinatorEntity[MadVRCoordinator]):
-    """Defines a base madVR entity."""
+class MadvrEnvyEntity(CoordinatorEntity[MadvrEnvyCoordinator]):
+    """Common entity behavior for madVR Envy entities."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = False
 
-    def __init__(self, coordinator: MadVRCoordinator) -> None:
-        """Initialize madvr entity."""
+    def __init__(self, coordinator: MadvrEnvyCoordinator, entity_key: str) -> None:
         super().__init__(coordinator)
+        self._entity_key = entity_key
+        self._client = coordinator.client
+
+        device_id = coordinator.mac
+        mac = self._mac_address
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.mac)},
-            name="madVR Envy",
-            manufacturer="madVR",
-            model="Envy",
-            connections={(CONNECTION_NETWORK_MAC, coordinator.mac)},
+            identifiers={(DOMAIN, device_id)},
+            name=NAME,
+            manufacturer=MANUFACTURER,
+            model=MODEL,
+            sw_version=self.data.get("version"),
+            configuration_url=f"http://{self._client.host}",
+            connections={(CONNECTION_NETWORK_MAC, mac)} if mac else None,
         )
+
+    @property
+    def available(self) -> bool:
+        return bool(self.data.get("available"))
+
+    @property
+    def data(self) -> dict[str, Any]:
+        if self.coordinator.data is None:
+            return {}
+        return self.coordinator.data
+
+    @property
+    def _device_id(self) -> str:
+        return self.coordinator.mac
+
+    @property
+    def _mac_address(self) -> str | None:
+        mac = self.data.get("mac_address")
+        if isinstance(mac, str) and mac:
+            return mac
+        if self.coordinator.mac:
+            return self.coordinator.mac
+        return None
+
+    async def _execute(self, command_name: str, command: Callable[[], Any]) -> None:
+        try:
+            await command()
+        except (
+            TimeoutError,
+            exceptions.NotConnectedError,
+            exceptions.CommandRejectedError,
+            exceptions.ConnectionFailedError,
+            exceptions.ConnectionTimeoutError,
+        ) as err:
+            raise HomeAssistantError(f"{command_name} failed: {err}") from err

--- a/homeassistant/components/madvr/manifest.json
+++ b/homeassistant/components/madvr/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "madvr",
   "name": "madVR Envy",
-  "codeowners": ["@iloveicedgreentea"],
+  "codeowners": ["@binarylogic"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/madvr",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["py-madvr2==1.6.40"]
+  "loggers": ["madvr_envy"],
+  "requirements": ["madvr-envy==0.1.7"]
 }

--- a/homeassistant/components/madvr/models.py
+++ b/homeassistant/components/madvr/models.py
@@ -1,0 +1,19 @@
+"""Runtime models for madVR Envy integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from madvr_envy import MadvrEnvyClient
+
+from .coordinator import MadvrEnvyCoordinator
+
+
+@dataclass(slots=True)
+class MadvrEnvyRuntimeData:
+    """Stored runtime state for a config entry."""
+
+    client: MadvrEnvyClient
+    coordinator: MadvrEnvyCoordinator
+    last_data: dict[str, Any]

--- a/homeassistant/components/madvr/remote.py
+++ b/homeassistant/components/madvr/remote.py
@@ -7,69 +7,68 @@ import logging
 from typing import Any
 
 from homeassistant.components.remote import RemoteEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from madvr_envy.integration_bridge import iter_remote_operations, resolve_action_method
+
+from .entity import MadvrEnvyEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the madVR remote."""
-    coordinator = entry.runtime_data
-    async_add_entities(
-        [
-            MadvrRemote(coordinator),
-        ]
-    )
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([MadvrRemote(coordinator)])
 
 
-class MadvrRemote(MadVREntity, RemoteEntity):
+class MadvrRemote(MadvrEnvyEntity, RemoteEntity):
     """Remote entity for the madVR integration."""
 
     _attr_name = None
+    _attr_translation_key = "remote"
 
-    def __init__(
-        self,
-        coordinator: MadVRCoordinator,
-    ) -> None:
+    def __init__(self, coordinator) -> None:  # noqa: ANN001
         """Initialize the remote entity."""
-        super().__init__(coordinator)
-        self.madvr_client = coordinator.client
+        super().__init__(coordinator, "remote")
         self._attr_unique_id = coordinator.mac
 
     @property
     def is_on(self) -> bool:
         """Return true if the device is on."""
-        return self.madvr_client.is_on
+        return self.available and self.data.get("power_state") != "off"
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
         _LOGGER.debug("Turning off")
-        try:
-            await self.madvr_client.power_off()
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn off device %s", err)
+        await self._execute("Standby", self._client.standby)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
         _LOGGER.debug("Turning on device")
-
-        try:
-            await self.madvr_client.power_on(mac=self.coordinator.mac)
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn on device %s", err)
+        await self._execute("KeyPress POWER", lambda: self._client.key_press("POWER"))
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
-        _LOGGER.debug("adding command %s", command)
+        _LOGGER.debug("Adding command %s", command)
+        for operation in iter_remote_operations(command):
+            if operation.kind == "action":
+                await self._run_action(operation.value)
+                continue
+            key = operation.value
+            await self._execute(
+                f"KeyPress {key}", lambda button=key: self._client.key_press(button)
+            )
+
+    async def _run_action(self, action: str) -> None:
         try:
-            await self.madvr_client.add_command_to_queue(command)
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to send command %s", err)
+            command = resolve_action_method(self._client, action)
+        except ValueError:
+            return
+        await self._execute(action.strip().lower(), command)

--- a/homeassistant/components/madvr/sensor.py
+++ b/homeassistant/components/madvr/sensor.py
@@ -11,9 +11,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import (
@@ -24,8 +25,8 @@ from .const import (
     INCOMING_ASPECT_RATIO,
     INCOMING_BIT_DEPTH,
     INCOMING_BLACK_LEVELS,
-    INCOMING_COLOR_SPACE,
     INCOMING_COLORIMETRY,
+    INCOMING_COLOR_SPACE,
     INCOMING_FRAME_RATE,
     INCOMING_RES,
     INCOMING_SIGNAL_TYPE,
@@ -34,8 +35,8 @@ from .const import (
     MASKING_RES,
     OUTGOING_BIT_DEPTH,
     OUTGOING_BLACK_LEVELS,
-    OUTGOING_COLOR_SPACE,
     OUTGOING_COLORIMETRY,
+    OUTGOING_COLOR_SPACE,
     OUTGOING_FRAME_RATE,
     OUTGOING_RES,
     OUTGOING_SIGNAL_TYPE,
@@ -44,8 +45,8 @@ from .const import (
     TEMP_HDMI,
     TEMP_MAINBOARD,
 )
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from .coordinator import MadvrEnvyCoordinator
+from .entity import MadvrEnvyEntity
 
 
 def is_valid_temperature(value: float | None) -> bool:
@@ -53,21 +54,20 @@ def is_valid_temperature(value: float | None) -> bool:
     return value is not None and value > 0
 
 
-def get_temperature(coordinator: MadVRCoordinator, key: str) -> float | None:
+def get_temperature(coordinator: MadvrEnvyCoordinator, key: str) -> float | None:
     """Get temperature value if valid, otherwise return None."""
     try:
         temp = float(coordinator.data.get(key, 0))
-    except AttributeError, ValueError:
+    except (TypeError, ValueError):
         return None
-    else:
-        return temp if is_valid_temperature(temp) else None
+    return temp if is_valid_temperature(temp) else None
 
 
 @dataclass(frozen=True, kw_only=True)
 class MadvrSensorEntityDescription(SensorEntityDescription):
     """Describe madVR sensor entity."""
 
-    value_fn: Callable[[MadVRCoordinator], StateType]
+    value_fn: Callable[[MadvrEnvyCoordinator], StateType]
 
 
 SENSORS: tuple[MadvrSensorEntityDescription, ...] = (
@@ -252,39 +252,30 @@ SENSORS: tuple[MadvrSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor entities."""
-    coordinator = entry.runtime_data
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(MadvrSensor(coordinator, description) for description in SENSORS)
 
 
-class MadvrSensor(MadVREntity, SensorEntity):
+class MadvrSensor(MadvrEnvyEntity, SensorEntity):
     """Base class for madVR sensors."""
+
+    entity_description: MadvrSensorEntityDescription
 
     def __init__(
         self,
-        coordinator: MadVRCoordinator,
+        coordinator: MadvrEnvyCoordinator,
         description: MadvrSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self.entity_description: MadvrSensorEntityDescription = description
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
         self._attr_unique_id = f"{coordinator.mac}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
-        """Return the state of the sensor."""
-        val = self.entity_description.value_fn(self.coordinator)
-        # check if sensor is enum
-        if self.entity_description.device_class == SensorDeviceClass.ENUM:
-            if (
-                self.entity_description.options
-                and val in self.entity_description.options
-            ):
-                return val
-            # return None for values that are not in the options
-            return None
-
-        return val
+    def native_value(self) -> StateType:
+        """Return the native value."""
+        return self.entity_description.value_fn(self.coordinator)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1850,7 +1850,7 @@ py-dormakaba-dkey==1.0.6
 py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
-py-madvr2==1.6.40
+madvr-envy==0.1.7
 
 # homeassistant.components.melissa
 py-melissa-climate==3.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1602,7 +1602,7 @@ py-dormakaba-dkey==1.0.6
 py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
-py-madvr2==1.6.40
+madvr-envy==0.1.7
 
 # homeassistant.components.melissa
 py-melissa-climate==3.0.3


### PR DESCRIPTION
## Summary
This is PR 1 of a split sequence from #164410 to improve reviewability.

This PR only covers runtime migration to `madvr-envy` for existing madvr platforms (`sensor`, `binary_sensor`, `remote`).

## What is included
- Replace `py-madvr2` dependency with `madvr-envy==0.1.7`
- New coordinator/runtime model using `madvr-envy`
- Keep existing domain (`madvr`)
- Keep legacy entity compatibility for existing entities by preserving legacy keys/unique ID patterns
- Keep existing platforms only (no new platforms/services in this PR)

## What is intentionally excluded (follow-up PRs)
- Additional platforms (`button`, `switch`, `select`)
- New integration services
- Expanded telemetry additions

## Compatibility notes
- Existing `remote`/`sensor`/`binary_sensor` unique ID patterns are preserved.
- This addresses the compatibility concern raised in review on #164410.

## Validation
- Local compile check passed for `homeassistant/components/madvr` and `tests/components/madvr`.
- Full pytest run was not available in this temporary environment; CI is expected to run full validation.

Part of split from: #164410
Context: #154722
