### PR TITLE
Add Casper Glow integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -137,6 +137,7 @@ homeassistant.components.calendar.*
 homeassistant.components.cambridge_audio.*
 homeassistant.components.camera.*
 homeassistant.components.canary.*
+homeassistant.components.casper_glow.*
 homeassistant.components.cert_expiry.*
 homeassistant.components.clickatell.*
 homeassistant.components.clicksend.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -273,6 +273,8 @@ build.json @home-assistant/supervisor
 /tests/components/cambridge_audio/ @noahhusby
 /homeassistant/components/camera/ @home-assistant/core
 /tests/components/camera/ @home-assistant/core
+/homeassistant/components/casper_glow/ @mikeodr
+/tests/components/casper_glow/ @mikeodr
 /homeassistant/components/cast/ @emontnemery
 /tests/components/cast/ @emontnemery
 /homeassistant/components/ccm15/ @ocalvo

--- a/homeassistant/components/casper_glow/__init__.py
+++ b/homeassistant/components/casper_glow/__init__.py
@@ -1,0 +1,39 @@
+"""The Casper Glow integration."""
+
+from __future__ import annotations
+
+from pycasperglow import CasperGlow
+
+from homeassistant.components import bluetooth
+from homeassistant.const import CONF_ADDRESS, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .coordinator import CasperGlowConfigEntry, CasperGlowCoordinator
+
+PLATFORMS: list[Platform] = [Platform.LIGHT]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: CasperGlowConfigEntry) -> bool:
+    """Set up Casper Glow from a config entry."""
+    address: str = entry.data[CONF_ADDRESS]
+    ble_device = bluetooth.async_ble_device_from_address(hass, address.upper(), True)
+    if not ble_device:
+        raise ConfigEntryNotReady(
+            f"Could not find Casper Glow device with address {address}"
+        )
+
+    glow = CasperGlow(ble_device)
+    coordinator = CasperGlowCoordinator(hass, glow, entry.title)
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(coordinator.async_start())
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: CasperGlowConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/casper_glow/config_flow.py
+++ b/homeassistant/components/casper_glow/config_flow.py
@@ -1,0 +1,151 @@
+"""Config flow for Casper Glow integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bluetooth_data_tools import human_readable_name
+from pycasperglow import CasperGlow, CasperGlowError
+import voluptuous as vol
+
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import DOMAIN, LOCAL_NAMES
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CasperGlowConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Casper Glow."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: BluetoothServiceInfoBleak | None = None
+        self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
+
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle the bluetooth discovery step."""
+        await self.async_set_unique_id(format_mac(discovery_info.address))
+        self._abort_if_unique_id_configured()
+        self._discovery_info = discovery_info
+        self.context["title_placeholders"] = {
+            "name": human_readable_name(
+                None, discovery_info.name, discovery_info.address
+            )
+        }
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm a discovered Casper Glow device."""
+        assert self._discovery_info is not None
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.context["title_placeholders"]["name"],
+                data={CONF_ADDRESS: self._discovery_info.address},
+            )
+        glow = CasperGlow(self._discovery_info.device)
+        try:
+            await glow.handshake()
+        except CasperGlowError:
+            return self.async_abort(reason="cannot_connect")
+        except Exception:
+            _LOGGER.exception(
+                "Unexpected error during Casper Glow config flow "
+                "(step=bluetooth_confirm, address=%s)",
+                self._discovery_info.address,
+            )
+            return self.async_abort(reason="unknown")
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            description_placeholders=self.context["title_placeholders"],
+        )
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the user step to pick discovered device."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            discovery_info = self._discovered_devices[address]
+            await self.async_set_unique_id(
+                format_mac(discovery_info.address), raise_on_progress=False
+            )
+            self._abort_if_unique_id_configured()
+            glow = CasperGlow(discovery_info.device)
+            try:
+                await glow.handshake()
+            except CasperGlowError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception(
+                    "Unexpected error during Casper Glow config flow "
+                    "(step=user, address=%s)",
+                    discovery_info.address,
+                )
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title=human_readable_name(
+                        None, discovery_info.name, discovery_info.address
+                    ),
+                    data={
+                        CONF_ADDRESS: discovery_info.address,
+                    },
+                )
+
+        if discovery := self._discovery_info:
+            self._discovered_devices[discovery.address] = discovery
+        else:
+            current_addresses = self._async_current_ids(include_ignore=False)
+            for discovery in async_discovered_service_info(self.hass):
+                if (
+                    format_mac(discovery.address) in current_addresses
+                    or discovery.address in self._discovered_devices
+                    or not (
+                        discovery.name
+                        and any(
+                            discovery.name.startswith(local_name)
+                            for local_name in LOCAL_NAMES
+                        )
+                    )
+                ):
+                    continue
+                self._discovered_devices[discovery.address] = discovery
+
+        if not self._discovered_devices:
+            return self.async_abort(reason="no_devices_found")
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_ADDRESS): vol.In(
+                    {
+                        service_info.address: human_readable_name(
+                            None, service_info.name, service_info.address
+                        )
+                        for service_info in self._discovered_devices.values()
+                    }
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )

--- a/homeassistant/components/casper_glow/const.py
+++ b/homeassistant/components/casper_glow/const.py
@@ -1,0 +1,16 @@
+"""Constants for the Casper Glow integration."""
+
+from datetime import timedelta
+
+from pycasperglow import BRIGHTNESS_LEVELS, DEVICE_NAME_PREFIX, DIMMING_TIME_MINUTES
+
+DOMAIN = "casper_glow"
+
+LOCAL_NAMES = {DEVICE_NAME_PREFIX}
+
+SORTED_BRIGHTNESS_LEVELS = sorted(BRIGHTNESS_LEVELS)
+
+DEFAULT_DIMMING_TIME_MINUTES: int = DIMMING_TIME_MINUTES[0]
+
+# Interval between periodic state polls to catch externally-triggered changes.
+STATE_POLL_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/casper_glow/coordinator.py
+++ b/homeassistant/components/casper_glow/coordinator.py
@@ -1,0 +1,103 @@
+"""Coordinator for the Casper Glow integration."""
+
+from __future__ import annotations
+
+import logging
+
+from bleak import BleakError
+from bluetooth_data_tools import monotonic_time_coarse
+from pycasperglow import CasperGlow
+
+from homeassistant.components.bluetooth import (
+    BluetoothChange,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+)
+from homeassistant.components.bluetooth.active_update_coordinator import (
+    ActiveBluetoothDataUpdateCoordinator,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+
+from .const import STATE_POLL_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type CasperGlowConfigEntry = ConfigEntry[CasperGlowCoordinator]
+
+
+class CasperGlowCoordinator(ActiveBluetoothDataUpdateCoordinator[None]):
+    """Coordinator for Casper Glow BLE devices."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        device: CasperGlow,
+        title: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            address=device.address,
+            mode=BluetoothScanningMode.PASSIVE,
+            needs_poll_method=self._needs_poll,
+            poll_method=self._async_update,
+            connectable=True,
+        )
+        self.device = device
+        self.last_dimming_time_minutes: int | None = (
+            device.state.configured_dimming_time_minutes
+        )
+        self.title = title
+
+    @callback
+    def _needs_poll(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        seconds_since_last_poll: float | None,
+    ) -> bool:
+        """Return True if a poll is needed."""
+        return (
+            seconds_since_last_poll is None
+            or seconds_since_last_poll >= STATE_POLL_INTERVAL.total_seconds()
+        )
+
+    async def _async_update(self, service_info: BluetoothServiceInfoBleak) -> None:
+        """Poll device state."""
+        await self.device.query_state()
+
+    async def _async_poll(self) -> None:
+        """Poll the device and log availability changes."""
+        assert self._last_service_info
+
+        try:
+            await self._async_poll_data(self._last_service_info)
+        except BleakError as exc:
+            if self.last_poll_successful:
+                _LOGGER.info("%s is unavailable: %s", self.title, exc)
+                self.last_poll_successful = False
+            return
+        except Exception:
+            if self.last_poll_successful:
+                _LOGGER.exception("%s: unexpected error while polling", self.title)
+                self.last_poll_successful = False
+            return
+        finally:
+            self._last_poll = monotonic_time_coarse()
+
+        if not self.last_poll_successful:
+            _LOGGER.info("%s is back online", self.title)
+            self.last_poll_successful = True
+
+        self._async_handle_bluetooth_poll()
+
+    @callback
+    def _async_handle_bluetooth_event(
+        self,
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Update BLE device reference on each advertisement."""
+        self.device.set_ble_device(service_info.device)
+        super()._async_handle_bluetooth_event(service_info, change)

--- a/homeassistant/components/casper_glow/entity.py
+++ b/homeassistant/components/casper_glow/entity.py
@@ -1,0 +1,47 @@
+"""Base entity for the Casper Glow integration."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+
+from pycasperglow import CasperGlowError
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+)
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+
+from .const import DOMAIN
+from .coordinator import CasperGlowCoordinator
+
+
+class CasperGlowEntity(PassiveBluetoothCoordinatorEntity[CasperGlowCoordinator]):
+    """Base class for Casper Glow entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: CasperGlowCoordinator) -> None:
+        """Initialize a Casper Glow entity."""
+        super().__init__(coordinator)
+        self._device = coordinator.device
+        self._attr_device_info = DeviceInfo(
+            manufacturer="Casper",
+            model="Glow",
+            model_id="G01",
+            connections={
+                (dr.CONNECTION_BLUETOOTH, format_mac(coordinator.device.address))
+            },
+        )
+
+    async def _async_command(self, coro: Awaitable[None]) -> None:
+        """Execute a device command."""
+        try:
+            await coro
+        except CasperGlowError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/casper_glow/light.py
+++ b/homeassistant/components/casper_glow/light.py
@@ -1,0 +1,104 @@
+"""Casper Glow integration light platform."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pycasperglow import GlowState
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .const import DEFAULT_DIMMING_TIME_MINUTES, SORTED_BRIGHTNESS_LEVELS
+from .coordinator import CasperGlowConfigEntry, CasperGlowCoordinator
+from .entity import CasperGlowEntity
+
+PARALLEL_UPDATES = 1
+
+
+def _ha_brightness_to_device_pct(brightness: int) -> int:
+    """Convert HA brightness (1-255) to device percentage by snapping to nearest."""
+    return percentage_to_ordered_list_item(
+        SORTED_BRIGHTNESS_LEVELS, round(brightness * 100 / 255)
+    )
+
+
+def _device_pct_to_ha_brightness(pct: int) -> int:
+    """Convert device brightness percentage (60-100) to HA brightness (1-255)."""
+    percent = ordered_list_item_to_percentage(SORTED_BRIGHTNESS_LEVELS, pct)
+    return round(percent * 255 / 100)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CasperGlowConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the light platform for Casper Glow."""
+    async_add_entities([CasperGlowLight(entry.runtime_data)])
+
+
+class CasperGlowLight(CasperGlowEntity, LightEntity):
+    """Representation of a Casper Glow light."""
+
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_name = None
+
+    def __init__(self, coordinator: CasperGlowCoordinator) -> None:
+        """Initialize a Casper Glow light."""
+        super().__init__(coordinator)
+        self._attr_unique_id = format_mac(coordinator.device.address)
+        self._update_from_state(coordinator.device.state)
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback when entity is added."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._device.register_callback(self._async_handle_state_update)
+        )
+
+    @callback
+    def _update_from_state(self, state: GlowState) -> None:
+        """Update entity attributes from device state."""
+        if state.is_on is not None:
+            self._attr_is_on = state.is_on
+            self._attr_color_mode = ColorMode.BRIGHTNESS
+        if state.brightness_level is not None:
+            self._attr_brightness = _device_pct_to_ha_brightness(state.brightness_level)
+
+    @callback
+    def _async_handle_state_update(self, state: GlowState) -> None:
+        """Handle a state update from the device."""
+        self._update_from_state(state)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        brightness_pct: int | None = None
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness_pct = _ha_brightness_to_device_pct(kwargs[ATTR_BRIGHTNESS])
+
+        await self._async_command(self._device.turn_on())
+        self._attr_is_on = True
+        self._attr_color_mode = ColorMode.BRIGHTNESS
+        if brightness_pct is not None:
+            await self._async_command(
+                self._device.set_brightness_and_dimming_time(
+                    brightness_pct,
+                    self.coordinator.last_dimming_time_minutes
+                    if self.coordinator.last_dimming_time_minutes is not None
+                    else DEFAULT_DIMMING_TIME_MINUTES,
+                )
+            )
+            self._attr_brightness = _device_pct_to_ha_brightness(brightness_pct)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._async_command(self._device.turn_off())
+        self._attr_is_on = False

--- a/homeassistant/components/casper_glow/manifest.json
+++ b/homeassistant/components/casper_glow/manifest.json
@@ -1,0 +1,19 @@
+{
+  "domain": "casper_glow",
+  "name": "Casper Glow",
+  "bluetooth": [
+    {
+      "connectable": true,
+      "local_name": "Jar*"
+    }
+  ],
+  "codeowners": ["@mikeodr"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters"],
+  "documentation": "https://www.home-assistant.io/integrations/casper_glow",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "loggers": ["pycasperglow"],
+  "quality_scale": "bronze",
+  "requirements": ["pycasperglow==1.1.0"]
+}

--- a/homeassistant/components/casper_glow/quality_scale.yaml
+++ b/homeassistant/components/casper_glow/quality_scale.yaml
@@ -1,0 +1,74 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: No custom services.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: No custom actions/services.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: todo
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: No network discovery.
+  discovery: done
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations:
+    status: exempt
+    comment: No entity translations needed.
+  exception-translations:
+    status: exempt
+    comment: No custom services that raise exceptions.
+  icon-translations:
+    status: exempt
+    comment: No icon translations needed.
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: No web session is used by this integration.
+  strict-typing: done

--- a/homeassistant/components/casper_glow/strings.json
+++ b/homeassistant/components/casper_glow/strings.json
@@ -1,0 +1,34 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Do you want to set up {name}?"
+      },
+      "user": {
+        "data": {
+          "address": "Bluetooth address"
+        },
+        "data_description": {
+          "address": "The Bluetooth address of the Casper Glow light"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the Casper Glow: {error}"
+    }
+  }
+}

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -86,6 +86,11 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "service_data_uuid": "0000fcd2-0000-1000-8000-00805f9b34fb",
     },
     {
+        "connectable": True,
+        "domain": "casper_glow",
+        "local_name": "Jar*",
+    },
+    {
         "domain": "dormakaba_dkey",
         "service_uuid": "e7a60000-6639-429f-94fd-86de8ea26897",
     },

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -117,6 +117,7 @@ FLOWS = {
         "caldav",
         "cambridge_audio",
         "canary",
+        "casper_glow",
         "cast",
         "ccm15",
         "cert_expiry",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -973,6 +973,12 @@
       "iot_class": "cloud_polling",
       "single_config_entry": true
     },
+    "casper_glow": {
+      "name": "Casper Glow",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "ccm15": {
       "name": "Midea ccm15 AC Controller",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -1125,6 +1125,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.casper_glow.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.cert_expiry.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1997,6 +1997,9 @@ pybravia==0.4.1
 # homeassistant.components.nissan_leaf
 pycarwings2==2.14
 
+# homeassistant.components.casper_glow
+pycasperglow==1.1.0
+
 # homeassistant.components.cloudflare
 pycfdns==3.0.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1725,6 +1725,9 @@ pybotvac==0.0.28
 # homeassistant.components.braviatv
 pybravia==0.4.1
 
+# homeassistant.components.casper_glow
+pycasperglow==1.1.0
+
 # homeassistant.components.cloudflare
 pycfdns==3.0.0
 

--- a/tests/components/casper_glow/__init__.py
+++ b/tests/components/casper_glow/__init__.py
@@ -1,0 +1,51 @@
+"""Tests for the Casper Glow integration."""
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import (
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_bluetooth_service_info,
+)
+
+CASPER_GLOW_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="Jar",
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    manufacturer_data={},
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Jar"),
+    advertisement=generate_advertisement_data(
+        service_uuids=[],
+    ),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
+
+async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set up the Casper Glow integration."""
+    entry.add_to_hass(hass)
+    inject_bluetooth_service_info(hass, CASPER_GLOW_DISCOVERY_INFO)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+
+NOT_CASPER_GLOW_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="NotGlow",
+    address="AA:BB:CC:DD:EE:00",
+    rssi=-60,
+    manufacturer_data={},
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="AA:BB:CC:DD:EE:00", name="NotGlow"),
+    advertisement=generate_advertisement_data(),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)

--- a/tests/components/casper_glow/conftest.py
+++ b/tests/components/casper_glow/conftest.py
@@ -1,0 +1,62 @@
+"""Casper Glow session fixtures."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+from pycasperglow import GlowState
+import pytest
+
+from homeassistant.components.casper_glow.const import DOMAIN
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+
+from . import CASPER_GLOW_DISCOVERY_INFO, setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+def mock_bluetooth(enable_bluetooth: None) -> None:
+    """Auto mock bluetooth."""
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a Casper Glow config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Jar",
+        data={CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address},
+        unique_id=format_mac(CASPER_GLOW_DISCOVERY_INFO.address),
+    )
+
+
+@pytest.fixture
+def mock_casper_glow() -> Generator[MagicMock]:
+    """Mock a CasperGlow device."""
+    with (
+        patch(
+            "homeassistant.components.casper_glow.CasperGlow",
+            autospec=True,
+        ) as mock_device_class,
+        patch(
+            "homeassistant.components.casper_glow.config_flow.CasperGlow",
+            new=mock_device_class,
+        ),
+    ):
+        mock_device = mock_device_class.return_value
+        mock_device.address = CASPER_GLOW_DISCOVERY_INFO.address
+        mock_device.state = GlowState()
+        yield mock_device
+
+
+@pytest.fixture
+async def config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> MockConfigEntry:
+    """Set up a Casper Glow config entry."""
+    await setup_integration(hass, mock_config_entry)
+    return mock_config_entry

--- a/tests/components/casper_glow/snapshots/test_init.ambr
+++ b/tests/components/casper_glow/snapshots/test_init.ambr
@@ -1,0 +1,32 @@
+# serializer version: 1
+# name: test_device_info
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'bluetooth',
+        'aa:bb:cc:dd:ee:ff',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Casper',
+    'model': 'Glow',
+    'model_id': 'G01',
+    'name': 'Jar',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/components/casper_glow/snapshots/test_light.ambr
+++ b/tests/components/casper_glow/snapshots/test_light.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_entities[light.jar-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.jar',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'casper_glow',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[light.jar-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'brightness': None,
+      'color_mode': None,
+      'friendly_name': 'Jar',
+      'supported_color_modes': list([
+        <ColorMode.BRIGHTNESS: 'brightness'>,
+      ]),
+      'supported_features': <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.jar',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/casper_glow/test_config_flow.py
+++ b/tests/components/casper_glow/test_config_flow.py
@@ -1,0 +1,206 @@
+"""Test the Casper Glow config flow."""
+
+from unittest.mock import MagicMock, patch
+
+from bluetooth_data_tools import human_readable_name
+from pycasperglow import CasperGlowError
+import pytest
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.casper_glow.const import DOMAIN
+from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.device_registry import format_mac
+
+from . import CASPER_GLOW_DISCOVERY_INFO, NOT_CASPER_GLOW_DISCOVERY_INFO
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import (
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_bluetooth_service_info,
+)
+
+
+async def test_bluetooth_step_success(
+    hass: HomeAssistant, mock_casper_glow: MagicMock
+) -> None:
+    """Test bluetooth discovery step success."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=CASPER_GLOW_DISCOVERY_INFO,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+
+    # Inject before configure so async_setup_entry can find the device via
+    # async_ble_device_from_address. The unique_id is already claimed by our
+    # flow so the BT manager's auto-started flow will abort as a duplicate.
+    inject_bluetooth_service_info(hass, CASPER_GLOW_DISCOVERY_INFO)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert result["result"].unique_id == format_mac(CASPER_GLOW_DISCOVERY_INFO.address)
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "reason"),
+    [(CasperGlowError, "cannot_connect"), (RuntimeError, "unknown")],
+)
+async def test_bluetooth_confirm_error(
+    hass: HomeAssistant,
+    side_effect: type[Exception],
+    reason: str,
+) -> None:
+    """Test bluetooth confirm step error handling."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        side_effect=side_effect,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_BLUETOOTH},
+            data=CASPER_GLOW_DISCOVERY_INFO,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+
+
+async def test_user_step_success(
+    hass: HomeAssistant, mock_casper_glow: MagicMock
+) -> None:
+    """Test user step success path."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[NOT_CASPER_GLOW_DISCOVERY_INFO, CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    # Inject before configure so async_setup_entry can find the device via
+    # async_ble_device_from_address.
+    inject_bluetooth_service_info(hass, CASPER_GLOW_DISCOVERY_INFO)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == human_readable_name(
+        None, CASPER_GLOW_DISCOVERY_INFO.name, CASPER_GLOW_DISCOVERY_INFO.address
+    )
+    assert result["data"] == {
+        CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address,
+    }
+    assert result["result"].unique_id == format_mac(CASPER_GLOW_DISCOVERY_INFO.address)
+
+
+async def test_user_step_no_devices(hass: HomeAssistant) -> None:
+    """Test user step with no devices found."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[NOT_CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [(CasperGlowError, "cannot_connect"), (RuntimeError, "unknown")],
+)
+async def test_user_step_error(
+    hass: HomeAssistant,
+    side_effect: type[Exception],
+    expected_error: str,
+) -> None:
+    """Test user step error handling."""
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[CASPER_GLOW_DISCOVERY_INFO],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.CasperGlow.handshake",
+        side_effect=side_effect,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_ADDRESS: CASPER_GLOW_DISCOVERY_INFO.address},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}
+
+
+async def test_already_configured(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test already configured device."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=CASPER_GLOW_DISCOVERY_INFO,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_step_skips_unrecognized_device(hass: HomeAssistant) -> None:
+    """Test that devices without a matching local name prefix are skipped."""
+    unrecognized_discovery = BluetoothServiceInfoBleak(
+        name="",
+        address="AA:BB:CC:DD:EE:11",
+        rssi=-60,
+        manufacturer_data={},
+        service_uuids=[],
+        service_data={},
+        source="local",
+        device=generate_ble_device(address="AA:BB:CC:DD:EE:11", name=""),
+        advertisement=generate_advertisement_data(service_uuids=[]),
+        time=0,
+        connectable=True,
+        tx_power=-127,
+    )
+    with patch(
+        "homeassistant.components.casper_glow.config_flow.async_discovered_service_info",
+        return_value=[unrecognized_discovery],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"

--- a/tests/components/casper_glow/test_init.py
+++ b/tests/components/casper_glow/test_init.py
@@ -1,0 +1,173 @@
+"""Test the Casper Glow integration init."""
+
+from collections.abc import Generator
+from datetime import timedelta
+from itertools import count
+from unittest.mock import MagicMock, patch
+
+from bleak import BleakError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import format_mac
+import homeassistant.util.dt as dt_util
+
+from . import CASPER_GLOW_DISCOVERY_INFO, setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.bluetooth import (
+    generate_advertisement_data,
+    generate_ble_device,
+    inject_bluetooth_service_info,
+)
+
+
+async def test_async_setup_entry_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test successful setup of a config entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_async_setup_entry_device_not_found(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test setup raises ConfigEntryNotReady when BLE device is not found."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Do not inject BLE info — device is not in the cache
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_async_unload_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test unloading a config entry."""
+    result = await hass.config_entries.async_unload(config_entry.entry_id)
+
+    assert result is True
+    assert config_entry.state == ConfigEntryState.NOT_LOADED
+
+
+async def test_device_info(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test device info is correctly populated."""
+    device = device_registry.async_get_device(
+        connections={
+            (dr.CONNECTION_BLUETOOTH, format_mac(CASPER_GLOW_DISCOVERY_INFO.address))
+        }
+    )
+    assert device is not None
+    assert device == snapshot
+
+
+_adv_counter = count(1)
+
+
+@pytest.fixture(autouse=True)
+def mock_monotonic() -> Generator[None]:
+    """Patch monotonic_time_coarse to 0 so _last_poll is always falsy."""
+    with patch(
+        "homeassistant.components.casper_glow.coordinator.monotonic_time_coarse",
+        return_value=0.0,
+    ):
+        yield
+
+
+async def _trigger_poll(hass: HomeAssistant) -> None:
+    """Trigger a debounced coordinator poll.
+
+    Each call produces a unique manufacturer_data key so habluetooth's
+    content-based deduplication (manufacturer_data / service_data /
+    service_uuids / name) does not suppress the advertisement.
+    """
+    n = next(_adv_counter)
+    inject_bluetooth_service_info(
+        hass,
+        BluetoothServiceInfoBleak(
+            name="Jar",
+            address="AA:BB:CC:DD:EE:FF",
+            rssi=-60,
+            manufacturer_data={n: b"\x01"},
+            service_uuids=[],
+            service_data={},
+            source="local",
+            device=generate_ble_device(address="AA:BB:CC:DD:EE:FF", name="Jar"),
+            advertisement=generate_advertisement_data(
+                manufacturer_data={n: b"\x01"}, service_uuids=[]
+            ),
+            time=0,
+            connectable=True,
+            tx_power=-127,
+        ),
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=11))
+
+
+async def test_poll_bleak_error_logs_unavailable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a BleakError during polling logs unavailable at info level once."""
+    mock_casper_glow.query_state.side_effect = BleakError("connection failed")
+
+    await _trigger_poll(hass)
+
+    assert "Jar is unavailable" in caplog.text
+    assert caplog.text.count("Jar is unavailable") == 1
+
+    # A second poll failure must not log again
+    caplog.clear()
+    await _trigger_poll(hass)
+
+    assert "Jar is unavailable" not in caplog.text
+
+
+async def test_poll_generic_exception_logs_unavailable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a generic exception during polling logs an unexpected error."""
+    mock_casper_glow.query_state.side_effect = Exception("unexpected")
+
+    await _trigger_poll(hass)
+
+    assert "unexpected error while polling" in caplog.text
+
+
+async def test_poll_recovery_logs_back_online(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that recovery after a failed poll logs back online at info level."""
+    mock_casper_glow.query_state.side_effect = BleakError("gone")
+
+    await _trigger_poll(hass)
+
+    assert "Jar is unavailable" in caplog.text
+    caplog.clear()
+
+    mock_casper_glow.query_state.side_effect = None
+    await _trigger_poll(hass)
+
+    assert "Jar is back online" in caplog.text

--- a/tests/components/casper_glow/test_light.py
+++ b/tests/components/casper_glow/test_light.py
@@ -1,0 +1,249 @@
+"""Test the Casper Glow light platform."""
+
+from unittest.mock import MagicMock, patch
+
+from pycasperglow import CasperGlowError, GlowState
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.casper_glow.const import DEFAULT_DIMMING_TIME_MINUTES
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "light.jar"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test all light entities match the snapshot."""
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.LIGHT]):
+        await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_turn_on(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test turning on the light."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_casper_glow.turn_on.assert_called_once_with()
+
+
+async def test_turn_off(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test turning off the light."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    mock_casper_glow.turn_off.assert_called_once_with()
+
+
+async def test_state_update_via_callback(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test that the entity updates state when the device fires a callback."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    callback = mock_casper_glow.register_callback.call_args[0][0]
+
+    callback(GlowState(is_on=True))
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+
+    callback(GlowState(is_on=False))
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_color_mode(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that the light reports BRIGHTNESS color mode."""
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    # color_mode is None until the device reports its state
+    assert state.attributes.get(ATTR_COLOR_MODE) is None
+    # supported_color_modes is a static class attribute, always present
+    assert ColorMode.BRIGHTNESS in state.attributes["supported_color_modes"]
+
+
+async def test_turn_on_with_brightness(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test turning on the light with brightness."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_BRIGHTNESS: 255},
+        blocking=True,
+    )
+
+    mock_casper_glow.turn_on.assert_called_once_with()
+    mock_casper_glow.set_brightness_and_dimming_time.assert_called_once_with(
+        100, DEFAULT_DIMMING_TIME_MINUTES
+    )
+
+
+@pytest.mark.parametrize(
+    ("ha_brightness", "device_pct"),
+    [
+        (1, 60),
+        (51, 60),
+        (102, 70),
+        (153, 80),
+        (204, 90),
+        (255, 100),
+    ],
+)
+async def test_brightness_snap_to_nearest(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    ha_brightness: int,
+    device_pct: int,
+) -> None:
+    """Test that brightness values map correctly to device percentages."""
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_BRIGHTNESS: ha_brightness},
+        blocking=True,
+    )
+
+    mock_casper_glow.turn_on.assert_called_once_with()
+    mock_casper_glow.set_brightness_and_dimming_time.assert_called_once_with(
+        device_pct, DEFAULT_DIMMING_TIME_MINUTES
+    )
+
+
+async def test_brightness_update_via_callback(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test that brightness updates via device callback."""
+    callback = mock_casper_glow.register_callback.call_args[0][0]
+    callback(GlowState(is_on=True, brightness_level=80))
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 153
+
+
+async def test_turn_on_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test that a turn on error raises HomeAssistantError without marking entity unavailable."""
+    mock_casper_glow.turn_on.side_effect = CasperGlowError("Connection failed")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_turn_off_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test that a turn off error raises HomeAssistantError."""
+    mock_casper_glow.turn_off.side_effect = CasperGlowError("Connection failed")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+
+async def test_state_update_via_callback_after_command_failure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+) -> None:
+    """Test that device callbacks correctly update state even after a command failure."""
+    mock_casper_glow.turn_on.side_effect = CasperGlowError("Connection failed")
+
+    # Fail a command — entity remains in last known state (unknown), not unavailable
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Device sends a push state update — entity reflects true device state
+    callback = mock_casper_glow.register_callback.call_args[0][0]
+    callback(GlowState(is_on=True))
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new integration for [Casper Glow](https://casper.com/products/glow) Bluetooth controllable lights.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43793
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


## Quality Checklist

## Bronze
- [x] `action-setup` - Service actions are registered in [async_setup](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/__init__.py#L42-L45)
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval - [`STATE_POLL_INTERVAL = timedelta(seconds=30)`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/const.py#L27) used in [`coordinator._needs_poll()`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/coordinator.py#L52-L62)
- [x] `brands` - Has branding assets available for the integration - https://github.com/home-assistant/brands/pull/9878
- [x] `common-modules` - Place common patterns in common modules - [entity.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/entity.py), [models.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/models.py), [coordinator.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/coordinator.py), [const.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/const.py)
- [x] `config-flow-test-coverage` - Full test coverage for the config flow - [test_config_flow.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/tests/components/casper_glow/test_config_flow.py)
- [x] `config-flow` - Integration needs to be able to be set up via the UI - [config_flow.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/config_flow.py)
    - [x] Uses `data_description` to give context to fields - [strings.json#L18-L20](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/strings.json#L18-L20)
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly - [__init__.py#L59](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/__init__.py#L59), [models.py](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/models.py)
- [x] `dependency-transparency` - Dependency transparency - [`"requirements": ["pycasperglow==1.1.0"]`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/manifest.json#L18) [pypi](https://pypi.org/project/pycasperglow/) [OSI License](https://github.com/mikeodr/pycasperglow/blob/main/LICENSE) [CI Pipeline](https://github.com/mikeodr/pycasperglow/blob/main/.github/workflows/publish.yml#L38)
- [x] `docs-actions` - The documentation describes the provided service actions that can be used - [services.yaml](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/services.yaml), https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `docs-removal-instructions` - The documentation provides removal instructions - https://github.com/home-assistant/home-assistant.io/pull/43793
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods - callbacks registered via `async_on_remove` in `async_added_to_hass` in [light.py#L60-L65](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/light.py#L60-L65)
- [x] `entity-unique-id` - Entities have a unique ID - [light.py#L57](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/light.py#L57) (MAC address)
- [x] `has-entity-name` - Entities use has_entity_name = True - [`_attr_has_entity_name = True`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/entity.py#L26), light uses [`_attr_name = None`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/light.py#L52)
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data - [`type CasperGlowConfigEntry = ConfigEntry[CasperGlowData]`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/models.py), set at [__init__.py#L59](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/__init__.py#L59)
- [x] `test-before-configure` - Test a connection in the config flow - [`await glow.handshake()`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/config_flow.py#L62-L69), tested in [test_config_flow.py#L114](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/tests/components/casper_glow/test_config_flow.py#L114)
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly - [`ConfigEntryNotReady`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/__init__.py#L53-L55) if BLE device not found, tested in [test_init.py#L43](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/tests/components/casper_glow/test_init.py#L43)
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice - [`_abort_if_unique_id_configured()`](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/homeassistant/components/casper_glow/config_flow.py#L39), tested in [test_config_flow.py#L226](https://github.com/home-assistant/core/blob/21307489b9cbc79ed32151e5e3ad4c962244e951/tests/components/casper_glow/test_config_flow.py#L226)
