### PR TITLE
Remove unnecessary volume_up/volume_down overrides from demo media player

### DIFF
--- a/homeassistant/components/demo/media_player.py
+++ b/homeassistant/components/demo/media_player.py
@@ -139,18 +139,6 @@ class AbstractDemoPlayer(MediaPlayerEntity):
         self._attr_is_volume_muted = mute
         self.schedule_update_ha_state()
 
-    def volume_up(self) -> None:
-        """Increase volume."""
-        assert self.volume_level is not None
-        self._attr_volume_level = min(1.0, self.volume_level + 0.1)
-        self.schedule_update_ha_state()
-
-    def volume_down(self) -> None:
-        """Decrease volume."""
-        assert self.volume_level is not None
-        self._attr_volume_level = max(0.0, self.volume_level - 0.1)
-        self.schedule_update_ha_state()
-
     def set_volume_level(self, volume: float) -> None:
         """Set the volume level, range 0..1."""
         self._attr_volume_level = volume


### PR DESCRIPTION
## Proposed change

Remove the `volume_up` and `volume_down` method overrides from the demo media player. These overrides are unnecessary because they replicate exactly what the `MediaPlayerEntity` base class already does: adjust `volume_level` by `volume_step` (default 0.1) and call `set_volume_level`.

The base class implementation (`async_volume_up`/`async_volume_down` in `MediaPlayerEntity`) checks if `volume_level` is known and `VOLUME_SET` is supported, then calls `set_volume_level(min(1, volume_level + volume_step))` — which is identical to what the overrides were doing.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr