### PR TITLE
Validate set_system_mode params in code instead of by schema for Evohome

### DIFF
--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Final
 
-from evohomeasync2.schemas.const import SystemMode as EvoSystemMode
+import evohomeasync2 as ec2
+from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
+from evohomeasync2.schemas.const import (
+    S2_DURATION,
+    S2_PERIOD,
+    SystemMode as EvoSystemMode,
+)
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
@@ -64,6 +71,42 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
     )
 
 
+def _validate_set_system_mode_params(call: ServiceCall, tcs: ec2.ControlSystem) -> None:
+    """Validate that a set_system_mode service call is properly formed."""
+
+    mode = call.data[ATTR_MODE]
+    evo_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
+
+    if (mode_info := evo_modes.get(mode)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_not_supported",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+    if not mode_info[SZ_CAN_BE_TEMPORARY]:
+        if ATTR_DURATION in call.data or ATTR_PERIOD in call.data:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="mode_cant_be_temporary",
+                translation_placeholders={ATTR_MODE: mode},
+            )
+
+    elif mode_info[SZ_TIMING_MODE] == S2_DURATION and ATTR_PERIOD in call.data:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_cant_have_period",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+    elif mode_info[SZ_TIMING_MODE] == S2_PERIOD and ATTR_DURATION in call.data:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_cant_have_duration",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+
 @callback
 def setup_service_functions(
     hass: HomeAssistant, coordinator: EvoDataUpdateCoordinator
@@ -82,7 +125,10 @@ def setup_service_functions(
 
     @verify_domain_control(DOMAIN)
     async def set_system_mode(call: ServiceCall) -> None:
-        """Set the system mode."""
+        """Set the system mode or reset the system."""
+
+        if call.service == EvoService.SET_SYSTEM_MODE:  # no validation for RESET_SYSTEM
+            _validate_set_system_mode_params(call, coordinator.tcs)
 
         payload = {
             "unique_id": coordinator.tcs.id,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,8 +23,18 @@ from homeassistant.helpers.service import verify_domain_control
 from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, DOMAIN, EvoService
 from .coordinator import EvoDataUpdateCoordinator
 
-# system mode schemas are built dynamically when the services are registered
-# because supported modes can vary for edge-case systems
+# System service schemas (registered as domain services)
+SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
+    vol.Required(ATTR_MODE): vol.In(EvoSystemMode),
+    vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
+    ),
+    vol.Exclusive(ATTR_PERIOD, "temporary"): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
+    ),
+}
 
 # Zone service schemas (registered as entity services)
 SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -7,11 +7,7 @@ from typing import Any, Final
 
 import evohomeasync2 as ec2
 from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
-from evohomeasync2.schemas.const import (
-    S2_DURATION,
-    S2_PERIOD,
-    SystemMode as EvoSystemMode,
-)
+from evohomeasync2.schemas.const import S2_DURATION, S2_PERIOD
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -27,7 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(ATTR_MODE): vol.In(EvoSystemMode),
+    vol.Required(ATTR_MODE): str,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,7 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(ATTR_MODE): str,  # avoid vol.In(SystemMode)
+    vol.Required(ATTR_MODE): cv.string,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Final
 
-from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
-from evohomeasync2.schemas.const import (
-    S2_DURATION as SZ_DURATION,
-    S2_PERIOD as SZ_PERIOD,
-    SystemMode as EvoSystemMode,
-)
+from evohomeasync2.schemas.const import SystemMode as EvoSystemMode
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -101,54 +96,11 @@ def setup_service_functions(
     hass.services.async_register(DOMAIN, EvoService.REFRESH_SYSTEM, force_refresh)
     hass.services.async_register(DOMAIN, EvoService.RESET_SYSTEM, set_system_mode)
 
-    # Enumerate which operating modes are supported by this system
-    modes = list(coordinator.tcs.allowed_system_modes)
-
-    system_mode_schemas = []
-    modes = [m for m in modes if m[SZ_SYSTEM_MODE] != EvoSystemMode.AUTO_WITH_RESET]
-
-    # Permanent-only modes will use this schema
-    perm_modes = [m[SZ_SYSTEM_MODE] for m in modes if not m[SZ_CAN_BE_TEMPORARY]]
-    if perm_modes:  # any of: "Auto", "HeatingOff": permanent only
-        schema = vol.Schema({vol.Required(ATTR_MODE): vol.In(perm_modes)})
-        system_mode_schemas.append(schema)
-
-    modes = [m for m in modes if m[SZ_CAN_BE_TEMPORARY]]
-
-    # These modes are set for a number of hours (or indefinitely): use this schema
-    temp_modes = [m[SZ_SYSTEM_MODE] for m in modes if m[SZ_TIMING_MODE] == SZ_DURATION]
-    if temp_modes:  # any of: "AutoWithEco", permanent or for 0-24 hours
-        schema = vol.Schema(
-            {
-                vol.Required(ATTR_MODE): vol.In(temp_modes),
-                vol.Optional(ATTR_DURATION): vol.All(
-                    cv.time_period,
-                    vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
-                ),
-            }
-        )
-        system_mode_schemas.append(schema)
-
-    # These modes are set for a number of days (or indefinitely): use this schema
-    temp_modes = [m[SZ_SYSTEM_MODE] for m in modes if m[SZ_TIMING_MODE] == SZ_PERIOD]
-    if temp_modes:  # any of: "Away", "Custom", "DayOff", permanent or for 1-99 days
-        schema = vol.Schema(
-            {
-                vol.Required(ATTR_MODE): vol.In(temp_modes),
-                vol.Optional(ATTR_PERIOD): vol.All(
-                    cv.time_period,
-                    vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
-                ),
-            }
-        )
-        system_mode_schemas.append(schema)
-
-    if system_mode_schemas:
-        hass.services.async_register(
-            DOMAIN,
-            EvoService.SET_SYSTEM_MODE,
-            set_system_mode,
-            schema=vol.Schema(vol.Any(*system_mode_schemas)),
-        )
+    hass.services.async_register(
+        DOMAIN,
+        EvoService.SET_SYSTEM_MODE,
+        set_system_mode,
+        schema=vol.Schema(SET_SYSTEM_MODE_SCHEMA),
+    )
 
     _register_zone_entity_services(hass)

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -1,5 +1,17 @@
 {
   "exceptions": {
+    "mode_cant_be_temporary": {
+      "message": "The mode `{mode}` does not support `duration` or `period`"
+    },
+    "mode_cant_have_duration": {
+      "message": "The mode `{mode}` does not support `duration`; use `period` instead"
+    },
+    "mode_cant_have_period": {
+      "message": "The mode `{mode}` does not support `period`; use `duration` instead"
+    },
+    "mode_not_supported": {
+      "message": "The mode `{mode}` is not supported by this controller"
+    },
     "zone_only_service": {
       "message": "Only zones support the `{service}` action"
     }

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -44,9 +44,9 @@ async def test_refresh_system(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)  # some don't support AutoWithReset
+@pytest.mark.usefixtures("evohome")
 async def test_reset_system(
     hass: HomeAssistant,
-    ctl_id: str,
 ) -> None:
     """Test Evohome's reset_system service (for a temperature control system)."""
 

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -43,7 +43,7 @@ async def test_refresh_system(
         mock_fcn.assert_awaited_once_with()
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)  # not all TCSs support AutoWithReset
+@pytest.mark.parametrize("install", TEST_INSTALLS)  # some dont support AutoWithReset
 async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -43,7 +43,7 @@ async def test_refresh_system(
         mock_fcn.assert_awaited_once_with()
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)  # some dont support AutoWithReset
+@pytest.mark.parametrize("install", TEST_INSTALLS)  # some don't support AutoWithReset
 async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -270,3 +270,52 @@ async def test_zone_services_with_ctl_id(
 
     assert exc_info.value.translation_key == "zone_only_service"
     assert exc_info.value.translation_placeholders == {"service": service}
+
+
+_SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
+    (
+        {"mode": "NotARealMode"},
+        "mode_not_supported",
+    ),
+    (
+        {"mode": "Auto", "duration": {"hours": 1}},
+        "mode_cant_be_temporary",
+    ),
+    (
+        {"mode": "AutoWithEco", "period": {"days": 1}},
+        "mode_cant_have_period",
+    ),
+    (
+        {"mode": "DayOff", "duration": {"hours": 1}},
+        "mode_cant_have_duration",
+    ),
+]
+
+
+@pytest.mark.parametrize("install", ["default"])
+@pytest.mark.parametrize(
+    ("service_data", "expected_translation_key"),
+    _SET_SYSTEM_MODE_VALIDATOR_PARAMS,
+    ids=[k for _, k in _SET_SYSTEM_MODE_VALIDATOR_PARAMS],
+)
+async def test_set_system_mode_validator(
+    hass: HomeAssistant,
+    evohome: EvohomeClient,
+    service_data: dict[str, Any],
+    expected_translation_key: str,
+) -> None:
+    """Test ServiceValidationError for all controller system mode validation cases."""
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_SYSTEM_MODE,
+            service_data,
+            target={},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == expected_translation_key
+    assert exc_info.value.translation_placeholders == {
+        ATTR_MODE: service_data[ATTR_MODE]
+    }

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -274,19 +274,19 @@ async def test_zone_services_with_ctl_id(
 
 _SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
     (
-        {"mode": "NotARealMode"},
+        {ATTR_MODE: "NotARealMode"},
         "mode_not_supported",
     ),
     (
-        {"mode": "Auto", "duration": {"hours": 1}},
+        {ATTR_MODE: "Auto", ATTR_DURATION: {"hours": 1}},
         "mode_cant_be_temporary",
     ),
     (
-        {"mode": "AutoWithEco", "period": {"days": 1}},
+        {ATTR_MODE: "AutoWithEco", ATTR_PERIOD: {"days": 1}},
         "mode_cant_have_period",
     ),
     (
-        {"mode": "DayOff", "duration": {"hours": 1}},
+        {ATTR_MODE: "DayOff", ATTR_DURATION: {"hours": 1}},
         "mode_cant_have_duration",
     ),
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move most of the validation of the `set_system_mode` service call parameters from a voluptuous schema to code.

> This PR prepares this integration for config flow.

Most evohome-compatible systems support the same system modes (although older systems do not support `AutoWithReset`). However, a minority of systems support a subset, or a distinct set of such modes.

Therefore, the evohome integration builds the service schemas dynamically when the integration is first loaded.

But evohome will soon support multiple systems (rather than simply the first system it finds), and each could have a different set of modes.

Thus, validation of the `set_system_mode` service call parameters is being moved; from a voluptuous schema, into code (a method in the corresponding entity class, EvoController, invokes these checks).

A subsequent PR will migrate these services from domain- to entity-level service calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
