### PR TITLE
Require user code to be set when toggling Satel Integra switches

### DIFF
--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -162,6 +162,11 @@
       }
     }
   },
+  "exceptions": {
+    "missing_output_access_code": {
+      "message": "Switchable outputs require a code to be set on the config flow"
+    }
+  },
   "issues": {
     "deprecated_yaml_import_issue_cannot_connect": {
       "description": "Configuring {integration_title} using YAML is being removed but there was an connection error importing your existing configuration.\n\nEnsure connection to {integration_title} works and restart Home Assistant to try again or remove the `{domain}` YAML configuration from your configuration.yaml file and add the {integration_title} integration manually.",

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -164,7 +164,7 @@
   },
   "exceptions": {
     "missing_output_access_code": {
-      "message": "Switchable outputs require a code to be set on the config flow"
+      "message": "Cannot control switchable outputs because no user code is configured for this Satel Integra entry. Configure a code in the integration options to enable output control."
     }
   },
   "issues": {

--- a/homeassistant/components/satel_integra/switch.py
+++ b/homeassistant/components/satel_integra/switch.py
@@ -8,9 +8,14 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_SWITCHABLE_OUTPUT_NUMBER, SUBENTRY_TYPE_SWITCHABLE_OUTPUT
+from .const import (
+    CONF_SWITCHABLE_OUTPUT_NUMBER,
+    DOMAIN,
+    SUBENTRY_TYPE_SWITCHABLE_OUTPUT,
+)
 from .coordinator import SatelConfigEntry, SatelIntegraOutputsCoordinator
 from .entity import SatelIntegraEntity
 
@@ -83,12 +88,24 @@ class SatelIntegraSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
+        if self._code is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="missing_output_access_code",
+            )
+
         await self._controller.set_output(self._code, self._device_number, True)
         self._attr_is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
+        if self._code is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="missing_output_access_code",
+            )
+
         await self._controller.set_output(self._code, self._device_number, False)
         self._attr_is_on = False
         self.async_write_ha_state()

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -185,13 +185,14 @@ async def test_switch_actions_require_code(
     mock_satel: AsyncMock,
     mock_config_entry_with_subentries: MockConfigEntry,
 ) -> None:
-    """Test switch actions with an access code."""
+    """Test switch actions fail when access code is missing."""
 
     await setup_integration(hass, mock_config_entry_with_subentries)
 
     hass.config_entries.async_update_entry(
         mock_config_entry_with_subentries, options={CONF_CODE: None}
     )
+    await hass.async_block_till_done()
 
     # Turning the device on or off should raise ServiceValidationError.
     with pytest.raises(ServiceValidationError):

--- a/tests/components/satel_integra/test_switch.py
+++ b/tests/components/satel_integra/test_switch.py
@@ -15,12 +15,14 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    CONF_CODE,
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -176,3 +178,34 @@ async def test_switch_last_reported(
 
     assert first_reported != hass.states.get("switch.switchable_output").last_reported
     assert len(events) == 1  # last_reported shall not fire state_changed
+
+
+async def test_switch_actions_require_code(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test switch actions with an access code."""
+
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    hass.config_entries.async_update_entry(
+        mock_config_entry_with_subentries, options={CONF_CODE: None}
+    )
+
+    # Turning the device on or off should raise ServiceValidationError.
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.switchable_output"},
+            blocking=True,
+        )
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.switchable_output"},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Satel Integra requires a user code to toggle switches. Previously in YAML, this validation was done during the schema validation, but in the UI config, we only need 1 user code to be configured (in the options flow) for the entire config entry.

Without this validation, an internal error message from the client library bubble up (as it just expects a code to be passed along).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
