### PR TITLE
Update iZone integration to support hubs on different VLANs

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -68,8 +69,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if host := entry.data.get(CONF_HOST):
         try:
             await async_add_controller_by_ip(hass, host)
-        except ConnectionError:
-            return False
+        except ConnectionError as err:
+            raise ConfigEntryNotReady(
+                f"Unable to connect to iZone device at {host}"
+            ) from err
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -4,7 +4,12 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EXCLUDE, CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import (
+    CONF_EXCLUDE,
+    CONF_HOST,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -79,5 +79,5 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload the config entry and stop discovery process."""
+    """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -4,13 +4,17 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EXCLUDE, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import CONF_EXCLUDE, CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_CONFIG, IZONE
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .discovery import (
+    async_add_controller_by_ip,
+    async_start_discovery_service,
+    async_stop_discovery_service,
+)
 
 PLATFORMS = [Platform.CLIMATE]
 
@@ -55,6 +59,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
+    # If a host is configured, manually add the controller by IP
+    if host := entry.data.get(CONF_HOST):
+        try:
+            await async_add_controller_by_ip(hass, host)
+        except ConnectionError:
+            return False
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -65,10 +65,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
-    # If a host is configured, manually add the controller by IP
+    # If a host is configured, manually add the controller by IP.
+    # Pass unique_id (device UID) to skip redundant HTTP lookup.
     if host := entry.data.get(CONF_HOST):
         try:
-            await async_add_controller_by_ip(hass, host)
+            await async_add_controller_by_ip(hass, host, entry.unique_id)
         except ConnectionError as err:
             raise ConfigEntryNotReady(
                 f"Unable to connect to iZone device at {host}"

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -36,13 +36,17 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     def dispatch_discovered(_):
         controller_ready.set()
 
-    async_dispatcher_connect(hass, DISPATCH_CONTROLLER_DISCOVERED, dispatch_discovered)
+    unsub = async_dispatcher_connect(
+        hass, DISPATCH_CONTROLLER_DISCOVERED, dispatch_discovered
+    )
 
     disco = await async_start_discovery_service(hass)
 
     with suppress(TimeoutError):
         async with asyncio.timeout(TIMEOUT_DISCOVERY):
             await controller_ready.wait()
+
+    unsub()
 
     if not disco.pi_disco.controllers:
         await async_stop_discovery_service(hass)

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -3,18 +3,34 @@
 import asyncio
 from contextlib import suppress
 import logging
+from typing import Any
 
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_entry_flow
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DISPATCH_CONTROLLER_DISCOVERED, IZONE, TIMEOUT_DISCOVERY
-from .discovery import async_start_discovery_service, async_stop_discovery_service
+from .discovery import (
+    async_add_controller_by_ip,
+    async_get_device_uid,
+    async_start_discovery_service,
+    async_stop_discovery_service,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_HOST): str,
+    }
+)
+
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:
+    """Check if there are any iZone devices on the network via broadcast."""
     controller_ready = asyncio.Event()
 
     @callback
@@ -38,4 +54,96 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
     return True
 
 
-config_entry_flow.register_discovery_flow(IZONE, "iZone Aircon", _async_has_devices)
+class IZoneConfigFlow(ConfigFlow, domain=IZONE):
+    """Handle a config flow for iZone."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._host: str | None = None
+        self._device_uid: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step.
+
+        The user can either enter an IP address for a remote iZone hub,
+        or leave it blank to use auto-discovery on the local network.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input.get(CONF_HOST, "").strip()
+
+            if host:
+                # Manual IP entry - try to connect
+                try:
+                    device_uid = await async_get_device_uid(self.hass, host)
+                except ConnectionError:
+                    errors[CONF_HOST] = "cannot_connect"
+                else:
+                    await self.async_set_unique_id(device_uid)
+                    self._abort_if_unique_id_configured(
+                        updates={CONF_HOST: host}
+                    )
+                    self._host = host
+                    self._device_uid = device_uid
+
+                    # Initialize the controller
+                    try:
+                        await async_add_controller_by_ip(self.hass, host)
+                    except ConnectionError:
+                        errors[CONF_HOST] = "cannot_connect"
+                    else:
+                        return self.async_create_entry(
+                            title=f"iZone {device_uid}",
+                            data={CONF_HOST: host},
+                        )
+            else:
+                # Auto-discovery (blank host)
+                return await self.async_step_discover()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={},
+        )
+
+    async def async_step_discover(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle auto-discovery of iZone controllers on local network."""
+        if user_input is not None:
+            # User confirmed discovery
+            return self.async_create_entry(
+                title="iZone",
+                data={},
+            )
+
+        has_devices = await _async_has_devices(self.hass)
+        if not has_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="discover",
+        )
+
+    async def async_step_import(
+        self, import_data: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle import from configuration.yaml."""
+        # Check if already configured
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        has_devices = await _async_has_devices(self.hass)
+        if not has_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        return self.async_create_entry(
+            title="iZone",
+            data={},
+        )

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import DISPATCH_CONTROLLER_DISCOVERED, IZONE, TIMEOUT_DISCOVERY
 from .discovery import (
-    async_add_controller_by_ip,
     async_get_device_uid,
     async_start_discovery_service,
     async_stop_discovery_service,
@@ -58,11 +57,7 @@ class IZoneConfigFlow(ConfigFlow, domain=IZONE):
     """Handle a config flow for iZone."""
 
     VERSION = 1
-
-    def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._host: str | None = None
-        self._device_uid: str | None = None
+    MINOR_VERSION = 1
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -78,7 +73,7 @@ class IZoneConfigFlow(ConfigFlow, domain=IZONE):
             host = user_input.get(CONF_HOST, "").strip()
 
             if host:
-                # Manual IP entry - try to connect
+                # Manual IP entry - validate connectivity and get UID
                 try:
                     device_uid = await async_get_device_uid(self.hass, host)
                 except ConnectionError:
@@ -86,19 +81,11 @@ class IZoneConfigFlow(ConfigFlow, domain=IZONE):
                 else:
                     await self.async_set_unique_id(device_uid)
                     self._abort_if_unique_id_configured(updates={CONF_HOST: host})
-                    self._host = host
-                    self._device_uid = device_uid
 
-                    # Initialize the controller
-                    try:
-                        await async_add_controller_by_ip(self.hass, host)
-                    except ConnectionError:
-                        errors[CONF_HOST] = "cannot_connect"
-                    else:
-                        return self.async_create_entry(
-                            title=f"iZone {device_uid}",
-                            data={CONF_HOST: host},
-                        )
+                    return self.async_create_entry(
+                        title=f"iZone {device_uid}",
+                        data={CONF_HOST: host},
+                    )
             else:
                 # Auto-discovery (blank host)
                 return await self.async_step_discover()
@@ -114,6 +101,12 @@ class IZoneConfigFlow(ConfigFlow, domain=IZONE):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle auto-discovery of iZone controllers on local network."""
+        # Prevent multiple discovery entries
+        if any(
+            not entry.data.get(CONF_HOST) for entry in self._async_current_entries()
+        ):
+            return self.async_abort(reason="single_instance_allowed")
+
         if user_input is not None:
             # User confirmed discovery
             return self.async_create_entry(

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -85,9 +85,7 @@ class IZoneConfigFlow(ConfigFlow, domain=IZONE):
                     errors[CONF_HOST] = "cannot_connect"
                 else:
                     await self.async_set_unique_id(device_uid)
-                    self._abort_if_unique_id_configured(
-                        updates={CONF_HOST: host}
-                    )
+                    self._abort_if_unique_id_configured(updates={CONF_HOST: host})
                     self._host = host
                     self._device_uid = device_uid
 

--- a/homeassistant/components/izone/const.py
+++ b/homeassistant/components/izone/const.py
@@ -12,3 +12,4 @@ DISPATCH_CONTROLLER_UPDATE = "izone_controller_update"
 DISPATCH_ZONE_UPDATE = "izone_zone_update"
 
 TIMEOUT_DISCOVERY = 20
+TIMEOUT_CONNECT = 10

--- a/homeassistant/components/izone/const.py
+++ b/homeassistant/components/izone/const.py
@@ -13,3 +13,8 @@ DISPATCH_ZONE_UPDATE = "izone_zone_update"
 
 TIMEOUT_DISCOVERY = 20
 TIMEOUT_CONNECT = 10
+
+# How often (seconds) to retry reconnecting static-IP controllers
+# that have become disconnected. This replaces the broadcast-based
+# reconnection that doesn't work across VLANs.
+STATIC_RECONNECT_INTERVAL = 30

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -58,7 +58,52 @@ class DiscoveryService(pizone.Listener):
         """Zone update message is received from the controller."""
         async_dispatcher_send(self.hass, DISPATCH_ZONE_UPDATE, ctrl, zone)
 
-    def start_keepalive(self) -> None:
+    def _track_static_controller(
+        self, device_uid: str, host: str, ctrl: pizone.Controller
+    ) -> None:
+        """Track a static-IP controller and refresh its address.
+
+        Updates the controller's address and starts the keepalive
+        mechanism if not already running.
+        """
+        ctrl._refresh_address(host)  # noqa: SLF001
+        self._static_hosts[device_uid] = host
+        self._start_keepalive()
+
+    async def async_register_controller(
+        self, host: str, device_uid: str
+    ) -> pizone.Controller:
+        """Register a controller by IP address.
+
+        If the controller is already known, updates its address.
+        Otherwise creates, initializes, and registers a new controller.
+        """
+        assert self.pi_disco is not None
+
+        # Check if controller is already discovered
+        if device_uid in self.pi_disco.controllers:
+            ctrl = self.pi_disco.controllers[device_uid]
+            self._track_static_controller(device_uid, host, ctrl)
+            return ctrl
+
+        # Create controller via the pizone library internals
+        controller = pizone.Controller(
+            self.pi_disco,
+            device_uid=device_uid,
+            device_ip=host,
+            is_v2=False,
+            is_ipower=False,
+        )
+        await controller._initialize()  # noqa: SLF001
+
+        # Register it in the discovery service
+        self.pi_disco.controllers[device_uid] = controller
+        self.pi_disco.controller_discovered(controller)
+
+        self._track_static_controller(device_uid, host, controller)
+        return controller
+
+    def _start_keepalive(self) -> None:
         """Start periodic keepalive for static-IP controllers.
 
         The pizone library relies on UDP broadcast responses to trigger
@@ -163,43 +208,16 @@ async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
 
 
 async def async_add_controller_by_ip(
-    hass: HomeAssistant, host: str
+    hass: HomeAssistant, host: str, device_uid: str | None = None
 ) -> pizone.Controller:
     """Manually add a controller by IP address.
 
-    This queries the device for its UID, creates a Controller instance,
-    initialises it, and registers it with the discovery service.
+    If device_uid is provided, skips the HTTP lookup to avoid a redundant
+    network call (the UID is already known from config flow validation).
     """
     disco = await async_start_discovery_service(hass)
 
-    device_uid = await async_get_device_uid(hass, host)
+    if device_uid is None:
+        device_uid = await async_get_device_uid(hass, host)
 
-    # Check if controller is already discovered
-    if device_uid in disco.pi_disco.controllers:
-        ctrl = disco.pi_disco.controllers[device_uid]
-        # Update IP in case it changed
-        ctrl._refresh_address(host)  # noqa: SLF001
-        # Track this as a static-IP controller and start keepalive
-        disco._static_hosts[device_uid] = host  # noqa: SLF001
-        disco.start_keepalive()
-        return ctrl
-
-    # Create controller via the pizone library internals
-    controller = pizone.Controller(
-        disco.pi_disco,
-        device_uid=device_uid,
-        device_ip=host,
-        is_v2=False,
-        is_ipower=False,
-    )
-    await controller._initialize()  # noqa: SLF001
-
-    # Register it in the discovery service
-    disco.pi_disco.controllers[device_uid] = controller
-    disco.pi_disco.controller_discovered(controller)
-
-    # Track this as a static-IP controller and start keepalive
-    disco._static_hosts[device_uid] = host  # noqa: SLF001
-    disco.start_keepalive()
-
-    return controller
+    return await disco.async_register_controller(host, device_uid)

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -1,13 +1,16 @@
 """Internal discovery service for  iZone AC."""
 
+import asyncio
 import logging
+from datetime import timedelta
 
 import aiohttp
 import pizone
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DATA_DISCOVERY_SERVICE,
@@ -16,6 +19,7 @@ from .const import (
     DISPATCH_CONTROLLER_RECONNECTED,
     DISPATCH_CONTROLLER_UPDATE,
     DISPATCH_ZONE_UPDATE,
+    STATIC_RECONNECT_INTERVAL,
     TIMEOUT_CONNECT,
 )
 
@@ -30,6 +34,9 @@ class DiscoveryService(pizone.Listener):
         super().__init__()
         self.hass = hass
         self.pi_disco: pizone.DiscoveryService | None = None
+        # Track static-IP controllers and their keepalive unsub callbacks
+        self._static_hosts: dict[str, str] = {}  # device_uid -> host
+        self._keepalive_unsub: CALLBACK_TYPE | None = None
 
     # Listener interface
     def controller_discovered(self, ctrl: pizone.Controller) -> None:
@@ -51,6 +58,48 @@ class DiscoveryService(pizone.Listener):
     def zone_update(self, ctrl: pizone.Controller, zone: pizone.Zone) -> None:
         """Zone update message is received from the controller."""
         async_dispatcher_send(self.hass, DISPATCH_ZONE_UPDATE, ctrl, zone)
+
+    def start_keepalive(self) -> None:
+        """Start periodic keepalive for static-IP controllers.
+
+        The pizone library relies on UDP broadcast responses to trigger
+        reconnection after a connection failure. Since broadcasts don't
+        cross VLANs, we periodically call _refresh_address on static-IP
+        controllers to simulate the broadcast response and trigger the
+        library's built-in retry logic.
+        """
+        if self._keepalive_unsub is not None:
+            return  # Already running
+
+        async def _keepalive_tick(_now) -> None:
+            """Periodic keepalive for static-IP controllers."""
+            if not self.pi_disco:
+                return
+            for device_uid, host in self._static_hosts.items():
+                ctrl = self.pi_disco.controllers.get(device_uid)
+                if ctrl is None:
+                    continue
+                # If controller has a pending failure, poke _refresh_address
+                # to trigger the library's _retry_connection logic
+                if ctrl._fail_exception is not None:  # noqa: SLF001
+                    _LOGGER.debug(
+                        "Keepalive: triggering reconnect for %s at %s",
+                        device_uid,
+                        host,
+                    )
+                    ctrl._refresh_address(host)  # noqa: SLF001
+
+        self._keepalive_unsub = async_track_time_interval(
+            self.hass,
+            _keepalive_tick,
+            timedelta(seconds=STATIC_RECONNECT_INTERVAL),
+        )
+
+    def stop_keepalive(self) -> None:
+        """Stop the periodic keepalive."""
+        if self._keepalive_unsub is not None:
+            self._keepalive_unsub()
+            self._keepalive_unsub = None
 
 
 async def async_start_discovery_service(hass: HomeAssistant):
@@ -77,6 +126,7 @@ async def async_stop_discovery_service(hass: HomeAssistant):
     if not (disco := hass.data.get(DATA_DISCOVERY_SERVICE)):
         return
 
+    disco.stop_keepalive()
     await disco.pi_disco.close()
     del hass.data[DATA_DISCOVERY_SERVICE]
 
@@ -125,6 +175,9 @@ async def async_add_controller_by_ip(
         ctrl = disco.pi_disco.controllers[device_uid]
         # Update IP in case it changed
         ctrl._refresh_address(host)  # noqa: SLF001
+        # Track this as a static-IP controller and start keepalive
+        disco._static_hosts[device_uid] = host
+        disco.start_keepalive()
         return ctrl
 
     # Create controller via the pizone library internals
@@ -140,5 +193,9 @@ async def async_add_controller_by_ip(
     # Register it in the discovery service
     disco.pi_disco.controllers[device_uid] = controller
     disco.pi_disco.controller_discovered(controller)
+
+    # Track this as a static-IP controller and start keepalive
+    disco._static_hosts[device_uid] = host
+    disco.start_keepalive()
 
     return controller

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -1,8 +1,7 @@
-"""Internal discovery service for  iZone AC."""
+"""Internal discovery service for iZone AC."""
 
-import asyncio
-import logging
 from datetime import timedelta
+import logging
 
 import aiohttp
 import pizone
@@ -145,6 +144,7 @@ async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
             f"http://{host}/SystemSettings",
             timeout=aiohttp.ClientTimeout(total=TIMEOUT_CONNECT),
         ) as response:
+            response.raise_for_status()
             data = await response.json(content_type=None)
             device_uid = data.get("AirStreamDeviceUId")
             if not device_uid:
@@ -152,7 +152,13 @@ async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
                     "Device did not return a valid AirStreamDeviceUId"
                 )
             return device_uid
-    except (aiohttp.ClientError, TimeoutError, KeyError, TypeError) as ex:
+    except (
+        aiohttp.ClientError,
+        TimeoutError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as ex:
         raise ConnectionError(f"Unable to connect to iZone device at {host}") from ex
 
 
@@ -174,7 +180,7 @@ async def async_add_controller_by_ip(
         # Update IP in case it changed
         ctrl._refresh_address(host)  # noqa: SLF001
         # Track this as a static-IP controller and start keepalive
-        disco._static_hosts[device_uid] = host
+        disco._static_hosts[device_uid] = host  # noqa: SLF001
         disco.start_keepalive()
         return ctrl
 
@@ -193,7 +199,7 @@ async def async_add_controller_by_ip(
     disco.pi_disco.controller_discovered(controller)
 
     # Track this as a static-IP controller and start keepalive
-    disco._static_hosts[device_uid] = host
+    disco._static_hosts[device_uid] = host  # noqa: SLF001
     disco.start_keepalive()
 
     return controller

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -153,9 +153,7 @@ async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
                 )
             return device_uid
     except (aiohttp.ClientError, TimeoutError, KeyError, TypeError) as ex:
-        raise ConnectionError(
-            f"Unable to connect to iZone device at {host}"
-        ) from ex
+        raise ConnectionError(f"Unable to connect to iZone device at {host}") from ex
 
 
 async def async_add_controller_by_ip(

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import aiohttp
 import pizone
 
 from homeassistant.core import HomeAssistant
@@ -15,6 +16,7 @@ from .const import (
     DISPATCH_CONTROLLER_RECONNECTED,
     DISPATCH_CONTROLLER_UPDATE,
     DISPATCH_ZONE_UPDATE,
+    TIMEOUT_CONNECT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,3 +81,64 @@ async def async_stop_discovery_service(hass: HomeAssistant):
     del hass.data[DATA_DISCOVERY_SERVICE]
 
     _LOGGER.debug("Stopped iZone Discovery Service")
+
+
+async def async_get_device_uid(hass: HomeAssistant, host: str) -> str:
+    """Query an iZone device at the given IP address and return its UID.
+
+    Raises ConnectionError if the device cannot be reached or doesn't
+    respond with valid iZone system settings.
+    """
+    session = aiohttp_client.async_get_clientsession(hass)
+    try:
+        async with session.get(
+            f"http://{host}/SystemSettings",
+            timeout=aiohttp.ClientTimeout(total=TIMEOUT_CONNECT),
+        ) as response:
+            data = await response.json(content_type=None)
+            device_uid = data.get("AirStreamDeviceUId")
+            if not device_uid:
+                raise ConnectionError(
+                    "Device did not return a valid AirStreamDeviceUId"
+                )
+            return device_uid
+    except (aiohttp.ClientError, TimeoutError, KeyError, TypeError) as ex:
+        raise ConnectionError(
+            f"Unable to connect to iZone device at {host}"
+        ) from ex
+
+
+async def async_add_controller_by_ip(
+    hass: HomeAssistant, host: str
+) -> pizone.Controller:
+    """Manually add a controller by IP address.
+
+    This queries the device for its UID, creates a Controller instance,
+    initialises it, and registers it with the discovery service.
+    """
+    disco = await async_start_discovery_service(hass)
+
+    device_uid = await async_get_device_uid(hass, host)
+
+    # Check if controller is already discovered
+    if device_uid in disco.pi_disco.controllers:
+        ctrl = disco.pi_disco.controllers[device_uid]
+        # Update IP in case it changed
+        ctrl._refresh_address(host)  # noqa: SLF001
+        return ctrl
+
+    # Create controller via the pizone library internals
+    controller = pizone.Controller(
+        disco.pi_disco,
+        device_uid=device_uid,
+        device_ip=host,
+        is_v2=False,
+        is_ipower=False,
+    )
+    await controller._initialize()  # noqa: SLF001
+
+    # Register it in the discovery service
+    disco.pi_disco.controllers[device_uid] = controller
+    disco.pi_disco.controller_discovered(controller)
+
+    return controller

--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "izone",
   "name": "iZone",
-  "version": "1.0.0",
   "codeowners": ["@Swamp-Ig"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/izone",

--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "izone",
   "name": "iZone",
+  "version": "1.0.0",
   "codeowners": ["@Swamp-Ig"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/izone",

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -2,11 +2,24 @@
   "config": {
     "abort": {
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "step": {
-      "confirm": {
-        "description": "Do you want to set up iZone?"
+      "user": {
+        "description": "Enter the IP address of your iZone hub, or leave blank to auto-discover on the local network.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "IP address of the iZone hub (e.g. 192.168.1.100). Leave empty for auto-discovery."
+        }
+      },
+      "discover": {
+        "description": "iZone controller(s) found on your network. Do you want to set up iZone?"
       }
     }
   },

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -96,6 +96,7 @@ async def mock_discovery(
         "homeassistant.components.izone.discovery.pizone.discovery", autospec=True
     ) as mock_disco:
         mock_disco.return_value.start_discovery = AsyncMock()
+        mock_disco.return_value.close = AsyncMock()
         mock_disco.return_value.controllers = {
             mock_controller.device_uid: mock_controller
         }

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -53,9 +53,7 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
         assert result["step_id"] == "user"
 
         # Submit with blank host to trigger auto-discovery
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "no_devices_found"
 
@@ -91,17 +89,13 @@ async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
         assert result["step_id"] == "user"
 
         # Submit with blank host to trigger auto-discovery
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
         # Discovery confirmation form
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "discover"
 
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {}
-        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == {}
 

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,12 +2,13 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.izone.const import DISPATCH_CONTROLLER_DISCOVERED, IZONE
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -31,7 +32,7 @@ def _mock_start_discovery(hass: HomeAssistant, mock_disco: Mock) -> Callable[...
 
 
 async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
-    """Test not finding iZone controller."""
+    """Test not finding iZone controller via auto-discovery."""
 
     with (
         patch(
@@ -47,11 +48,16 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
             IZONE, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
+        # User form with optional host field
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        # Submit with blank host to trigger auto-discovery
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {}
+        )
         assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_devices_found"
 
         await hass.async_block_till_done()
 
@@ -59,7 +65,7 @@ async def test_not_found(hass: HomeAssistant, mock_disco: Mock) -> None:
 
 
 async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
-    """Test not finding iZone controller."""
+    """Test finding iZone controller via auto-discovery."""
     mock_disco.pi_disco.controllers["blah"] = object()
 
     with (
@@ -80,12 +86,128 @@ async def test_found(hass: HomeAssistant, mock_disco: Mock) -> None:
             IZONE, context={"source": config_entries.SOURCE_USER}
         )
 
-        # Confirmation form
+        # User form with optional host field
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
 
-        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        # Submit with blank host to trigger auto-discovery
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {}
+        )
+
+        # Discovery confirmation form
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "discover"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {}
+        )
         assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"] == {}
 
         await hass.async_block_till_done()
 
     mock_setup.assert_called_once()
+
+
+async def test_manual_ip_success(hass: HomeAssistant) -> None:
+    """Test manually configuring an iZone controller by IP address."""
+    mock_controller = Mock()
+    mock_controller.device_uid = "000013170"
+
+    with (
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.izone.config_flow.async_get_device_uid",
+            return_value="000013170",
+        ),
+        patch(
+            "homeassistant.components.izone.config_flow.async_add_controller_by_ip",
+            return_value=mock_controller,
+        ),
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            return_value=mock_controller,
+        ),
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "iZone 000013170"
+        assert result["data"] == {CONF_HOST: "192.168.2.100"}
+
+        await hass.async_block_till_done()
+
+    mock_setup.assert_called_once()
+
+
+async def test_manual_ip_cannot_connect(hass: HomeAssistant) -> None:
+    """Test manually configuring with an unreachable IP address."""
+    with patch(
+        "homeassistant.components.izone.config_flow.async_get_device_uid",
+        side_effect=ConnectionError("Unable to connect"),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+
+        # Should show form again with error
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {CONF_HOST: "cannot_connect"}
+
+
+async def test_manual_ip_already_configured(hass: HomeAssistant) -> None:
+    """Test manually configuring an already-configured device."""
+    from tests.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.50"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.config_flow.async_get_device_uid",
+        return_value="000013170",
+    ):
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.168.2.100"}
+        )
+
+        # Should abort because unique_id already exists (IP gets updated)
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
+        # Verify the host was updated
+        assert entry.data[CONF_HOST] == "192.168.2.100"

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -228,3 +228,153 @@ async def test_single_instance_allowed_when_entry_exists(
     # Should abort because a discovery entry already exists
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+async def test_import_flow(hass: HomeAssistant, mock_disco: Mock) -> None:
+    """Test import from configuration.yaml."""
+    mock_disco.pi_disco.controllers["blah"] = object()
+
+    with (
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.izone.config_flow.async_start_discovery_service"
+        ) as start_disco,
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        start_disco.side_effect = _mock_start_discovery(hass, mock_disco)
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_IMPORT}
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "iZone"
+        assert result["data"] == {}
+
+        await hass.async_block_till_done()
+
+    mock_setup.assert_called_once()
+
+
+async def test_import_already_configured(hass: HomeAssistant) -> None:
+    """Test import aborts when already configured."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        IZONE, context={"source": config_entries.SOURCE_IMPORT}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"
+
+
+async def test_import_no_devices(hass: HomeAssistant, mock_disco: Mock) -> None:
+    """Test import aborts when no devices found."""
+    with (
+        patch(
+            "homeassistant.components.izone.config_flow.async_start_discovery_service"
+        ) as start_disco,
+        patch(
+            "homeassistant.components.izone.config_flow.async_stop_discovery_service",
+            return_value=None,
+        ),
+    ):
+        start_disco.side_effect = _mock_start_discovery(hass, mock_disco)
+        result = await hass.config_entries.flow.async_init(
+            IZONE, context={"source": config_entries.SOURCE_IMPORT}
+        )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "no_devices_found"
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Test unloading a config entry."""
+    from . import setup_controller, setup_integration
+
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    assert mock_config_entry.state is config_entries.ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_entry_with_host(hass: HomeAssistant) -> None:
+    """Test setup entry when host is configured."""
+    mock_controller = Mock()
+    mock_controller.device_uid = "000013170"
+
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.100"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            return_value=mock_controller,
+        ) as mock_add,
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_add.assert_called_once_with(hass, "192.168.2.100")
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_setup_entry_with_host_connection_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test setup entry raises ConfigEntryNotReady on connection error."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone 000013170",
+        data={CONF_HOST: "192.168.2.100"},
+        unique_id="000013170",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.async_add_controller_by_ip",
+            side_effect=ConnectionError("Unable to connect"),
+        ),
+        patch(
+            "homeassistant.components.izone.async_start_discovery_service",
+            return_value=None,
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -12,6 +12,8 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -119,10 +121,6 @@ async def test_manual_ip_success(hass: HomeAssistant) -> None:
             return_value="000013170",
         ),
         patch(
-            "homeassistant.components.izone.config_flow.async_add_controller_by_ip",
-            return_value=mock_controller,
-        ),
-        patch(
             "homeassistant.components.izone.async_add_controller_by_ip",
             return_value=mock_controller,
         ),
@@ -175,8 +173,6 @@ async def test_manual_ip_cannot_connect(hass: HomeAssistant) -> None:
 
 async def test_manual_ip_already_configured(hass: HomeAssistant) -> None:
     """Test manually configuring an already-configured device."""
-    from tests.common import MockConfigEntry
-
     entry = MockConfigEntry(
         domain=IZONE,
         title="iZone 000013170",
@@ -205,3 +201,30 @@ async def test_manual_ip_already_configured(hass: HomeAssistant) -> None:
 
         # Verify the host was updated
         assert entry.data[CONF_HOST] == "192.168.2.100"
+
+
+async def test_single_instance_allowed_when_entry_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Test that auto-discovery aborts when a discovery entry already exists."""
+    entry = MockConfigEntry(
+        domain=IZONE,
+        title="iZone",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        IZONE, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # User form should still show (allows adding manual IP)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Submit blank host to trigger auto-discovery
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    # Should abort because a discovery entry already exists
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -348,7 +348,7 @@ async def test_setup_entry_with_host(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    mock_add.assert_called_once_with(hass, "192.168.2.100")
+    mock_add.assert_called_once_with(hass, "192.168.2.100", "000013170")
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Description
The iZone integration relies on UDP broadcast discovery, which doesn't work when the controller is on a different VLAN or subnet.

This PR adds an optional Host field to the config flow, allowing users to specify the controller's IP address directly. Leaving it blank preserves the existing auto-discovery behavior, so this is fully backwards compatible.

Key changes:
- Config flow: Replaced register_discovery_flow with a full ConfigFlow that supports both auto-discovery (blank host) and manual IP entry
- Direct connection: New async_get_device_uid() and async_add_controller_by_ip() functions connect to the controller over HTTP without requiring broadcast
- Cross-VLAN keepalive: The pizone library's reconnection path depends on broadcast responses. For static-IP controllers, a periodic keepalive (30s) detects disconnected controllers and triggers the library's built-in retry logic, replacing the broadcast dependency

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [125116](https://github.com/home-assistant/core/issues/125116)
- Link to documentation pull request: [43843](https://github.com/home-assistant/home-assistant.io/pull/43843)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
