### PR TITLE
Add API key instructions link to Anthropic config flow

### DIFF
--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -182,7 +182,12 @@ class AnthropicConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors or None
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors or None,
+            description_placeholders={
+                "api_key_url": "https://console.anthropic.com/settings/keys",
+            },
         )
 
     @classmethod

--- a/homeassistant/components/anthropic/strings.json
+++ b/homeassistant/components/anthropic/strings.json
@@ -13,6 +13,9 @@
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "api_key": "The API key for your Anthropic account. You can create one at the [Anthropic console]({api_key_url})."
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add a data_description with a link to the Anthropic console API keys page in the config flow user step
- Matches the pattern used by OpenAI and Google Generative AI conversation integrations, which both provide instructions on where to obtain an API key
- Currently the Anthropic integration just shows a bare API key input with no guidance

## Test plan
- [ ] Set up Anthropic conversation integration and verify the API key field shows a description with a clickable link to the Anthropic console
- [ ] Verify the link goes to https://console.anthropic.com/settings/keys

Generated with [Claude Code](https://claude.com/claude-code)