### PR TITLE
Remove unnecessary volume_up/volume_down overrides from clementine media player

### DIFF
--- a/homeassistant/components/clementine/media_player.py
+++ b/homeassistant/components/clementine/media_player.py
@@ -66,6 +66,7 @@ class ClementineDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.SELECT_SOURCE
         | MediaPlayerEntityFeature.PLAY
     )
+    _attr_volume_step = 0.04
 
     def __init__(self, client, name):
         """Initialize the Clementine device."""
@@ -123,16 +124,6 @@ class ClementineDevice(MediaPlayerEntity):
             return (image, "image/png")
 
         return None, None
-
-    def volume_up(self) -> None:
-        """Volume up the media player."""
-        newvolume = min(self._client.volume + 4, 100)
-        self._client.set_volume(newvolume)
-
-    def volume_down(self) -> None:
-        """Volume down media player."""
-        newvolume = max(self._client.volume - 4, 0)
-        self._client.set_volume(newvolume)
 
     def mute_volume(self, mute: bool) -> None:
         """Send mute command."""


### PR DESCRIPTION
## Proposed change

Remove the `volume_up` and `volume_down` method overrides from the clementine media player and set `_attr_volume_step = 0.04` instead. The overrides were manually computing `current_volume +/- 4` (on a 0-100 raw scale) and calling `set_volume` — which is equivalent to the base class stepping by 0.04 (4/100) and calling `set_volume_level`.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does exactly `set_volume_level(min(1, volume_level + volume_step))`. The existing `set_volume_level` method converts the 0..1 float back to the 0-100 raw scale, so the end result is identical.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr