### PR TITLE
Disable usb monitor during tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -656,6 +656,8 @@ filterwarnings = [
   "ignore:with timeout\\(\\) is deprecated:DeprecationWarning:pyqwikswitch.async_",
   # https://pypi.org/project/rxv/ - v0.7.0 - 2021-10-10
   "ignore:defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead:DeprecationWarning:rxv.ssdp",
+  # https://github.com/ProCern/asyncinotify/blob/20204dcf9361a5cf3b52bc8e16dabfeb36aeb0a8/src/asyncinotify/_ffi.py#L71
+  "ignore:inotify is a Linux-only API.  You can package this library on other platforms, but not run it.",
 ]
 
 [tool.coverage.run]

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -52,6 +52,11 @@ slae_sh_device = USBDevice(
 )
 
 
+@pytest.fixture(autouse=True)
+def disable_usb_monitor() -> None:
+    """Re-enable usb integration that was disabled in global conftest."""
+
+
 async def test_aiousbwatcher_discovery(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2142,3 +2142,14 @@ def disable_http_server() -> Generator[None]:
     """
     with patch("homeassistant.components.http.start_http_server_and_save_config"):
         yield
+
+
+@pytest.fixture(autouse=True)
+def disable_usb_monitor() -> Generator[None]:
+    """Disable USB device discovery during tests.
+
+    This prevents the USB component to start up monitoring during tests.
+    """
+
+    with patch("homeassistant.components.usb.AIOUSBWatcher"):
+        yield


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These are unsupported on some platforms like OSX and trigger unexpected exceptions in tests there. Also this does not need to be enabled for the general amount of tests.

```
/Users/joakim/src/hass/home-assistant/.venv/lib/python3.13/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <function Inotify.__del__ at 0x11e621800>
  
  Traceback (most recent call last):
    File "/Users/joakim/src/hass/home-assistant/.venv/lib/python3.13/site-packages/asyncinotify/__init__.py", line 524, in __del__
      self.close()
      ~~~~~~~~~~^^
    File "/Users/joakim/src/hass/home-assistant/.venv/lib/python3.13/site-packages/asyncinotify/__init__.py", line 539, in close
      if self._fd is not None:
         ^^^^^^^^
  AttributeError: 'asyncinotify.Inotify' object has no attribute '_fd'. Did you mean: 'fd'?
  
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
