### PR TITLE
Fix Matter lock credential slot iteration bound

### DIFF
--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from chip.clusters import Objects as clusters
-from chip.clusters.Types import Nullable
+from chip.clusters.Types import NullValue
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .const import (
+    CLEAR_ALL_INDEX,
     CRED_TYPE_FACE,
     CRED_TYPE_FINGER_VEIN,
     CRED_TYPE_FINGERPRINT,
@@ -164,7 +165,7 @@ def _get_attr(obj: Any, attr: str) -> Any:
     else:
         value = getattr(obj, attr, None)
     # The Matter SDK uses NullValue for nullable fields instead of None.
-    if isinstance(value, Nullable):
+    if value is NullValue:
         return None
     return value
 
@@ -216,6 +217,45 @@ def _format_user_response(user_data: Any) -> LockUserData | None:
         credentials=credentials,
         next_user_index=_get_attr(user_data, "nextUserIndex"),
     )
+
+
+# --- Credential management helpers ---
+
+
+async def _clear_user_credentials(
+    matter_client: MatterClient,
+    node_id: int,
+    endpoint_id: int,
+    user_index: int,
+) -> None:
+    """Clear all credentials for a specific user.
+
+    Fetches the user to get credential list, then clears each credential.
+    """
+    get_user_response = await matter_client.send_device_command(
+        node_id=node_id,
+        endpoint_id=endpoint_id,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=user_index),
+    )
+
+    creds = _get_attr(get_user_response, "credentials")
+    if not creds:
+        return
+
+    for cred in creds:
+        cred_type = _get_attr(cred, "credentialType")
+        cred_index = _get_attr(cred, "credentialIndex")
+        await matter_client.send_device_command(
+            node_id=node_id,
+            endpoint_id=endpoint_id,
+            command=clusters.DoorLock.Commands.ClearCredential(
+                credential=clusters.DoorLock.Structs.CredentialStruct(
+                    credentialType=cred_type,
+                    credentialIndex=cred_index,
+                ),
+            ),
+            timed_request_timeout_ms=LOCK_TIMED_REQUEST_TIMEOUT_MS,
+        )
 
 
 class LockEndpointNotFoundError(HomeAssistantError):
@@ -517,15 +557,32 @@ async def clear_lock_user(
     node: MatterNode,
     user_index: int,
 ) -> None:
-    """Clear a user from the lock.
+    """Clear a user from the lock, cleaning up credentials first.
 
-    Per the Matter spec, ClearUser also clears all associated credentials
-    and schedules for the user.
     Use index 0xFFFE (CLEAR_ALL_INDEX) to clear all users.
     Raises HomeAssistantError on failure.
     """
     lock_endpoint = _get_lock_endpoint_or_raise(node)
     _ensure_usr_support(lock_endpoint)
+
+    if user_index == CLEAR_ALL_INDEX:
+        # Clear all: clear all credentials first, then all users
+        await matter_client.send_device_command(
+            node_id=node.node_id,
+            endpoint_id=lock_endpoint.endpoint_id,
+            command=clusters.DoorLock.Commands.ClearCredential(
+                credential=None,
+            ),
+            timed_request_timeout_ms=LOCK_TIMED_REQUEST_TIMEOUT_MS,
+        )
+    else:
+        # Clear credentials for this specific user before deleting them
+        await _clear_user_credentials(
+            matter_client,
+            node.node_id,
+            lock_endpoint.endpoint_id,
+            user_index,
+        )
 
     await matter_client.send_device_command(
         node_id=node.node_id,
@@ -546,6 +603,13 @@ _CREDENTIAL_TYPE_FEATURE_MAP: dict[str, int] = {
     CRED_TYPE_FINGERPRINT: DoorLockFeature.kFingerCredentials,
     CRED_TYPE_FINGER_VEIN: DoorLockFeature.kFingerCredentials,
     CRED_TYPE_FACE: DoorLockFeature.kFaceCredentials,
+}
+
+# Map credential type strings to the capacity attribute for slot iteration.
+# Biometric types have no dedicated capacity attribute; fall back to total users.
+_CREDENTIAL_TYPE_CAPACITY_ATTR = {
+    CRED_TYPE_PIN: clusters.DoorLock.Attributes.NumberOfPINUsersSupported,
+    CRED_TYPE_RFID: clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported,
 }
 
 
@@ -688,17 +752,14 @@ async def set_lock_credential(
     if credential_index is None:
         # Auto-find first available credential slot.
         # Use the credential-type-specific capacity as the upper bound.
-        _CREDENTIAL_TYPE_CAPACITY_ATTR = {
-            CRED_TYPE_PIN: clusters.DoorLock.Attributes.NumberOfPINUsersSupported,
-            CRED_TYPE_RFID: clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported,
-        }
         max_creds_attr = _CREDENTIAL_TYPE_CAPACITY_ATTR.get(
             credential_type,
-            # Biometric types (fingerprint, finger_vein, face) have no
-            # dedicated capacity attribute; fall back to total users.
             clusters.DoorLock.Attributes.NumberOfTotalUsersSupported,
         )
-        max_creds = lock_endpoint.get_attribute_value(None, max_creds_attr) or 5
+        max_creds_raw = lock_endpoint.get_attribute_value(None, max_creds_attr)
+        max_creds = (
+            max_creds_raw if isinstance(max_creds_raw, int) and max_creds_raw > 0 else 5
+        )
         for idx in range(1, max_creds + 1):
             status_response = await matter_client.send_device_command(
                 node_id=node.node_id,

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -195,7 +195,7 @@ def _format_user_response(user_data: Any) -> LockUserData | None:
             type=CREDENTIAL_TYPE_MAP.get(_get_attr(cred, "credentialType"), "unknown"),
             index=_get_attr(cred, "credentialIndex"),
         )
-        for cred in (creds or [])
+        for cred in (creds if isinstance(creds, list) else [])
     ]
 
     return LockUserData(
@@ -232,7 +232,7 @@ async def _clear_user_credentials(
     )
 
     creds = _get_attr(get_user_response, "credentials")
-    if not creds:
+    if not creds or not isinstance(creds, list):
         return
 
     for cred in creds:

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -737,13 +737,13 @@ async def set_lock_credential(
 
     if credential_index is None:
         # Auto-find first available credential slot
-        max_creds = (
-            lock_endpoint.get_attribute_value(
-                None,
-                clusters.DoorLock.Attributes.NumberOfCredentialsSupportedPerUser,
-            )
-            or 5
+        # Use the credential-type-specific user count as the upper bound
+        max_creds_attr = (
+            clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported
+            if credential_type == CRED_TYPE_RFID
+            else clusters.DoorLock.Attributes.NumberOfPINUsersSupported
         )
+        max_creds = lock_endpoint.get_attribute_value(None, max_creds_attr) or 5
         for idx in range(1, max_creds + 1):
             status_response = await matter_client.send_device_command(
                 node_id=node.node_id,

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -14,7 +14,6 @@ from chip.clusters.Types import Nullable
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .const import (
-    CLEAR_ALL_INDEX,
     CRED_TYPE_FACE,
     CRED_TYPE_FINGER_VEIN,
     CRED_TYPE_FINGERPRINT,
@@ -217,45 +216,6 @@ def _format_user_response(user_data: Any) -> LockUserData | None:
         credentials=credentials,
         next_user_index=_get_attr(user_data, "nextUserIndex"),
     )
-
-
-# --- Credential management helpers ---
-
-
-async def _clear_user_credentials(
-    matter_client: MatterClient,
-    node_id: int,
-    endpoint_id: int,
-    user_index: int,
-) -> None:
-    """Clear all credentials for a specific user.
-
-    Fetches the user to get credential list, then clears each credential.
-    """
-    get_user_response = await matter_client.send_device_command(
-        node_id=node_id,
-        endpoint_id=endpoint_id,
-        command=clusters.DoorLock.Commands.GetUser(userIndex=user_index),
-    )
-
-    creds = _get_attr(get_user_response, "credentials")
-    if not creds:
-        return
-
-    for cred in creds:
-        cred_type = _get_attr(cred, "credentialType")
-        cred_index = _get_attr(cred, "credentialIndex")
-        await matter_client.send_device_command(
-            node_id=node_id,
-            endpoint_id=endpoint_id,
-            command=clusters.DoorLock.Commands.ClearCredential(
-                credential=clusters.DoorLock.Structs.CredentialStruct(
-                    credentialType=cred_type,
-                    credentialIndex=cred_index,
-                ),
-            ),
-            timed_request_timeout_ms=LOCK_TIMED_REQUEST_TIMEOUT_MS,
-        )
 
 
 class LockEndpointNotFoundError(HomeAssistantError):
@@ -557,32 +517,15 @@ async def clear_lock_user(
     node: MatterNode,
     user_index: int,
 ) -> None:
-    """Clear a user from the lock, cleaning up credentials first.
+    """Clear a user from the lock.
 
+    Per the Matter spec, ClearUser also clears all associated credentials
+    and schedules for the user.
     Use index 0xFFFE (CLEAR_ALL_INDEX) to clear all users.
     Raises HomeAssistantError on failure.
     """
     lock_endpoint = _get_lock_endpoint_or_raise(node)
     _ensure_usr_support(lock_endpoint)
-
-    if user_index == CLEAR_ALL_INDEX:
-        # Clear all: clear all credentials first, then all users
-        await matter_client.send_device_command(
-            node_id=node.node_id,
-            endpoint_id=lock_endpoint.endpoint_id,
-            command=clusters.DoorLock.Commands.ClearCredential(
-                credential=None,
-            ),
-            timed_request_timeout_ms=LOCK_TIMED_REQUEST_TIMEOUT_MS,
-        )
-    else:
-        # Clear credentials for this specific user before deleting them
-        await _clear_user_credentials(
-            matter_client,
-            node.node_id,
-            lock_endpoint.endpoint_id,
-            user_index,
-        )
 
     await matter_client.send_device_command(
         node_id=node.node_id,

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -738,7 +738,7 @@ async def set_lock_credential(
     if credential_index is None:
         # Auto-find first available credential slot.
         # Use the credential-type-specific capacity as the upper bound.
-        _CREDENTIAL_TYPE_CAPACITY_ATTR: dict[str, type] = {
+        _CREDENTIAL_TYPE_CAPACITY_ATTR = {
             CRED_TYPE_PIN: clusters.DoorLock.Attributes.NumberOfPINUsersSupported,
             CRED_TYPE_RFID: clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported,
         }

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -736,12 +736,17 @@ async def set_lock_credential(
     operation_type = clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd
 
     if credential_index is None:
-        # Auto-find first available credential slot
-        # Use the credential-type-specific user count as the upper bound
-        max_creds_attr = (
-            clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported
-            if credential_type == CRED_TYPE_RFID
-            else clusters.DoorLock.Attributes.NumberOfPINUsersSupported
+        # Auto-find first available credential slot.
+        # Use the credential-type-specific capacity as the upper bound.
+        _CREDENTIAL_TYPE_CAPACITY_ATTR: dict[str, type] = {
+            CRED_TYPE_PIN: clusters.DoorLock.Attributes.NumberOfPINUsersSupported,
+            CRED_TYPE_RFID: clusters.DoorLock.Attributes.NumberOfRFIDUsersSupported,
+        }
+        max_creds_attr = _CREDENTIAL_TYPE_CAPACITY_ATTR.get(
+            credential_type,
+            # Biometric types (fingerprint, finger_vein, face) have no
+            # dedicated capacity attribute; fall back to total users.
+            clusters.DoorLock.Attributes.NumberOfTotalUsersSupported,
         )
         max_creds = lock_endpoint.get_attribute_value(None, max_creds_attr) or 5
         for idx in range(1, max_creds + 1):

--- a/homeassistant/components/matter/lock_helpers.py
+++ b/homeassistant/components/matter/lock_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from chip.clusters import Objects as clusters
+from chip.clusters.Types import Nullable
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
@@ -156,11 +157,17 @@ def _get_attr(obj: Any, attr: str) -> Any:
     """Get attribute from object or dict.
 
     Matter SDK responses can be either dataclass objects or dicts depending on
-    the SDK version and serialization context.
+    the SDK version and serialization context. NullValue (a truthy,
+    non-iterable singleton) is normalized to None.
     """
     if isinstance(obj, dict):
-        return obj.get(attr)
-    return getattr(obj, attr, None)
+        value = obj.get(attr)
+    else:
+        value = getattr(obj, attr, None)
+    # The Matter SDK uses NullValue for nullable fields instead of None.
+    if isinstance(value, Nullable):
+        return None
+    return value
 
 
 def _get_supported_credential_types(feature_map: int) -> list[str]:
@@ -195,7 +202,7 @@ def _format_user_response(user_data: Any) -> LockUserData | None:
             type=CREDENTIAL_TYPE_MAP.get(_get_attr(cred, "credentialType"), "unknown"),
             index=_get_attr(cred, "credentialIndex"),
         )
-        for cred in (creds if isinstance(creds, list) else [])
+        for cred in (creds or [])
     ]
 
     return LockUserData(
@@ -232,7 +239,7 @@ async def _clear_user_credentials(
     )
 
     creds = _get_attr(get_user_response, "credentials")
-    if not creds or not isinstance(creds, list):
+    if not creds:
         return
 
     for cred in creds:

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call
 
 from chip.clusters import Objects as clusters
+from chip.clusters.Types import NullValue
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
 from matter_server.common.models import EventType, MatterNodeEvent
@@ -518,6 +519,42 @@ async def test_clear_lock_user_service(
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
 @pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_clear_lock_user_credentials_nullvalue(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test clear_lock_user handles NullValue credentials from Matter SDK."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # GetUser returns user with credentials as NullValue (not None)
+            {"userStatus": 1, "credentials": NullValue},
+            None,  # ClearUser
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_lock_user",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_USER_INDEX: 2,
+        },
+        blocking=True,
+    )
+
+    # Should skip credential clearing and go straight to ClearUser
+    assert matter_client.send_device_command.call_count == 2
+    assert matter_client.send_device_command.call_args_list[1] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearUser(userIndex=2),
+        timed_request_timeout_ms=10000,
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
 async def test_clear_lock_user_clears_credentials_first(
     hass: HomeAssistant,
     matter_client: MagicMock,
@@ -973,6 +1010,42 @@ async def test_get_lock_users_with_credentials(
             }
         ],
     }
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_get_lock_users_with_nullvalue_credentials(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test get_lock_users handles NullValue credentials from Matter SDK."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            {
+                "userIndex": 1,
+                "userStatus": 1,
+                "userName": "User No Creds",
+                "userUniqueID": 100,
+                "userType": 0,
+                "credentialRule": 0,
+                "credentials": NullValue,
+                "nextUserIndex": None,
+            },
+        ]
+    )
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "get_lock_users",
+        {ATTR_ENTITY_ID: "lock.mock_door_lock"},
+        blocking=True,
+        return_response=True,
+    )
+
+    lock_users = result["lock.mock_door_lock"]
+    assert len(lock_users["users"]) == 1
+    assert lock_users["users"][0]["credentials"] == []
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1490,6 +1490,18 @@ async def test_set_lock_credential_no_available_slot(
     # Verify it iterated over NumberOfPINUsersSupported (3), not
     # NumberOfCredentialsSupportedPerUser (5)
     assert matter_client.send_device_command.call_count == 3
+    pin_type = clusters.DoorLock.Enums.CredentialTypeEnum.kPin
+    for idx in range(3):
+        assert matter_client.send_device_command.call_args_list[idx] == call(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            command=clusters.DoorLock.Commands.GetCredentialStatus(
+                credential=clusters.DoorLock.Structs.CredentialStruct(
+                    credentialType=pin_type,
+                    credentialIndex=idx + 1,
+                ),
+            ),
+        )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1534,6 +1546,18 @@ async def test_set_lock_credential_auto_find_defaults_to_five(
 
     # With NumberOfPINUsersSupported=None, falls back to default of 5
     assert matter_client.send_device_command.call_count == 5
+    pin_type = clusters.DoorLock.Enums.CredentialTypeEnum.kPin
+    for idx in range(5):
+        assert matter_client.send_device_command.call_args_list[idx] == call(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            command=clusters.DoorLock.Commands.GetCredentialStatus(
+                credential=clusters.DoorLock.Structs.CredentialStruct(
+                    credentialType=pin_type,
+                    credentialIndex=idx + 1,
+                ),
+            ),
+        )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1844,6 +1868,17 @@ async def test_set_lock_credential_rfid_auto_find_slot(
 
     # 3 GetCredentialStatus calls + 1 SetCredential = 4 total
     assert matter_client.send_device_command.call_count == 4
+    # Verify SetCredential was called with kAdd for the empty slot at index 3
+    set_cred_cmd = matter_client.send_device_command.call_args_list[3]
+    assert (
+        set_cred_cmd.kwargs["command"].operationType
+        == clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd
+    )
+    assert set_cred_cmd.kwargs["command"].credential.credentialIndex == 3
+    assert (
+        set_cred_cmd.kwargs["command"].credential.credentialType
+        == clusters.DoorLock.Enums.CredentialTypeEnum.kRfid
+    )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1889,6 +1924,18 @@ async def test_set_lock_credential_rfid_no_available_slot(
     # Verify it iterated over NumberOfRFIDUsersSupported (3), not
     # NumberOfCredentialsSupportedPerUser (5)
     assert matter_client.send_device_command.call_count == 3
+    rfid_type = clusters.DoorLock.Enums.CredentialTypeEnum.kRfid
+    for idx in range(3):
+        assert matter_client.send_device_command.call_args_list[idx] == call(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            command=clusters.DoorLock.Commands.GetCredentialStatus(
+                credential=clusters.DoorLock.Structs.CredentialStruct(
+                    credentialType=rfid_type,
+                    credentialIndex=idx + 1,
+                ),
+            ),
+        )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -483,7 +483,13 @@ async def test_clear_lock_user_service(
     matter_node: MatterNode,
 ) -> None:
     """Test clear_lock_user entity service."""
-    matter_client.send_device_command = AsyncMock(return_value=None)
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # clear_user_credentials: GetUser returns user with no creds
+            {"userStatus": 1, "credentials": None},
+            None,  # ClearUser
+        ]
+    )
 
     await hass.services.async_call(
         DOMAIN,
@@ -495,9 +501,116 @@ async def test_clear_lock_user_service(
         blocking=True,
     )
 
-    # ClearUser handles credential cleanup per the Matter spec
-    assert matter_client.send_device_command.call_count == 1
-    assert matter_client.send_device_command.call_args == call(
+    assert matter_client.send_device_command.call_count == 2
+    # Verify GetUser was called to check credentials
+    assert matter_client.send_device_command.call_args_list[0] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
+    )
+    # Verify ClearUser was called
+    assert matter_client.send_device_command.call_args_list[1] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearUser(userIndex=1),
+        timed_request_timeout_ms=10000,
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_clear_lock_user_credentials_nullvalue(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test clear_lock_user handles NullValue credentials from Matter SDK."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # GetUser returns NullValue for credentials (truthy but not iterable)
+            {"userStatus": 1, "credentials": NullValue},
+            None,  # ClearUser
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_lock_user",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_USER_INDEX: 1,
+        },
+        blocking=True,
+    )
+
+    # GetUser + ClearUser (no ClearCredential since NullValue means no credentials)
+    assert matter_client.send_device_command.call_count == 2
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
+async def test_clear_lock_user_clears_credentials_first(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test clear_lock_user clears credentials before clearing user."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # clear_user_credentials: GetUser returns user with credentials
+            {
+                "userStatus": 1,
+                "credentials": [
+                    {"credentialType": 1, "credentialIndex": 1},
+                    {"credentialType": 1, "credentialIndex": 2},
+                ],
+            },
+            None,  # ClearCredential for first
+            None,  # ClearCredential for second
+            None,  # ClearUser
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_lock_user",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_USER_INDEX: 1,
+        },
+        blocking=True,
+    )
+
+    # GetUser + 2 ClearCredential + ClearUser
+    assert matter_client.send_device_command.call_count == 4
+    assert matter_client.send_device_command.call_args_list[0] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
+    )
+    assert matter_client.send_device_command.call_args_list[1] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearCredential(
+            credential=clusters.DoorLock.Structs.CredentialStruct(
+                credentialType=1,
+                credentialIndex=1,
+            ),
+        ),
+        timed_request_timeout_ms=10000,
+    )
+    assert matter_client.send_device_command.call_args_list[2] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearCredential(
+            credential=clusters.DoorLock.Structs.CredentialStruct(
+                credentialType=1,
+                credentialIndex=2,
+            ),
+        ),
+        timed_request_timeout_ms=10000,
+    )
+    assert matter_client.send_device_command.call_args_list[3] == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
         command=clusters.DoorLock.Commands.ClearUser(userIndex=1),
@@ -1914,8 +2027,13 @@ async def test_clear_lock_user_clear_all(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test clear_lock_user with CLEAR_ALL_INDEX clears all users."""
-    matter_client.send_device_command = AsyncMock(return_value=None)
+    """Test clear_lock_user with CLEAR_ALL_INDEX clears all credentials then users."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            None,  # ClearCredential(None) - clear all credentials
+            None,  # ClearUser(0xFFFE) - clear all users
+        ]
+    )
 
     await hass.services.async_call(
         DOMAIN,
@@ -1927,8 +2045,16 @@ async def test_clear_lock_user_clear_all(
         blocking=True,
     )
 
-    assert matter_client.send_device_command.call_count == 1
-    assert matter_client.send_device_command.call_args == call(
+    assert matter_client.send_device_command.call_count == 2
+    # First: ClearCredential with None (clear all)
+    assert matter_client.send_device_command.call_args_list[0] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearCredential(credential=None),
+        timed_request_timeout_ms=10000,
+    )
+    # Second: ClearUser with CLEAR_ALL_INDEX
+    assert matter_client.send_device_command.call_args_list[1] == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
         command=clusters.DoorLock.Commands.ClearUser(userIndex=CLEAR_ALL_INDEX),
@@ -2431,6 +2557,72 @@ async def test_set_lock_user_update_with_explicit_type_and_rule(
             userStatus=1,  # Preserved
             userType=clusters.DoorLock.Enums.UserTypeEnum.kProgrammingUser,
             credentialRule=clusters.DoorLock.Enums.CredentialRuleEnum.kTri,
+        ),
+        timed_request_timeout_ms=10000,
+    )
+
+
+# --- clear_lock_user with mixed credential types ---
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
+async def test_clear_lock_user_mixed_credential_types(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test clear_lock_user clears mixed PIN and RFID credentials."""
+    pin_type = clusters.DoorLock.Enums.CredentialTypeEnum.kPin
+    rfid_type = clusters.DoorLock.Enums.CredentialTypeEnum.kRfid
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # GetUser returns user with PIN and RFID credentials
+            {
+                "userStatus": 1,
+                "credentials": [
+                    {"credentialType": pin_type, "credentialIndex": 1},
+                    {"credentialType": rfid_type, "credentialIndex": 2},
+                ],
+            },
+            None,  # ClearCredential for PIN
+            None,  # ClearCredential for RFID
+            None,  # ClearUser
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_lock_user",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_USER_INDEX: 1,
+        },
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 4
+    # Verify PIN credential was cleared
+    assert matter_client.send_device_command.call_args_list[1] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearCredential(
+            credential=clusters.DoorLock.Structs.CredentialStruct(
+                credentialType=pin_type,
+                credentialIndex=1,
+            ),
+        ),
+        timed_request_timeout_ms=10000,
+    )
+    # Verify RFID credential was cleared
+    assert matter_client.send_device_command.call_args_list[2] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearCredential(
+            credential=clusters.DoorLock.Structs.CredentialStruct(
+                credentialType=rfid_type,
+                credentialIndex=2,
+            ),
         ),
         timed_request_timeout_ms=10000,
     )

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1050,9 +1050,20 @@ async def test_get_lock_users_with_nullvalue_credentials(
         return_response=True,
     )
 
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
+    )
+
     lock_users = result["lock.mock_door_lock"]
     assert len(lock_users["users"]) == 1
-    assert lock_users["users"][0]["credentials"] == []
+    user = lock_users["users"][0]
+    assert user["user_index"] == 1
+    assert user["user_name"] == "User No Creds"
+    assert user["user_unique_id"] == 100
+    assert user["credentials"] == []
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -547,6 +547,17 @@ async def test_clear_lock_user_credentials_nullvalue(
 
     # GetUser + ClearUser (no ClearCredential since NullValue means no credentials)
     assert matter_client.send_device_command.call_count == 2
+    assert matter_client.send_device_command.call_args_list[0] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
+    )
+    assert matter_client.send_device_command.call_args_list[1] == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.DoorLock.Commands.ClearUser(userIndex=1),
+        timed_request_timeout_ms=10000,
+    )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1938,6 +1949,17 @@ async def test_set_lock_credential_fingerprint_auto_find_slot(
 
     # 3 GetCredentialStatus calls + 1 SetCredential = 4 total
     assert matter_client.send_device_command.call_count == 4
+    # Verify SetCredential was called with kAdd for the empty slot at index 3
+    set_cred_cmd = matter_client.send_device_command.call_args_list[3]
+    assert (
+        set_cred_cmd.kwargs["command"].operationType
+        == clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd
+    )
+    assert set_cred_cmd.kwargs["command"].credential.credentialIndex == 3
+    assert (
+        set_cred_cmd.kwargs["command"].credential.credentialType
+        == clusters.DoorLock.Enums.CredentialTypeEnum.kFingerprint
+    )
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1116,6 +1116,8 @@ async def test_set_lock_credential_pin(
     [
         {
             "1/257/65532": _FEATURE_USR_PIN,
+            "1/257/18": 3,  # NumberOfPINUsersSupported
+            "1/257/28": 2,  # NumberOfCredentialsSupportedPerUser (must NOT be used)
             "1/257/24": 4,  # MinPINCodeLength
             "1/257/23": 8,  # MaxPINCodeLength
         }
@@ -1126,19 +1128,24 @@ async def test_set_lock_credential_auto_find_slot(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test set_lock_credential auto-finds first available slot."""
+    """Test set_lock_credential auto-finds first available PIN slot."""
+    # Place the empty slot at index 3 (the last position within
+    # NumberOfPINUsersSupported=3) so the test would fail if the code
+    # used NumberOfCredentialsSupportedPerUser=2 instead.
     matter_client.send_device_command = AsyncMock(
         side_effect=[
             # GetCredentialStatus(1): occupied
             {"credentialExists": True, "userIndex": 1, "nextCredentialIndex": 2},
-            # GetCredentialStatus(2): empty
+            # GetCredentialStatus(2): occupied
+            {"credentialExists": True, "userIndex": 2, "nextCredentialIndex": 3},
+            # GetCredentialStatus(3): empty — found at the bound limit
             {
                 "credentialExists": False,
                 "userIndex": None,
-                "nextCredentialIndex": 3,
+                "nextCredentialIndex": None,
             },
             # SetCredential response
-            {"status": 0, "userIndex": 1, "nextCredentialIndex": 3},
+            {"status": 0, "userIndex": 1, "nextCredentialIndex": None},
         ]
     )
 
@@ -1155,19 +1162,20 @@ async def test_set_lock_credential_auto_find_slot(
     )
 
     assert result["lock.mock_door_lock"] == {
-        "credential_index": 2,
+        "credential_index": 3,
         "user_index": 1,
-        "next_credential_index": 3,
+        "next_credential_index": None,
     }
 
-    assert matter_client.send_device_command.call_count == 3
-    # Verify SetCredential was called with kAdd for the empty slot at index 2
-    set_cred_cmd = matter_client.send_device_command.call_args_list[2]
+    # 3 GetCredentialStatus calls + 1 SetCredential = 4 total
+    assert matter_client.send_device_command.call_count == 4
+    # Verify SetCredential was called with kAdd for the empty slot at index 3
+    set_cred_cmd = matter_client.send_device_command.call_args_list[3]
     assert (
         set_cred_cmd.kwargs["command"].operationType
         == clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd
     )
-    assert set_cred_cmd.kwargs["command"].credential.credentialIndex == 2
+    assert set_cred_cmd.kwargs["command"].credential.credentialIndex == 3
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1402,6 +1410,50 @@ async def test_set_lock_credential_no_available_slot(
     # Verify it iterated over NumberOfPINUsersSupported (3), not
     # NumberOfCredentialsSupportedPerUser (5)
     assert matter_client.send_device_command.call_count == 3
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            "1/257/65532": _FEATURE_USR_PIN,
+            "1/257/18": None,  # NumberOfPINUsersSupported not available
+            "1/257/24": 4,  # MinPINCodeLength
+            "1/257/23": 8,  # MaxPINCodeLength
+        }
+    ],
+)
+async def test_set_lock_credential_auto_find_defaults_to_five(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test set_lock_credential falls back to 5 slots when capacity attribute is None."""
+    # All GetCredentialStatus calls return occupied
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "credentialExists": True,
+            "userIndex": 1,
+            "nextCredentialIndex": None,
+        }
+    )
+
+    with pytest.raises(ServiceValidationError, match="No available credential slots"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_lock_credential",
+            {
+                ATTR_ENTITY_ID: "lock.mock_door_lock",
+                ATTR_CREDENTIAL_TYPE: "pin",
+                ATTR_CREDENTIAL_DATA: "1234",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    # With NumberOfPINUsersSupported=None, falls back to default of 5
+    assert matter_client.send_device_command.call_count == 5
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1659,7 +1711,7 @@ async def test_set_lock_credential_rfid(
         {
             "1/257/65532": _FEATURE_USR_RFID,
             "1/257/19": 3,  # NumberOfRFIDUsersSupported
-            "1/257/28": 5,  # NumberOfCredentialsSupportedPerUser (should NOT be used)
+            "1/257/28": 2,  # NumberOfCredentialsSupportedPerUser (must NOT be used)
             "1/257/26": 4,  # MinRFIDCodeLength
             "1/257/25": 20,  # MaxRFIDCodeLength
         }
@@ -1671,18 +1723,24 @@ async def test_set_lock_credential_rfid_auto_find_slot(
     matter_node: MatterNode,
 ) -> None:
     """Test set_lock_credential auto-finds RFID slot using NumberOfRFIDUsersSupported."""
+    # Place the empty slot at index 3 (the last position within
+    # NumberOfRFIDUsersSupported=3) so the test would fail if the code
+    # used a smaller bound like NumberOfCredentialsSupportedPerUser=2
+    # or stopped iterating too early.
     matter_client.send_device_command = AsyncMock(
         side_effect=[
             # GetCredentialStatus(1): occupied
             {"credentialExists": True, "userIndex": 1, "nextCredentialIndex": 2},
-            # GetCredentialStatus(2): empty
+            # GetCredentialStatus(2): occupied
+            {"credentialExists": True, "userIndex": 2, "nextCredentialIndex": 3},
+            # GetCredentialStatus(3): empty — found at the bound limit
             {
                 "credentialExists": False,
                 "userIndex": None,
-                "nextCredentialIndex": 3,
+                "nextCredentialIndex": None,
             },
             # SetCredential response
-            {"status": 0, "userIndex": 1, "nextCredentialIndex": 3},
+            {"status": 0, "userIndex": 1, "nextCredentialIndex": None},
         ]
     )
 
@@ -1699,12 +1757,13 @@ async def test_set_lock_credential_rfid_auto_find_slot(
     )
 
     assert result["lock.mock_door_lock"] == {
-        "credential_index": 2,
+        "credential_index": 3,
         "user_index": 1,
-        "next_credential_index": 3,
+        "next_credential_index": None,
     }
 
-    assert matter_client.send_device_command.call_count == 3
+    # 3 GetCredentialStatus calls + 1 SetCredential = 4 total
+    assert matter_client.send_device_command.call_count == 4
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -483,13 +483,7 @@ async def test_clear_lock_user_service(
     matter_node: MatterNode,
 ) -> None:
     """Test clear_lock_user entity service."""
-    matter_client.send_device_command = AsyncMock(
-        side_effect=[
-            # clear_user_credentials: GetUser returns user with no creds
-            {"userStatus": 1, "credentials": None},
-            None,  # ClearUser
-        ]
-    )
+    matter_client.send_device_command = AsyncMock(return_value=None)
 
     await hass.services.async_call(
         DOMAIN,
@@ -501,122 +495,9 @@ async def test_clear_lock_user_service(
         blocking=True,
     )
 
-    assert matter_client.send_device_command.call_count == 2
-    # Verify GetUser was called to check credentials
-    assert matter_client.send_device_command.call_args_list[0] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
-    )
-    # Verify ClearUser was called
-    assert matter_client.send_device_command.call_args_list[1] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearUser(userIndex=1),
-        timed_request_timeout_ms=10000,
-    )
-
-
-@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
-@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
-async def test_clear_lock_user_credentials_nullvalue(
-    hass: HomeAssistant,
-    matter_client: MagicMock,
-    matter_node: MatterNode,
-) -> None:
-    """Test clear_lock_user handles NullValue credentials from Matter SDK."""
-    matter_client.send_device_command = AsyncMock(
-        side_effect=[
-            # GetUser returns user with credentials as NullValue (not None)
-            {"userStatus": 1, "credentials": NullValue},
-            None,  # ClearUser
-        ]
-    )
-
-    await hass.services.async_call(
-        DOMAIN,
-        "clear_lock_user",
-        {
-            ATTR_ENTITY_ID: "lock.mock_door_lock",
-            ATTR_USER_INDEX: 2,
-        },
-        blocking=True,
-    )
-
-    # Should skip credential clearing and go straight to ClearUser
-    assert matter_client.send_device_command.call_count == 2
-    assert matter_client.send_device_command.call_args_list[1] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearUser(userIndex=2),
-        timed_request_timeout_ms=10000,
-    )
-
-
-@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
-@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN}])
-async def test_clear_lock_user_clears_credentials_first(
-    hass: HomeAssistant,
-    matter_client: MagicMock,
-    matter_node: MatterNode,
-) -> None:
-    """Test clear_lock_user clears credentials before clearing user."""
-    matter_client.send_device_command = AsyncMock(
-        side_effect=[
-            # clear_user_credentials: GetUser returns user with credentials
-            {
-                "userStatus": 1,
-                "credentials": [
-                    {"credentialType": 1, "credentialIndex": 1},
-                    {"credentialType": 1, "credentialIndex": 2},
-                ],
-            },
-            None,  # ClearCredential for first
-            None,  # ClearCredential for second
-            None,  # ClearUser
-        ]
-    )
-
-    await hass.services.async_call(
-        DOMAIN,
-        "clear_lock_user",
-        {
-            ATTR_ENTITY_ID: "lock.mock_door_lock",
-            ATTR_USER_INDEX: 1,
-        },
-        blocking=True,
-    )
-
-    # GetUser + 2 ClearCredential + ClearUser
-    assert matter_client.send_device_command.call_count == 4
-    assert matter_client.send_device_command.call_args_list[0] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.GetUser(userIndex=1),
-    )
-    assert matter_client.send_device_command.call_args_list[1] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearCredential(
-            credential=clusters.DoorLock.Structs.CredentialStruct(
-                credentialType=1,
-                credentialIndex=1,
-            ),
-        ),
-        timed_request_timeout_ms=10000,
-    )
-    assert matter_client.send_device_command.call_args_list[2] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearCredential(
-            credential=clusters.DoorLock.Structs.CredentialStruct(
-                credentialType=1,
-                credentialIndex=2,
-            ),
-        ),
-        timed_request_timeout_ms=10000,
-    )
-    assert matter_client.send_device_command.call_args_list[3] == call(
+    # ClearUser handles credential cleanup per the Matter spec
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
         command=clusters.DoorLock.Commands.ClearUser(userIndex=1),
@@ -2033,13 +1914,8 @@ async def test_clear_lock_user_clear_all(
     matter_client: MagicMock,
     matter_node: MatterNode,
 ) -> None:
-    """Test clear_lock_user with CLEAR_ALL_INDEX clears all credentials then users."""
-    matter_client.send_device_command = AsyncMock(
-        side_effect=[
-            None,  # ClearCredential(None) - clear all credentials
-            None,  # ClearUser(0xFFFE) - clear all users
-        ]
-    )
+    """Test clear_lock_user with CLEAR_ALL_INDEX clears all users."""
+    matter_client.send_device_command = AsyncMock(return_value=None)
 
     await hass.services.async_call(
         DOMAIN,
@@ -2051,16 +1927,8 @@ async def test_clear_lock_user_clear_all(
         blocking=True,
     )
 
-    assert matter_client.send_device_command.call_count == 2
-    # First: ClearCredential with None (clear all)
-    assert matter_client.send_device_command.call_args_list[0] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearCredential(credential=None),
-        timed_request_timeout_ms=10000,
-    )
-    # Second: ClearUser with CLEAR_ALL_INDEX
-    assert matter_client.send_device_command.call_args_list[1] == call(
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
         node_id=matter_node.node_id,
         endpoint_id=1,
         command=clusters.DoorLock.Commands.ClearUser(userIndex=CLEAR_ALL_INDEX),
@@ -2563,72 +2431,6 @@ async def test_set_lock_user_update_with_explicit_type_and_rule(
             userStatus=1,  # Preserved
             userType=clusters.DoorLock.Enums.UserTypeEnum.kProgrammingUser,
             credentialRule=clusters.DoorLock.Enums.CredentialRuleEnum.kTri,
-        ),
-        timed_request_timeout_ms=10000,
-    )
-
-
-# --- clear_lock_user with mixed credential types ---
-
-
-@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
-@pytest.mark.parametrize("attributes", [{"1/257/65532": _FEATURE_USR_PIN_RFID}])
-async def test_clear_lock_user_mixed_credential_types(
-    hass: HomeAssistant,
-    matter_client: MagicMock,
-    matter_node: MatterNode,
-) -> None:
-    """Test clear_lock_user clears mixed PIN and RFID credentials."""
-    pin_type = clusters.DoorLock.Enums.CredentialTypeEnum.kPin
-    rfid_type = clusters.DoorLock.Enums.CredentialTypeEnum.kRfid
-    matter_client.send_device_command = AsyncMock(
-        side_effect=[
-            # GetUser returns user with PIN and RFID credentials
-            {
-                "userStatus": 1,
-                "credentials": [
-                    {"credentialType": pin_type, "credentialIndex": 1},
-                    {"credentialType": rfid_type, "credentialIndex": 2},
-                ],
-            },
-            None,  # ClearCredential for PIN
-            None,  # ClearCredential for RFID
-            None,  # ClearUser
-        ]
-    )
-
-    await hass.services.async_call(
-        DOMAIN,
-        "clear_lock_user",
-        {
-            ATTR_ENTITY_ID: "lock.mock_door_lock",
-            ATTR_USER_INDEX: 1,
-        },
-        blocking=True,
-    )
-
-    assert matter_client.send_device_command.call_count == 4
-    # Verify PIN credential was cleared
-    assert matter_client.send_device_command.call_args_list[1] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearCredential(
-            credential=clusters.DoorLock.Structs.CredentialStruct(
-                credentialType=pin_type,
-                credentialIndex=1,
-            ),
-        ),
-        timed_request_timeout_ms=10000,
-    )
-    # Verify RFID credential was cleared
-    assert matter_client.send_device_command.call_args_list[2] == call(
-        node_id=matter_node.node_id,
-        endpoint_id=1,
-        command=clusters.DoorLock.Commands.ClearCredential(
-            credential=clusters.DoorLock.Structs.CredentialStruct(
-                credentialType=rfid_type,
-                credentialIndex=2,
-            ),
         ),
         timed_request_timeout_ms=10000,
     )

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call
 
 from chip.clusters import Objects as clusters
-from chip.clusters.Types import NullValue
+from chip.clusters.Objects import NullValue
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
 from matter_server.common.models import EventType, MatterNodeEvent

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -1364,6 +1364,8 @@ async def test_set_lock_credential_status_failure(
     [
         {
             "1/257/65532": _FEATURE_USR_PIN,
+            "1/257/18": 3,  # NumberOfPINUsersSupported
+            "1/257/28": 5,  # NumberOfCredentialsSupportedPerUser (should NOT be used)
             "1/257/24": 4,  # MinPINCodeLength
             "1/257/23": 8,  # MaxPINCodeLength
         }
@@ -1396,6 +1398,10 @@ async def test_set_lock_credential_no_available_slot(
             blocking=True,
             return_response=True,
         )
+
+    # Verify it iterated over NumberOfPINUsersSupported (3), not
+    # NumberOfCredentialsSupportedPerUser (5)
+    assert matter_client.send_device_command.call_count == 3
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
@@ -1644,6 +1650,106 @@ async def test_set_lock_credential_rfid(
         ),
         timed_request_timeout_ms=10000,
     )
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            "1/257/65532": _FEATURE_USR_RFID,
+            "1/257/19": 3,  # NumberOfRFIDUsersSupported
+            "1/257/28": 5,  # NumberOfCredentialsSupportedPerUser (should NOT be used)
+            "1/257/26": 4,  # MinRFIDCodeLength
+            "1/257/25": 20,  # MaxRFIDCodeLength
+        }
+    ],
+)
+async def test_set_lock_credential_rfid_auto_find_slot(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test set_lock_credential auto-finds RFID slot using NumberOfRFIDUsersSupported."""
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # GetCredentialStatus(1): occupied
+            {"credentialExists": True, "userIndex": 1, "nextCredentialIndex": 2},
+            # GetCredentialStatus(2): empty
+            {
+                "credentialExists": False,
+                "userIndex": None,
+                "nextCredentialIndex": 3,
+            },
+            # SetCredential response
+            {"status": 0, "userIndex": 1, "nextCredentialIndex": 3},
+        ]
+    )
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "set_lock_credential",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_CREDENTIAL_TYPE: "rfid",
+            ATTR_CREDENTIAL_DATA: "AABBCCDD",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert result["lock.mock_door_lock"] == {
+        "credential_index": 2,
+        "user_index": 1,
+        "next_credential_index": 3,
+    }
+
+    assert matter_client.send_device_command.call_count == 3
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            "1/257/65532": _FEATURE_USR_RFID,
+            "1/257/19": 3,  # NumberOfRFIDUsersSupported
+            "1/257/28": 5,  # NumberOfCredentialsSupportedPerUser (should NOT be used)
+            "1/257/26": 4,  # MinRFIDCodeLength
+            "1/257/25": 20,  # MaxRFIDCodeLength
+        }
+    ],
+)
+async def test_set_lock_credential_rfid_no_available_slot(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test set_lock_credential RFID raises error when all slots are full."""
+    matter_client.send_device_command = AsyncMock(
+        return_value={
+            "credentialExists": True,
+            "userIndex": 1,
+            "nextCredentialIndex": None,
+        }
+    )
+
+    with pytest.raises(ServiceValidationError, match="No available credential slots"):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_lock_credential",
+            {
+                ATTR_ENTITY_ID: "lock.mock_door_lock",
+                ATTR_CREDENTIAL_TYPE: "rfid",
+                ATTR_CREDENTIAL_DATA: "AABBCCDD",
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    # Verify it iterated over NumberOfRFIDUsersSupported (3), not
+    # NumberOfCredentialsSupportedPerUser (5)
+    assert matter_client.send_device_command.call_count == 3
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])

--- a/tests/components/matter/test_lock.py
+++ b/tests/components/matter/test_lock.py
@@ -38,10 +38,12 @@ from .common import (
 # Feature map bits
 _FEATURE_PIN = 1  # kPinCredential (bit 0)
 _FEATURE_RFID = 2  # kRfidCredential (bit 1)
+_FEATURE_FINGER = 4  # kFingerCredentials (bit 2)
 _FEATURE_USR = 256  # kUser (bit 8)
 _FEATURE_USR_PIN = _FEATURE_USR | _FEATURE_PIN  # 257
 _FEATURE_USR_RFID = _FEATURE_USR | _FEATURE_RFID  # 258
 _FEATURE_USR_PIN_RFID = _FEATURE_USR | _FEATURE_PIN | _FEATURE_RFID  # 259
+_FEATURE_USR_FINGER = _FEATURE_USR | _FEATURE_FINGER  # 260
 
 
 @pytest.mark.usefixtures("matter_devices")
@@ -1876,6 +1878,66 @@ async def test_set_lock_credential_rfid_no_available_slot(
     # Verify it iterated over NumberOfRFIDUsersSupported (3), not
     # NumberOfCredentialsSupportedPerUser (5)
     assert matter_client.send_device_command.call_count == 3
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_door_lock"])
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {
+            "1/257/65532": _FEATURE_USR_FINGER,
+            "1/257/17": 3,  # NumberOfTotalUsersSupported (fallback for biometrics)
+            "1/257/18": 10,  # NumberOfPINUsersSupported (should NOT be used)
+            "1/257/28": 2,  # NumberOfCredentialsSupportedPerUser (should NOT be used)
+        }
+    ],
+)
+async def test_set_lock_credential_fingerprint_auto_find_slot(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test set_lock_credential auto-finds fingerprint slot using NumberOfTotalUsersSupported."""
+    # Place the empty slot at index 3 (the last position within
+    # NumberOfTotalUsersSupported=3) so the test would fail if the code
+    # used NumberOfPINUsersSupported (10) or NumberOfCredentialsSupportedPerUser (2).
+    matter_client.send_device_command = AsyncMock(
+        side_effect=[
+            # GetCredentialStatus(1): occupied
+            {"credentialExists": True, "userIndex": 1, "nextCredentialIndex": 2},
+            # GetCredentialStatus(2): occupied
+            {"credentialExists": True, "userIndex": 2, "nextCredentialIndex": 3},
+            # GetCredentialStatus(3): empty — found at the bound limit
+            {
+                "credentialExists": False,
+                "userIndex": None,
+                "nextCredentialIndex": None,
+            },
+            # SetCredential response
+            {"status": 0, "userIndex": 1, "nextCredentialIndex": None},
+        ]
+    )
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        "set_lock_credential",
+        {
+            ATTR_ENTITY_ID: "lock.mock_door_lock",
+            ATTR_CREDENTIAL_TYPE: "fingerprint",
+            ATTR_CREDENTIAL_DATA: "AABBCCDD",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert result["lock.mock_door_lock"] == {
+        "credential_index": 3,
+        "user_index": 1,
+        "next_credential_index": None,
+    }
+
+    # 3 GetCredentialStatus calls + 1 SetCredential = 4 total
+    assert matter_client.send_device_command.call_count == 4
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_door_lock"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Fix `set_lock_credential` to use `NumberOfPINUsersSupported` / `NumberOfRFIDUsersSupported` (depending on credential type) instead of `NumberOfCredentialsSupportedPerUser` as the iteration bound when auto-finding an available credential slot
- `NumberOfCredentialsSupportedPerUser` represents how many credentials a single user can have, not the total number of credential slots on the lock
- Biometric types (fingerprint, finger_vein, face) fall back to `NumberOfTotalUsersSupported` since the Matter spec has no dedicated capacity attribute for them
- Fix crash when Matter SDK returns `NullValue` (a truthy, non-iterable singleton) instead of `None` for nullable `credentials` fields — this caused `TypeError` in `_clear_user_credentials` and `_format_user_response`, preventing `clear_lock_user` from working on real devices

## Details
Follow-up fix to #161936.

**Credential slot iteration**: When auto-finding an available credential slot, the code was iterating up to `NumberOfCredentialsSupportedPerUser` which is the wrong bound — it should iterate up to the credential-type-specific user count.

**NullValue handling**: The Matter SDK can return `NullValue` for nullable fields like `credentials`. Unlike Python's `None`, `NullValue` is truthy (`bool(NullValue) == True`) but not iterable, so `if not creds` didn't catch it and `for cred in creds` threw `TypeError`. This `TypeError` was not caught by the `except MatterError` handler, causing an unhandled error in the frontend.

## Test plan
- [x] Strengthened PIN/RFID auto-find tests to set distinct values for type-specific capacity vs `NumberOfCredentialsSupportedPerUser`, with empty slot placed at the bound limit
- [x] Added no-available-slot tests for both PIN and RFID that verify call count matches the correct bound
- [x] Added test for fallback to default of 5 when capacity attribute is `None`
- [x] Added tests for `clear_lock_user` and `get_lock_users` with `NullValue` credentials
- [x] All 64 lock tests pass


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr