### PR TITLE
Remove unnecessary volume_up/volume_down overrides from aquostv media player

### DIFF
--- a/homeassistant/components/aquostv/media_player.py
+++ b/homeassistant/components/aquostv/media_player.py
@@ -117,6 +117,7 @@ class SharpAquosTVDevice(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.PLAY
     )
+    _attr_volume_step = 2 / 60
 
     def __init__(
         self, name: str, remote: sharp_aquos_rc.TV, power_on_enabled: bool = False
@@ -160,22 +161,6 @@ class SharpAquosTVDevice(MediaPlayerEntity):
     def turn_off(self) -> None:
         """Turn off tvplayer."""
         self._remote.power(0)
-
-    @_retry
-    def volume_up(self) -> None:
-        """Volume up the media player."""
-        if self.volume_level is None:
-            _LOGGER.debug("Unknown volume in volume_up")
-            return
-        self._remote.volume(int(self.volume_level * 60) + 2)
-
-    @_retry
-    def volume_down(self) -> None:
-        """Volume down media player."""
-        if self.volume_level is None:
-            _LOGGER.debug("Unknown volume in volume_down")
-            return
-        self._remote.volume(int(self.volume_level * 60) - 2)
 
     @_retry
     def set_volume_level(self, volume: float) -> None:


### PR DESCRIPTION
## Proposed change

Remove the `volume_up` and `volume_down` method overrides from the aquostv media player and set `_attr_volume_step = 2 / 60` instead. The overrides were manually computing `int(volume_level * 60) +/- 2` and calling `self._remote.volume()` — which is equivalent to the base class stepping by `2/60` (~0.033) and calling `set_volume_level`.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does `set_volume_level(min(1, volume_level + volume_step))`. The existing `set_volume_level` method converts the 0..1 float back to the 0-60 raw range via `int(round(volume * 60))`, so the end result is identical.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr