### PR TITLE
Remove unnecessary volume_up/volume_down overrides from bluesound media player

### DIFF
--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -85,6 +85,7 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
     _attr_media_content_type = MediaType.MUSIC
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_volume_step = 0.01
 
     def __init__(
         self,
@@ -687,24 +688,6 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
         url = async_process_play_media_url(self.hass, media_id)
 
         await self._player.play_url(url)
-
-    async def async_volume_up(self) -> None:
-        """Volume up the media player."""
-        if self.volume_level is None:
-            return
-
-        new_volume = self.volume_level + 0.01
-        new_volume = min(1, new_volume)
-        await self.async_set_volume_level(new_volume)
-
-    async def async_volume_down(self) -> None:
-        """Volume down the media player."""
-        if self.volume_level is None:
-            return
-
-        new_volume = self.volume_level - 0.01
-        new_volume = max(0, new_volume)
-        await self.async_set_volume_level(new_volume)
 
     async def async_set_volume_level(self, volume: float) -> None:
         """Send volume_up command to media player."""


### PR DESCRIPTION
## Proposed change

Remove the `async_volume_up` and `async_volume_down` method overrides from the bluesound media player and set `_attr_volume_step = 0.01` instead. The overrides were manually doing what the base class already handles: adjusting `volume_level` by a step and calling `async_set_volume_level`.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does exactly `set_volume_level(min(1, volume_level + volume_step))`. By setting `_attr_volume_step = 0.01` (matching the 1% step the overrides used), the base class produces identical behavior.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr