### PR TITLE
Remove unnecessary volume_up/volume_down overrides from ws66i media player

### DIFF
--- a/homeassistant/components/ws66i/media_player.py
+++ b/homeassistant/components/ws66i/media_player.py
@@ -55,6 +55,7 @@ class Ws66iZone(CoordinatorEntity[Ws66iDataUpdateCoordinator], MediaPlayerEntity
         | MediaPlayerEntityFeature.TURN_OFF
         | MediaPlayerEntityFeature.SELECT_SOURCE
     )
+    _attr_volume_step = 1 / MAX_VOL
 
     def __init__(
         self,
@@ -145,20 +146,6 @@ class Ws66iZone(CoordinatorEntity[Ws66iDataUpdateCoordinator], MediaPlayerEntity
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self.hass.async_add_executor_job(self._set_volume, int(volume * MAX_VOL))
-        self._async_update_attrs_write_ha_state()
-
-    async def async_volume_up(self) -> None:
-        """Volume up the media player."""
-        await self.hass.async_add_executor_job(
-            self._set_volume, min(self._status.volume + 1, MAX_VOL)
-        )
-        self._async_update_attrs_write_ha_state()
-
-    async def async_volume_down(self) -> None:
-        """Volume down media player."""
-        await self.hass.async_add_executor_job(
-            self._set_volume, max(self._status.volume - 1, 0)
-        )
         self._async_update_attrs_write_ha_state()
 
     def _set_volume(self, volume: int) -> None:


### PR DESCRIPTION
## Proposed change

Remove the `async_volume_up` and `async_volume_down` method overrides from the ws66i media player and set `_attr_volume_step = 1 / MAX_VOL` instead. The overrides were manually computing `status.volume +/- 1` (on a 0-38 raw scale) and calling `_set_volume` — which is equivalent to the base class stepping by `1/38` and calling `async_set_volume_level`.

The base class `async_volume_up`/`async_volume_down` in `MediaPlayerEntity` does `set_volume_level(min(1, volume_level + volume_step))`. The existing `async_set_volume_level` converts the 0..1 float back to the raw range via `int(volume * MAX_VOL)` and calls `_set_volume`, preserving the automatic unmute behavior when volume changes.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr