### PR TITLE
Remove unnecessary volume_up/volume_down overrides from mpd media player

### DIFF
--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -93,6 +93,7 @@ class MpdDevice(MediaPlayerEntity):
     _attr_media_content_type = MediaType.MUSIC
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_volume_step = 0.05
 
     def __init__(
         self, server: str, port: int, password: str | None, unique_id: str
@@ -392,24 +393,6 @@ class MpdDevice(MediaPlayerEntity):
         async with self.connection():
             if "volume" in self._status:
                 await self._client.setvol(int(volume * 100))
-
-    async def async_volume_up(self) -> None:
-        """Service to send the MPD the command for volume up."""
-        async with self.connection():
-            if "volume" in self._status:
-                current_volume = int(self._status["volume"])
-
-                if current_volume <= 100:
-                    self._client.setvol(current_volume + 5)
-
-    async def async_volume_down(self) -> None:
-        """Service to send the MPD the command for volume down."""
-        async with self.connection():
-            if "volume" in self._status:
-                current_volume = int(self._status["volume"])
-
-                if current_volume >= 0:
-                    await self._client.setvol(current_volume - 5)
 
     async def async_media_play(self) -> None:
         """Service to send the MPD the command for play/pause."""


### PR DESCRIPTION
## Proposed change

Remove the `async_volume_up` and `async_volume_down` method overrides from the mpd media player and set `_attr_volume_step = 0.05` instead. The overrides were manually computing `current_volume +/- 5` (on a 0-100 raw scale) and calling `setvol` directly.

This also fixes a bug where `async_volume_up` was missing an `await` on the `self._client.setvol()` call, meaning volume up commands were silently dropped (the coroutine was created but never awaited). By delegating to the base class, which calls `async_set_volume_level`, the proper awaited code path is used.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does `set_volume_level(min(1, volume_level + volume_step))`. The existing `async_set_volume_level` method converts the 0..1 float to the 0-100 raw scale and calls `setvol`, so the end result is identical (but correctly awaited).

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr