### PR TITLE
Add support for samsungce.lamp as light entity and when not under main component

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -591,7 +591,8 @@ def process_status(status: dict[str, ComponentStatus]) -> dict[str, ComponentSta
                 if "burner" in component:
                     burner_id = int(component.split("-")[-1])
                     component = f"burner-0{burner_id}"
-                if component in status:
+                # Don't delete 'lamp' component even when disabled
+                if (component in status) and ("lamp" not in component):
                     del status[component]
     for component_status in status.values():
         process_component_status(component_status)

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -592,7 +592,7 @@ def process_status(status: dict[str, ComponentStatus]) -> dict[str, ComponentSta
                     burner_id = int(component.split("-")[-1])
                     component = f"burner-0{burner_id}"
                 # Don't delete 'lamp' component even when disabled
-                if (component in status) and ("lamp" not in component):
+                if (component in status) and (component != "lamp"):
                     del status[component]
     for component_status in status.values():
         process_component_status(component_status)

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -592,7 +592,7 @@ def process_status(status: dict[str, ComponentStatus]) -> dict[str, ComponentSta
                     burner_id = int(component.split("-")[-1])
                     component = f"burner-0{burner_id}"
                 # Don't delete 'lamp' component even when disabled
-                if (component in status) and (component != "lamp"):
+                if component in status and component != "lamp":
                     del status[component]
     for component_status in status.values():
         process_component_status(component_status)

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -49,10 +49,8 @@ async def async_setup_entry(
         for device in entry_data.devices.values()
         for component in device.status
         if (
-            Capability.SWITCH in device.status[component]
-            and any(
-                capability in device.status[component] for capability in CAPABILITIES
-            )
+            Capability.SWITCH in device.status[MAIN]
+            and any(capability in device.status[MAIN] for capability in CAPABILITIES)
             and Capability.SAMSUNG_CE_LAMP not in device.status[component]
         )
     ]
@@ -261,8 +259,7 @@ class SmartThingsLight(SmartThingsEntity, LightEntity, RestoreEntity):
 class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
     """Define a SmartThings lamp component as a light entity."""
 
-    _attr_name = None
-    _attr_supported_color_modes: set[ColorMode]
+    translation_key = "light"
 
     def __init__(
         self, client: SmartThings, device: FullDevice, component: str = MAIN
@@ -285,13 +282,8 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             color_modes.add(ColorMode.BRIGHTNESS)
         if not color_modes:
             color_modes.add(ColorMode.ONOFF)
-        if len(color_modes) == 1:
-            self._attr_color_mode = list(color_modes)[0]
+        self._attr_color_mode = list(color_modes)[0]
         self._attr_supported_color_modes = color_modes
-        features = LightEntityFeature(0)
-        if self.supports_capability(Capability.SWITCH_LEVEL):
-            features |= LightEntityFeature.TRANSITION
-        self._attr_supported_features = features
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the lamp on."""
@@ -319,9 +311,6 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the lamp off."""
-        if ATTR_TRANSITION in kwargs:
-            await self.async_set_level(0, int(kwargs[ATTR_TRANSITION]))
-            return
         if self.supports_capability(Capability.SWITCH):
             await self.execute_device_command(Capability.SWITCH, Command.OFF)
             return
@@ -339,16 +328,18 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             )
             or []
         )
-        value = self.get_attribute_value(
+        level = self.get_attribute_value(
             Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
         )
-        if value is None:
+        if level is None:
             self._attr_brightness = None
             return
-        try:
-            percent = ordered_list_item_to_percentage(levels, value)
-        except ValueError:
-            percent = 0 if str(value).lower() == "off" else 100
+        if "off" in levels:
+            if level == "off":
+                self._attr_brightness = 0
+                return
+            levels = [level for level in levels if level != "off"]
+        percent = ordered_list_item_to_percentage(levels, level)
         self._attr_brightness = int(convert_scale(percent, 100, 255))
 
     async def async_set_level(self, brightness: int, transition: int) -> None:
@@ -359,6 +350,19 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             )
             or []
         )
+        if brightness == 0:
+            if "off" in levels:
+                await self.execute_device_command(
+                    Capability.SAMSUNG_CE_LAMP,
+                    Command.SET_BRIGHTNESS_LEVEL,
+                    argument="off",
+                )
+            else:
+                await self.execute_device_command(
+                    Capability.SWITCH,
+                    Command.OFF,
+                )
+            return
         # remove 'off' for brightness mapping
         if "off" in levels:
             levels = [level for level in levels if level != "off"]
@@ -391,4 +395,4 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
         )
         if brightness is None:
             return None
-        return str(brightness).lower() != "off"
+        return brightness != "off"

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from typing import Any, cast
 
-from pysmartthings import Attribute, Capability, Command, DeviceEvent, SmartThings
+from pysmartthings import (
+    Attribute,
+    Capability,
+    Category,
+    Command,
+    ComponentStatus,
+    DeviceEvent,
+    SmartThings,
+)
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -36,6 +45,22 @@ CAPABILITIES = (
     Capability.COLOR_TEMPERATURE,
 )
 
+LAMP_CAPABILITY_EXISTS: dict[str, Callable[[FullDevice, ComponentStatus], bool]] = {
+    "lamp": lambda _, __: True,
+    "hood": lambda device, component: (
+        Capability.SAMSUNG_CE_CONNECTION_STATE not in component
+        or component[Capability.SAMSUNG_CE_CONNECTION_STATE][
+            Attribute.CONNECTION_STATE
+        ].value
+        != "disconnected"
+    ),
+    "cavity-02": lambda _, __: True,
+    "main": lambda device, component: (
+        device.device.components[MAIN].manufacturer_category
+        in {Category.MICROWAVE, Category.OVEN, Category.RANGE}
+    ),
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -57,8 +82,10 @@ async def async_setup_entry(
     entities.extend(
         SmartThingsLamp(entry_data.client, device, component)
         for device in entry_data.devices.values()
-        for component in device.status
-        if Capability.SAMSUNG_CE_LAMP in device.status[component]
+        for component, exists_fn in LAMP_CAPABILITY_EXISTS.items()
+        if component in device.status
+        and Capability.SAMSUNG_CE_LAMP in device.status[component]
+        and exists_fn(device, device.status[component])
     )
     async_add_entities(entities)
 
@@ -256,10 +283,10 @@ class SmartThingsLight(SmartThingsEntity, LightEntity, RestoreEntity):
         return state == "on"
 
 
-class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
+class SmartThingsLamp(SmartThingsEntity, LightEntity):
     """Define a SmartThings lamp component as a light entity."""
 
-    translation_key = "light"
+    _attr_translation_key = "light"
 
     def __init__(
         self, client: SmartThings, device: FullDevice, component: str = MAIN
@@ -289,25 +316,13 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
         """Turn the lamp on."""
         # Switch/brightness/transition
         if ATTR_BRIGHTNESS in kwargs:
-            await self.async_set_level(
-                kwargs[ATTR_BRIGHTNESS], kwargs.get(ATTR_TRANSITION, 0)
-            )
+            await self.async_set_level(kwargs[ATTR_BRIGHTNESS])
             return
         if self.supports_capability(Capability.SWITCH):
             await self.execute_device_command(Capability.SWITCH, Command.ON)
         # if no switch, turn on via brightness level
-        elif supported_levels := (
-            self.get_attribute_value(
-                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
-            )
-            or []
-        ):
-            level = percentage_to_ordered_list_item(supported_levels, 100)
-            await self.execute_device_command(
-                Capability.SAMSUNG_CE_LAMP,
-                Command.SET_BRIGHTNESS_LEVEL,
-                argument=level,
-            )
+        else:
+            await self.async_set_level(255)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the lamp off."""
@@ -320,29 +335,7 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             argument="off",
         )
 
-    def _update_attr(self) -> None:
-        """Update lamp-specific attributes."""
-        levels = (
-            self.get_attribute_value(
-                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
-            )
-            or []
-        )
-        level = self.get_attribute_value(
-            Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
-        )
-        if level is None:
-            self._attr_brightness = None
-            return
-        if "off" in levels:
-            if level == "off":
-                self._attr_brightness = 0
-                return
-            levels = [level for level in levels if level != "off"]
-        percent = ordered_list_item_to_percentage(levels, level)
-        self._attr_brightness = int(convert_scale(percent, 100, 255))
-
-    async def async_set_level(self, brightness: int, transition: int) -> None:
+    async def async_set_level(self, brightness: int) -> None:
         """Set lamp brightness via supported levels."""
         levels = (
             self.get_attribute_value(
@@ -350,19 +343,6 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             )
             or []
         )
-        if brightness == 0:
-            if "off" in levels:
-                await self.execute_device_command(
-                    Capability.SAMSUNG_CE_LAMP,
-                    Command.SET_BRIGHTNESS_LEVEL,
-                    argument="off",
-                )
-            else:
-                await self.execute_device_command(
-                    Capability.SWITCH,
-                    Command.OFF,
-                )
-            return
         # remove 'off' for brightness mapping
         if "off" in levels:
             levels = [level for level in levels if level != "off"]
@@ -382,6 +362,28 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
         ):
             await self.execute_device_command(Capability.SWITCH, Command.ON)
 
+    def _update_attr(self) -> None:
+        """Update lamp-specific attributes."""
+        level = self.get_attribute_value(
+            Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
+        )
+        if level is None:
+            self._attr_brightness = None
+            return
+        levels = (
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
+            )
+            or []
+        )
+        if "off" in levels:
+            if level == "off":
+                self._attr_brightness = 0
+                return
+            levels = [level for level in levels if level != "off"]
+        percent = ordered_list_item_to_percentage(levels, level)
+        self._attr_brightness = int(convert_scale(percent, 100, 255))
+
     @property
     def is_on(self) -> bool | None:
         """Return true if lamp is on."""
@@ -390,9 +392,6 @@ class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
             if state is None:
                 return None
             return state == "on"
-        brightness = self.get_attribute_value(
-            Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
-        )
-        if brightness is None:
-            return None
-        return brightness != "off"
+        if (brightness := self.brightness) is not None:
+            return brightness > 0
+        return None

--- a/homeassistant/components/smartthings/light.py
+++ b/homeassistant/components/smartthings/light.py
@@ -21,6 +21,10 @@ from homeassistant.components.light import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
 
 from . import FullDevice, SmartThingsConfigEntry
 from .const import MAIN
@@ -40,12 +44,25 @@ async def async_setup_entry(
 ) -> None:
     """Add lights for a config entry."""
     entry_data = entry.runtime_data
-    async_add_entities(
-        SmartThingsLight(entry_data.client, device)
+    entities: list[LightEntity] = [
+        SmartThingsLight(entry_data.client, device, component)
         for device in entry_data.devices.values()
-        if Capability.SWITCH in device.status[MAIN]
-        and any(capability in device.status[MAIN] for capability in CAPABILITIES)
+        for component in device.status
+        if (
+            Capability.SWITCH in device.status[component]
+            and any(
+                capability in device.status[component] for capability in CAPABILITIES
+            )
+            and Capability.SAMSUNG_CE_LAMP not in device.status[component]
+        )
+    ]
+    entities.extend(
+        SmartThingsLamp(entry_data.client, device, component)
+        for device in entry_data.devices.values()
+        for component in device.status
+        if Capability.SAMSUNG_CE_LAMP in device.status[component]
     )
+    async_add_entities(entities)
 
 
 def convert_scale(
@@ -71,7 +88,9 @@ class SmartThingsLight(SmartThingsEntity, LightEntity, RestoreEntity):
     # highest kelvin found supported across 20+ handlers.
     _attr_max_color_temp_kelvin = 9000  # 111 mireds
 
-    def __init__(self, client: SmartThings, device: FullDevice) -> None:
+    def __init__(
+        self, client: SmartThings, device: FullDevice, component: str = MAIN
+    ) -> None:
         """Initialize a SmartThingsLight."""
         super().__init__(
             client,
@@ -82,6 +101,7 @@ class SmartThingsLight(SmartThingsEntity, LightEntity, RestoreEntity):
                 Capability.SWITCH_LEVEL,
                 Capability.SWITCH,
             },
+            component=component,
         )
         color_modes = set()
         if self.supports_capability(Capability.COLOR_TEMPERATURE):
@@ -236,3 +256,139 @@ class SmartThingsLight(SmartThingsEntity, LightEntity, RestoreEntity):
         ) is None:
             return None
         return state == "on"
+
+
+class SmartThingsLamp(SmartThingsEntity, LightEntity, RestoreEntity):
+    """Define a SmartThings lamp component as a light entity."""
+
+    _attr_name = None
+    _attr_supported_color_modes: set[ColorMode]
+
+    def __init__(
+        self, client: SmartThings, device: FullDevice, component: str = MAIN
+    ) -> None:
+        """Initialize a SmartThingsLamp."""
+        super().__init__(
+            client,
+            device,
+            {Capability.SWITCH, Capability.SAMSUNG_CE_LAMP},
+            component=component,
+        )
+        levels = (
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
+            )
+            or []
+        )
+        color_modes = set()
+        if "off" not in levels or len(levels) > 2:
+            color_modes.add(ColorMode.BRIGHTNESS)
+        if not color_modes:
+            color_modes.add(ColorMode.ONOFF)
+        if len(color_modes) == 1:
+            self._attr_color_mode = list(color_modes)[0]
+        self._attr_supported_color_modes = color_modes
+        features = LightEntityFeature(0)
+        if self.supports_capability(Capability.SWITCH_LEVEL):
+            features |= LightEntityFeature.TRANSITION
+        self._attr_supported_features = features
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the lamp on."""
+        # Switch/brightness/transition
+        if ATTR_BRIGHTNESS in kwargs:
+            await self.async_set_level(
+                kwargs[ATTR_BRIGHTNESS], kwargs.get(ATTR_TRANSITION, 0)
+            )
+            return
+        if self.supports_capability(Capability.SWITCH):
+            await self.execute_device_command(Capability.SWITCH, Command.ON)
+        # if no switch, turn on via brightness level
+        elif supported_levels := (
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
+            )
+            or []
+        ):
+            level = percentage_to_ordered_list_item(supported_levels, 100)
+            await self.execute_device_command(
+                Capability.SAMSUNG_CE_LAMP,
+                Command.SET_BRIGHTNESS_LEVEL,
+                argument=level,
+            )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the lamp off."""
+        if ATTR_TRANSITION in kwargs:
+            await self.async_set_level(0, int(kwargs[ATTR_TRANSITION]))
+            return
+        if self.supports_capability(Capability.SWITCH):
+            await self.execute_device_command(Capability.SWITCH, Command.OFF)
+            return
+        await self.execute_device_command(
+            Capability.SAMSUNG_CE_LAMP,
+            Command.SET_BRIGHTNESS_LEVEL,
+            argument="off",
+        )
+
+    def _update_attr(self) -> None:
+        """Update lamp-specific attributes."""
+        levels = (
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
+            )
+            or []
+        )
+        value = self.get_attribute_value(
+            Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
+        )
+        if value is None:
+            self._attr_brightness = None
+            return
+        try:
+            percent = ordered_list_item_to_percentage(levels, value)
+        except ValueError:
+            percent = 0 if str(value).lower() == "off" else 100
+        self._attr_brightness = int(convert_scale(percent, 100, 255))
+
+    async def async_set_level(self, brightness: int, transition: int) -> None:
+        """Set lamp brightness via supported levels."""
+        levels = (
+            self.get_attribute_value(
+                Capability.SAMSUNG_CE_LAMP, Attribute.SUPPORTED_BRIGHTNESS_LEVEL
+            )
+            or []
+        )
+        # remove 'off' for brightness mapping
+        if "off" in levels:
+            levels = [level for level in levels if level != "off"]
+        level = percentage_to_ordered_list_item(
+            levels, int(round(brightness * 100 / 255))
+        )
+        await self.execute_device_command(
+            Capability.SAMSUNG_CE_LAMP,
+            Command.SET_BRIGHTNESS_LEVEL,
+            argument=level,
+        )
+        # turn on switch separately if needed
+        if (
+            self.supports_capability(Capability.SWITCH)
+            and not self.is_on
+            and brightness > 0
+        ):
+            await self.execute_device_command(Capability.SWITCH, Command.ON)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if lamp is on."""
+        if self.supports_capability(Capability.SWITCH):
+            state = self.get_attribute_value(Capability.SWITCH, Attribute.SWITCH)
+            if state is None:
+                return None
+            return state == "on"
+        brightness = self.get_attribute_value(
+            Capability.SAMSUNG_CE_LAMP, Attribute.BRIGHTNESS_LEVEL
+        )
+        if brightness is None:
+            return None
+        return str(brightness).lower() != "off"

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -161,7 +161,7 @@
     },
     "light": {
       "light": {
-        "name": "Light"
+        "name": "[%key:component::light::title%]"
       }
     },
     "number": {

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -161,7 +161,7 @@
     },
     "light": {
       "light": {
-        "name": "light"
+        "name": "Light"
       }
     },
     "number": {

--- a/homeassistant/components/smartthings/strings.json
+++ b/homeassistant/components/smartthings/strings.json
@@ -159,6 +159,11 @@
         }
       }
     },
+    "light": {
+      "light": {
+        "name": "light"
+      }
+    },
     "number": {
       "cool_select_plus_temperature": {
         "name": "CoolSelect+ temperature"

--- a/tests/components/smartthings/fixtures/device_status/da_ks_hood_01001.json
+++ b/tests/components/smartthings/fixtures/device_status/da_ks_hood_01001.json
@@ -471,13 +471,13 @@
     "lamp": {
       "switch": {
         "switch": {
-          "value": "off",
+          "value": "on",
           "timestamp": "2025-11-12T00:04:46.554Z"
         }
       },
       "samsungce.lamp": {
         "brightnessLevel": {
-          "value": "high",
+          "value": "low",
           "timestamp": "2025-11-12T00:04:44.863Z"
         },
         "supportedBrightnessLevel": {

--- a/tests/components/smartthings/snapshots/test_light.ambr
+++ b/tests/components/smartthings/snapshots/test_light.ambr
@@ -125,64 +125,6 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob_light-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'supported_color_modes': list([
-        <ColorMode.ONOFF: 'onoff'>,
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'light',
-    'entity_category': None,
-    'entity_id': 'light.induction_hob_light',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'light',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'light',
-    'platform': 'smartthings',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'light',
-    'unique_id': '808dbd84-f357-47e2-a0cd-3b66fa22d584_hood',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob_light-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'color_mode': None,
-      'friendly_name': 'Induction Hob light',
-      'supported_color_modes': list([
-        <ColorMode.ONOFF: 'onoff'>,
-      ]),
-      'supported_features': <LightEntityFeature: 0>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'light.induction_hob_light',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_all_entities[da_ks_hood_01001][light.range_hood_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -208,12 +150,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -226,9 +168,9 @@
 # name: test_all_entities[da_ks_hood_01001][light.range_hood_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'brightness': None,
-      'color_mode': None,
-      'friendly_name': 'Range hood light',
+      'brightness': 127,
+      'color_mode': <ColorMode.BRIGHTNESS: 'brightness'>,
+      'friendly_name': 'Range hood Light',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
@@ -239,7 +181,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[da_ks_microwave_0101x][light.microwave_light-entry]
@@ -267,12 +209,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -287,7 +229,7 @@
     'attributes': ReadOnlyDict({
       'brightness': None,
       'color_mode': None,
-      'friendly_name': 'Microwave light',
+      'friendly_name': 'Microwave Light',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
@@ -326,12 +268,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -345,7 +287,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Oven light',
+      'friendly_name': 'Oven Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
@@ -384,12 +326,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -403,7 +345,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'Kitchen oven light',
+      'friendly_name': 'Kitchen oven Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
@@ -442,12 +384,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -461,7 +403,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Vulcan light',
+      'friendly_name': 'Vulcan Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
@@ -500,12 +442,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -519,7 +461,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'Four light',
+      'friendly_name': 'Four Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
@@ -558,12 +500,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'light',
+    'object_id_base': 'Light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'light',
+    'original_name': 'Light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -577,7 +519,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Four light',
+      'friendly_name': 'Four Light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
@@ -585,64 +527,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'light.four_light_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum_light-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'supported_color_modes': list([
-        <ColorMode.ONOFF: 'onoff'>,
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'light',
-    'entity_category': None,
-    'entity_id': 'light.robot_vacuum_light',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'light',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'light',
-    'platform': 'smartthings',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'light',
-    'unique_id': '01b28624-5907-c8bc-0325-8ad23f03a637_main',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum_light-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Robot Vacuum light',
-      'supported_color_modes': list([
-        <ColorMode.ONOFF: 'onoff'>,
-      ]),
-      'supported_features': <LightEntityFeature: 0>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'light.robot_vacuum_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/smartthings/snapshots/test_light.ambr
+++ b/tests/components/smartthings/snapshots/test_light.ambr
@@ -125,7 +125,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob-entry]
+# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -142,7 +142,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.induction_hob',
+    'entity_id': 'light.induction_hob_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -150,40 +150,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '808dbd84-f357-47e2-a0cd-3b66fa22d584_hood',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob-state]
+# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'Induction Hob',
+      'friendly_name': 'Induction Hob light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.induction_hob',
+    'entity_id': 'light.induction_hob_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_all_entities[da_ks_hood_01001][light.range_hood-entry]
+# name: test_all_entities[da_ks_hood_01001][light.range_hood_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -200,7 +200,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.range_hood',
+    'entity_id': 'light.range_hood_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -208,41 +208,41 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': 'fa5fca25-fa7a-1807-030a-2f72ee0f7bff_lamp',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_hood_01001][light.range_hood-state]
+# name: test_all_entities[da_ks_hood_01001][light.range_hood_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': None,
       'color_mode': None,
-      'friendly_name': 'Range hood',
+      'friendly_name': 'Range hood light',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.range_hood',
+    'entity_id': 'light.range_hood_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_microwave_0101x][light.microwave-entry]
+# name: test_all_entities[da_ks_microwave_0101x][light.microwave_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -259,7 +259,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.microwave',
+    'entity_id': 'light.microwave_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -267,41 +267,41 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '2bad3237-4886-e699-1b90-4a51a3d55c8a_hood',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_microwave_0101x][light.microwave-state]
+# name: test_all_entities[da_ks_microwave_0101x][light.microwave_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'brightness': None,
       'color_mode': None,
-      'friendly_name': 'Microwave',
+      'friendly_name': 'Microwave light',
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.microwave',
+    'entity_id': 'light.microwave_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_oven_01061][light.oven-entry]
+# name: test_all_entities[da_ks_oven_01061][light.oven_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -318,7 +318,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.oven',
+    'entity_id': 'light.oven_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -326,40 +326,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '9447959a-0dfa-6b27-d40d-650da525c53f_main',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_oven_01061][light.oven-state]
+# name: test_all_entities[da_ks_oven_01061][light.oven_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Oven',
+      'friendly_name': 'Oven light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.oven',
+    'entity_id': 'light.oven_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven-entry]
+# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -376,7 +376,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.kitchen_oven',
+    'entity_id': 'light.kitchen_oven_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -384,40 +384,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '199d7863-ad04-793d-176d-658f10062575_main',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven-state]
+# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'Kitchen oven',
+      'friendly_name': 'Kitchen oven light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.kitchen_oven',
+    'entity_id': 'light.kitchen_oven_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_range_0101x][light.vulcan-entry]
+# name: test_all_entities[da_ks_range_0101x][light.vulcan_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -434,7 +434,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.vulcan',
+    'entity_id': 'light.vulcan_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -442,40 +442,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18_main',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_range_0101x][light.vulcan-state]
+# name: test_all_entities[da_ks_range_0101x][light.vulcan_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Vulcan',
+      'friendly_name': 'Vulcan light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.vulcan',
+    'entity_id': 'light.vulcan_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[da_ks_walloven_0107x][light.four-entry]
+# name: test_all_entities[da_ks_walloven_0107x][light.four_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -492,7 +492,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.four',
+    'entity_id': 'light.four_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -500,40 +500,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '1c77a562-df00-7d6a-ca73-b67f6d4c4607_cavity-02',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_walloven_0107x][light.four-state]
+# name: test_all_entities[da_ks_walloven_0107x][light.four_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': None,
-      'friendly_name': 'Four',
+      'friendly_name': 'Four light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.four',
+    'entity_id': 'light.four_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_all_entities[da_ks_walloven_0107x][light.four_2-entry]
+# name: test_all_entities[da_ks_walloven_0107x][light.four_light_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -550,7 +550,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.four_2',
+    'entity_id': 'light.four_light_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -558,40 +558,40 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '1c77a562-df00-7d6a-ca73-b67f6d4c4607_main',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_ks_walloven_0107x][light.four_2-state]
+# name: test_all_entities[da_ks_walloven_0107x][light.four_light_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Four',
+      'friendly_name': 'Four light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.four_2',
+    'entity_id': 'light.four_light_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum-entry]
+# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -608,7 +608,7 @@
     'disabled_by': None,
     'domain': 'light',
     'entity_category': None,
-    'entity_id': 'light.robot_vacuum',
+    'entity_id': 'light.robot_vacuum_light',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -616,33 +616,33 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'light',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'light',
     'platform': 'smartthings',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'light',
     'unique_id': '01b28624-5907-c8bc-0325-8ad23f03a637_main',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum-state]
+# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'color_mode': <ColorMode.ONOFF: 'onoff'>,
-      'friendly_name': 'Robot Vacuum',
+      'friendly_name': 'Robot Vacuum light',
       'supported_color_modes': list([
         <ColorMode.ONOFF: 'onoff'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
     }),
     'context': <ANY>,
-    'entity_id': 'light.robot_vacuum',
+    'entity_id': 'light.robot_vacuum_light',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/smartthings/snapshots/test_light.ambr
+++ b/tests/components/smartthings/snapshots/test_light.ambr
@@ -125,6 +125,530 @@
     'state': 'off',
   })
 # ---
+# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.induction_hob',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '808dbd84-f357-47e2-a0cd-3b66fa22d584_hood',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_cooktop_31001][light.induction_hob-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': None,
+      'friendly_name': 'Induction Hob',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.induction_hob',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[da_ks_hood_01001][light.range_hood-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.range_hood',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'fa5fca25-fa7a-1807-030a-2f72ee0f7bff_lamp',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_hood_01001][light.range_hood-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Range hood',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.range_hood',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ks_microwave_0101x][light.microwave-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.microwave',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2bad3237-4886-e699-1b90-4a51a3d55c8a_hood',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_microwave_0101x][light.microwave-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Microwave',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.microwave',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ks_oven_01061][light.oven-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.oven',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '9447959a-0dfa-6b27-d40d-650da525c53f_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_oven_01061][light.oven-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': <ColorMode.ONOFF: 'onoff'>,
+      'friendly_name': 'Oven',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.oven',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.kitchen_oven',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '199d7863-ad04-793d-176d-658f10062575_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_oven_0107x][light.kitchen_oven-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': None,
+      'friendly_name': 'Kitchen oven',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.kitchen_oven',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][light.vulcan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.vulcan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '2c3cbaa0-1899-5ddc-7b58-9d657bd48f18_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_range_0101x][light.vulcan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': <ColorMode.ONOFF: 'onoff'>,
+      'friendly_name': 'Vulcan',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.vulcan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[da_ks_walloven_0107x][light.four-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.four',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1c77a562-df00-7d6a-ca73-b67f6d4c4607_cavity-02',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_walloven_0107x][light.four-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': None,
+      'friendly_name': 'Four',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.four',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[da_ks_walloven_0107x][light.four_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.four_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '1c77a562-df00-7d6a-ca73-b67f6d4c4607_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_ks_walloven_0107x][light.four_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': <ColorMode.ONOFF: 'onoff'>,
+      'friendly_name': 'Four',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.four_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.robot_vacuum',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'smartthings',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '01b28624-5907-c8bc-0325-8ad23f03a637_main',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[da_rvc_map_01011][light.robot_vacuum-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'color_mode': <ColorMode.ONOFF: 'onoff'>,
+      'friendly_name': 'Robot Vacuum',
+      'supported_color_modes': list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.robot_vacuum',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_all_entities[ge_in_wall_smart_dimmer][light.basement_exit_light-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
@@ -455,26 +456,10 @@ async def test_availability_at_start(
 
 @pytest.mark.parametrize("device_fixture", ["da_ks_hood_01001"])
 @pytest.mark.parametrize(
-    ("service", "service_data", "command_data"),
+    ("service", "command"),
     [
-        (
-            SERVICE_TURN_ON,
-            {},
-            {
-                "capability": Capability.SWITCH,
-                "command": Command.ON,
-                "component": "lamp",
-            },
-        ),
-        (
-            SERVICE_TURN_OFF,
-            {},
-            {
-                "capability": Capability.SWITCH,
-                "command": Command.OFF,
-                "component": "lamp",
-            },
-        ),
+        (SERVICE_TURN_ON, Command.ON),
+        (SERVICE_TURN_OFF, Command.OFF),
     ],
 )
 async def test_lamp_with_switch(
@@ -482,97 +467,93 @@ async def test_lamp_with_switch(
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
     service: str,
-    service_data: dict[str, Any],
-    command_data: dict[str, Any],
+    command: Command,
 ) -> None:
     """Test samsungce.lamp on/off with switch capability."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
-
     await hass.services.async_call(
         LIGHT_DOMAIN,
         service,
-        {ATTR_ENTITY_ID: entity_id} | service_data,
+        {ATTR_ENTITY_ID: "light.range_hood_light"},
         blocking=True,
     )
     devices.execute_device_command.assert_called_once_with(
         "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
-        command_data["capability"],
-        command_data["command"],
-        command_data["component"],
+        Capability.SWITCH,
+        command,
+        "lamp",
+    )
+
+
+@pytest.mark.parametrize(
+    ("brightness", "brightness_level"),
+    [(128, "low"), (129, "high"), (240, "high")],
+)
+@pytest.mark.parametrize(
+    ("device_fixture", "entity_id", "device_id", "component"),
+    [
+        (
+            "da_ks_hood_01001",
+            "light.range_hood_light",
+            "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
+            "lamp",
+        ),
+        (
+            "da_ks_microwave_0101x",
+            "light.microwave_light",
+            "2bad3237-4886-e699-1b90-4a51a3d55c8a",
+            "hood",
+        ),
+    ],
+)
+async def test_lamp_component_with_brightness(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    device_id: str,
+    component: str,
+    brightness: int,
+    brightness_level: str,
+) -> None:
+    """Test samsungce.lamp on/off with switch capability."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: brightness},
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        device_id,
+        Capability.SAMSUNG_CE_LAMP,
+        Command.SET_BRIGHTNESS_LEVEL,
+        component,
+        argument=brightness_level,
     )
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ks_range_0101x"])
 @pytest.mark.parametrize(
-    ("service", "service_data", "command_data"),
-    [
-        (
-            SERVICE_TURN_ON,
-            {ATTR_BRIGHTNESS: 255},
-            {
-                "capability": Capability.SAMSUNG_CE_LAMP,
-                "command": Command.SET_BRIGHTNESS_LEVEL,
-                "component": MAIN,
-                "argument": "extraHigh",
-            },
-        ),
-        (
-            SERVICE_TURN_OFF,
-            {},
-            {
-                "capability": Capability.SAMSUNG_CE_LAMP,
-                "command": Command.SET_BRIGHTNESS_LEVEL,
-                "component": MAIN,
-                "argument": "off",
-            },
-        ),
-    ],
+    ("service", "argument"),
+    [(SERVICE_TURN_ON, "extraHigh"), (SERVICE_TURN_OFF, "off")],
 )
 async def test_lamp_without_switch(
     hass: HomeAssistant,
     devices: AsyncMock,
     mock_config_entry: MockConfigEntry,
     service: str,
-    service_data: dict[str, Any],
-    command_data: dict[str, Any],
+    argument: str,
 ) -> None:
     """Test samsungce.lamp on/off without switch capability."""
     await setup_integration(hass, mock_config_entry)
 
-    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
-
     await hass.services.async_call(
         LIGHT_DOMAIN,
         service,
-        {ATTR_ENTITY_ID: entity_id} | service_data,
-        blocking=True,
-    )
-    devices.execute_device_command.assert_called_once_with(
-        "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
-        command_data["capability"],
-        command_data["command"],
-        command_data["component"],
-        argument=command_data["argument"],
-    )
-
-
-@pytest.mark.parametrize("device_fixture", ["da_ks_range_0101x"])
-async def test_lamp_brightness_zero_turns_off(
-    hass: HomeAssistant,
-    devices: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Setting brightness=0 should turn the lamp off for samsungce.lamp."""
-    await setup_integration(hass, mock_config_entry)
-
-    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
-
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 0},
+        {ATTR_ENTITY_ID: "light.vulcan_light"},
         blocking=True,
     )
     devices.execute_device_command.assert_called_once_with(
@@ -580,37 +561,84 @@ async def test_lamp_brightness_zero_turns_off(
         Capability.SAMSUNG_CE_LAMP,
         Command.SET_BRIGHTNESS_LEVEL,
         MAIN,
-        argument="off",
+        argument=argument,
     )
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ks_hood_01001"])
-async def test_lamp_lowest_discrete_level_not_zero(
-    hass: HomeAssistant,
-    devices: AsyncMock,
-    mock_config_entry: MockConfigEntry,
+async def test_lamp_from_off(
+    hass: HomeAssistant, devices: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
-    """The lowest discrete brightness level must not surface as 0 when the lamp is on."""
-    # Ensure the switch component is reported as on for this lamp
+    """Test samsungce.lamp on with brightness level from off state."""
     set_attribute_value(
-        devices, Capability.SWITCH, Attribute.SWITCH, "on", component="lamp"
+        devices, Capability.SWITCH, Attribute.SWITCH, "off", component="lamp"
     )
     await setup_integration(hass, mock_config_entry)
 
-    # Simulate the lamp reporting the lowest discrete level ('low')
+    assert hass.states.get("light.range_hood_light").state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.range_hood_light", ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+    assert devices.execute_device_command.mock_calls == [
+        call(
+            "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
+            Capability.SAMSUNG_CE_LAMP,
+            Command.SET_BRIGHTNESS_LEVEL,
+            "lamp",
+            argument="high",
+        ),
+        call(
+            "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
+            Capability.SWITCH,
+            Command.ON,
+            "lamp",
+        ),
+    ]
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_hood_01001"])
+async def test_lamp_unknown_switch(
+    hass: HomeAssistant, devices: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test lamp state becomes unknown when switch state is unknown."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("light.range_hood_light").state == STATE_ON
+
     await trigger_update(
         hass,
         devices,
         "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
-        Capability.SAMSUNG_CE_LAMP,
-        Attribute.BRIGHTNESS_LEVEL,
-        "low",
+        Capability.SWITCH,
+        Attribute.SWITCH,
+        None,
         component="lamp",
     )
 
-    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    # brightness should be a positive integer (not zero)
-    assert state.attributes[ATTR_BRIGHTNESS] is not None
-    assert state.attributes[ATTR_BRIGHTNESS] > 0
+    assert hass.states.get("light.range_hood_light").state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_range_0101x"])
+async def test_lamp_unknown_brightness(
+    hass: HomeAssistant, devices: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test lamp state becomes unknown when brightness level is unknown."""
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("light.vulcan_light").state == STATE_ON
+
+    await trigger_update(
+        hass,
+        devices,
+        "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+        Capability.SAMSUNG_CE_LAMP,
+        Attribute.BRIGHTNESS_LEVEL,
+        None,
+    )
+
+    assert hass.states.get("light.vulcan_light").state == STATE_UNKNOWN

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -451,3 +451,108 @@ async def test_availability_at_start(
     """Test unavailable at boot."""
     await setup_integration(hass, mock_config_entry)
     assert hass.states.get("light.standing_light").state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_hood_01001"])
+@pytest.mark.parametrize(
+    ("service", "service_data", "command_data"),
+    [
+        (
+            SERVICE_TURN_ON,
+            {},
+            {
+                "capability": Capability.SWITCH,
+                "command": Command.ON,
+                "component": "lamp",
+            },
+        ),
+        (
+            SERVICE_TURN_OFF,
+            {},
+            {
+                "capability": Capability.SWITCH,
+                "command": Command.OFF,
+                "component": "lamp",
+            },
+        ),
+    ],
+)
+async def test_lamp_with_switch(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, Any],
+    command_data: dict[str, Any],
+) -> None:
+    """Test samsungce.lamp on/off with switch capability."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id} | service_data,
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
+        command_data["capability"],
+        command_data["command"],
+        command_data["component"],
+    )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_range_0101x"])
+@pytest.mark.parametrize(
+    ("service", "service_data", "command_data"),
+    [
+        (
+            SERVICE_TURN_ON,
+            {ATTR_BRIGHTNESS: 255},
+            {
+                "capability": Capability.SAMSUNG_CE_LAMP,
+                "command": Command.SET_BRIGHTNESS_LEVEL,
+                "component": MAIN,
+                "argument": "extraHigh",
+            },
+        ),
+        (
+            SERVICE_TURN_OFF,
+            {},
+            {
+                "capability": Capability.SAMSUNG_CE_LAMP,
+                "command": Command.SET_BRIGHTNESS_LEVEL,
+                "component": MAIN,
+                "argument": "off",
+            },
+        ),
+    ],
+)
+async def test_lamp_without_switch(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, Any],
+    command_data: dict[str, Any],
+) -> None:
+    """Test samsungce.lamp on/off without switch capability."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id} | service_data,
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+        command_data["capability"],
+        command_data["command"],
+        command_data["component"],
+        argument=command_data["argument"],
+    )

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -556,3 +556,61 @@ async def test_lamp_without_switch(
         command_data["component"],
         argument=command_data["argument"],
     )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_range_0101x"])
+async def test_lamp_brightness_zero_turns_off(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Setting brightness=0 should turn the lamp off for samsungce.lamp."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 0},
+        blocking=True,
+    )
+    devices.execute_device_command.assert_called_once_with(
+        "2c3cbaa0-1899-5ddc-7b58-9d657bd48f18",
+        Capability.SAMSUNG_CE_LAMP,
+        Command.SET_BRIGHTNESS_LEVEL,
+        MAIN,
+        argument="off",
+    )
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ks_hood_01001"])
+async def test_lamp_lowest_discrete_level_not_zero(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The lowest discrete brightness level must not surface as 0 when the lamp is on."""
+    # Ensure the switch component is reported as on for this lamp
+    set_attribute_value(
+        devices, Capability.SWITCH, Attribute.SWITCH, "on", component="lamp"
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    # Simulate the lamp reporting the lowest discrete level ('low')
+    await trigger_update(
+        hass,
+        devices,
+        "fa5fca25-fa7a-1807-030a-2f72ee0f7bff",
+        Capability.SAMSUNG_CE_LAMP,
+        Attribute.BRIGHTNESS_LEVEL,
+        "low",
+        component="lamp",
+    )
+
+    entity_id = next(iter(hass.states.async_entity_ids(LIGHT_DOMAIN)))
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    # brightness should be a positive integer (not zero)
+    assert state.attributes[ATTR_BRIGHTNESS] is not None
+    assert state.attributes[ATTR_BRIGHTNESS] > 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds support for the samsungce.lamp capability as a light entity, supports this capability regardless of what component it is under, and adds support to devices that have an accompanying switch capability to control the light. Previously, the integration only created a select entity for samsungce.lamp brightness and only when part of the "main" component.

Some devices with samsungce.lamp have a brightness setting which includes "off", and this is how you control the light. Others have no "off" setting in the brightness and instead control on/off through a separate switch capability. This change combines them and creates a light entity, showing a simple on/off light when only "off" and another brightness setting exist, and maps the brightness slider to the appropriate brightness setting (e.g., 100% -> "high") when applicable. It also handles the additional switch capability when present.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162867 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
