### PR TITLE
Revert "Remove unnecessary volume_up/volume_down overrides from frontier_silicon media player"

### DIFF
--- a/homeassistant/components/frontier_silicon/media_player.py
+++ b/homeassistant/components/frontier_silicon/media_player.py
@@ -151,8 +151,6 @@ class AFSAPIDevice(MediaPlayerEntity):
         # If call to get_volume fails set to 0 and try again next time.
         if not self._max_volume:
             self._max_volume = int(await afsapi.get_volume_steps() or 1) - 1
-        if self._max_volume:
-            self._attr_volume_step = 1 / self._max_volume
 
         if self._attr_state != MediaPlayerState.OFF:
             info_name = await afsapi.get_play_name()
@@ -241,6 +239,18 @@ class AFSAPIDevice(MediaPlayerEntity):
         await self.fs_device.set_mute(mute)
 
     # volume
+    async def async_volume_up(self) -> None:
+        """Send volume up command."""
+        volume = await self.fs_device.get_volume()
+        volume = int(volume or 0) + 1
+        await self.fs_device.set_volume(min(volume, self._max_volume or 1))
+
+    async def async_volume_down(self) -> None:
+        """Send volume down command."""
+        volume = await self.fs_device.get_volume()
+        volume = int(volume or 0) - 1
+        await self.fs_device.set_volume(max(volume, 0))
+
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume command."""
         if self._max_volume:  # Can't do anything sensible if not set


### PR DESCRIPTION
Reverts home-assistant/core#164430

Rationale:
The PR introduces a regression as pointed out by the bot here: https://github.com/home-assistant/core/pull/164430#discussion_r2866768947