### PR TITLE
Add correct speed fan mapping for Z-Wave GE/Jasco Enbrighten ZWA4013

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -205,7 +205,7 @@ DISCOVERY_SCHEMAS = [
             FanValueMapping(speeds=[(1, 33), (34, 67), (68, 99)]),
         ),
     ),
-    # GE/Jasco - In-Wall Smart Fan Controls
+    # GE/Jasco - In-Wall Smart Fan Controls - 14287 / 55258 / ZW4002 and 14314 / ZW4002
     ZWaveDiscoverySchema(
         platform=Platform.FAN,
         hint="has_fan_value_mapping",
@@ -213,13 +213,24 @@ DISCOVERY_SCHEMAS = [
         product_id={
             0x3131,
             0x3337,  # 14287 / 55258 / ZW4002
-            0x3533,  # 58446 / ZWA4013
             0x3138,  # 14314 / ZW4002
         },
         product_type={0x4944},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
         data_template=FixedFanValueMappingDataTemplate(
             FanValueMapping(speeds=[(1, 32), (33, 66), (67, 99)]),
+        ),
+    ),
+    # GE/Jasco - In-Wall Smart Fan Controls - 58446 / ZWA4013
+    ZWaveDiscoverySchema(
+        platform=Platform.FAN,
+        hint="has_fan_value_mapping",
+        manufacturer_id={0x0063},
+        product_id={0x3533},
+        product_type={0x4944},
+        primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+        data_template=FixedFanValueMappingDataTemplate(
+            FanValueMapping(speeds=[(1, 25), (26, 50), (51, 75), (76, 99)]),
         ),
     ),
     # Leviton ZW4SF fan controllers using switch multilevel CC

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -719,6 +719,77 @@ async def test_leviton_zw4sf_fan(
     assert state.attributes[ATTR_PRESET_MODES] == []
 
 
+async def test_enbrighten_58446_zwa4013_fan(
+    hass: HomeAssistant, client, enbrighten_58446_zwa4013, integration
+) -> None:
+    """Test a GE/Jasco Enbrighten 58446/ZWA4013 fan with 4 fixed speeds."""
+    node = enbrighten_58446_zwa4013
+    node_id = 19
+    entity_id = "fan.zwa4013_fan"
+
+    async def get_zwave_speed_from_percentage(percentage):
+        """Set the fan to a particular percentage and get the resulting Zwave speed."""
+        client.async_send_command.reset_mock()
+
+        await hass.services.async_call(
+            "fan",
+            "turn_on",
+            {"entity_id": entity_id, "percentage": percentage},
+            blocking=True,
+        )
+
+        assert len(client.async_send_command.call_args_list) == 1
+        args = client.async_send_command.call_args[0][0]
+        assert args["command"] == "node.set_value"
+        assert args["nodeId"] == node_id
+        return args["value"]
+
+    async def get_percentage_from_zwave_speed(zwave_speed):
+        """Set the underlying device speed and get the resulting percentage."""
+        event = Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": zwave_speed,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+        node.receive_event(event)
+        state = hass.states.get(entity_id)
+        return state.attributes[ATTR_PERCENTAGE]
+
+    # This device has the speeds:
+    # 1 = 1-25, 2 = 26-50, 3 = 51-75, 4 = 76-99
+    percentages_to_zwave_speeds = [
+        [[0], [0]],
+        [range(1, 26), range(1, 26)],
+        [range(26, 51), range(26, 51)],
+        [range(51, 76), range(51, 76)],
+        [range(76, 101), range(76, 100)],
+    ]
+
+    for percentages, zwave_speeds in percentages_to_zwave_speeds:
+        for percentage in percentages:
+            actual_zwave_speed = await get_zwave_speed_from_percentage(percentage)
+            assert actual_zwave_speed in zwave_speeds
+        for zwave_speed in zwave_speeds:
+            actual_percentage = await get_percentage_from_zwave_speed(zwave_speed)
+            assert actual_percentage in percentages
+
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(25, rel=1e-3)
+    assert state.attributes[ATTR_PRESET_MODES] == []
+
+
 async def test_thermostat_fan(
     hass: HomeAssistant,
     client,


### PR DESCRIPTION
Unlike the ZW4002, the ZWA4013 supports 4 different speeds instead of 3 (excluding off), and this change modifies the fan value mapping to accurately match the hardware.

This change splits the existing ZWaveDiscoverySchema for GE/Jasco ZW4002 and ZWA4013 fan control switches into two:
- The ZW4002 remains unmodified using a 3-speed fan value mapping.
- The ZWA4013 now advertises a 4-speed fan value mapping allowing accurate control of the 4 speeds (or 5 if counting off) the actual hardware switch supports from HA.

## Proposed change

The Enbrighten ZWA4013 in-wall fan controller supports five discrete speed steps (0%, 25%, 50%, 75%, 100%).
Currently it is mapped as a 3-speed fan (plus off), resulting in only four modes being exposed in HA.
This change adds a Z-Wave JS discovery mapping specifically for the ZWA4013 to expose all five supported fan speeds.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/150602

## Checklist

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
