### PR TITLE
Remove unnecessary volume_up/volume_down overrides from songpal media player

### DIFF
--- a/homeassistant/components/songpal/media_player.py
+++ b/homeassistant/components/songpal/media_player.py
@@ -288,6 +288,8 @@ class SongpalEntity(MediaPlayerEntity):
             self._volume_min = volume.minVolume
             self._volume = volume.volume
             self._volume_control = volume
+            if self._volume_max:
+                self._attr_volume_step = 1 / self._volume_max
             self._attr_is_volume_muted = self._volume_control.is_muted
 
             status = await self._dev.get_power()
@@ -380,14 +382,6 @@ class SongpalEntity(MediaPlayerEntity):
         volume = int(volume * self._volume_max)
         _LOGGER.debug("Setting volume to %s", volume)
         return await self._volume_control.set_volume(volume)
-
-    async def async_volume_up(self) -> None:
-        """Set volume up."""
-        return await self._volume_control.set_volume(self._volume + 1)
-
-    async def async_volume_down(self) -> None:
-        """Set volume down."""
-        return await self._volume_control.set_volume(self._volume - 1)
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""


### PR DESCRIPTION
## Proposed change

Remove the `async_volume_up` and `async_volume_down` method overrides from the songpal media player and dynamically set `_attr_volume_step = 1 / volume_max` once the device's volume range is known.

The overrides were calling `set_volume(self._volume +/- 1)` on the device — which is equivalent to the base class stepping by `1/volume_max` and calling `set_volume_level`. The existing `async_set_volume_level` converts the 0..1 float to the device's raw range via `int(volume * self._volume_max)`, so the end result is identical.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr