### PR TITLE
Log Withings webhook URL warning only once

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -214,6 +214,7 @@ class WithingsWebhookManager:
     """Manager that manages the Withings webhooks."""
 
     _webhooks_registered = False
+    _webhook_url_invalid = False
     _register_lock = asyncio.Lock()
 
     def __init__(self, hass: HomeAssistant, entry: WithingsConfigEntry) -> None:
@@ -260,16 +261,20 @@ class WithingsWebhookManager:
                 )
             url = URL(webhook_url)
             if url.scheme != "https":
-                LOGGER.warning(
-                    "Webhook not registered - HTTPS is required. "
-                    "See https://www.home-assistant.io/integrations/withings/#webhook-requirements"
-                )
+                if not self._webhook_url_invalid:
+                    LOGGER.warning(
+                        "Webhook not registered - HTTPS is required. "
+                        "See https://www.home-assistant.io/integrations/withings/#webhook-requirements"
+                    )
+                    self._webhook_url_invalid = True
                 return
             if url.port != 443:
-                LOGGER.warning(
-                    "Webhook not registered - port 443 is required. "
-                    "See https://www.home-assistant.io/integrations/withings/#webhook-requirements"
-                )
+                if not self._webhook_url_invalid:
+                    LOGGER.warning(
+                        "Webhook not registered - port 443 is required. "
+                        "See https://www.home-assistant.io/integrations/withings/#webhook-requirements"
+                    )
+                    self._webhook_url_invalid = True
                 return
 
             webhook_name = "Withings"

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -386,6 +386,60 @@ async def test_setup_no_webhook(
         mock_async_generate_url.assert_called_once()
 
     assert expected_message in caplog.text
+    assert caplog.text.count(expected_message) == 1
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_message"),
+    [
+        ("http://example.com", "HTTPS is required"),
+        ("https://example.com:444", "port 443 is required"),
+    ],
+)
+async def test_setup_no_webhook_logged_once(
+    hass: HomeAssistant,
+    webhook_config_entry: MockConfigEntry,
+    withings: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+    url: str,
+    expected_message: str,
+) -> None:
+    """Test webhook warning is only logged once on repeated retries."""
+    await mock_cloud(hass)
+    await hass.async_block_till_done()
+
+    with (
+        patch("homeassistant.components.cloud.async_is_logged_in", return_value=True),
+        patch.object(cloud, "async_is_connected", return_value=True),
+        patch.object(cloud, "async_active_subscription", return_value=True),
+        patch(
+            "homeassistant.components.cloud.async_create_cloudhook",
+            return_value=url,
+        ),
+        patch(
+            "homeassistant.components.withings.async_get_config_entry_implementation",
+        ),
+        patch(
+            "homeassistant.components.cloud.async_delete_cloudhook",
+        ),
+        patch("homeassistant.components.withings.webhook_generate_url"),
+    ):
+        await setup_integration(hass, webhook_config_entry)
+        await prepare_webhook_setup(hass, freezer)
+        await hass.async_block_till_done()
+
+        assert caplog.text.count(expected_message) == 1
+
+        # Simulate cloud disconnect then reconnect, triggering register_webhook again
+        async_mock_cloud_connection_status(hass, False)
+        await hass.async_block_till_done()
+
+        async_mock_cloud_connection_status(hass, True)
+        await hass.async_block_till_done()
+
+        # Warning should still only be logged once
+        assert caplog.text.count(expected_message) == 1
 
 
 async def test_cloud_disconnect(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Withings integration logs a warning when the webhook URL doesn't meet requirements (HTTPS on port 443). Currently, this warning is logged on every `register_webhook` call, which can happen repeatedly due to cloud disconnect/reconnect cycles and retry timers.

In my case, running Home Assistant on port 8123 without a cloud subscription, the warning was logging every 5-10 minutes — filling the log with hundreds of identical warnings per day.

This PR adds a `_webhook_url_invalid` flag to `WithingsWebhookManager` so the warning is only logged once per config entry lifecycle. Subsequent calls to `register_webhook` with the same invalid URL silently return without re-logging.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr