### PR TITLE
Improve Roborock device info creation and enhance device registration for disabled or failed devices.

### DIFF
--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -47,6 +47,7 @@ from .coordinator import (
     RoborockWashingMachineUpdateCoordinator,
     RoborockWetDryVacUpdateCoordinator,
 )
+from .models import get_device_info
 from .roborock_storage import CacheStore, async_cleanup_map_storage
 from .services import async_setup_services
 
@@ -130,8 +131,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
     devices = await device_manager.get_devices()
     _LOGGER.debug("Device manager found %d devices", len(devices))
 
+    # Register all discovered devices in the device registry so we can
+    # check the disabled state before creating coordinators.
+    device_registry = dr.async_get(hass)
+    for device in devices:
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            **get_device_info(device),
+        )
+
+    enabled_devices = [
+        device for device in devices if not _is_device_disabled(device_registry, device)
+    ]
+    _LOGGER.debug("%d of %d devices are enabled", len(enabled_devices), len(devices))
+
     coordinators = await asyncio.gather(
-        *build_setup_functions(hass, entry, devices, user_data),
+        *build_setup_functions(hass, entry, enabled_devices, user_data),
         return_exceptions=True,
     )
     v1_coords = [
@@ -149,7 +164,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
         for coord in coordinators
         if isinstance(coord, RoborockB01Q7UpdateCoordinator)
     ]
-    if len(v1_coords) + len(a01_coords) + len(b01_q7_coords) == 0:
+    if len(v1_coords) + len(a01_coords) + len(b01_q7_coords) == 0 and enabled_devices:
         raise ConfigEntryNotReady(
             "No devices were able to successfully setup",
             translation_domain=DOMAIN,
@@ -162,6 +177,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: RoborockConfigEntry) -> 
     _remove_stale_devices(hass, entry, devices)
 
     return True
+
+
+def _is_device_disabled(
+    device_registry: dr.DeviceRegistry,
+    device: RoborockDevice,
+) -> bool:
+    """Check if a device is disabled in the device registry."""
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, device.duid)})
+    return device_entry is not None and device_entry.disabled
 
 
 def _remove_stale_devices(

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -104,7 +104,6 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
         self._device = device
         self.properties_api = properties_api
         self.device_info = get_device_info(device)
-        self.device_info["model_id"] = device.product.model
         if mac := properties_api.network_info.mac:
             self.device_info[ATTR_CONNECTIONS] = {
                 (dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac))

--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -45,7 +45,7 @@ from .const import (
     V1_LOCAL_IN_CLEANING_INTERVAL,
     V1_LOCAL_NOT_CLEANING_INTERVAL,
 )
-from .models import DeviceState
+from .models import DeviceState, get_device_info
 
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -103,14 +103,8 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState]):
         )
         self._device = device
         self.properties_api = properties_api
-        self.device_info = DeviceInfo(
-            name=self._device.device_info.name,
-            identifiers={(DOMAIN, self.duid)},
-            manufacturer="Roborock",
-            model=self._device.product.model,
-            model_id=self._device.product.model,
-            sw_version=self._device.device_info.fv,
-        )
+        self.device_info = get_device_info(device)
+        self.device_info["model_id"] = device.product.model
         if mac := properties_api.network_info.mac:
             self.device_info[ATTR_CONNECTIONS] = {
                 (dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac))
@@ -385,13 +379,7 @@ class RoborockDataUpdateCoordinatorA01(DataUpdateCoordinator[dict[_V, StateType]
             update_interval=A01_UPDATE_INTERVAL,
         )
         self._device = device
-        self.device_info = DeviceInfo(
-            name=device.name,
-            identifiers={(DOMAIN, device.duid)},
-            manufacturer="Roborock",
-            model=device.product.model,
-            sw_version=device.device_info.fv,
-        )
+        self.device_info = get_device_info(device)
         self.request_protocols: list[_V] = []
 
     @cached_property
@@ -517,13 +505,7 @@ class RoborockDataUpdateCoordinatorB01(DataUpdateCoordinator[B01Props]):
             update_interval=A01_UPDATE_INTERVAL,
         )
         self._device = device
-        self.device_info = DeviceInfo(
-            name=device.name,
-            identifiers={(DOMAIN, device.duid)},
-            manufacturer="Roborock",
-            model=device.product.model,
-            sw_version=device.device_info.fv,
-        )
+        self.device_info = get_device_info(device)
 
     @cached_property
     def duid(self) -> str:

--- a/homeassistant/components/roborock/models.py
+++ b/homeassistant/components/roborock/models.py
@@ -31,6 +31,7 @@ def get_device_info(device: RoborockDevice) -> DeviceInfo:
         identifiers={(DOMAIN, device.duid)},
         manufacturer="Roborock",
         model=device.product.model,
+        model_id=device.product.model,
         sw_version=device.device_info.fv,
     )
 

--- a/homeassistant/components/roborock/models.py
+++ b/homeassistant/components/roborock/models.py
@@ -13,10 +13,26 @@ from roborock.data import (
     HomeDataProduct,
     NetworkInfo,
 )
+from roborock.devices.device import RoborockDevice
 from roborock.devices.traits.v1.status import StatusTrait
 from vacuum_map_parser_base.map_data import MapData
 
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
+
+
+def get_device_info(device: RoborockDevice) -> DeviceInfo:
+    """Create a DeviceInfo for a Roborock device."""
+    return DeviceInfo(
+        name=device.name,
+        identifiers={(DOMAIN, device.duid)},
+        manufacturer="Roborock",
+        model=device.product.model,
+        sw_version=device.device_info.fv,
+    )
 
 
 @dataclass

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -23,8 +23,13 @@ from homeassistant.components.roborock.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.setup import async_setup_component
 
 from .conftest import FakeDevice
@@ -515,6 +520,7 @@ async def test_zeo_device_fails_setup(
     hass: HomeAssistant,
     mock_roborock_entry: MockConfigEntry,
     device_registry: DeviceRegistry,
+    entity_registry: EntityRegistry,
     fake_devices: list[FakeDevice],
 ) -> None:
     """Simulate an error while setting up a zeo device."""
@@ -529,11 +535,27 @@ async def test_zeo_device_fails_setup(
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    # The current behavior is that we do not add the Zeo device if it fails to setup
-    found_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    # The Zeo device should be in the registry but have no entities
+    # because its coordinator failed to set up.
+    zeo_device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, zeo_device.duid)}
     )
-    assert {device.name for device in found_devices} == {
+    assert zeo_device_entry is not None
+    zeo_entities = er.async_entries_for_device(
+        entity_registry, zeo_device_entry.id, include_disabled_entities=True
+    )
+    assert len(zeo_entities) == 0
+
+    # Other devices should have entities.
+    all_entities = er.async_entries_for_config_entry(
+        entity_registry, mock_roborock_entry.entry_id
+    )
+    devices_with_entities = {
+        device_registry.async_get(entity.device_id).name
+        for entity in all_entities
+        if entity.device_id is not None
+    }
+    assert devices_with_entities == {
         "Roborock S7 MaxV",
         "Roborock S7 MaxV Dock",
         "Roborock S7 2",
@@ -549,6 +571,7 @@ async def test_dyad_device_fails_setup(
     hass: HomeAssistant,
     mock_roborock_entry: MockConfigEntry,
     device_registry: DeviceRegistry,
+    entity_registry: EntityRegistry,
     fake_devices: list[FakeDevice],
 ) -> None:
     """Simulate an error while setting up a dyad device."""
@@ -565,11 +588,27 @@ async def test_dyad_device_fails_setup(
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
     assert mock_roborock_entry.state is ConfigEntryState.LOADED
 
-    # The current behavior is that we do not add the Dyad device if it fails to setup
-    found_devices = device_registry.devices.get_devices_for_config_entry_id(
-        mock_roborock_entry.entry_id
+    # The Dyad device should be in the registry but have no entities
+    # because its coordinator failed to set up.
+    dyad_device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, dyad_device.duid)}
     )
-    assert {device.name for device in found_devices} == {
+    assert dyad_device_entry is not None
+    dyad_entities = er.async_entries_for_device(
+        entity_registry, dyad_device_entry.id, include_disabled_entities=True
+    )
+    assert len(dyad_entities) == 0
+
+    # Other devices should have entities.
+    all_entities = er.async_entries_for_config_entry(
+        entity_registry, mock_roborock_entry.entry_id
+    )
+    devices_with_entities = {
+        device_registry.async_get(entity.device_id).name
+        for entity in all_entities
+        if entity.device_id is not None
+    }
+    assert devices_with_entities == {
         "Roborock S7 MaxV",
         "Roborock S7 MaxV Dock",
         "Roborock S7 2",
@@ -578,3 +617,95 @@ async def test_dyad_device_fails_setup(
         "Zeo One",
         "Roborock Q7",
     }
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_disabled_device_no_coordinator(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that a disabled device is registered but no coordinator is created."""
+    # Pre-create the first device as disabled so that async_get_or_create
+    # finds it already disabled when async_setup_entry runs.
+    first_device = fake_devices[0]
+    device_registry.async_get_or_create(
+        config_entry_id=mock_roborock_entry.entry_id,
+        identifiers={(DOMAIN, first_device.duid)},
+        name=first_device.device_info.name,
+        manufacturer="Roborock",
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+
+    # The disabled device should still be registered in the device registry
+    disabled_device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, first_device.duid)}
+    )
+    assert disabled_device_entry is not None
+    assert disabled_device_entry.disabled
+
+    # No coordinator should have been created for the disabled device,
+    # so no entities should exist for it.
+    coordinators = mock_roborock_entry.runtime_data
+    assert all(coord.duid != first_device.duid for coord in coordinators.v1)
+
+    # Other devices should still be set up
+    found_devices = device_registry.devices.get_devices_for_config_entry_id(
+        mock_roborock_entry.entry_id
+    )
+    enabled_device_names = {
+        device.name for device in found_devices if not device.disabled
+    }
+    assert "Roborock S7 MaxV" not in enabled_device_names
+    assert "Roborock S7 2" in enabled_device_names
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SENSOR]])
+async def test_all_devices_disabled(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    entity_registry: EntityRegistry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that the integration loads successfully when all devices are disabled."""
+    # Pre-create all devices as disabled
+    for fake_device in fake_devices:
+        device_registry.async_get_or_create(
+            config_entry_id=mock_roborock_entry.entry_id,
+            identifiers={(DOMAIN, fake_device.duid)},
+            name=fake_device.device_info.name,
+            manufacturer="Roborock",
+            disabled_by=dr.DeviceEntryDisabler.USER,
+        )
+
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The integration should still load successfully
+    assert mock_roborock_entry.state is ConfigEntryState.LOADED
+
+    # All coordinator lists should be empty
+    coordinators = mock_roborock_entry.runtime_data
+    assert len(coordinators.v1) == 0
+    assert len(coordinators.a01) == 0
+    assert len(coordinators.b01_q7) == 0
+
+    # No entities should exist since all devices are disabled
+    all_entities = er.async_entries_for_config_entry(
+        entity_registry, mock_roborock_entry.entry_id
+    )
+    assert len(all_entities) == 0
+
+    # All devices should still exist in the registry but be disabled
+    for fake_device in fake_devices:
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN, fake_device.duid)}
+        )
+        assert device_entry is not None
+        assert device_entry.disabled


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Roborock device info creation and enhance device registration for disabled or failed devices. This allows users to disable devices to stop traffic going to the device.

In the future we will support dynamic devices, but for now this is handled on startup only.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes  #164549 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
