### PR TITLE
Remove unnecessary volume_up/volume_down overrides from frontier_silicon media player

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -151,8 +151,8 @@ class AFSAPIDevice(MediaPlayerEntity):
         # If call to get_volume fails set to 0 and try again next time.
         if not self._max_volume:
             self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
-            if self._max_volume:
-                self._attr_volume_step = 1 / self._max_volume
+        if self._max_volume:
+            self._attr_volume_step = 1 / self._max_volume
 
         if self._attr_state != MediaPlayerState.OFF:
             info_name = await afsapi.get_play_name()

--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -151,6 +151,8 @@ class AFSAPIDevice(MediaPlayerEntity):
         # If call to get_volume fails set to 0 and try again next time.
         if not self._max_volume:
             self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
+            if self._max_volume:
+                self._attr_volume_step = 1 / self._max_volume
 
         if self._attr_state != MediaPlayerState.OFF:
             info_name = await afsapi.get_play_name()
@@ -239,18 +241,6 @@ class AFSAPIDevice(MediaPlayerEntity):
         await self.fs_device.set_mute(mute)
 
     # volume
-    async def async_volume_up(self) -> None:
-        """Send volume up command."""
-        volume = await self.fs_device.get_volume()
-        volume = int(volume or 0) + 1
-        await self.fs_device.set_volume(min(volume, self._max_volume or 1))
-
-    async def async_volume_down(self) -> None:
-        """Send volume down command."""
-        volume = await self.fs_device.get_volume()
-        volume = int(volume or 0) - 1
-        await self.fs_device.set_volume(max(volume, 0))
-
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume command."""
         if self._max_volume:  # Can't do anything sensible if not set


### PR DESCRIPTION
## Proposed change

Remove the `async_volume_up` and `async_volume_down` method overrides from the frontier_silicon media player and dynamically set `_attr_volume_step = 1 / max_volume` once the device's volume range is known.

The overrides were fetching the current volume from the device, adjusting by 1 raw unit, and calling `set_volume` — which is equivalent to the base class stepping by `1/max_volume` and calling `set_volume_level`. The existing `async_set_volume_level` already converts the 0..1 float to the device's raw integer range, so the end result is identical.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr