### PR TITLE
Refactor Tuya wrappers to use generics

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -47,7 +47,7 @@ class _AlarmChangedByWrapper(DPCodeRawWrapper):
         """Read the device status."""
         if (
             device.status.get(DPCode.MASTER_STATE) != "alarm"
-            or (status := super().read_device_status(device)) is None
+            or (status := self._read_dpcode_value(device)) is None
         ):
             return None
         return status.decode("utf-16be")
@@ -84,7 +84,7 @@ class _AlarmStateWrapper(DPCodeEnumWrapper):
             ):
                 return AlarmControlPanelState.TRIGGERED
 
-        if (status := super().read_device_status(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return self._STATE_MAPPINGS.get(status)
 

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -139,10 +139,10 @@ async def async_setup_entry(
                         action_wrapper=_AlarmActionWrapper(
                             master_mode.dpcode, master_mode
                         ),
-                        changed_by_wrapper=_AlarmChangedByWrapper.find_dpcode(  # type: ignore[arg-type]
+                        changed_by_wrapper=_AlarmChangedByWrapper.find_dpcode(
                             device, DPCode.ALARM_MSG
                         ),
-                        state_wrapper=_AlarmStateWrapper(  # type: ignore[arg-type]
+                        state_wrapper=_AlarmStateWrapper(
                             master_mode.dpcode, master_mode
                         ),
                     )

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -43,7 +43,7 @@ class _AlarmChangedByWrapper(DPCodeRawWrapper):
     Decode base64 to utf-16be string, but only if alarm has been triggered.
     """
 
-    def read_device_status(self, device: CustomerDevice) -> str | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> str | None:
         """Read the device status."""
         if (
             device.status.get(DPCode.MASTER_STATE) != "alarm"

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -37,7 +37,7 @@ ALARM: dict[DeviceCategory, tuple[AlarmControlPanelEntityDescription, ...]] = {
 }
 
 
-class _AlarmChangedByWrapper(DPCodeRawWrapper):
+class _AlarmChangedByWrapper(DPCodeRawWrapper[str]):
     """Wrapper for changed_by.
 
     Decode base64 to utf-16be string, but only if alarm has been triggered.
@@ -53,7 +53,7 @@ class _AlarmChangedByWrapper(DPCodeRawWrapper):
         return status.decode("utf-16be")
 
 
-class _AlarmStateWrapper(DPCodeEnumWrapper):
+class _AlarmStateWrapper(DPCodeEnumWrapper[AlarmControlPanelState]):
     """Wrapper for the alarm state of a device.
 
     Handles alarm mode enum values and determines the alarm state,

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -376,7 +376,7 @@ BINARY_SENSORS: dict[DeviceCategory, tuple[TuyaBinarySensorEntityDescription, ..
 }
 
 
-class _CustomDPCodeWrapper(DPCodeWrapper):
+class _CustomDPCodeWrapper(DPCodeWrapper[bool]):
     """Custom DPCode Wrapper to check for values in a set."""
 
     _valid_values: set[bool | float | int | str]

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -358,7 +358,7 @@ async def async_setup_entry(
                         device,
                         manager,
                         CLIMATE_DESCRIPTIONS[device.category],
-                        current_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(  # type: ignore[arg-type]
+                        current_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(
                             device, DPCode.HUMIDITY_CURRENT
                         ),
                         current_temperature_wrapper=temperature_wrappers[0],
@@ -367,7 +367,7 @@ async def async_setup_entry(
                             (DPCode.FAN_SPEED_ENUM, DPCode.LEVEL, DPCode.WINDSPEED),
                             prefer_function=True,
                         ),
-                        hvac_mode_wrapper=_HvacModeWrapper.find_dpcode(  # type: ignore[arg-type]
+                        hvac_mode_wrapper=_HvacModeWrapper.find_dpcode(
                             device, DPCode.MODE, prefer_function=True
                         ),
                         preset_wrapper=_PresetWrapper.find_dpcode(
@@ -378,7 +378,7 @@ async def async_setup_entry(
                         switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device, DPCode.SWITCH, prefer_function=True
                         ),
-                        target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(  # type: ignore[arg-type]
+                        target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(
                             device, DPCode.HUMIDITY_SET, prefer_function=True
                         ),
                         temperature_unit=temperature_wrappers[2],

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -54,7 +54,7 @@ TUYA_HVAC_TO_HA = {
 }
 
 
-class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
+class _RoundedIntegerWrapper(DPCodeIntegerWrapper[int]):
     """An integer that always rounds its value."""
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
@@ -65,7 +65,7 @@ class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
 
 
 @dataclass(kw_only=True)
-class _SwingModeWrapper(DeviceWrapper):
+class _SwingModeWrapper(DeviceWrapper[str]):
     """Wrapper for managing climate swing mode operations across multiple DPCodes."""
 
     on_off: DPCodeBooleanWrapper | None = None
@@ -158,7 +158,7 @@ def _filter_hvac_mode_mappings(tuya_range: list[str]) -> dict[str, HVACMode | No
     return modes_in_range
 
 
-class _HvacModeWrapper(DPCodeEnumWrapper):
+class _HvacModeWrapper(DPCodeEnumWrapper[HVACMode]):
     """Wrapper for managing climate HVACMode."""
 
     # Modes that do not map to HVAC modes are ignored (they are handled by PresetWrapper)

--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -59,7 +59,7 @@ class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Read and round the device status."""
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return round(value)
 
@@ -173,7 +173,7 @@ class _HvacModeWrapper(DPCodeEnumWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> HVACMode | None:
         """Read the device status."""
-        if (raw := super().read_device_status(device)) not in TUYA_HVAC_TO_HA:
+        if (raw := self._read_dpcode_value(device)) not in TUYA_HVAC_TO_HA:
             return None
         return TUYA_HVAC_TO_HA[raw]
 
@@ -205,7 +205,7 @@ class _PresetWrapper(DPCodeEnumWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> str | None:
         """Read the device status."""
-        if (raw := super().read_device_status(device)) in TUYA_HVAC_TO_HA:
+        if (raw := self._read_dpcode_value(device)) in TUYA_HVAC_TO_HA:
             return None
         return raw
 

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -291,19 +291,19 @@ async def async_setup_entry(
                         device,
                         manager,
                         description,
-                        current_position=description.position_wrapper.find_dpcode(  # type: ignore[arg-type]
+                        current_position=description.position_wrapper.find_dpcode(
                             device, description.current_position
                         ),
-                        current_state_wrapper=description.current_state_wrapper.find_dpcode(  # type: ignore[arg-type]
+                        current_state_wrapper=description.current_state_wrapper.find_dpcode(
                             device, description.current_state
                         ),
                         instruction_wrapper=_get_instruction_wrapper(
                             device, description
                         ),
-                        set_position=description.position_wrapper.find_dpcode(  # type: ignore[arg-type]
+                        set_position=description.position_wrapper.find_dpcode(
                             device, description.set_position, prefer_function=True
                         ),
-                        tilt_position=description.position_wrapper.find_dpcode(  # type: ignore[arg-type]
+                        tilt_position=description.position_wrapper.find_dpcode(
                             device,
                             (DPCode.ANGLE_HORIZONTAL, DPCode.ANGLE_VERTICAL),
                             prefer_function=True,

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -133,7 +133,7 @@ class _IsClosedEnumWrapper(DPCodeEnumWrapper):
         "fully_open": False,
     }
 
-    def read_device_status(self, device: CustomerDevice) -> bool | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> bool | None:
         if (value := self._read_dpcode_value(device)) is None:
             return None
         return self._MAPPINGS.get(value)

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -35,7 +35,7 @@ from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 
 
-class _DPCodePercentageMappingWrapper(DPCodeIntegerWrapper):
+class _DPCodePercentageMappingWrapper(DPCodeIntegerWrapper[int]):
     """Wrapper for DPCode position values mapping to 0-100 range."""
 
     def __init__(self, dpcode: str, type_information: IntegerTypeInformation) -> None:
@@ -47,7 +47,7 @@ class _DPCodePercentageMappingWrapper(DPCodeIntegerWrapper):
         """Check if the position and direction should be reversed."""
         return False
 
-    def read_device_status(self, device: CustomerDevice) -> float | None:
+    def read_device_status(self, device: CustomerDevice) -> int | None:
         if (value := device.status.get(self.dpcode)) is None:
             return None
 
@@ -123,7 +123,7 @@ class _IsClosedInvertedWrapper(DPCodeBooleanWrapper):
         return not value
 
 
-class _IsClosedEnumWrapper(DPCodeEnumWrapper):
+class _IsClosedEnumWrapper(DPCodeEnumWrapper[bool]):
     """Enum wrapper for checking if state is closed."""
 
     _MAPPINGS = {

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -118,7 +118,7 @@ class _IsClosedInvertedWrapper(DPCodeBooleanWrapper):
     """Boolean wrapper for checking if cover is closed (inverted)."""
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return not value
 
@@ -134,7 +134,7 @@ class _IsClosedEnumWrapper(DPCodeEnumWrapper):
     }
 
     def read_device_status(self, device: CustomerDevice) -> bool | None:  # type: ignore[override]
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return self._MAPPINGS.get(value)
 

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -36,7 +36,7 @@ class _EventEnumWrapper(DPCodeEnumWrapper):
         self, device: CustomerDevice
     ) -> tuple[str, None] | None:
         """Return the event details."""
-        if (raw_value := super().read_device_status(device)) is None:
+        if (raw_value := self._read_dpcode_value(device)) is None:
             return None
         return (raw_value, None)
 
@@ -53,7 +53,7 @@ class _AlarmMessageWrapper(DPCodeStringWrapper):
         self, device: CustomerDevice
     ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the alarm message."""
-        if (raw_value := super().read_device_status(device)) is None:
+        if (raw_value := self._read_dpcode_value(device)) is None:
             return None
         return ("triggered", {"message": b64decode(raw_value).decode("utf-8")})
 
@@ -73,7 +73,7 @@ class _DoorbellPicWrapper(DPCodeRawWrapper):
         self, device: CustomerDevice
     ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the doorbell picture."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return ("triggered", {"message": status.decode("utf-8")})
 

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -47,7 +47,7 @@ class _AlarmMessageWrapper(DPCodeStringWrapper[tuple[str, dict[str, Any]]]):
         super().__init__(dpcode, type_information)
         self.options = ["triggered"]
 
-    def read_device_status(  # type: ignore[override]
+    def read_device_status(
         self, device: CustomerDevice
     ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the alarm message."""

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -32,9 +32,7 @@ from .entity import TuyaEntity
 class _EventEnumWrapper(DPCodeEnumWrapper):
     """Wrapper for event enum DP codes."""
 
-    def read_device_status(  # type: ignore[override]
-        self, device: CustomerDevice
-    ) -> tuple[str, None] | None:
+    def read_device_status(self, device: CustomerDevice) -> tuple[str, None] | None:
         """Return the event details."""
         if (raw_value := self._read_dpcode_value(device)) is None:
             return None
@@ -69,7 +67,7 @@ class _DoorbellPicWrapper(DPCodeRawWrapper):
         super().__init__(dpcode, type_information)
         self.options = ["triggered"]
 
-    def read_device_status(  # type: ignore[override]
+    def read_device_status(
         self, device: CustomerDevice
     ) -> tuple[str, dict[str, Any]] | None:
         """Return the event attributes for the doorbell picture."""

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -29,7 +29,7 @@ from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 
 
-class _EventEnumWrapper(DPCodeEnumWrapper):
+class _EventEnumWrapper(DPCodeEnumWrapper[tuple[str, None]]):
     """Wrapper for event enum DP codes."""
 
     def read_device_status(self, device: CustomerDevice) -> tuple[str, None] | None:
@@ -39,7 +39,7 @@ class _EventEnumWrapper(DPCodeEnumWrapper):
         return (raw_value, None)
 
 
-class _AlarmMessageWrapper(DPCodeStringWrapper):
+class _AlarmMessageWrapper(DPCodeStringWrapper[tuple[str, dict[str, Any]]]):
     """Wrapper for a STRING message on DPCode.ALARM_MESSAGE."""
 
     def __init__(self, dpcode: str, type_information: Any) -> None:
@@ -56,7 +56,7 @@ class _AlarmMessageWrapper(DPCodeStringWrapper):
         return ("triggered", {"message": b64decode(raw_value).decode("utf-8")})
 
 
-class _DoorbellPicWrapper(DPCodeRawWrapper):
+class _DoorbellPicWrapper(DPCodeRawWrapper[tuple[str, dict[str, Any]]]):
     """Wrapper for a RAW message on DPCode.DOORBELL_PIC.
 
     It is expected that the RAW data is base64/utf8 encoded URL of the picture.

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -83,7 +83,7 @@ def _has_a_valid_dpcode(device: CustomerDevice) -> bool:
 class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
     """Wrapper for fan speed DP code (from an enum)."""
 
-    def read_device_status(self, device: CustomerDevice) -> int | None:  # type: ignore[override]
+    def read_device_status(self, device: CustomerDevice) -> int | None:
         """Get the current speed as a percentage."""
         if (value := self._read_dpcode_value(device)) is None:
             return None

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -80,7 +80,7 @@ def _has_a_valid_dpcode(device: CustomerDevice) -> bool:
     return any(get_dpcode(device, code) for code in properties_to_check)
 
 
-class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
+class _FanSpeedEnumWrapper(DPCodeEnumWrapper[int]):
     """Wrapper for fan speed DP code (from an enum)."""
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
@@ -94,7 +94,7 @@ class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
         return percentage_to_ordered_list_item(self.options, value)
 
 
-class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper):
+class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper[int]):
     """Wrapper for fan speed DP code (from an integer)."""
 
     def __init__(self, dpcode: str, type_information: IntegerTypeInformation) -> None:

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -59,7 +59,7 @@ class _DirectionEnumWrapper(DPCodeEnumWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> str | None:
         """Read the device status and return the direction string."""
-        if (value := super().read_device_status(device)) and value in {
+        if (value := self._read_dpcode_value(device)) and value in {
             DIRECTION_FORWARD,
             DIRECTION_REVERSE,
         }:
@@ -85,7 +85,7 @@ class _FanSpeedEnumWrapper(DPCodeEnumWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:  # type: ignore[override]
         """Get the current speed as a percentage."""
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return ordered_list_item_to_percentage(self.options, value)
 
@@ -104,7 +104,7 @@ class _FanSpeedIntegerWrapper(DPCodeIntegerWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Get the current speed as a percentage."""
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return round(self._remap_helper.remap_value_to(value))
 

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -154,7 +154,7 @@ async def async_setup_entry(
                         oscillate_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device, _OSCILLATE_DPCODES, prefer_function=True
                         ),
-                        speed_wrapper=_get_speed_wrapper(device),  # type: ignore[arg-type]
+                        speed_wrapper=_get_speed_wrapper(device),
                         switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
                             device, _SWITCH_DPCODES, prefer_function=True
                         ),

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -34,7 +34,7 @@ class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
 
     def read_device_status(self, device: CustomerDevice) -> int | None:
         """Read and round the device status."""
-        if (value := super().read_device_status(device)) is None:
+        if (value := self._read_dpcode_value(device)) is None:
             return None
         return round(value)
 

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -29,7 +29,7 @@ from .entity import TuyaEntity
 from .util import ActionDPCodeNotFoundError, get_dpcode
 
 
-class _RoundedIntegerWrapper(DPCodeIntegerWrapper):
+class _RoundedIntegerWrapper(DPCodeIntegerWrapper[int]):
     """An integer that always rounds its value."""
 
     def read_device_status(self, device: CustomerDevice) -> int | None:

--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -104,7 +104,7 @@ async def async_setup_entry(
                         device,
                         manager,
                         description,
-                        current_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(  # type: ignore[arg-type]
+                        current_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(
                             device, description.current_humidity
                         ),
                         mode_wrapper=DPCodeEnumWrapper.find_dpcode(
@@ -115,7 +115,7 @@ async def async_setup_entry(
                             description.dpcode or description.key,
                             prefer_function=True,
                         ),
-                        target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(  # type: ignore[arg-type]
+                        target_humidity_wrapper=_RoundedIntegerWrapper.find_dpcode(
                             device, description.humidity, prefer_function=True
                         ),
                     )

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -59,7 +59,7 @@ class _BrightnessWrapper(DPCodeIntegerWrapper):
         super().__init__(dpcode, type_information)
         self._remap_helper = RemapHelper.from_type_information(type_information, 0, 255)
 
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
+    def read_device_status(self, device: CustomerDevice) -> int | None:
         """Return the brightness of this light between 0..255."""
         if (brightness := device.status.get(self.dpcode)) is None:
             return None
@@ -133,7 +133,7 @@ class _ColorTempWrapper(DPCodeIntegerWrapper):
             type_information, MIN_MIREDS, MAX_MIREDS
         )
 
-    def read_device_status(self, device: CustomerDevice) -> Any | None:
+    def read_device_status(self, device: CustomerDevice) -> int | None:
         """Return the color temperature value in Kelvin."""
         if (temperature := device.status.get(self.dpcode)) is None:
             return None

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -633,17 +633,17 @@ async def async_setup_entry(
                         manager,
                         description,
                         brightness_wrapper=(
-                            brightness_wrapper := _get_brightness_wrapper(  # type: ignore[arg-type]
+                            brightness_wrapper := _get_brightness_wrapper(
                                 device, description
                             )
                         ),
-                        color_data_wrapper=_get_color_data_wrapper(  # type: ignore[arg-type]
+                        color_data_wrapper=_get_color_data_wrapper(
                             device, description, brightness_wrapper
                         ),
                         color_mode_wrapper=DPCodeEnumWrapper.find_dpcode(
                             device, description.color_mode, prefer_function=True
                         ),
-                        color_temp_wrapper=_ColorTempWrapper.find_dpcode(  # type: ignore[arg-type]
+                        color_temp_wrapper=_ColorTempWrapper.find_dpcode(
                             device, description.color_temp, prefer_function=True
                         ),
                         switch_wrapper=switch_wrapper,

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -178,7 +178,7 @@ class _ColorDataWrapper(DPCodeJsonWrapper):
         self, device: CustomerDevice
     ) -> tuple[float, float, float] | None:
         """Return a tuple (H, S, V) from this color data."""
-        if (status := super().read_device_status(device)) is None:
+        if (status := self._read_dpcode_value(device)) is None:
             return None
         return (
             self.h_type.remap_value_to(status["h"]),

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -41,7 +41,7 @@ from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode, WorkMode
 from .entity import TuyaEntity
 
 
-class _BrightnessWrapper(DPCodeIntegerWrapper):
+class _BrightnessWrapper(DPCodeIntegerWrapper[int]):
     """Wrapper for brightness DP code.
 
     Handles brightness value conversion between device scale and Home Assistant's
@@ -123,7 +123,7 @@ class _BrightnessWrapper(DPCodeIntegerWrapper):
         return round(self._remap_helper.remap_value_from(value))
 
 
-class _ColorTempWrapper(DPCodeIntegerWrapper):
+class _ColorTempWrapper(DPCodeIntegerWrapper[int]):
     """Wrapper for color temperature DP code."""
 
     def __init__(self, dpcode: str, type_information: IntegerTypeInformation) -> None:
@@ -167,7 +167,7 @@ DEFAULT_V_TYPE_V2 = RemapHelper(
 )
 
 
-class _ColorDataWrapper(DPCodeJsonWrapper):
+class _ColorDataWrapper(DPCodeJsonWrapper[tuple[float, float, float]]):
     """Wrapper for color data DP code."""
 
     h_type = DEFAULT_H_TYPE

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -174,7 +174,7 @@ class _ColorDataWrapper(DPCodeJsonWrapper):
     s_type = DEFAULT_S_TYPE
     v_type = DEFAULT_V_TYPE
 
-    def read_device_status(  # type: ignore[override]
+    def read_device_status(
         self, device: CustomerDevice
     ) -> tuple[float, float, float] | None:
         """Return a tuple (H, S, V) from this color data."""

--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -25,7 +25,7 @@ from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 
 
-class _VacuumActivityWrapper(DeviceWrapper):
+class _VacuumActivityWrapper(DeviceWrapper[VacuumActivity]):
     """Wrapper for the state of a device."""
 
     _TUYA_STATUS_TO_HA = {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor Tuya wrappers to use generics

As follow-up to https://github.com/home-assistant-libs/tuya-device-handlers/pull/19 and #164586
- replace `super().read_device_status` with `self._read_dpcode_value`
- set generic type on the subclasses

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
