### PR TITLE
Remove unnecessary volume_up/volume_down overrides from NADtcp media player

### DIFF
--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -201,9 +201,7 @@ class NADtcp(MediaPlayerEntity):
         self._nad_volume = None
         vol_range = self._max_vol - self._min_vol
         if vol_range:
-            self._attr_volume_step = (
-                2 * config[CONF_VOLUME_STEP] / vol_range
-            )
+            self._attr_volume_step = 2 * config[CONF_VOLUME_STEP] / vol_range
         self._source_list = self._nad_receiver.available_sources()
 
     def turn_off(self) -> None:

--- a/homeassistant/components/nad/media_player.py
+++ b/homeassistant/components/nad/media_player.py
@@ -198,8 +198,12 @@ class NADtcp(MediaPlayerEntity):
         self._nad_receiver = NADReceiverTCP(config.get(CONF_HOST))
         self._min_vol = (config[CONF_MIN_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
         self._max_vol = (config[CONF_MAX_VOLUME] + 90) * 2  # from dB to nad vol (0-200)
-        self._volume_step = config[CONF_VOLUME_STEP]
         self._nad_volume = None
+        vol_range = self._max_vol - self._min_vol
+        if vol_range:
+            self._attr_volume_step = (
+                2 * config[CONF_VOLUME_STEP] / vol_range
+            )
         self._source_list = self._nad_receiver.available_sources()
 
     def turn_off(self) -> None:
@@ -209,14 +213,6 @@ class NADtcp(MediaPlayerEntity):
     def turn_on(self) -> None:
         """Turn the media player on."""
         self._nad_receiver.power_on()
-
-    def volume_up(self) -> None:
-        """Step volume up in the configured increments."""
-        self._nad_receiver.set_volume(self._nad_volume + 2 * self._volume_step)
-
-    def volume_down(self) -> None:
-        """Step volume down in the configured increments."""
-        self._nad_receiver.set_volume(self._nad_volume - 2 * self._volume_step)
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""


### PR DESCRIPTION
## Proposed change

Remove the `volume_up` and `volume_down` method overrides from the NADtcp media player and translate the configurable volume step to `_attr_volume_step` instead.

The overrides were calling `set_volume(nad_volume +/- 2 * volume_step)` in NAD units (0-200 range). By converting this to the 0..1 HA scale (`2 * config_step / volume_range`), the base class produces identical behavior: it calls `set_volume_level(volume_level +/- volume_step)`, and the existing `set_volume_level` converts back to NAD units.

See the [full analysis of all media player volume controls](https://gist.github.com/balloob/652c3c1f06f24be6899ae49f04e33ba4) for context.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr