### PR TITLE
madvr: add button/switch/select platforms and integration services

### DIFF
--- a/homeassistant/components/madvr/__init__.py
+++ b/homeassistant/components/madvr/__init__.py
@@ -1,65 +1,116 @@
-"""The madvr-envy integration."""
+"""The madVR Envy integration."""
 
 from __future__ import annotations
 
-import logging
+from typing import Any
 
-from madvr.madvr import Madvr
-
-from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.REMOTE, Platform.SENSOR]
+from .const import (
+    DEFAULT_COMMAND_TIMEOUT,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+    DEFAULT_RECONNECT_JITTER,
+    DEFAULT_RECONNECT_MAX_BACKOFF,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    OPT_COMMAND_TIMEOUT,
+    OPT_CONNECT_TIMEOUT,
+    OPT_READ_TIMEOUT,
+    OPT_RECONNECT_INITIAL_BACKOFF,
+    OPT_RECONNECT_JITTER,
+    OPT_RECONNECT_MAX_BACKOFF,
+    OPT_SYNC_TIMEOUT,
+    PLATFORMS,
+)
+from .coordinator import MadvrEnvyCoordinator
+from .models import MadvrEnvyRuntimeData
 
-_LOGGER = logging.getLogger(__name__)
+MadvrEnvyConfigEntry = ConfigEntry
 
 
-async def async_handle_unload(coordinator: MadVRCoordinator) -> None:
-    """Handle unload."""
-    _LOGGER.debug("Integration unloading")
-    coordinator.client.stop()
-    await coordinator.client.async_cancel_tasks()
-    _LOGGER.debug("Integration closing connection")
-    await coordinator.client.close_connection()
-    _LOGGER.debug("Unloaded")
+async def async_setup_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> bool:
+    """Set up madVR Envy from a config entry."""
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
 
-
-async def async_setup_entry(hass: HomeAssistant, entry: MadVRConfigEntry) -> bool:
-    """Set up the integration from a config entry."""
-    assert entry.unique_id
-    madVRClient = Madvr(
-        host=entry.data[CONF_HOST],
-        logger=_LOGGER,
-        port=entry.data[CONF_PORT],
-        mac=entry.unique_id,
-        connect_timeout=10,
-        loop=hass.loop,
+    client = MadvrEnvyClient(
+        host=host,
+        port=port,
+        connect_timeout=_get_float_option(entry, OPT_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+        command_timeout=_get_float_option(entry, OPT_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+        read_timeout=_get_float_option(entry, OPT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT),
+        reconnect_initial_backoff=_get_float_option(
+            entry,
+            OPT_RECONNECT_INITIAL_BACKOFF,
+            DEFAULT_RECONNECT_INITIAL_BACKOFF,
+        ),
+        reconnect_max_backoff=_get_float_option(
+            entry,
+            OPT_RECONNECT_MAX_BACKOFF,
+            DEFAULT_RECONNECT_MAX_BACKOFF,
+        ),
+        reconnect_jitter=_get_float_option(
+            entry,
+            OPT_RECONNECT_JITTER,
+            DEFAULT_RECONNECT_JITTER,
+        ),
+        auto_reconnect=True,
     )
-    coordinator = MadVRCoordinator(hass, entry, madVRClient)
+    coordinator = MadvrEnvyCoordinator(
+        hass,
+        client,
+        sync_timeout=_get_float_option(entry, OPT_SYNC_TIMEOUT, DEFAULT_SYNC_TIMEOUT),
+    )
 
-    entry.runtime_data = coordinator
+    try:
+        await coordinator.async_start()
+    except (
+        envy_exceptions.ConnectionFailedError,
+        envy_exceptions.ConnectionTimeoutError,
+        TimeoutError,
+    ) as err:
+        await coordinator.async_shutdown()
+        raise ConfigEntryNotReady(f"Could not connect to madVR Envy at {host}:{port}") from err
+    except Exception:
+        await coordinator.async_shutdown()
+        raise
 
+    runtime_data = MadvrEnvyRuntimeData(client=client, coordinator=coordinator, last_data={})
+    entry.runtime_data = runtime_data
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
+
+    async def _handle_hass_stop(_event: Event) -> None:
+        await coordinator.async_shutdown()
+
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _handle_hass_stop))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    async def handle_unload(event: Event) -> None:
-        """Handle unload."""
-        await async_handle_unload(coordinator=coordinator)
-
-    # listen for core stop event
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, handle_unload)
-
-    # handle loading operations
-    await coordinator.handle_coordinator_load()
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: MadVRConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        coordinator: MadVRCoordinator = entry.runtime_data
-        await async_handle_unload(coordinator=coordinator)
-
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await entry.runtime_data.coordinator.async_shutdown()
+        if not hass.data[DOMAIN]:
+            hass.data.pop(DOMAIN, None)
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -> None:
+    """Handle reload request."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+def _get_float_option(entry: ConfigEntry, key: str, default: float) -> float:
+    value: Any = entry.options.get(key, default)
+    return float(value)

--- a/homeassistant/components/madvr/__init__.py
+++ b/homeassistant/components/madvr/__init__.py
@@ -32,6 +32,7 @@ from .const import (
 )
 from .coordinator import MadvrEnvyCoordinator
 from .models import MadvrEnvyRuntimeData
+from .services import async_setup_services, async_unload_services
 
 MadvrEnvyConfigEntry = ConfigEntry
 
@@ -86,6 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) ->
     runtime_data = MadvrEnvyRuntimeData(client=client, coordinator=coordinator, last_data={})
     entry.runtime_data = runtime_data
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = runtime_data
+    await async_setup_services(hass)
 
     async def _handle_hass_stop(_event: Event) -> None:
         await coordinator.async_shutdown()
@@ -102,6 +104,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: MadvrEnvyConfigEntry) -
         hass.data[DOMAIN].pop(entry.entry_id, None)
         await entry.runtime_data.coordinator.async_shutdown()
         if not hass.data[DOMAIN]:
+            await async_unload_services(hass)
             hass.data.pop(DOMAIN, None)
     return unload_ok
 

--- a/homeassistant/components/madvr/binary_sensor.py
+++ b/homeassistant/components/madvr/binary_sensor.py
@@ -9,11 +9,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from .coordinator import MadvrEnvyCoordinator
+from .entity import MadvrEnvyEntity
 
 _HDR_FLAG = "hdr_flag"
 _OUTGOING_HDR_FLAG = "outgoing_hdr_flag"
@@ -25,7 +26,7 @@ _SIGNAL_STATE = "signal_state"
 class MadvrBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describe madVR binary sensor entity."""
 
-    value_fn: Callable[[MadVRCoordinator], bool]
+    value_fn: Callable[[MadvrEnvyCoordinator], bool]
 
 
 BINARY_SENSORS: tuple[MadvrBinarySensorEntityDescription, ...] = (
@@ -54,28 +55,28 @@ BINARY_SENSORS: tuple[MadvrBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the binary sensor entities."""
-    coordinator = entry.runtime_data
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(
         MadvrBinarySensor(coordinator, description) for description in BINARY_SENSORS
     )
 
 
-class MadvrBinarySensor(MadVREntity, BinarySensorEntity):
+class MadvrBinarySensor(MadvrEnvyEntity, BinarySensorEntity):
     """Base class for madVR binary sensors."""
 
     entity_description: MadvrBinarySensorEntityDescription
 
     def __init__(
         self,
-        coordinator: MadVRCoordinator,
+        coordinator: MadvrEnvyCoordinator,
         description: MadvrBinarySensorEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator)
+        super().__init__(coordinator, description.key)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.mac}_{description.key}"
 

--- a/homeassistant/components/madvr/button.py
+++ b/homeassistant/components/madvr/button.py
@@ -1,0 +1,123 @@
+"""Button platform for madVR Envy."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import OPT_ENABLE_ADVANCED_ENTITIES
+from .entity import MadvrEnvyEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class MadvrEnvyButtonDescription(ButtonEntityDescription):
+    press_fn: Callable[[MadvrEnvyEntity], Awaitable[None]]
+
+
+BUTTONS: tuple[MadvrEnvyButtonDescription, ...] = (
+    MadvrEnvyButtonDescription(
+        key="power_on",
+        translation_key="power_on",
+        icon="mdi:power-on",
+        press_fn=lambda entity: entity._execute(
+            "KeyPress POWER", lambda: entity._client.key_press("POWER")
+        ),
+    ),
+    MadvrEnvyButtonDescription(
+        key="standby",
+        translation_key="standby",
+        icon="mdi:sleep",
+        press_fn=lambda entity: entity._execute("Standby", entity._client.standby),
+    ),
+    MadvrEnvyButtonDescription(
+        key="power_off",
+        translation_key="power_off",
+        icon="mdi:power-off",
+        press_fn=lambda entity: entity._execute("PowerOff", entity._client.power_off),
+    ),
+    MadvrEnvyButtonDescription(
+        key="hotplug",
+        translation_key="hotplug",
+        icon="mdi:video-input-hdmi",
+        press_fn=lambda entity: entity._execute("Hotplug", entity._client.hotplug),
+    ),
+    MadvrEnvyButtonDescription(
+        key="restart",
+        translation_key="restart",
+        icon="mdi:restart",
+        press_fn=lambda entity: entity._execute("Restart", entity._client.restart),
+    ),
+    MadvrEnvyButtonDescription(
+        key="reload_software",
+        translation_key="reload_software",
+        icon="mdi:update",
+        press_fn=lambda entity: entity._execute("ReloadSoftware", entity._client.reload_software),
+    ),
+    MadvrEnvyButtonDescription(
+        key="remote_menu",
+        translation_key="remote_menu",
+        icon="mdi:menu",
+        press_fn=lambda entity: entity._execute(
+            "KeyPress MENU", lambda: entity._client.key_press("MENU")
+        ),
+    ),
+    MadvrEnvyButtonDescription(
+        key="remote_info",
+        translation_key="remote_info",
+        icon="mdi:information",
+        press_fn=lambda entity: entity._execute(
+            "KeyPress INFO", lambda: entity._client.key_press("INFO")
+        ),
+    ),
+    MadvrEnvyButtonDescription(
+        key="remote_ok",
+        translation_key="remote_ok",
+        icon="mdi:check-circle-outline",
+        press_fn=lambda entity: entity._execute(
+            "KeyPress OK", lambda: entity._client.key_press("OK")
+        ),
+    ),
+    MadvrEnvyButtonDescription(
+        key="remote_back",
+        translation_key="remote_back",
+        icon="mdi:arrow-left-circle-outline",
+        press_fn=lambda entity: entity._execute(
+            "KeyPress BACK", lambda: entity._client.key_press("BACK")
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    enable_advanced = entry.options.get(OPT_ENABLE_ADVANCED_ENTITIES, True)
+    coordinator = entry.runtime_data.coordinator
+
+    entities: list[MadvrEnvyButton] = []
+    for description in BUTTONS:
+        if description.key.startswith("remote_") and not enable_advanced:
+            continue
+        entities.append(MadvrEnvyButton(coordinator, description))
+
+    async_add_entities(entities)
+
+
+class MadvrEnvyButton(MadvrEnvyEntity, ButtonEntity):
+    """madVR Envy button."""
+
+    entity_description: MadvrEnvyButtonDescription
+
+    def __init__(self, coordinator, description: MadvrEnvyButtonDescription) -> None:  # noqa: ANN001
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
+
+    async def async_press(self) -> None:
+        await self.entity_description.press_fn(self)

--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -1,139 +1,235 @@
-"""Config flow for the integration."""
+"""Config flow for madVR Envy integration."""
 
-import asyncio
+from __future__ import annotations
+
 import logging
 from typing import Any
 
-import aiohttp
-from madvr.madvr import HeartBeatError, Madvr
 import voluptuous as vol
-
-from homeassistant.config_entries import (
-    SOURCE_RECONFIGURE,
-    ConfigFlow,
-    ConfigFlowResult,
-)
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
 
-from .const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
-from .errors import CannotConnect
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
+
+from .const import (
+    DEFAULT_COMMAND_TIMEOUT,
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_NAME,
+    DEFAULT_ENABLE_ADVANCED_ENTITIES,
+    DEFAULT_PORT,
+    DEFAULT_READ_TIMEOUT,
+    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+    DEFAULT_RECONNECT_JITTER,
+    DEFAULT_RECONNECT_MAX_BACKOFF,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    OPT_COMMAND_TIMEOUT,
+    OPT_CONNECT_TIMEOUT,
+    OPT_ENABLE_ADVANCED_ENTITIES,
+    OPT_READ_TIMEOUT,
+    OPT_RECONNECT_INITIAL_BACKOFF,
+    OPT_RECONNECT_JITTER,
+    OPT_RECONNECT_MAX_BACKOFF,
+    OPT_SYNC_TIMEOUT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
-        vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Required(CONF_PORT, default=DEFAULT_PORT): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=65535)
+        ),
     }
 )
 
-RETRY_INTERVAL = 1
 
-
-class MadVRConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for the integration."""
+class MadvrEnvyConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for madVR Envy."""
 
     VERSION = 1
+    _reauth_entry: ConfigEntry | None = None
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        return await self._handle_config_step(user_input)
-
-    async def async_step_reconfigure(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a reconfiguration flow initialized by the user."""
-        return await self._handle_config_step(user_input, step_id="reconfigure")
-
-    async def _handle_config_step(
-        self, user_input: dict[str, Any] | None = None, step_id: str = "user"
-    ) -> ConfigFlowResult:
-        """Handle the configuration step for both initial setup and reconfiguration."""
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            _LOGGER.debug("User input: %s", user_input)
-            host = user_input[CONF_HOST]
-            port = user_input[CONF_PORT]
+            host = user_input[CONF_HOST].strip()
+            port = int(user_input[CONF_PORT])
+            self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
 
-            try:
-                mac = await test_connection(self.hass, host, port)
-            except CannotConnect:
-                _LOGGER.error("CannotConnect error caught")
+            unique_id, _mac_address = await _validate_connection(host, port)
+            if unique_id is None:
                 errors["base"] = "cannot_connect"
             else:
-                if not mac:
-                    errors["base"] = "no_mac"
-                else:
-                    _LOGGER.debug("MAC address found: %s", mac)
-                    # abort if the detected mac differs from the one in the entry
-                    await self.async_set_unique_id(mac)
-                    if self.source == SOURCE_RECONFIGURE:
-                        self._abort_if_unique_id_mismatch(reason="set_up_new_device")
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
+                title = DEFAULT_NAME
+                return self.async_create_entry(
+                    title=title,
+                    data={CONF_HOST: host, CONF_PORT: port},
+                )
 
-                        _LOGGER.debug("Reconfiguration done")
-                        return self.async_update_reload_and_abort(
-                            entry=self._get_reconfigure_entry(),
-                            data={**user_input, CONF_HOST: host, CONF_PORT: port},
-                        )
-                    # abort if already configured with same mac
-                    self._abort_if_unique_id_configured(updates={CONF_HOST: host})
-
-                    _LOGGER.debug("Configuration successful")
-                    return self.async_create_entry(
-                        title=DEFAULT_NAME,
-                        data=user_input,
-                    )
-        _LOGGER.debug("Showing form with errors: %s", errors)
         return self.async_show_form(
-            step_id=step_id,
-            data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, user_input
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+        """Handle reauth flow."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm(entry_data)
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if self._reauth_entry is None:
+            return self.async_abort(reason="unknown")
+
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            port = int(user_input[CONF_PORT])
+
+            unique_id, _ = await _validate_connection(host, port)
+            if unique_id is None:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_mismatch()
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={**self._reauth_entry.data, CONF_HOST: host, CONF_PORT: port},
+                )
+                await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST, default=self._reauth_entry.data.get(CONF_HOST, "")
+                    ): str,
+                    vol.Required(
+                        CONF_PORT,
+                        default=self._reauth_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+                }
             ),
             errors=errors,
         )
 
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        return MadvrEnvyOptionsFlowHandler(config_entry)
 
-async def test_connection(hass: HomeAssistant, host: str, port: int) -> str:
-    """Test if we can connect to the device and grab the mac."""
-    madvr_client = Madvr(host=host, port=port, loop=hass.loop)
-    _LOGGER.debug("Testing connection to madVR at %s:%s", host, port)
-    # try to connect
+
+class MadvrEnvyOptionsFlowHandler(OptionsFlow):
+    """Handle madVR Envy options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        if user_input is not None:
+            initial_backoff = float(user_input[OPT_RECONNECT_INITIAL_BACKOFF])
+            max_backoff = float(user_input[OPT_RECONNECT_MAX_BACKOFF])
+            jitter = float(user_input[OPT_RECONNECT_JITTER])
+            if initial_backoff > max_backoff:
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=_build_options_schema(self._config_entry),
+                    errors={"base": "invalid_backoff"},
+                )
+            if jitter < 0.0 or jitter > 1.0:
+                return self.async_show_form(
+                    step_id="init",
+                    data_schema=_build_options_schema(self._config_entry),
+                    errors={"base": "invalid_jitter"},
+                )
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_build_options_schema(self._config_entry),
+        )
+
+
+async def _validate_connection(host: str, port: int) -> tuple[str | None, str | None]:
+    client = MadvrEnvyClient(host=host, port=port)
     try:
-        await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
-    # connection can raise HeartBeatError if the device is not available or connection does not work
-    except (TimeoutError, aiohttp.ClientError, OSError, HeartBeatError) as err:
-        _LOGGER.error("Error connecting to madVR: %s", err)
-        raise CannotConnect from err
+        await client.start()
+        await client.wait_synced(timeout=DEFAULT_SYNC_TIMEOUT)
+    except (
+        envy_exceptions.ConnectionFailedError,
+        envy_exceptions.ConnectionTimeoutError,
+        envy_exceptions.NotConnectedError,
+        TimeoutError,
+    ):
+        return None, None
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("Unexpected error during madVR Envy connection validation")
+        return None, None
+    finally:
+        await client.stop()
 
-    # check if we are connected
-    if not madvr_client.connected:
-        raise CannotConnect("Connection failed")
-
-    # background tasks needed to capture realtime info
-    await madvr_client.async_add_tasks()
-
-    # wait for client to capture device info
-    retry_time = 15
-    while not madvr_client.mac_address and retry_time > 0:
-        await asyncio.sleep(RETRY_INTERVAL)
-        retry_time -= 1
-
-    mac_address = madvr_client.mac_address
+    mac_address = client.state.mac_address
     if mac_address:
-        _LOGGER.debug("Connected to madVR with MAC: %s", mac_address)
-    # close this connection because this client object will not be reused
-    await close_test_connection(madvr_client)
-    _LOGGER.debug("Connection test successful")
-    return mac_address
+        return mac_address.lower().replace(":", ""), mac_address
+
+    return f"{host}_{port}", None
 
 
-async def close_test_connection(madvr_client: Madvr) -> None:
-    """Close the test connection."""
-    _LOGGER.debug("Closing test connection")
-    madvr_client.stop()
-    await madvr_client.async_cancel_tasks()
-    await madvr_client.close_connection()
+def _build_options_schema(config_entry: ConfigEntry) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(
+                OPT_SYNC_TIMEOUT,
+                default=config_entry.options.get(OPT_SYNC_TIMEOUT, DEFAULT_SYNC_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_CONNECT_TIMEOUT,
+                default=config_entry.options.get(OPT_CONNECT_TIMEOUT, DEFAULT_CONNECT_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_COMMAND_TIMEOUT,
+                default=config_entry.options.get(OPT_COMMAND_TIMEOUT, DEFAULT_COMMAND_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_READ_TIMEOUT,
+                default=config_entry.options.get(OPT_READ_TIMEOUT, DEFAULT_READ_TIMEOUT),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.1)),
+            vol.Required(
+                OPT_RECONNECT_INITIAL_BACKOFF,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_INITIAL_BACKOFF,
+                    DEFAULT_RECONNECT_INITIAL_BACKOFF,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0)),
+            vol.Required(
+                OPT_RECONNECT_MAX_BACKOFF,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_MAX_BACKOFF,
+                    DEFAULT_RECONNECT_MAX_BACKOFF,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0)),
+            vol.Required(
+                OPT_RECONNECT_JITTER,
+                default=config_entry.options.get(
+                    OPT_RECONNECT_JITTER,
+                    DEFAULT_RECONNECT_JITTER,
+                ),
+            ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0)),
+            vol.Required(
+                OPT_ENABLE_ADVANCED_ENTITIES,
+                default=config_entry.options.get(
+                    OPT_ENABLE_ADVANCED_ENTITIES,
+                    DEFAULT_ENABLE_ADVANCED_ENTITIES,
+                ),
+            ): bool,
+        }
+    )

--- a/homeassistant/components/madvr/const.py
+++ b/homeassistant/components/madvr/const.py
@@ -34,6 +34,9 @@ EVENT_PREFIX = f"{DOMAIN}."
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.BUTTON,
+    Platform.SELECT,
     Platform.REMOTE,
 ]
 
@@ -71,3 +74,7 @@ ASPECT_NAME = "aspect_name"
 MASKING_RES = "masking_res"
 MASKING_DEC = "masking_dec"
 MASKING_INT = "masking_int"
+
+SERVICE_PRESS_KEY = "press_key"
+SERVICE_ACTIVATE_PROFILE = "activate_profile"
+SERVICE_RUN_ACTION = "run_action"

--- a/homeassistant/components/madvr/const.py
+++ b/homeassistant/components/madvr/const.py
@@ -1,11 +1,50 @@
-"""Constants for the madvr-envy integration."""
+"""Constants for the madVR Envy integration."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
 
 DOMAIN = "madvr"
-
+NAME = "madVR Envy"
 DEFAULT_NAME = "envy"
-DEFAULT_PORT = 44077
+MANUFACTURER = "madVR Labs"
+MODEL = "Envy"
 
-# Sensor keys
+DEFAULT_PORT = 44077
+DEFAULT_SYNC_TIMEOUT = 10.0
+DEFAULT_CONNECT_TIMEOUT = 3.0
+DEFAULT_COMMAND_TIMEOUT = 2.0
+DEFAULT_READ_TIMEOUT = 30.0
+DEFAULT_RECONNECT_INITIAL_BACKOFF = 1.0
+DEFAULT_RECONNECT_MAX_BACKOFF = 30.0
+DEFAULT_RECONNECT_JITTER = 0.2
+DEFAULT_ENABLE_ADVANCED_ENTITIES = True
+
+OPT_SYNC_TIMEOUT = "sync_timeout"
+OPT_CONNECT_TIMEOUT = "connect_timeout"
+OPT_COMMAND_TIMEOUT = "command_timeout"
+OPT_READ_TIMEOUT = "read_timeout"
+OPT_RECONNECT_INITIAL_BACKOFF = "reconnect_initial_backoff"
+OPT_RECONNECT_MAX_BACKOFF = "reconnect_max_backoff"
+OPT_RECONNECT_JITTER = "reconnect_jitter"
+OPT_ENABLE_ADVANCED_ENTITIES = "enable_advanced_entities"
+
+EVENT_PREFIX = f"{DOMAIN}."
+
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.REMOTE,
+]
+
+SENSITIVE_DIAGNOSTIC_KEYS = {
+    "host",
+    "mac",
+    "mac_address",
+    "configuration_url",
+}
+
+# Legacy sensor keys retained for entity ID/unique ID compatibility.
 TEMP_GPU = "temp_gpu"
 TEMP_HDMI = "temp_hdmi"
 TEMP_CPU = "temp_cpu"

--- a/homeassistant/components/madvr/coordinator.py
+++ b/homeassistant/components/madvr/coordinator.py
@@ -1,54 +1,215 @@
-"""Coordinator for handling data fetching and updates."""
+"""Push coordinator for madVR Envy integration."""
 
 from __future__ import annotations
 
-import logging
+from copy import deepcopy
 from typing import Any
 
-from madvr.madvr import Madvr
-
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from madvr_envy import MadvrEnvyClient
+from madvr_envy import exceptions as envy_exceptions
+from madvr_envy.adapter import EnvyStateAdapter
+from madvr_envy.ha_bridge import HABridgeDispatcher, coordinator_payload
 
-_LOGGER = logging.getLogger(__name__)
+from .const import (
+    ASPECT_DEC,
+    ASPECT_INT,
+    ASPECT_NAME,
+    ASPECT_RES,
+    DEFAULT_SYNC_TIMEOUT,
+    DOMAIN,
+    INCOMING_ASPECT_RATIO,
+    INCOMING_BIT_DEPTH,
+    INCOMING_BLACK_LEVELS,
+    INCOMING_COLORIMETRY,
+    INCOMING_COLOR_SPACE,
+    INCOMING_FRAME_RATE,
+    INCOMING_RES,
+    INCOMING_SIGNAL_TYPE,
+    MASKING_DEC,
+    MASKING_INT,
+    MASKING_RES,
+    OUTGOING_BIT_DEPTH,
+    OUTGOING_BLACK_LEVELS,
+    OUTGOING_COLORIMETRY,
+    OUTGOING_COLOR_SPACE,
+    OUTGOING_FRAME_RATE,
+    OUTGOING_RES,
+    OUTGOING_SIGNAL_TYPE,
+    TEMP_CPU,
+    TEMP_GPU,
+    TEMP_HDMI,
+    TEMP_MAINBOARD,
+)
 
-type MadVRConfigEntry = ConfigEntry[MadVRCoordinator]
 
-
-class MadVRCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Madvr coordinator for Envy (push-based API)."""
-
-    config_entry: MadVRConfigEntry
+class MadvrEnvyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Bridge madvr_envy push updates into Home Assistant entities."""
 
     def __init__(
         self,
         hass: HomeAssistant,
-        config_entry: MadVRConfigEntry,
-        client: Madvr,
+        client: MadvrEnvyClient,
+        *,
+        sync_timeout: float = DEFAULT_SYNC_TIMEOUT,
     ) -> None:
-        """Initialize madvr coordinator."""
-        super().__init__(hass, _LOGGER, config_entry=config_entry, name=DOMAIN)
-        assert self.config_entry.unique_id
-        self.mac = self.config_entry.unique_id
+        super().__init__(hass, logger=client.logger, name=DOMAIN)
         self.client = client
-        # this does not use poll/refresh, so we need to set this to not None on init
-        self.data = {}
-        # this passes a callback to the client to push new data to the coordinator
-        self.client.set_update_callback(self.handle_push_data)
-        _LOGGER.debug("MadVRCoordinator initialized with mac: %s", self.mac)
+        self._sync_timeout = sync_timeout
 
-    def handle_push_data(self, data: dict[str, Any]) -> None:
-        """Handle new data pushed from the API."""
-        _LOGGER.debug("Received push data: %s", data)
-        # inform HA that we have new data
-        self.async_set_updated_data(data)
+        self._adapter = EnvyStateAdapter()
+        self._dispatcher = HABridgeDispatcher(event_emitter=self._emit_bus_event)
 
-    async def handle_coordinator_load(self) -> None:
-        """Handle operations on integration load."""
-        _LOGGER.debug("Using loop: %s", self.client.loop)
-        # tell the library to start background tasks
-        await self.client.async_add_tasks()
-        _LOGGER.debug("Added %s tasks to client", len(self.client.tasks))
+        self._adapter_callback_handle: Any | None = None
+        self._client_callback_registered = False
+        self._started = False
+        self.mac = f"{self.client.host}_{self.client.port}"
+
+    async def async_start(self) -> None:
+        """Start client and register callbacks once."""
+        if self._started:
+            return
+
+        if self._adapter_callback_handle is None:
+            self._adapter_callback_handle = self.client.register_adapter_callback(
+                self._adapter,
+                self._handle_adapter_update,
+            )
+
+        if not self._client_callback_registered:
+            self.client.register_callback(self._handle_client_event)
+            self._client_callback_registered = True
+
+        await self.client.start()
+        await self.client.wait_synced(timeout=self._sync_timeout)
+        await self._prime_state()
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        self.async_set_updated_data(self._legacy_payload(coordinator_payload(snapshot)))
+        self._started = True
+
+    async def async_shutdown(self) -> None:
+        """Stop runtime and clean callbacks."""
+        if self._adapter_callback_handle is not None:
+            self.client.deregister_adapter_callback(self._adapter_callback_handle)
+            self._adapter_callback_handle = None
+
+        if self._client_callback_registered:
+            self.client.deregister_callback(self._handle_client_event)
+            self._client_callback_registered = False
+
+        await self.client.stop()
+        self._started = False
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Return latest known data for manual refresh calls."""
+        if self.data is not None:
+            return deepcopy(self.data)
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        return self._legacy_payload(coordinator_payload(snapshot))
+
+    def _emit_bus_event(self, event_type: str, event_data: dict[str, object]) -> None:
+        self.hass.bus.async_fire(event_type, event_data)
+
+    def _handle_adapter_update(self, snapshot, deltas, events) -> None:  # noqa: ANN001
+        update = self._dispatcher.handle_adapter_update(snapshot, deltas, events)
+        self.async_set_updated_data(self._legacy_payload(update.coordinator_data))
+
+    def _handle_client_event(self, event: str, _message: object | None = None) -> None:
+        if event == "disconnected":
+            self.async_set_updated_data(self._with_available(False))
+        elif event == "connected":
+            self.async_set_updated_data(self._with_available(True))
+
+    def _with_available(self, available: bool) -> dict[str, Any]:
+        if self.data is not None:
+            data = dict(self.data)
+            data["available"] = available
+            return data
+
+        snapshot, _, _ = self._adapter.update(self.client.state)
+        data = self._legacy_payload(coordinator_payload(snapshot))
+        data["available"] = available
+        return data
+
+    async def _prime_state(self) -> None:
+        """Best-effort startup priming for richer initial entity state."""
+        try:
+            await self.client.get_mac_address()
+            await self.client.get_temperatures()
+
+            groups = await self.client.enum_profile_groups_collect()
+            for group in groups:
+                await self.client.enum_profiles_collect(group.group_id)
+        except (
+            TimeoutError,
+            envy_exceptions.MadvrEnvyError,
+            OSError,
+        ) as err:
+            self.logger.debug("Startup priming skipped due to command failure: %s", err)
+
+    def _legacy_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Map adapter payload to legacy madVR keys for entity compatibility."""
+        data = dict(payload)
+
+        mac_address = data.get("mac_address")
+        if isinstance(mac_address, str) and mac_address:
+            self.mac = mac_address.lower().replace(":", "")
+
+        temperatures = data.get("temperatures")
+        if isinstance(temperatures, (list, tuple)):
+            if len(temperatures) > 0:
+                data[TEMP_GPU] = temperatures[0]
+            if len(temperatures) > 1:
+                data[TEMP_HDMI] = temperatures[1]
+            if len(temperatures) > 2:
+                data[TEMP_CPU] = temperatures[2]
+            if len(temperatures) > 3:
+                data[TEMP_MAINBOARD] = temperatures[3]
+
+        incoming = data.get("incoming_signal")
+        if isinstance(incoming, dict):
+            data[INCOMING_RES] = incoming.get("resolution")
+            data[INCOMING_SIGNAL_TYPE] = incoming.get("signal_type")
+            data[INCOMING_FRAME_RATE] = incoming.get("frame_rate")
+            data[INCOMING_COLOR_SPACE] = incoming.get("color_space")
+            data[INCOMING_BIT_DEPTH] = incoming.get("bit_depth")
+            data[INCOMING_COLORIMETRY] = incoming.get("colorimetry")
+            data[INCOMING_BLACK_LEVELS] = incoming.get("black_levels")
+            data[INCOMING_ASPECT_RATIO] = incoming.get("aspect_ratio")
+            hdr_mode = incoming.get("hdr_mode")
+            data["hdr_flag"] = isinstance(hdr_mode, str) and hdr_mode.upper() != "SDR"
+
+        outgoing = data.get("outgoing_signal")
+        if isinstance(outgoing, dict):
+            data[OUTGOING_RES] = outgoing.get("resolution")
+            data[OUTGOING_SIGNAL_TYPE] = outgoing.get("signal_type")
+            data[OUTGOING_FRAME_RATE] = outgoing.get("frame_rate")
+            data[OUTGOING_COLOR_SPACE] = outgoing.get("color_space")
+            data[OUTGOING_BIT_DEPTH] = outgoing.get("bit_depth")
+            data[OUTGOING_COLORIMETRY] = outgoing.get("colorimetry")
+            data[OUTGOING_BLACK_LEVELS] = outgoing.get("black_levels")
+            hdr_mode = outgoing.get("hdr_mode")
+            data["outgoing_hdr_flag"] = (
+                isinstance(hdr_mode, str) and hdr_mode.upper() != "SDR"
+            )
+
+        aspect_ratio = data.get("aspect_ratio")
+        if isinstance(aspect_ratio, dict):
+            data[ASPECT_RES] = aspect_ratio.get("resolution")
+            data[ASPECT_DEC] = aspect_ratio.get("decimal_ratio")
+            data[ASPECT_INT] = aspect_ratio.get("integer_ratio")
+            data[ASPECT_NAME] = aspect_ratio.get("name")
+
+        masking_ratio = data.get("masking_ratio")
+        if isinstance(masking_ratio, dict):
+            data[MASKING_RES] = masking_ratio.get("resolution")
+            data[MASKING_DEC] = masking_ratio.get("decimal_ratio")
+            data[MASKING_INT] = masking_ratio.get("integer_ratio")
+
+        data["is_on"] = data.get("power_state") != "off"
+        data["is_signal"] = bool(data.get("signal_present"))
+        return data

--- a/homeassistant/components/madvr/diagnostics.py
+++ b/homeassistant/components/madvr/diagnostics.py
@@ -5,19 +5,18 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-
-from .coordinator import MadVRConfigEntry
 
 TO_REDACT = [CONF_HOST]
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: MadVRConfigEntry
+    hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data = config_entry.runtime_data.data
+    data = config_entry.runtime_data.coordinator.data
 
     return {
         "config_entry": async_redact_data(config_entry.as_dict(), TO_REDACT),

--- a/homeassistant/components/madvr/entity.py
+++ b/homeassistant/components/madvr/entity.py
@@ -28,6 +28,7 @@ class MadvrEnvyEntity(CoordinatorEntity[MadvrEnvyCoordinator]):
 
         device_id = coordinator.mac
         mac = self._mac_address
+        self._attr_unique_id = f"{device_id}_{entity_key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
             name=NAME,

--- a/homeassistant/components/madvr/entity.py
+++ b/homeassistant/components/madvr/entity.py
@@ -1,24 +1,74 @@
-"""Base class for madVR entities."""
+"""Entity base classes for madVR Envy."""
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
-from .coordinator import MadVRCoordinator
+from madvr_envy import exceptions
+
+from .const import DOMAIN, MANUFACTURER, MODEL, NAME
+from .coordinator import MadvrEnvyCoordinator
 
 
-class MadVREntity(CoordinatorEntity[MadVRCoordinator]):
-    """Defines a base madVR entity."""
+class MadvrEnvyEntity(CoordinatorEntity[MadvrEnvyCoordinator]):
+    """Common entity behavior for madVR Envy entities."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = False
 
-    def __init__(self, coordinator: MadVRCoordinator) -> None:
-        """Initialize madvr entity."""
+    def __init__(self, coordinator: MadvrEnvyCoordinator, entity_key: str) -> None:
         super().__init__(coordinator)
+        self._entity_key = entity_key
+        self._client = coordinator.client
+
+        device_id = coordinator.mac
+        mac = self._mac_address
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.mac)},
-            name="madVR Envy",
-            manufacturer="madVR",
-            model="Envy",
-            connections={(CONNECTION_NETWORK_MAC, coordinator.mac)},
+            identifiers={(DOMAIN, device_id)},
+            name=NAME,
+            manufacturer=MANUFACTURER,
+            model=MODEL,
+            sw_version=self.data.get("version"),
+            configuration_url=f"http://{self._client.host}",
+            connections={(CONNECTION_NETWORK_MAC, mac)} if mac else None,
         )
+
+    @property
+    def available(self) -> bool:
+        return bool(self.data.get("available"))
+
+    @property
+    def data(self) -> dict[str, Any]:
+        if self.coordinator.data is None:
+            return {}
+        return self.coordinator.data
+
+    @property
+    def _device_id(self) -> str:
+        return self.coordinator.mac
+
+    @property
+    def _mac_address(self) -> str | None:
+        mac = self.data.get("mac_address")
+        if isinstance(mac, str) and mac:
+            return mac
+        if self.coordinator.mac:
+            return self.coordinator.mac
+        return None
+
+    async def _execute(self, command_name: str, command: Callable[[], Any]) -> None:
+        try:
+            await command()
+        except (
+            TimeoutError,
+            exceptions.NotConnectedError,
+            exceptions.CommandRejectedError,
+            exceptions.ConnectionFailedError,
+            exceptions.ConnectionTimeoutError,
+        ) as err:
+            raise HomeAssistantError(f"{command_name} failed: {err}") from err

--- a/homeassistant/components/madvr/icons.json
+++ b/homeassistant/components/madvr/icons.json
@@ -1,112 +1,90 @@
 {
   "entity": {
     "binary_sensor": {
-      "hdr_flag": {
-        "default": "mdi:hdr",
-        "state": {
-          "off": "mdi:hdr-off"
-        }
-      },
-      "outgoing_hdr_flag": {
-        "default": "mdi:hdr",
-        "state": {
-          "off": "mdi:hdr-off"
-        }
-      },
-      "power_state": {
-        "default": "mdi:power",
-        "state": {
-          "off": "mdi:power-off"
-        }
-      },
-      "signal_state": {
+      "signal_present": {
         "default": "mdi:signal",
         "state": {
           "off": "mdi:signal-off"
         }
       }
     },
+    "button": {
+      "hotplug": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "power_off": {
+        "default": "mdi:power-off"
+      },
+      "power_on": {
+        "default": "mdi:power-on"
+      },
+      "reload_software": {
+        "default": "mdi:update"
+      },
+      "remote_back": {
+        "default": "mdi:arrow-left-circle-outline"
+      },
+      "remote_info": {
+        "default": "mdi:information"
+      },
+      "remote_menu": {
+        "default": "mdi:menu"
+      },
+      "remote_ok": {
+        "default": "mdi:check-circle-outline"
+      },
+      "restart": {
+        "default": "mdi:restart"
+      },
+      "standby": {
+        "default": "mdi:sleep"
+      }
+    },
+    "remote": {
+      "remote": {
+        "default": "mdi:remote"
+      }
+    },
+    "select": {
+      "active_profile": {
+        "default": "mdi:format-list-bulleted"
+      },
+      "power_mode": {
+        "default": "mdi:power-settings"
+      }
+    },
     "sensor": {
-      "aspect_dec": {
+      "active_profile": {
+        "default": "mdi:playlist-play"
+      },
+      "aspect_ratio_mode": {
         "default": "mdi:aspect-ratio"
       },
-      "aspect_int": {
-        "default": "mdi:aspect-ratio"
-      },
-      "aspect_name": {
-        "default": "mdi:aspect-ratio"
-      },
-      "aspect_res": {
-        "default": "mdi:aspect-ratio"
-      },
-      "incoming_aspect_ratio": {
-        "default": "mdi:aspect-ratio"
-      },
-      "incoming_bit_depth": {
-        "default": "mdi:television"
-      },
-      "incoming_black_levels": {
-        "default": "mdi:television"
-      },
-      "incoming_color_space": {
-        "default": "mdi:television"
-      },
-      "incoming_colorimetry": {
-        "default": "mdi:television"
-      },
-      "incoming_frame_rate": {
-        "default": "mdi:television"
-      },
-      "incoming_res": {
-        "default": "mdi:television"
-      },
-      "incoming_signal_type": {
-        "default": "mdi:video-image"
-      },
-      "mac_address": {
-        "default": "mdi:ethernet"
-      },
-      "masking_dec": {
-        "default": "mdi:television"
-      },
-      "masking_int": {
-        "default": "mdi:television"
-      },
-      "masking_res": {
-        "default": "mdi:television"
-      },
-      "outgoing_bit_depth": {
-        "default": "mdi:television"
-      },
-      "outgoing_black_levels": {
-        "default": "mdi:television"
-      },
-      "outgoing_color_space": {
-        "default": "mdi:television"
-      },
-      "outgoing_colorimetry": {
-        "default": "mdi:television"
-      },
-      "outgoing_frame_rate": {
-        "default": "mdi:television"
-      },
-      "outgoing_res": {
-        "default": "mdi:television"
-      },
-      "outgoing_signal_type": {
-        "default": "mdi:video-image"
-      },
-      "temp_cpu": {
+      "cpu_temperature": {
         "default": "mdi:thermometer"
       },
-      "temp_gpu": {
+      "current_menu": {
+        "default": "mdi:menu"
+      },
+      "gpu_temperature": {
         "default": "mdi:thermometer"
       },
-      "temp_hdmi": {
+      "hdmi_input_temperature": {
         "default": "mdi:thermometer"
       },
-      "temp_mainboard": {
+      "mainboard_temperature": {
         "default": "mdi:thermometer"
+      },
+      "power_state": {
+        "default": "mdi:power"
+      },
+      "version": {
+        "default": "mdi:identifier"
+      }
+    },
+    "switch": {
+      "tone_map": {
+        "default": "mdi:lightbulb-on"
       }
     }
   }

--- a/homeassistant/components/madvr/manifest.json
+++ b/homeassistant/components/madvr/manifest.json
@@ -1,10 +1,11 @@
 {
   "domain": "madvr",
   "name": "madVR Envy",
-  "codeowners": ["@iloveicedgreentea"],
+  "codeowners": ["@binarylogic"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/madvr",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["py-madvr2==1.6.40"]
+  "loggers": ["madvr_envy"],
+  "requirements": ["madvr-envy==0.1.7"]
 }

--- a/homeassistant/components/madvr/models.py
+++ b/homeassistant/components/madvr/models.py
@@ -1,0 +1,19 @@
+"""Runtime models for madVR Envy integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from madvr_envy import MadvrEnvyClient
+
+from .coordinator import MadvrEnvyCoordinator
+
+
+@dataclass(slots=True)
+class MadvrEnvyRuntimeData:
+    """Stored runtime state for a config entry."""
+
+    client: MadvrEnvyClient
+    coordinator: MadvrEnvyCoordinator
+    last_data: dict[str, Any]

--- a/homeassistant/components/madvr/remote.py
+++ b/homeassistant/components/madvr/remote.py
@@ -7,69 +7,68 @@ import logging
 from typing import Any
 
 from homeassistant.components.remote import RemoteEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from madvr_envy.integration_bridge import iter_remote_operations, resolve_action_method
+
+from .entity import MadvrEnvyEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the madVR remote."""
-    coordinator = entry.runtime_data
-    async_add_entities(
-        [
-            MadvrRemote(coordinator),
-        ]
-    )
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([MadvrRemote(coordinator)])
 
 
-class MadvrRemote(MadVREntity, RemoteEntity):
+class MadvrRemote(MadvrEnvyEntity, RemoteEntity):
     """Remote entity for the madVR integration."""
 
     _attr_name = None
+    _attr_translation_key = "remote"
 
-    def __init__(
-        self,
-        coordinator: MadVRCoordinator,
-    ) -> None:
+    def __init__(self, coordinator) -> None:  # noqa: ANN001
         """Initialize the remote entity."""
-        super().__init__(coordinator)
-        self.madvr_client = coordinator.client
+        super().__init__(coordinator, "remote")
         self._attr_unique_id = coordinator.mac
 
     @property
     def is_on(self) -> bool:
         """Return true if the device is on."""
-        return self.madvr_client.is_on
+        return self.available and self.data.get("power_state") != "off"
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the device."""
         _LOGGER.debug("Turning off")
-        try:
-            await self.madvr_client.power_off()
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn off device %s", err)
+        await self._execute("Standby", self._client.standby)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the device."""
         _LOGGER.debug("Turning on device")
-
-        try:
-            await self.madvr_client.power_on(mac=self.coordinator.mac)
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn on device %s", err)
+        await self._execute("KeyPress POWER", lambda: self._client.key_press("POWER"))
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to one device."""
-        _LOGGER.debug("adding command %s", command)
+        _LOGGER.debug("Adding command %s", command)
+        for operation in iter_remote_operations(command):
+            if operation.kind == "action":
+                await self._run_action(operation.value)
+                continue
+            key = operation.value
+            await self._execute(
+                f"KeyPress {key}", lambda button=key: self._client.key_press(button)
+            )
+
+    async def _run_action(self, action: str) -> None:
         try:
-            await self.madvr_client.add_command_to_queue(command)
-        except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to send command %s", err)
+            command = resolve_action_method(self._client, action)
+        except ValueError:
+            return
+        await self._execute(action.strip().lower(), command)

--- a/homeassistant/components/madvr/select.py
+++ b/homeassistant/components/madvr/select.py
@@ -1,0 +1,167 @@
+"""Select platform for madVR Envy."""
+
+from __future__ import annotations
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from madvr_envy.integration_bridge import (
+    ProfileOption,
+    build_profile_options as lib_build_profile_options,
+    parse_profile_id as lib_parse_profile_id,
+)
+
+from .entity import MadvrEnvyEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data.coordinator
+    entities: list[MadvrEnvyEntity] = [
+        MadvrEnvyPowerModeSelect(coordinator),
+        MadvrEnvyActiveProfileSelect(coordinator),
+    ]
+
+    profile_groups = coordinator.data.get("profile_groups", {}) if coordinator.data else {}
+    if isinstance(profile_groups, dict):
+        for group_id in profile_groups:
+            if not isinstance(group_id, str):
+                continue
+            entities.append(MadvrEnvyProfileGroupSelect(coordinator, group_id))
+
+    async_add_entities(entities)
+
+
+class MadvrEnvyPowerModeSelect(MadvrEnvyEntity, SelectEntity):
+    """Select target power mode."""
+
+    _attr_translation_key = "power_mode"
+    _attr_icon = "mdi:power-settings"
+    _attr_options = ["on", "standby", "off"]
+
+    def __init__(self, coordinator) -> None:  # noqa: ANN001
+        super().__init__(coordinator, "power_mode")
+
+    @property
+    def current_option(self) -> str | None:
+        power_state = self.data.get("power_state")
+        if isinstance(power_state, str) and power_state in self.options:
+            return power_state
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        if option == "on":
+            await self._execute("KeyPress POWER", lambda: self._client.key_press("POWER"))
+            return
+        if option == "standby":
+            await self._execute("Standby", self._client.standby)
+            return
+        if option == "off":
+            await self._execute("PowerOff", self._client.power_off)
+
+
+class MadvrEnvyActiveProfileSelect(MadvrEnvyEntity, SelectEntity):
+    """Select active profile by group/index."""
+
+    _attr_translation_key = "active_profile"
+    _attr_icon = "mdi:format-list-bulleted"
+
+    def __init__(self, coordinator) -> None:  # noqa: ANN001
+        super().__init__(coordinator, "active_profile")
+
+    @property
+    def options(self) -> list[str]:
+        return [entry.option for entry in self._profile_options]
+
+    @property
+    def current_option(self) -> str | None:
+        active_group = self.data.get("active_profile_group")
+        active_index = self.data.get("active_profile_index")
+        if not isinstance(active_group, str) or not isinstance(active_index, int):
+            return None
+
+        for entry in self._profile_options:
+            if entry.group_id == active_group and entry.profile_index == active_index:
+                return entry.option
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        for entry in self._profile_options:
+            if entry.option == option:
+                await self._execute(
+                    f"ActivateProfile {entry.group_id}/{entry.profile_index}",
+                    lambda group_id=entry.group_id, profile_index=entry.profile_index: (
+                        self._client.activate_profile(group_id, profile_index)
+                    ),
+                )
+                return
+
+    @property
+    def _profile_options(self) -> list[ProfileOption]:
+        return _build_profile_options(self.data)
+
+
+class MadvrEnvyProfileGroupSelect(MadvrEnvyEntity, SelectEntity):
+    """Select active profile for a specific profile group."""
+
+    _attr_icon = "mdi:playlist-edit"
+
+    def __init__(self, coordinator, group_id: str) -> None:  # noqa: ANN001
+        self._group_id = group_id
+        super().__init__(coordinator, f"profile_group_{group_id}")
+
+    @property
+    def name(self) -> str:
+        group_names = self.data.get("profile_groups")
+        label = self._group_id
+        if not isinstance(group_names, dict):
+            return f"{label} Profile"
+        value = group_names.get(self._group_id)
+        if isinstance(value, str) and value:
+            label = value
+        return f"{label} Profile"
+
+    @property
+    def options(self) -> list[str]:
+        return [entry.option for entry in self._group_options]
+
+    @property
+    def current_option(self) -> str | None:
+        active_group = self.data.get("active_profile_group")
+        active_index = self.data.get("active_profile_index")
+        if active_group != self._group_id or not isinstance(active_index, int):
+            return None
+        for entry in self._group_options:
+            if entry.profile_index == active_index:
+                return entry.option
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        for entry in self._group_options:
+            if entry.option != option:
+                continue
+            await self._execute(
+                f"ActivateProfile {self._group_id}/{entry.profile_index}",
+                lambda profile_index=entry.profile_index: self._client.activate_profile(
+                    self._group_id, profile_index
+                ),
+            )
+            return
+
+    @property
+    def _group_options(self) -> list[ProfileOption]:
+        all_options = _build_profile_options(self.data)
+        return [entry for entry in all_options if entry.group_id == self._group_id]
+
+
+def _parse_profile_id(profile_id: str, fallback_group: object) -> tuple[str, int] | None:
+    return lib_parse_profile_id(profile_id, fallback_group)
+
+
+def _build_profile_options(data: dict[str, object]) -> list[ProfileOption]:
+    return lib_build_profile_options(data)

--- a/homeassistant/components/madvr/sensor.py
+++ b/homeassistant/components/madvr/sensor.py
@@ -11,9 +11,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import (
@@ -24,8 +25,8 @@ from .const import (
     INCOMING_ASPECT_RATIO,
     INCOMING_BIT_DEPTH,
     INCOMING_BLACK_LEVELS,
-    INCOMING_COLOR_SPACE,
     INCOMING_COLORIMETRY,
+    INCOMING_COLOR_SPACE,
     INCOMING_FRAME_RATE,
     INCOMING_RES,
     INCOMING_SIGNAL_TYPE,
@@ -34,8 +35,8 @@ from .const import (
     MASKING_RES,
     OUTGOING_BIT_DEPTH,
     OUTGOING_BLACK_LEVELS,
-    OUTGOING_COLOR_SPACE,
     OUTGOING_COLORIMETRY,
+    OUTGOING_COLOR_SPACE,
     OUTGOING_FRAME_RATE,
     OUTGOING_RES,
     OUTGOING_SIGNAL_TYPE,
@@ -44,8 +45,8 @@ from .const import (
     TEMP_HDMI,
     TEMP_MAINBOARD,
 )
-from .coordinator import MadVRConfigEntry, MadVRCoordinator
-from .entity import MadVREntity
+from .coordinator import MadvrEnvyCoordinator
+from .entity import MadvrEnvyEntity
 
 
 def is_valid_temperature(value: float | None) -> bool:
@@ -53,21 +54,20 @@ def is_valid_temperature(value: float | None) -> bool:
     return value is not None and value > 0
 
 
-def get_temperature(coordinator: MadVRCoordinator, key: str) -> float | None:
+def get_temperature(coordinator: MadvrEnvyCoordinator, key: str) -> float | None:
     """Get temperature value if valid, otherwise return None."""
     try:
         temp = float(coordinator.data.get(key, 0))
-    except AttributeError, ValueError:
+    except (TypeError, ValueError):
         return None
-    else:
-        return temp if is_valid_temperature(temp) else None
+    return temp if is_valid_temperature(temp) else None
 
 
 @dataclass(frozen=True, kw_only=True)
 class MadvrSensorEntityDescription(SensorEntityDescription):
     """Describe madVR sensor entity."""
 
-    value_fn: Callable[[MadVRCoordinator], StateType]
+    value_fn: Callable[[MadvrEnvyCoordinator], StateType]
 
 
 SENSORS: tuple[MadvrSensorEntityDescription, ...] = (
@@ -252,39 +252,30 @@ SENSORS: tuple[MadvrSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: MadVRConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor entities."""
-    coordinator = entry.runtime_data
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(MadvrSensor(coordinator, description) for description in SENSORS)
 
 
-class MadvrSensor(MadVREntity, SensorEntity):
+class MadvrSensor(MadvrEnvyEntity, SensorEntity):
     """Base class for madVR sensors."""
+
+    entity_description: MadvrSensorEntityDescription
 
     def __init__(
         self,
-        coordinator: MadVRCoordinator,
+        coordinator: MadvrEnvyCoordinator,
         description: MadvrSensorEntityDescription,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self.entity_description: MadvrSensorEntityDescription = description
+        super().__init__(coordinator, description.key)
+        self.entity_description = description
         self._attr_unique_id = f"{coordinator.mac}_{description.key}"
 
     @property
-    def native_value(self) -> float | str | None:
-        """Return the state of the sensor."""
-        val = self.entity_description.value_fn(self.coordinator)
-        # check if sensor is enum
-        if self.entity_description.device_class == SensorDeviceClass.ENUM:
-            if (
-                self.entity_description.options
-                and val in self.entity_description.options
-            ):
-                return val
-            # return None for values that are not in the options
-            return None
-
-        return val
+    def native_value(self) -> StateType:
+        """Return the native value."""
+        return self.entity_description.value_fn(self.coordinator)

--- a/homeassistant/components/madvr/services.py
+++ b/homeassistant/components/madvr/services.py
@@ -1,0 +1,124 @@
+"""Services for madVR Envy integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+
+from madvr_envy.integration_bridge import action_names, resolve_action_method
+
+from .const import DOMAIN, SERVICE_ACTIVATE_PROFILE, SERVICE_PRESS_KEY, SERVICE_RUN_ACTION
+from .models import MadvrEnvyRuntimeData
+
+_SERVICE_ACTIONS = action_names()
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Register integration services once."""
+    if hass.services.has_service(DOMAIN, SERVICE_PRESS_KEY):
+        return
+
+    async def handle_press_key(call: ServiceCall) -> None:
+        runtime_data = _resolve_runtime_data(hass, call.data.get("entry_id"))
+        key = str(call.data["key"])
+        await _run_per_entry(runtime_data, lambda item: item.client.key_press(key))
+
+    async def handle_activate_profile(call: ServiceCall) -> None:
+        runtime_data = _resolve_runtime_data(hass, call.data.get("entry_id"))
+        group_id = str(call.data["group_id"])
+        profile_index = int(call.data["profile_index"])
+        await _run_per_entry(
+            runtime_data,
+            lambda item: item.client.activate_profile(group_id, profile_index),
+        )
+
+    async def handle_run_action(call: ServiceCall) -> None:
+        runtime_data = _resolve_runtime_data(hass, call.data.get("entry_id"))
+        action = str(call.data["action"])
+        await _run_per_entry(
+            runtime_data,
+            lambda item: resolve_action_method(item.client, action)(),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_PRESS_KEY,
+        handle_press_key,
+        schema=vol.Schema(
+            {
+                vol.Required("key"): str,
+                vol.Optional("entry_id"): str,
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ACTIVATE_PROFILE,
+        handle_activate_profile,
+        schema=vol.Schema(
+            {
+                vol.Required("group_id"): str,
+                vol.Required("profile_index"): vol.Coerce(int),
+                vol.Optional("entry_id"): str,
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RUN_ACTION,
+        handle_run_action,
+        schema=vol.Schema(
+            {
+                vol.Required("action"): vol.In(_SERVICE_ACTIONS),
+                vol.Optional("entry_id"): str,
+            }
+        ),
+    )
+
+
+async def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload integration services."""
+    for service in (SERVICE_PRESS_KEY, SERVICE_ACTIVATE_PROFILE, SERVICE_RUN_ACTION):
+        hass.services.async_remove(DOMAIN, service)
+
+
+def _resolve_runtime_data(
+    hass: HomeAssistant, entry_id: object | None
+) -> list[MadvrEnvyRuntimeData]:
+    domain_data = hass.data.get(DOMAIN, {})
+    if not domain_data:
+        raise HomeAssistantError("No madVR entries are currently loaded")
+
+    if isinstance(entry_id, str) and entry_id:
+        runtime_data = domain_data.get(entry_id)
+        if runtime_data is None:
+            raise HomeAssistantError(f"Unknown madVR entry_id: {entry_id}")
+        return [runtime_data]
+
+    if len(domain_data) > 1:
+        raise HomeAssistantError(
+            "Multiple madVR entries are loaded. Provide an entry_id."
+        )
+
+    return list(domain_data.values())
+
+
+async def _run_per_entry(
+    runtime_data: list[MadvrEnvyRuntimeData],
+    command: Callable[[MadvrEnvyRuntimeData], Awaitable[object]],
+) -> None:
+    results = await asyncio.gather(
+        *(command(item) for item in runtime_data),
+        return_exceptions=True,
+    )
+    failures = [result for result in results if isinstance(result, Exception)]
+    if not failures:
+        return
+
+    if len(runtime_data) == 1:
+        raise HomeAssistantError(str(failures[0])) from failures[0]

--- a/homeassistant/components/madvr/services.yaml
+++ b/homeassistant/components/madvr/services.yaml
@@ -1,0 +1,67 @@
+press_key:
+  name: Press key
+  description: Send a remote key press to madVR Envy.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: Optional config entry id when multiple madVR devices are loaded.
+      required: false
+      selector:
+        text:
+    key:
+      name: Key
+      description: Remote key name (for example MENU, INFO, OK, BACK, LEFT, RIGHT, UP, DOWN).
+      required: true
+      selector:
+        text:
+
+activate_profile:
+  name: Activate profile
+  description: Activate a profile in a profile group.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: Optional config entry id when multiple madVR devices are loaded.
+      required: false
+      selector:
+        text:
+    group_id:
+      name: Group ID
+      description: Profile group id.
+      required: true
+      selector:
+        text:
+    profile_index:
+      name: Profile Index
+      description: Profile index in the group.
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 1
+          mode: box
+
+run_action:
+  name: Run action
+  description: Run a predefined Envy action.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: Optional config entry id when multiple madVR devices are loaded.
+      required: false
+      selector:
+        text:
+    action:
+      name: Action
+      description: Action name.
+      required: true
+      selector:
+        select:
+          options:
+            - standby
+            - power_off
+            - hotplug
+            - restart
+            - reload_software
+            - tone_map_on
+            - tone_map_off

--- a/homeassistant/components/madvr/strings.json
+++ b/homeassistant/components/madvr/strings.json
@@ -1,134 +1,164 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "set_up_new_device": "A new device was detected. Please set it up as a new entity instead of reconfiguring."
+    "step": {
+      "user": {
+        "title": "Connect to madVR Envy",
+        "description": "Set up a madVR Envy processor",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect madVR Envy",
+        "description": "Update host or port and revalidate the connection",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "no_mac": "A MAC address was not found. It is required to identify the device. Please ensure your device is connectable."
+      "invalid_backoff": "Reconnect max backoff must be greater than or equal to initial backoff",
+      "invalid_jitter": "Reconnect jitter must be between 0.0 and 1.0",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
+    "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
     "step": {
-      "reconfigure": {
+      "init": {
+        "title": "madVR Envy options",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
-        },
-        "data_description": {
-          "host": "[%key:component::madvr::config::step::user::data_description::host%]",
-          "port": "[%key:component::madvr::config::step::user::data_description::port%]"
-        },
-        "description": "Your device needs to be on in order to reconfigure the integration.",
-        "title": "Reconfigure madVR Envy"
-      },
-      "user": {
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
-        },
-        "data_description": {
-          "host": "The hostname or IP address of your madVR Envy device.",
-          "port": "The port your madVR Envy is listening on. In 99% of cases, leave this as the default."
-        },
-        "description": "Your device needs to be on in order to add the integration.",
-        "title": "Set up madVR Envy"
+          "sync_timeout": "Sync timeout (seconds)",
+          "connect_timeout": "Connect timeout (seconds)",
+          "command_timeout": "Command timeout (seconds)",
+          "read_timeout": "Read timeout (seconds)",
+          "reconnect_initial_backoff": "Reconnect initial backoff (seconds)",
+          "reconnect_max_backoff": "Reconnect max backoff (seconds)",
+          "reconnect_jitter": "Reconnect jitter factor",
+          "enable_advanced_entities": "Enable advanced entities"
+        }
       }
     }
   },
   "entity": {
-    "binary_sensor": {
-      "hdr_flag": {
-        "name": "HDR flag"
-      },
-      "outgoing_hdr_flag": {
-        "name": "Outgoing HDR flag"
-      },
+    "sensor": {
       "power_state": {
         "name": "Power state"
       },
-      "signal_state": {
-        "name": "Signal state"
-      }
-    },
-    "sensor": {
-      "aspect_dec": {
-        "name": "Aspect decimal"
-      },
-      "aspect_int": {
-        "name": "Aspect integer"
-      },
-      "aspect_name": {
-        "name": "Aspect name"
-      },
-      "aspect_res": {
-        "name": "Aspect resolution"
-      },
-      "incoming_aspect_ratio": {
-        "name": "Incoming aspect ratio"
-      },
-      "incoming_bit_depth": {
-        "name": "Incoming bit depth"
-      },
-      "incoming_black_levels": {
-        "name": "Incoming black levels"
-      },
-      "incoming_color_space": {
-        "name": "Incoming color space"
-      },
-      "incoming_colorimetry": {
-        "name": "Incoming colorimetry"
-      },
-      "incoming_frame_rate": {
-        "name": "Incoming frame rate"
-      },
-      "incoming_res": {
-        "name": "Incoming resolution"
-      },
-      "incoming_signal_type": {
-        "name": "Incoming signal type"
-      },
-      "masking_dec": {
-        "name": "Masking decimal"
-      },
-      "masking_int": {
-        "name": "Masking integer"
-      },
-      "masking_res": {
-        "name": "Masking resolution"
-      },
-      "outgoing_bit_depth": {
-        "name": "Outgoing bit depth"
-      },
-      "outgoing_black_levels": {
-        "name": "Outgoing black levels"
-      },
-      "outgoing_color_space": {
-        "name": "Outgoing color space"
-      },
-      "outgoing_colorimetry": {
-        "name": "Outgoing colorimetry"
-      },
-      "outgoing_frame_rate": {
-        "name": "Outgoing frame rate"
-      },
-      "outgoing_res": {
-        "name": "Outgoing resolution"
-      },
-      "outgoing_signal_type": {
-        "name": "Outgoing signal type"
-      },
-      "temp_cpu": {
-        "name": "CPU temperature"
-      },
-      "temp_gpu": {
+      "gpu_temperature": {
         "name": "GPU temperature"
       },
-      "temp_hdmi": {
-        "name": "HDMI temperature"
+      "hdmi_input_temperature": {
+        "name": "HDMI input temperature"
       },
-      "temp_mainboard": {
+      "cpu_temperature": {
+        "name": "CPU temperature"
+      },
+      "mainboard_temperature": {
         "name": "Mainboard temperature"
+      },
+      "version": {
+        "name": "Version"
+      },
+      "current_menu": {
+        "name": "Current menu"
+      },
+      "aspect_ratio_mode": {
+        "name": "Aspect ratio mode"
+      },
+      "incoming_signal_resolution": {
+        "name": "Incoming signal resolution"
+      },
+      "incoming_signal_frame_rate": {
+        "name": "Incoming signal frame rate"
+      },
+      "incoming_signal_aspect_ratio": {
+        "name": "Incoming signal aspect ratio"
+      },
+      "incoming_signal_hdr_mode": {
+        "name": "Incoming signal HDR mode"
+      },
+      "outgoing_signal_resolution": {
+        "name": "Outgoing signal resolution"
+      },
+      "outgoing_signal_frame_rate": {
+        "name": "Outgoing signal frame rate"
+      },
+      "outgoing_signal_hdr_mode": {
+        "name": "Outgoing signal HDR mode"
+      },
+      "aspect_ratio_name": {
+        "name": "Aspect ratio name"
+      },
+      "aspect_ratio_decimal": {
+        "name": "Aspect ratio decimal"
+      },
+      "masking_ratio_decimal": {
+        "name": "Masking ratio decimal"
+      },
+      "active_profile": {
+        "name": "Active profile"
+      }
+    },
+    "binary_sensor": {
+      "signal_present": {
+        "name": "Signal present"
+      }
+    },
+    "switch": {
+      "tone_map": {
+        "name": "Tone mapping"
+      }
+    },
+    "button": {
+      "power_on": {
+        "name": "Power on"
+      },
+      "standby": {
+        "name": "Standby"
+      },
+      "power_off": {
+        "name": "Power off"
+      },
+      "hotplug": {
+        "name": "Hotplug"
+      },
+      "restart": {
+        "name": "Restart"
+      },
+      "reload_software": {
+        "name": "Reload software"
+      },
+      "remote_menu": {
+        "name": "Remote menu"
+      },
+      "remote_info": {
+        "name": "Remote info"
+      },
+      "remote_ok": {
+        "name": "Remote OK"
+      },
+      "remote_back": {
+        "name": "Remote back"
+      }
+    },
+    "select": {
+      "power_mode": {
+        "name": "Power mode"
+      },
+      "active_profile": {
+        "name": "Active profile"
+      }
+    },
+    "remote": {
+      "remote": {
+        "name": "Remote"
       }
     }
   }

--- a/homeassistant/components/madvr/switch.py
+++ b/homeassistant/components/madvr/switch.py
@@ -1,0 +1,41 @@
+"""Switch platform for madVR Envy."""
+
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import MadvrEnvyEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    async_add_entities([MadvrEnvyToneMapSwitch(entry.runtime_data.coordinator)])
+
+
+class MadvrEnvyToneMapSwitch(MadvrEnvyEntity, SwitchEntity):
+    """Switch for Tone Mapping."""
+
+    _attr_translation_key = "tone_map"
+    _attr_icon = "mdi:lightbulb-on"
+
+    def __init__(self, coordinator) -> None:  # noqa: ANN001
+        super().__init__(coordinator, "tone_map")
+
+    @property
+    def is_on(self) -> bool | None:
+        value = self.data.get("tone_map_enabled")
+        if value is None:
+            return None
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ANN003
+        await self._execute("ToneMapOn", self._client.tone_map_on)
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ANN003
+        await self._execute("ToneMapOff", self._client.tone_map_off)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1850,7 +1850,7 @@ py-dormakaba-dkey==1.0.6
 py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
-py-madvr2==1.6.40
+madvr-envy==0.1.7
 
 # homeassistant.components.melissa
 py-melissa-climate==3.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1602,7 +1602,7 @@ py-dormakaba-dkey==1.0.6
 py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
-py-madvr2==1.6.40
+madvr-envy==0.1.7
 
 # homeassistant.components.melissa
 py-melissa-climate==3.0.3

--- a/tests/components/madvr/test_entities.py
+++ b/tests/components/madvr/test_entities.py
@@ -1,0 +1,165 @@
+"""Test entity behavior for madVR Envy platforms."""
+
+from __future__ import annotations
+
+from homeassistant.components.madvr.binary_sensor import BINARY_SENSORS, MadvrEnvyBinarySensor
+from homeassistant.components.madvr.button import BUTTONS, MadvrEnvyButton
+from homeassistant.components.madvr.coordinator import MadvrEnvyCoordinator
+from homeassistant.components.madvr.remote import MadvrEnvyRemote
+from homeassistant.components.madvr.select import (
+    MadvrEnvyActiveProfileSelect,
+    MadvrEnvyPowerModeSelect,
+    MadvrEnvyProfileGroupSelect,
+)
+from homeassistant.components.madvr.sensor import SENSORS, MadvrEnvySensor
+from homeassistant.components.madvr.switch import MadvrEnvyToneMapSwitch
+
+
+async def test_sensor_values(hass, mock_envy_client):
+    """Test sensor values are sourced from coordinator data."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    power_sensor = MadvrEnvySensor(
+        coordinator, next(item for item in SENSORS if item.key == "power_state")
+    )
+    gpu_sensor = MadvrEnvySensor(
+        coordinator, next(item for item in SENSORS if item.key == "gpu_temperature")
+    )
+    incoming_aspect_sensor = MadvrEnvySensor(
+        coordinator, next(item for item in SENSORS if item.key == "incoming_signal_aspect_ratio")
+    )
+    masking_ratio_sensor = MadvrEnvySensor(
+        coordinator, next(item for item in SENSORS if item.key == "masking_ratio_decimal")
+    )
+
+    assert power_sensor.native_value == "on"
+    assert gpu_sensor.native_value == 41
+    assert incoming_aspect_sensor.native_value == "16:9"
+    assert masking_ratio_sensor.native_value == 2.259
+
+    await coordinator.async_shutdown()
+
+
+async def test_binary_sensor_value(hass, mock_envy_client):
+    """Test binary sensor state."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyBinarySensor(coordinator, BINARY_SENSORS[0])
+    assert entity.is_on is True
+
+    await coordinator.async_shutdown()
+
+
+async def test_tone_map_switch_calls_client(hass, mock_envy_client):
+    """Test tone map switch command execution."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyToneMapSwitch(coordinator)
+    assert entity.is_on is True
+
+    await entity.async_turn_off()
+    await entity.async_turn_on()
+
+    mock_envy_client.tone_map_off.assert_awaited_once()
+    mock_envy_client.tone_map_on.assert_awaited_once()
+
+    await coordinator.async_shutdown()
+
+
+async def test_button_calls_client(hass, mock_envy_client):
+    """Test button actions call client methods."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    restart_desc = next(item for item in BUTTONS if item.key == "restart")
+    entity = MadvrEnvyButton(coordinator, restart_desc)
+    await entity.async_press()
+
+    mock_envy_client.restart.assert_awaited_once()
+
+    await coordinator.async_shutdown()
+
+
+async def test_profile_select_options_and_command(hass, mock_envy_client):
+    """Test profile select renders options and sends activate command."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyActiveProfileSelect(coordinator)
+
+    assert "Cinema: Day" in entity.options
+    assert "Cinema: Night" in entity.options
+    assert entity.current_option == "Cinema: Night"
+
+    await entity.async_select_option("Cinema: Day")
+    mock_envy_client.activate_profile.assert_awaited_once_with("1", 1)
+
+    await coordinator.async_shutdown()
+
+
+async def test_power_mode_select_calls_expected_commands(hass, mock_envy_client):
+    """Test power mode select dispatches power commands."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyPowerModeSelect(coordinator)
+    assert entity.current_option == "on"
+
+    await entity.async_select_option("standby")
+    await entity.async_select_option("off")
+    await entity.async_select_option("on")
+
+    mock_envy_client.standby.assert_awaited_once()
+    mock_envy_client.power_off.assert_awaited_once()
+    mock_envy_client.key_press.assert_awaited_with("POWER")
+
+    await coordinator.async_shutdown()
+
+
+async def test_profile_group_select(hass, mock_envy_client):
+    """Test profile-group scoped select entity behavior."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyProfileGroupSelect(coordinator, "1")
+    assert "Cinema: Day" in entity.options
+    assert entity.current_option == "Cinema: Night"
+
+    await entity.async_select_option("Cinema: Day")
+    mock_envy_client.activate_profile.assert_awaited_with("1", 1)
+
+    await coordinator.async_shutdown()
+
+
+async def test_remote_send_command_and_actions(hass, mock_envy_client):
+    """Test remote entity key and action command dispatch."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = MadvrEnvyRemote(coordinator)
+    assert entity.is_on is True
+    await entity.async_turn_on()
+    await entity.async_turn_off()
+    await entity.async_send_command(["MENU", "action:restart", "INFO"])
+    await entity.async_send_command(["", 123, "action:unknown"])  # type: ignore[list-item]
+
+    mock_envy_client.key_press.assert_any_await("POWER")
+    mock_envy_client.key_press.assert_any_await("MENU")
+    mock_envy_client.key_press.assert_any_await("INFO")
+    mock_envy_client.standby.assert_awaited()
+    mock_envy_client.restart.assert_awaited_once()
+
+    await coordinator.async_shutdown()
+
+
+async def test_profile_group_select_name_fallback(hass, mock_envy_client):
+    """Test profile-group select naming fallback behavior."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+    coordinator.data["profile_groups"] = {}
+    entity = MadvrEnvyProfileGroupSelect(coordinator, "custom")
+    assert entity.name == "custom Profile"
+    await coordinator.async_shutdown()

--- a/tests/components/madvr/test_init.py
+++ b/tests/components/madvr/test_init.py
@@ -1,28 +1,117 @@
-"""Tests for the MadVR integration."""
+"""Test integration setup and unload."""
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_HOST, CONF_PORT
 
-from . import setup_integration
+from homeassistant.components.madvr.const import (
+    DOMAIN,
+    SERVICE_ACTIVATE_PROFILE,
+    SERVICE_PRESS_KEY,
+    SERVICE_RUN_ACTION,
+)
 
-from tests.common import MockConfigEntry
+
+async def test_setup_and_unload_entry(hass, mock_config_entry, mock_envy_client):
+    """Test setup and unload lifecycle."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.madvr.MadvrEnvyClient", return_value=mock_envy_client),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ) as mock_forward,
+        patch.object(
+            hass.config_entries,
+            "async_unload_platforms",
+            AsyncMock(return_value=True),
+        ) as mock_unload,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        runtime_data = mock_config_entry.runtime_data
+        assert runtime_data.client is mock_envy_client
+        assert runtime_data.coordinator.data is not None
+        assert runtime_data.coordinator.data["power_state"] == "on"
+        assert DOMAIN in hass.data
+        assert mock_config_entry.entry_id in hass.data[DOMAIN]
+        assert hass.services.has_service(DOMAIN, SERVICE_PRESS_KEY)
+        assert hass.services.has_service(DOMAIN, SERVICE_ACTIVATE_PROFILE)
+        assert hass.services.has_service(DOMAIN, SERVICE_RUN_ACTION)
+
+        mock_forward.assert_awaited_once()
+
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        mock_unload.assert_awaited_once()
+        assert DOMAIN not in hass.data
+        assert not hass.services.has_service(DOMAIN, SERVICE_PRESS_KEY)
+        assert not hass.services.has_service(DOMAIN, SERVICE_ACTIVATE_PROFILE)
+        assert not hass.services.has_service(DOMAIN, SERVICE_RUN_ACTION)
+
+    mock_envy_client.start.assert_called_once()
+    assert mock_envy_client.stop.await_count >= 1
 
 
-async def test_load_unload_entry(
-    hass: HomeAssistant,
-    mock_madvr_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test load and unload entry."""
-    await setup_integration(hass, mock_config_entry)
+async def test_setup_entry_not_ready_on_sync_timeout(hass, mock_config_entry, mock_envy_client):
+    """Test setup fails gracefully if initial sync times out."""
+    mock_envy_client.wait_synced.side_effect = TimeoutError
+    mock_config_entry.add_to_hass(hass)
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
+    with (
+        patch("homeassistant.components.madvr.MadvrEnvyClient", return_value=mock_envy_client),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
-    await hass.config_entries.async_remove(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    assert mock_envy_client.stop.await_count >= 1
 
-    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+async def test_setup_entry_uses_options_for_timeouts(hass, mock_envy_client):
+    """Test entry options are used to construct client."""
+    from tests.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="madVR Envy",
+        data={CONF_HOST: "192.168.1.100", CONF_PORT: 44077},
+        options={
+            "connect_timeout": 5.0,
+            "command_timeout": 4.0,
+            "read_timeout": 15.0,
+            "sync_timeout": 12.0,
+            "reconnect_initial_backoff": 0.5,
+            "reconnect_max_backoff": 8.0,
+            "reconnect_jitter": 0.1,
+        },
+        unique_id="madvr_192.168.1.100_44077",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.madvr.MadvrEnvyClient", return_value=mock_envy_client
+        ) as mock_client_class,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    kwargs = mock_client_class.call_args.kwargs
+    assert kwargs["connect_timeout"] == 5.0
+    assert kwargs["command_timeout"] == 4.0
+    assert kwargs["read_timeout"] == 15.0

--- a/tests/components/madvr/test_platform_setup.py
+++ b/tests/components/madvr/test_platform_setup.py
@@ -1,0 +1,118 @@
+"""Test platform setup helpers and utility branches."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from homeassistant.components.madvr import binary_sensor, button, remote, select, sensor, switch
+from homeassistant.components.madvr.coordinator import MadvrEnvyCoordinator
+from homeassistant.components.madvr.entity import MadvrEnvyEntity
+
+
+async def test_platform_setup_entity_counts(hass, mock_envy_client):
+    """Test platform setup entity creation and advanced filtering."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    basic_entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        options={"enable_advanced_entities": False},
+    )
+    full_entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+        options={"enable_advanced_entities": True},
+    )
+
+    added_basic: list[object] = []
+    added_full: list[object] = []
+
+    await sensor.async_setup_entry(hass, basic_entry, added_basic.extend)
+    await sensor.async_setup_entry(hass, full_entry, added_full.extend)
+    assert len(added_basic) == len(sensor.SENSORS) - 2
+    assert len(added_full) == len(sensor.SENSORS)
+
+    added_buttons_basic: list[object] = []
+    added_buttons_full: list[object] = []
+    await button.async_setup_entry(hass, basic_entry, added_buttons_basic.extend)
+    await button.async_setup_entry(hass, full_entry, added_buttons_full.extend)
+    assert len(added_buttons_basic) < len(added_buttons_full)
+
+    added_binary: list[object] = []
+    await binary_sensor.async_setup_entry(hass, full_entry, added_binary.extend)
+    assert len(added_binary) == 1
+
+    added_switch: list[object] = []
+    await switch.async_setup_entry(hass, full_entry, added_switch.extend)
+    assert len(added_switch) == 1
+
+    added_select: list[object] = []
+    await select.async_setup_entry(hass, full_entry, added_select.extend)
+    assert len(added_select) >= 2
+
+    added_remote: list[object] = []
+    await remote.async_setup_entry(hass, full_entry, added_remote.extend)
+    assert len(added_remote) == 1
+
+    await coordinator.async_shutdown()
+
+
+def test_temperature_value_helper_branches():
+    """Test temperature helper fallback behavior."""
+    assert sensor._temperature_value({}, 0) is None
+    assert sensor._temperature_value({"temperatures": (1,)}, 1) is None
+    assert sensor._temperature_value({"temperatures": ("x",)}, 0) is None
+    assert sensor._nested_value({}, "incoming_signal", "resolution") is None
+    assert (
+        sensor._nested_value({"incoming_signal": {"aspect_ratio": "16:9"}}, "incoming_signal", "aspect_ratio")
+        == "16:9"
+    )
+    assert sensor._ratio_decimal_value({}, "masking_ratio") is None
+    assert sensor._ratio_decimal_value({"masking_ratio": {"decimal_ratio": 2.259}}, "masking_ratio") == 2.259
+    assert sensor._active_profile_value({}) is None
+    assert (
+        sensor._active_profile_value({"active_profile_group": "1", "active_profile_index": 2})
+        == "1: 2"
+    )
+    assert (
+        sensor._active_profile_value(
+            {
+                "active_profile_group": "1",
+                "active_profile_index": 2,
+                "profile_groups": {"1": "Cinema"},
+                "profiles": {"1_2": "Night"},
+            }
+        )
+        == "Cinema: Night"
+    )
+
+
+def test_select_profile_id_parsing_branches():
+    """Test profile id parsing edge cases."""
+    assert select._parse_profile_id("1_2", None) == ("1", 2)
+    assert select._parse_profile_id("2", "1") == ("1", 2)
+    assert select._parse_profile_id("invalid", "1") is None
+    assert select._build_profile_options({}) == []
+
+
+class _DummyEntity(MadvrEnvyEntity):
+    def __init__(self, coordinator):
+        super().__init__(coordinator, "dummy")
+
+
+async def test_entity_execute_wraps_command_errors(hass, mock_envy_client):
+    """Test command errors are translated to HomeAssistantError."""
+    coordinator = MadvrEnvyCoordinator(hass, mock_envy_client)
+    await coordinator.async_start()
+
+    entity = _DummyEntity(coordinator)
+
+    async def _failing_command():
+        raise TimeoutError
+
+    with pytest.raises(HomeAssistantError):
+        await entity._execute("test", _failing_command)
+
+    await coordinator.async_shutdown()

--- a/tests/components/madvr/test_services.py
+++ b/tests/components/madvr/test_services.py
@@ -1,0 +1,53 @@
+"""Test service APIs for madVR Envy integration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.madvr.const import (
+    DOMAIN,
+    SERVICE_ACTIVATE_PROFILE,
+    SERVICE_PRESS_KEY,
+    SERVICE_RUN_ACTION,
+)
+from homeassistant.components.madvr.services import async_setup_services, async_unload_services
+
+
+async def test_services_dispatch_commands(hass, mock_config_entry, mock_envy_client):
+    """Test registered services call through to client commands."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.madvr.MadvrEnvyClient", return_value=mock_envy_client),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(DOMAIN, SERVICE_PRESS_KEY, {"key": "MENU"}, blocking=True)
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_ACTIVATE_PROFILE,
+        {"group_id": "1", "profile_index": 2},
+        blocking=True,
+    )
+    await hass.services.async_call(DOMAIN, SERVICE_RUN_ACTION, {"action": "restart"}, blocking=True)
+
+    mock_envy_client.key_press.assert_any_await("MENU")
+    mock_envy_client.activate_profile.assert_awaited_with("1", 2)
+    mock_envy_client.restart.assert_awaited_once()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+
+
+async def test_services_setup_is_idempotent(hass):
+    """Test setting up multiple entries does not double-register services."""
+    await async_setup_services(hass)
+    await async_setup_services(hass)
+
+    assert hass.services.has_service(DOMAIN, SERVICE_PRESS_KEY)
+    await async_unload_services(hass)


### PR DESCRIPTION
## Summary
This is PR 2 of the split sequence that supersedes #164410.

This PR adds optional new functionality on top of the runtime migration introduced in #164419.

## Scope
- Add new madvr platforms: `button`, `switch`, `select`
- Add integration services: `press_key`, `activate_profile`, `run_action`
- Add tests for added entities/platform behavior/services
- Update strings/icons for the added entities/services

## Notes
- This PR is intentionally separate from runtime migration to keep review scope focused.
- Compatibility-sensitive runtime/entity-id migration is handled in #164419.

## Related pull requests
- Runtime/compatibility PR: https://github.com/home-assistant/core/pull/164419
- Documentation PR: https://github.com/home-assistant/home-assistant.io/pull/43821

Depends on: #164419
Context: #154722
