### PR TITLE
Add Trinnov Altitude integration (initial media_player platform)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1753,6 +1753,8 @@ build.json @home-assistant/supervisor
 /tests/components/trend/ @jpbede
 /homeassistant/components/triggercmd/ @rvmey
 /tests/components/triggercmd/ @rvmey
+/homeassistant/components/trinnov_altitude/ @binarylogic
+/tests/components/trinnov_altitude/ @binarylogic
 /homeassistant/components/tts/ @home-assistant/core
 /tests/components/tts/ @home-assistant/core
 /homeassistant/components/tuya/ @Tuya @zlinoliver

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -1,0 +1,56 @@
+"""The Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from trinnov_altitude.client import TrinnovAltitudeClient
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_MAC, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import CLIENT_ID
+
+PLATFORMS: list[Platform] = [
+    Platform.MEDIA_PLAYER,
+]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry for Trinnov Altitude."""
+
+    host = entry.data[CONF_HOST].strip()
+    mac = entry.data.get(CONF_MAC, "").strip() or None
+    device = TrinnovAltitudeClient(host=host, mac=mac, client_id=CLIENT_ID)
+
+    try:
+        await device.start()
+        await device.wait_synced()
+    except (ConnectionFailedError, ConnectionTimeoutError, TimeoutError) as err:
+        await device.stop()
+        raise ConfigEntryNotReady(
+            f"Could not connect to Trinnov Altitude at {host}"
+        ) from err
+
+    entry.runtime_data = device
+
+    async def stop(_event: Event) -> None:
+        await device.stop()
+
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop))
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Trinnov Altitude config entry."""
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        await entry.runtime_data.stop()
+
+    return unload_ok

--- a/homeassistant/components/trinnov_altitude/__init__.py
+++ b/homeassistant/components/trinnov_altitude/__init__.py
@@ -20,8 +20,18 @@ PLATFORMS: list[Platform] = [
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for Trinnov Altitude."""
 
-    host = entry.data[CONF_HOST].strip()
-    mac = entry.data.get(CONF_MAC, "").strip() or None
+    host_value = entry.data.get(CONF_HOST, "")
+    if isinstance(host_value, str):
+        host = host_value.strip()
+    else:
+        host = str(host_value)
+
+    mac_value = entry.data.get(CONF_MAC)
+    if isinstance(mac_value, str):
+        mac = mac_value.strip() or None
+    else:
+        mac = None
+
     device = TrinnovAltitudeClient(host=host, mac=mac, client_id=CLIENT_ID)
 
     try:

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -1,0 +1,73 @@
+"""Config flow for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from trinnov_altitude.client import TrinnovAltitudeClient
+from trinnov_altitude.exceptions import (
+    ConnectionFailedError,
+    ConnectionTimeoutError,
+    MalformedMacAddressError,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    CONN_CLASS_LOCAL_PUSH,
+    ConfigFlow,
+    ConfigFlowResult,
+)
+from homeassistant.const import CONF_HOST, CONF_MAC
+
+from .const import DOMAIN, NAME
+
+_LOGGER = logging.getLogger(__name__)
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_HOST): str, vol.Optional(CONF_MAC, default=""): str}
+)
+
+
+class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Trinnov Altitude."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+
+        errors = {}
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            mac = user_input.get(CONF_MAC, "").strip() or None
+
+            device = TrinnovAltitudeClient(host=host, mac=mac)
+            try:
+                await device.start()
+                await device.wait_synced()
+            except MalformedMacAddressError:
+                errors[CONF_MAC] = "invalid_mac"
+            except ConnectionFailedError:
+                errors[CONF_HOST] = "invalid_host"
+            except (ConnectionTimeoutError, TimeoutError):
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception while setting up device")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(device.state.id, raise_on_progress=False)
+                processed_input = {CONF_HOST: host, CONF_MAC: mac}
+                self._abort_if_unique_id_configured(processed_input)
+                return self.async_create_entry(
+                    title=f"{NAME} ({device.state.id})", data=processed_input
+                )
+            finally:
+                await device.stop()
+
+        return self.async_show_form(
+            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )

--- a/homeassistant/components/trinnov_altitude/config_flow.py
+++ b/homeassistant/components/trinnov_altitude/config_flow.py
@@ -59,11 +59,12 @@ class TrinnovAltitudeConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception while setting up device")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(device.state.id, raise_on_progress=False)
+                unique_id = str(device.state.id)
+                await self.async_set_unique_id(unique_id, raise_on_progress=False)
                 processed_input = {CONF_HOST: host, CONF_MAC: mac}
                 self._abort_if_unique_id_configured(processed_input)
                 return self.async_create_entry(
-                    title=f"{NAME} ({device.state.id})", data=processed_input
+                    title=f"{NAME} ({unique_id})", data=processed_input
                 )
             finally:
                 await device.stop()

--- a/homeassistant/components/trinnov_altitude/const.py
+++ b/homeassistant/components/trinnov_altitude/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Trinnov Altitude integration."""
+
+CLIENT_ID = "Home Assistant Trinnov Altitude Integration"
+MANUFACTURER = "Trinnov"
+MODEL = "Altitude"
+NAME = f"{MANUFACTURER} {MODEL}"
+DOMAIN = "trinnov_altitude"

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -13,8 +13,6 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN, MANUFACTURER, MODEL, NAME
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from trinnov_altitude.client import TrinnovAltitudeClient
     from trinnov_altitude.protocol import Message
 
@@ -31,11 +29,11 @@ class TrinnovAltitudeEntity(Entity):
         """Initialize entity."""
 
         self._device = device
-        self._callback: Callable[[Any], None] | None = None
+        self._callback: Callable[[str, Message | None], None] | None = None
+        self._device_id = str(device.state.id)
 
-        self._attr_unique_id = str(device.state.id)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(device.state.id))},
+            identifiers={(DOMAIN, self._device_id)},
             name=f"{NAME} ({device.state.id})",
             model=MODEL,
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/trinnov_altitude/entity.py
+++ b/homeassistant/components/trinnov_altitude/entity.py
@@ -1,0 +1,61 @@
+"""Base Entity for Trinnov Altitude."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN, MANUFACTURER, MODEL, NAME
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from trinnov_altitude.client import TrinnovAltitudeClient
+    from trinnov_altitude.protocol import Message
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TrinnovAltitudeEntity(Entity):
+    """Defines a base Trinnov Altitude entity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, device: TrinnovAltitudeClient) -> None:
+        """Initialize entity."""
+
+        self._device = device
+        self._callback: Callable[[Any], None] | None = None
+
+        self._attr_unique_id = str(device.state.id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, str(device.state.id))},
+            name=f"{NAME} ({device.state.id})",
+            model=MODEL,
+            manufacturer=MANUFACTURER,
+            sw_version=device.state.version,
+            configuration_url=f"http://{device.host}",
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Register update listener."""
+
+        @callback
+        def _update(_event: str, _message: Message | None) -> None:
+            """Handle device state changes."""
+            self.async_write_ha_state()
+
+        self._callback = _update
+        self._device.register_callback(self._callback)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Deregister update listener."""
+
+        if self._callback is not None:
+            self._device.deregister_callback(self._callback)

--- a/homeassistant/components/trinnov_altitude/manifest.json
+++ b/homeassistant/components/trinnov_altitude/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "trinnov_altitude",
+  "name": "Trinnov Altitude",
+  "codeowners": ["@binarylogic"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/trinnov_altitude",
+  "integration_type": "device",
+  "iot_class": "local_push",
+  "loggers": ["trinnov_altitude"],
+  "requirements": ["trinnov-altitude==3.1.0"],
+  "quality_scale": "bronze"
+}

--- a/homeassistant/components/trinnov_altitude/media_player.py
+++ b/homeassistant/components/trinnov_altitude/media_player.py
@@ -1,0 +1,116 @@
+"""Media player for Trinnov Altitude integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.media_player import (
+    MediaPlayerDeviceClass,
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
+    MediaPlayerState,
+)
+from homeassistant.exceptions import HomeAssistantError
+from trinnov_altitude.exceptions import NoMacAddressError
+
+from .entity import TrinnovAltitudeEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the media player platform from a config entry."""
+    async_add_entities([TrinnovAltitudeMediaPlayer(entry.runtime_data)])
+
+
+class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
+    """Representation of a Trinnov Altitude device."""
+
+    _attr_device_class = MediaPlayerDeviceClass.RECEIVER
+    _attr_name = None
+    _attr_supported_features = (
+        MediaPlayerEntityFeature.SELECT_SOURCE
+        | MediaPlayerEntityFeature.TURN_ON
+        | MediaPlayerEntityFeature.TURN_OFF
+        | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.VOLUME_SET
+        | MediaPlayerEntityFeature.VOLUME_STEP
+    )
+
+    async def async_mute_volume(self, mute: bool) -> None:
+        """Mute/unmute volume."""
+        await self._device.mute_set(mute)
+
+    async def async_select_source(self, source: str) -> None:
+        """Select source."""
+        try:
+            await self._device.source_set_by_name(source)
+        except ValueError as exc:
+            raise HomeAssistantError(str(exc)) from exc
+
+    async def async_turn_on(self) -> None:
+        """Power on."""
+        try:
+            self._device.power_on()
+        except NoMacAddressError as exc:
+            raise HomeAssistantError(
+                "Device is not configured with a MAC address. Add the MAC address in the integration configuration to power it on"
+            ) from exc
+
+    async def async_turn_off(self) -> None:
+        """Power off."""
+        await self._device.power_off()
+
+    async def async_volume_up(self) -> None:
+        """Volume up."""
+        await self._device.volume_up()
+
+    async def async_volume_down(self) -> None:
+        """Volume down."""
+        await self._device.volume_down()
+
+    async def async_set_volume_level(self, volume: float) -> None:
+        """Set volume level (0..1)."""
+        await self._device.volume_percentage_set(volume * 100.0)
+
+    @property
+    def available(self) -> bool:
+        """Return if device is available."""
+        return self._device.power_on_available() or self._device.connected
+
+    @property
+    def input_source(self) -> str | None:
+        """Current source."""
+        return self._device.state.source
+
+    @property
+    def input_source_list(self) -> list[str] | None:
+        """Available source list."""
+        return list(self._device.state.sources.values())
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Boolean if volume is currently muted."""
+        return self._device.state.mute
+
+    @property
+    def state(self) -> MediaPlayerState:
+        """State of device."""
+        if not self._device.connected or not self._device.state.synced:
+            return MediaPlayerState.OFF
+        if self._device.state.source_format:
+            return MediaPlayerState.PLAYING
+        return MediaPlayerState.IDLE
+
+    @property
+    def volume_level(self) -> float | None:
+        """Volume level (0..1)."""
+        percentage = self._device.volume_percentage
+        if percentage is None:
+            return None
+        return percentage / 100.0

--- a/homeassistant/components/trinnov_altitude/media_player.py
+++ b/homeassistant/components/trinnov_altitude/media_player.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from trinnov_altitude.client import TrinnovAltitudeClient
 
 
 async def async_setup_entry(
@@ -41,6 +42,11 @@ class TrinnovAltitudeMediaPlayer(TrinnovAltitudeEntity, MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
     )
+
+    def __init__(self, device: TrinnovAltitudeClient) -> None:
+        """Initialize the media player entity."""
+        super().__init__(device)
+        self._attr_unique_id = f"{self._device_id}_media_player"
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Mute/unmute volume."""

--- a/homeassistant/components/trinnov_altitude/quality_scale.yaml
+++ b/homeassistant/components/trinnov_altitude/quality_scale.yaml
@@ -1,0 +1,24 @@
+rules:
+  # Bronze
+  config-flow: done
+  test-before-configure: done
+  unique-config-entry: done
+  config-flow-test-coverage: done
+  runtime-data: done
+  test-before-setup: done
+  appropriate-polling: done
+  entity-unique-id: done
+  has-entity-name: done
+  entity-event-setup:
+    status: exempt
+    comment: The integration does not use event entities.
+  dependency-transparency: done
+  action-setup:
+    status: exempt
+    comment: The integration only uses platform services.
+  common-modules: done
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-actions: done
+  brands: done

--- a/homeassistant/components/trinnov_altitude/strings.json
+++ b/homeassistant/components/trinnov_altitude/strings.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "invalid_mac": "Invalid MAC address",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "mac": "MAC address"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -740,6 +740,7 @@ FLOWS = {
         "trane",
         "transmission",
         "triggercmd",
+        "trinnov_altitude",
         "tuya",
         "twentemilieu",
         "twilio",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7237,6 +7237,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "trinnov_altitude": {
+      "name": "Trinnov Altitude",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "tuya": {
       "name": "Tuya",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3114,6 +3114,9 @@ transmission-rpc==7.0.3
 # homeassistant.components.triggercmd
 triggercmd==0.0.36
 
+# homeassistant.components.trinnov_altitude
+trinnov-altitude==3.1.0
+
 # homeassistant.components.twinkly
 ttls==1.8.3
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2617,6 +2617,9 @@ transmission-rpc==7.0.3
 # homeassistant.components.triggercmd
 triggercmd==0.0.36
 
+# homeassistant.components.trinnov_altitude
+trinnov-altitude==3.1.0
+
 # homeassistant.components.twinkly
 ttls==1.8.3
 

--- a/tests/components/trinnov_altitude/__init__.py
+++ b/tests/components/trinnov_altitude/__init__.py
@@ -1,0 +1,5 @@
+"""Tests for Trinnov Altitude."""
+
+MOCK_MAC = "c8:7f:54:7a:eb:c2"
+MOCK_HOST = "127.0.0.1"
+MOCK_ID = "123456"

--- a/tests/components/trinnov_altitude/conftest.py
+++ b/tests/components/trinnov_altitude/conftest.py
@@ -1,0 +1,92 @@
+"""Fixtures for Trinnov Altitude integration."""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.trinnov_altitude.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_MAC
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_HOST, MOCK_ID, MOCK_MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="mock_device")
+def fixture_mock_device() -> Generator[AsyncMock, None, None]:
+    """Return a mocked TrinnovAltitude."""
+    with (
+        patch(
+            "homeassistant.components.trinnov_altitude.TrinnovAltitudeClient",
+            autospec=True,
+        ) as init_mock,
+        patch(
+            "homeassistant.components.trinnov_altitude.config_flow.TrinnovAltitudeClient",
+            autospec=True,
+        ) as flow_mock,
+    ):
+        altitude = init_mock.return_value
+        flow_mock.return_value = altitude
+        altitude.start = AsyncMock(return_value=None)
+        altitude.wait_synced = AsyncMock(return_value=None)
+        altitude.stop = AsyncMock(return_value=None)
+        altitude.power_off = AsyncMock(return_value=None)
+        altitude.mute_set = AsyncMock(return_value=None)
+        altitude.dim_set = AsyncMock(return_value=None)
+        altitude.bypass_set = AsyncMock(return_value=None)
+        altitude.source_set_by_name = AsyncMock(return_value=None)
+        altitude.preset_set = AsyncMock(return_value=None)
+        altitude.upmixer_set = AsyncMock(return_value=None)
+        altitude.volume_up = AsyncMock(return_value=None)
+        altitude.volume_down = AsyncMock(return_value=None)
+        altitude.volume_set = AsyncMock(return_value=None)
+        altitude.volume_percentage_set = AsyncMock(return_value=None)
+        altitude.power_on_available.return_value = True
+        altitude.power_on.return_value = None
+        altitude.volume_percentage = 50.0
+        altitude.host = MOCK_HOST
+        altitude.connected = True
+        altitude.state = SimpleNamespace(
+            id=MOCK_ID,
+            version="VERSION",
+            synced=True,
+            source="Apple TV",
+            sources={0: "Apple TV", 1: "Blu-ray"},
+            source_format="PCM",
+            decoder="Dolby Atmos",
+            audiosync=42,
+            mute=False,
+            dim=False,
+            bypass=False,
+            volume=-35.0,
+            preset="Movie",
+            presets={0: "Movie", 1: "Music"},
+            upmixer="native",
+        )
+        yield altitude
+
+
+@pytest.fixture(name="mock_config_entry")
+def fixture_mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_ID,
+        version=1,
+        data={CONF_HOST: MOCK_HOST, CONF_MAC: MOCK_MAC},
+    )
+
+
+@pytest.fixture(name="mock_integration")
+async def fixture_mock_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> MockConfigEntry:
+    """Return a mock ConfigEntry setup for Trinnov Altitude integration."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/trinnov_altitude/test_config_flow.py
+++ b/tests/components/trinnov_altitude/test_config_flow.py
@@ -1,0 +1,97 @@
+"""Tests for Trinnov Altitude config flow."""
+
+from unittest.mock import AsyncMock
+
+from trinnov_altitude.exceptions import ConnectionFailedError, ConnectionTimeoutError
+
+from homeassistant.components.trinnov_altitude.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import MOCK_HOST, MOCK_MAC
+
+from tests.common import MockConfigEntry
+
+CONTEXT = {"source": SOURCE_USER}
+DATA = {CONF_HOST: MOCK_HOST, CONF_MAC: MOCK_MAC}
+
+
+async def test_user_config_flow_connection_failed(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow connection failed."""
+    mock_device.start.side_effect = ConnectionFailedError(OSError("message"))
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context=CONTEXT, data=DATA
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"host": "invalid_host"}
+
+
+async def test_user_config_flow_connection_timeout(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow connection timeout."""
+    mock_device.start.side_effect = ConnectionTimeoutError("message")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context=CONTEXT, data=DATA
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_config_flow_success(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow success."""
+    mock_device.start.side_effect = None
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context=CONTEXT)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST, CONF_MAC: MOCK_MAC}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert "data" in result
+    assert result["data"][CONF_HOST] == MOCK_HOST
+
+
+async def test_user_config_flow_device_exists_abort(
+    hass: HomeAssistant, mock_device: AsyncMock, mock_integration: MockConfigEntry
+) -> None:
+    """Test flow aborts when device already configured."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context=CONTEXT,
+        data=DATA,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_config_flow_without_mac(
+    hass: HomeAssistant, mock_device: AsyncMock
+) -> None:
+    """Test user config flow without MAC address."""
+    result = await hass.config_entries.flow.async_init(DOMAIN, context=CONTEXT)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: MOCK_HOST}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_HOST] == MOCK_HOST
+    assert result["data"][CONF_MAC] is None

--- a/tests/components/trinnov_altitude/test_init.py
+++ b/tests/components/trinnov_altitude/test_init.py
@@ -1,0 +1,42 @@
+"""Tests for Trinnov Altitude config entry."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test config entry loading and unloading."""
+    mock_config_entry = mock_integration
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_device.start.call_count == 1
+    assert mock_device.stop.call_count == 0
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_device.stop.call_count == 1
+
+
+async def test_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_device: AsyncMock,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test device."""
+    device = device_registry.async_get_device(
+        identifiers={("trinnov_altitude", MOCK_ID)}
+    )
+    assert device is not None
+    assert device.identifiers == {("trinnov_altitude", MOCK_ID)}

--- a/tests/components/trinnov_altitude/test_media_player.py
+++ b/tests/components/trinnov_altitude/test_media_player.py
@@ -1,0 +1,115 @@
+"""Tests for Trinnov Altitude media player platform."""
+
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_VOLUME_LEVEL,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
+    MediaPlayerState,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ID
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = f"media_player.trinnov_altitude_{MOCK_ID}"
+
+
+async def test_entity(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test entity attributes and state."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == MediaPlayerState.PLAYING
+
+
+async def test_commands(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test media player service calls."""
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.power_on.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.power_off.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        {ATTR_ENTITY_ID: ENTITY_ID, "is_volume_muted": True},
+        blocking=True,
+    )
+    mock_device.mute_set.assert_called_once_with(True)
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_SET,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.35},
+        blocking=True,
+    )
+    mock_device.volume_percentage_set.assert_called_once_with(35.0)
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_UP,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.volume_up.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_DOWN,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_device.volume_down.assert_called_once_with()
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {ATTR_ENTITY_ID: ENTITY_ID, "source": "Apple TV"},
+        blocking=True,
+    )
+    mock_device.source_set_by_name.assert_called_once_with("Apple TV")
+
+
+async def test_state_off_when_not_synced(
+    hass: HomeAssistant,
+    mock_device,
+    mock_integration: MockConfigEntry,
+) -> None:
+    """Test state is OFF when disconnected/unsynced."""
+    mock_device.connected = False
+    mock_device.state.synced = False
+
+    callback = mock_device.register_callback.call_args[0][0]
+    callback("received_message", None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == MediaPlayerState.OFF


### PR DESCRIPTION
## Proposed change
Add an initial Home Assistant Core integration for Trinnov Altitude with a single platform (`media_player`) to keep first review scope minimal.

Included in this PR:
- New `trinnov_altitude` integration domain and config flow
- Runtime setup/unload using `entry.runtime_data`
- Initial `media_player` entity support (power, source, volume/mute)
- Initial tests for config flow, setup/unload, and media player behavior
- Generated metadata updates (`config_flows.py`, `integrations.json`)
- Dependency pin (`trinnov-altitude==3.1.0`)
- `quality_scale` metadata and `quality_scale.yaml` (bronze)

Follow-up PRs will add additional platforms (`remote`, `select`, `number`, `sensor`, `switch`) one at a time.

## Type of change
- [x] New integration

## Additional information
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43819

