### PR TITLE
Add deprecation timeline to flexit_bacnet fireplace switch

### DIFF
--- a/homeassistant/components/flexit_bacnet/strings.json
+++ b/homeassistant/components/flexit_bacnet/strings.json
@@ -154,7 +154,7 @@
   },
   "issues": {
     "deprecated_fireplace_switch": {
-      "description": "The fireplace mode switch entity `{entity_id}` is deprecated and will be removed in a future version.\n\nFireplace mode has been moved to a climate preset on the climate entity to better match the device interface.\n\nPlease update your automations to use the `climate.set_preset_mode` action with preset mode `fireplace` instead of using the switch entity.\n\nAfter updating your automations, you can safely disable this switch entity.",
+      "description": "The fireplace mode switch entity `{entity_id}` is deprecated and will be removed in Home Assistant 2026.9.\n\nFireplace mode has been moved to a climate preset on the climate entity to better match the device interface.\n\nPlease update your automations to use the `climate.set_preset_mode` action with preset mode `fireplace` instead of using the switch entity.\n\nAfter updating your automations, you can safely disable this switch entity.",
       "title": "Fireplace mode switch is deprecated"
     }
   }

--- a/homeassistant/components/flexit_bacnet/switch.py
+++ b/homeassistant/components/flexit_bacnet/switch.py
@@ -91,6 +91,7 @@ async def async_setup_entry(
                         hass,
                         DOMAIN,
                         f"deprecated_switch_{fireplace_switch_unique_id}",
+                        breaks_in_ha_version="2026.9.0",
                         is_fixable=False,
                         issue_domain=DOMAIN,
                         severity=IssueSeverity.WARNING,
@@ -102,7 +103,7 @@ async def async_setup_entry(
                     entities.append(FlexitSwitch(coordinator, description))
         else:
             entities.append(FlexitSwitch(coordinator, description))
-        async_add_entities(entities)
+    async_add_entities(entities)
 
 
 PARALLEL_UPDATES = 1


### PR DESCRIPTION
## Proposed change

Follow-up to #155760. Adds a concrete deprecation timeline and fixes a minor bug in the fireplace switch setup.

### Changes

1. **Add `breaks_in_ha_version="2026.9.0"`** to the deprecated fireplace switch repair issue, following the 6-month convention established by other integrations (Ring, tplink, Tuya, Litter-Robot, Homee, etc.) and aligned with ADR-0021.

2. **Update the repair issue description** to reference the specific version ("Home Assistant 2026.9") instead of the vague "a future version".

3. **Fix `async_add_entities` call placement** — it was incorrectly inside the `for` loop, causing it to be called on every iteration instead of once after all entities are collected.

> [!NOTE]
> The proposed `2026.9.0` target follows the 6-month deprecation convention used across the codebase. Happy to adjust this if a different timeline is preferred.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr