### PR TITLE
Remove unnecessary volume_up/volume_down overrides from monoprice media player

### DIFF
--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -212,4 +212,3 @@ class MonopriceZone(MediaPlayerEntity):
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self._monoprice.set_volume(self._zone_id, round(volume * MAX_VOLUME))
-

--- a/homeassistant/components/monoprice/media_player.py
+++ b/homeassistant/components/monoprice/media_player.py
@@ -128,6 +128,7 @@ class MonopriceZone(MediaPlayerEntity):
     )
     _attr_has_entity_name = True
     _attr_name = None
+    _attr_volume_step = 1 / MAX_VOLUME
 
     def __init__(self, monoprice, sources, namespace, zone_id):
         """Initialize new zone."""
@@ -212,16 +213,3 @@ class MonopriceZone(MediaPlayerEntity):
         """Set volume level, range 0..1."""
         self._monoprice.set_volume(self._zone_id, round(volume * MAX_VOLUME))
 
-    def volume_up(self) -> None:
-        """Volume up the media player."""
-        if self.volume_level is None:
-            return
-        volume = round(self.volume_level * MAX_VOLUME)
-        self._monoprice.set_volume(self._zone_id, min(volume + 1, MAX_VOLUME))
-
-    def volume_down(self) -> None:
-        """Volume down media player."""
-        if self.volume_level is None:
-            return
-        volume = round(self.volume_level * MAX_VOLUME)
-        self._monoprice.set_volume(self._zone_id, max(volume - 1, 0))


### PR DESCRIPTION
## Proposed change

Remove the `volume_up` and `volume_down` method overrides from the monoprice media player and set `_attr_volume_step = 1 / MAX_VOLUME` instead. The overrides were manually computing `round(volume_level * MAX_VOLUME) +/- 1` and calling `set_volume` — which is equivalent to the base class stepping by `1/38` (~0.026) and calling `set_volume_level`.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does `set_volume_level(min(1, volume_level + volume_step))`. The existing `set_volume_level` method converts the 0..1 float back to the 0-38 raw range via `round(volume * MAX_VOLUME)`, so the end result is identical.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr