### PR TITLE
Extend RESET_SYSTEM action to all Evohome controller types

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -363,10 +363,12 @@ class EvoController(EvoClimateEntity):
 
         Data validation is not required, it will have been done upstream.
         """
-        if service == EvoService.SET_SYSTEM_MODE:
-            mode = data[ATTR_MODE]
-        else:  # otherwise it is EvoService.RESET_SYSTEM
-            mode = EvoSystemMode.AUTO_WITH_RESET
+
+        if service == EvoService.RESET_SYSTEM:
+            await self.coordinator.call_client_api(self._evo_device.reset())
+            return
+
+        mode = data[ATTR_MODE]  # otherwise it is EvoService.SET_SYSTEM_MODE
 
         if ATTR_PERIOD in data:
             until = dt_util.start_of_local_day()

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -27,7 +27,6 @@ from .coordinator import EvoDataUpdateCoordinator
 # because supported modes can vary for edge-case systems
 
 # Zone service schemas (registered as entity services)
-CLEAR_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {}
 SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
     vol.Required(ATTR_SETPOINT): vol.All(
         vol.Coerce(float), vol.Range(min=4.0, max=35.0)
@@ -47,7 +46,7 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
         DOMAIN,
         EvoService.CLEAR_ZONE_OVERRIDE,
         entity_domain=CLIMATE_DOMAIN,
-        schema=CLEAR_ZONE_OVERRIDE_SCHEMA,
+        schema=None,
         func="async_clear_zone_override",
     )
     service.async_register_platform_entity_service(

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -91,17 +91,10 @@ def setup_service_functions(
     assert coordinator.tcs is not None  # mypy
 
     hass.services.async_register(DOMAIN, EvoService.REFRESH_SYSTEM, force_refresh)
+    hass.services.async_register(DOMAIN, EvoService.RESET_SYSTEM, set_system_mode)
 
     # Enumerate which operating modes are supported by this system
     modes = list(coordinator.tcs.allowed_system_modes)
-
-    # Not all systems support "AutoWithReset": register this handler only if required
-    if any(
-        m[SZ_SYSTEM_MODE]
-        for m in modes
-        if m[SZ_SYSTEM_MODE] == EvoSystemMode.AUTO_WITH_RESET
-    ):
-        hass.services.async_register(DOMAIN, EvoService.RESET_SYSTEM, set_system_mode)
 
     system_mode_schemas = []
     modes = [m for m in modes if m[SZ_SYSTEM_MODE] != EvoSystemMode.AUTO_WITH_RESET]

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -78,7 +78,6 @@ def setup_service_functions(
     @verify_domain_control(DOMAIN)
     async def set_system_mode(call: ServiceCall) -> None:
         """Set the system mode."""
-        assert coordinator.tcs is not None  # mypy
 
         payload = {
             "unique_id": coordinator.tcs.id,

--- a/tests/components/evohome/snapshots/test_init.ambr
+++ b/tests/components/evohome/snapshots/test_init.ambr
@@ -1,25 +1,4 @@
 # serializer version: 1
-# name: test_setup[botched]
-  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
 # name: test_setup[default]
   dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[h032585]
-  dict_keys(['refresh_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[h099625]
-  dict_keys(['refresh_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[h139906]
-  dict_keys(['refresh_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[h157546]
-  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[minimal]
-  dict_keys(['refresh_system', 'reset_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
-# ---
-# name: test_setup[sys_004]
-  dict_keys(['refresh_system', 'set_system_mode', 'clear_zone_override', 'set_zone_override'])
 # ---

--- a/tests/components/evohome/test_init.py
+++ b/tests/components/evohome/test_init.py
@@ -16,7 +16,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .conftest import mock_post_request
-from .const import TEST_INSTALLS
 
 _MSG_429 = (
     "You have exceeded the server's API rate limit. Wait a while "
@@ -172,7 +171,7 @@ async def test_client_request_failure_v2(
     assert caplog.record_tuples == CLIENT_REQUEST_TESTS[exception]
 
 
-@pytest.mark.parametrize("install", [*TEST_INSTALLS, "botched"])
+@pytest.mark.parametrize("install", ["default"])
 async def test_setup(
     hass: HomeAssistant,
     evohome: EvohomeClient,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -21,6 +21,8 @@ from homeassistant.const import ATTR_ENTITY_ID, ATTR_MODE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
+from .const import TEST_INSTALLS
+
 
 @pytest.mark.parametrize("install", ["default"])
 async def test_refresh_system(
@@ -41,15 +43,15 @@ async def test_refresh_system(
         mock_fcn.assert_awaited_once_with()
 
 
-@pytest.mark.parametrize("install", ["default"])
+@pytest.mark.parametrize("install", TEST_INSTALLS)  # not all TCSs support AutoWithReset
 async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,
 ) -> None:
     """Test Evohome's reset_system service (for a temperature control system)."""
 
-    # EvoService.RESET_SYSTEM (if SZ_AUTO_WITH_RESET in modes)
-    with patch("evohomeasync2.control_system.ControlSystem.set_mode") as mock_fcn:
+    # EvoService.RESET_SYSTEM
+    with patch("evohomeasync2.control_system.ControlSystem.reset") as mock_fcn:
         await hass.services.async_call(
             DOMAIN,
             EvoService.RESET_SYSTEM,
@@ -57,7 +59,7 @@ async def test_reset_system(
             blocking=True,
         )
 
-        mock_fcn.assert_awaited_once_with("AutoWithReset", until=None)
+        mock_fcn.assert_awaited_once_with()
 
 
 @pytest.mark.parametrize("install", ["default"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
WIth the latest client library, it is now possible to reset all controller types, not just those that support the `AutoWithReset` mode.
 - also adds test for those systems

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
