### PR TITLE
Add coordinator to Anthropic for availability check

### DIFF
--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-import anthropic
-
-from homeassistant.config_entries import ConfigEntry, ConfigSubentry
+from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_registry as er,
     issue_registry as ir,
 )
-from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -24,11 +20,10 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
+from .coordinator import AnthropicConfigEntry, AnthropicCoordinator
 
 PLATFORMS = (Platform.AI_TASK, Platform.CONVERSATION)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-type AnthropicConfigEntry = ConfigEntry[anthropic.AsyncClient]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -39,29 +34,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: AnthropicConfigEntry) -> bool:
     """Set up Anthropic from a config entry."""
-    client = anthropic.AsyncAnthropic(
-        api_key=entry.data[CONF_API_KEY], http_client=get_async_client(hass)
-    )
-    try:
-        await client.models.list(timeout=10.0)
-    except anthropic.AuthenticationError as err:
-        raise ConfigEntryAuthFailed(
-            translation_domain=DOMAIN,
-            translation_key="api_authentication_error",
-            translation_placeholders={"message": err.message},
-        ) from err
-    except anthropic.AnthropicError as err:
-        raise ConfigEntryNotReady(
-            translation_domain=DOMAIN,
-            translation_key="api_error",
-            translation_placeholders={
-                "message": err.message
-                if isinstance(err, anthropic.APIError)
-                else str(err)
-            },
-        ) from err
-
-    entry.runtime_data = client
+    coordinator = AnthropicCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -55,49 +55,15 @@ class AnthropicCoordinator(DataUpdateCoordinator[None]):
     def async_set_updated_data(self, data: None) -> None:
         """Manually update data, notify listeners and update refresh interval."""
         self.update_interval = UPDATE_INTERVAL_CONNECTED
-        super().async_set_updated_data(None)
-
-    @callback
-    def async_set_update_error(self, err: Exception) -> None:
-        """Manually set an error and reschedule next update."""
-        err = self._map_exception(err)
-        super().async_set_update_error(err)
-        self.update_interval = UPDATE_INTERVAL_DISCONNECTED
-
-        if isinstance(err, UpdateFailed) and err.retry_after is not None:
-            self._retry_after = err.retry_after
-            self.logger.debug(
-                "Retry after triggered. Scheduling next update in %s second(s)",
-                err.retry_after,
-            )
-
-        if isinstance(err, ConfigEntryAuthFailed):
-            self.logger.debug("Authentication failed, reauthentication required")
-            self._async_unsub_refresh()
-            self._debounced_refresh.async_cancel()
-            if self.config_entry is not None:
-                self.config_entry.async_start_reauth(self.hass)
-        elif self._listeners and not self.hass.is_stopping:
-            self._schedule_refresh()
-
-    def _map_exception(self, err: Exception) -> Exception:
-        """Map Anthropic API exceptions to Home Assistant exceptions."""
-        message = getattr(err, "message", None) or str(err)
-        exc = err
-        if isinstance(err, anthropic.APITimeoutError):
-            exc = TimeoutError(message)
-        elif isinstance(err, anthropic.AuthenticationError):
-            exc = ConfigEntryAuthFailed(message)
-        elif isinstance(err, anthropic.APIError):
-            exc = UpdateFailed(message)
-        if exc is not err:
-            exc.__cause__ = err
-            exc.__suppress_context__ = True
-        return exc
+        super().async_set_updated_data(data)
 
     async def async_update_data(self) -> None:
         """Fetch data from the API."""
         try:
             await self.client.models.list(timeout=10.0)
-        except anthropic.AnthropicError as err:
-            raise self._map_exception(err)  # noqa: B904
+        except anthropic.APITimeoutError as err:
+            raise TimeoutError(err.message or str(err)) from err
+        except anthropic.AuthenticationError as err:
+            raise ConfigEntryAuthFailed(err.message or str(err)) from err
+        except anthropic.APIError as err:
+            raise UpdateFailed(err.message or str(err)) from err

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any, TypeVar
 
 import anthropic
 
@@ -19,47 +18,51 @@ from .const import LOGGER
 UPDATE_INTERVAL_CONNECTED = timedelta(hours=12)
 UPDATE_INTERVAL_DISCONNECTED = timedelta(minutes=1)
 
-_DataT = TypeVar("_DataT", default=dict[str, Any])
-
 type AnthropicConfigEntry = ConfigEntry[AnthropicCoordinator]
 
 
-class DynamicIntervalDataUpdateCoordinator(DataUpdateCoordinator[_DataT]):
+class AnthropicCoordinator(DataUpdateCoordinator[None]):
     """DataUpdateCoordinator which uses different intervals after successful and unsuccessful updates."""
 
-    def __init__(
-        self,
-        *args: Any,
-        update_interval_successful: timedelta,
-        update_interval_unsuccessful: timedelta,
-        **kwargs: Any,
-    ) -> None:
+    client: anthropic.AsyncAnthropic
+
+    def __init__(self, hass: HomeAssistant, config_entry: AnthropicConfigEntry) -> None:
         """Initialize the coordinator."""
-        super().__init__(*args, **kwargs, update_interval=update_interval_successful)
-        self._update_interval_successful = update_interval_successful
-        self._update_interval_unsuccessful = update_interval_unsuccessful
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=config_entry.title,
+            update_interval=UPDATE_INTERVAL_CONNECTED,
+            update_method=self.async_update_data,
+            always_update=False,
+        )
+        self.client = anthropic.AsyncAnthropic(
+            api_key=config_entry.data[CONF_API_KEY], http_client=get_async_client(hass)
+        )
 
     @callback
     def _schedule_refresh(self) -> None:
         """Schedule the next refresh based on the current update interval."""
         self.update_interval = (
-            self._update_interval_successful
+            UPDATE_INTERVAL_CONNECTED
             if self.last_update_success
-            else self._update_interval_unsuccessful
+            else UPDATE_INTERVAL_DISCONNECTED
         )
         super()._schedule_refresh()
 
     @callback
-    def async_set_updated_data(self, data: _DataT) -> None:
+    def async_set_updated_data(self, data: None) -> None:
         """Manually update data, notify listeners and update refresh interval."""
-        self.update_interval = self._update_interval_successful
-        super().async_set_updated_data(data)
+        self.update_interval = UPDATE_INTERVAL_CONNECTED
+        super().async_set_updated_data(None)
 
     @callback
     def async_set_update_error(self, err: Exception) -> None:
         """Manually set an error and reschedule next update."""
+        err = self._map_exception(err)
         super().async_set_update_error(err)
-        self.update_interval = self._update_interval_unsuccessful
+        self.update_interval = UPDATE_INTERVAL_DISCONNECTED
 
         if isinstance(err, UpdateFailed) and err.retry_after is not None:
             self._retry_after = err.retry_after
@@ -76,28 +79,6 @@ class DynamicIntervalDataUpdateCoordinator(DataUpdateCoordinator[_DataT]):
                 self.config_entry.async_start_reauth(self.hass)
         elif self._listeners and not self.hass.is_stopping:
             self._schedule_refresh()
-
-
-class AnthropicCoordinator(DynamicIntervalDataUpdateCoordinator[None]):
-    """Coordinator for fetching and updating the list of available Anthropic models."""
-
-    client: anthropic.AsyncAnthropic
-
-    def __init__(self, hass: HomeAssistant, config_entry: AnthropicConfigEntry) -> None:
-        """Initialize the coordinator."""
-        super().__init__(
-            hass,
-            LOGGER,
-            config_entry=config_entry,
-            name=config_entry.title,
-            update_interval_successful=UPDATE_INTERVAL_CONNECTED,
-            update_interval_unsuccessful=UPDATE_INTERVAL_DISCONNECTED,
-            update_method=self.async_update_data,
-            always_update=False,
-        )
-        self.client = anthropic.AsyncAnthropic(
-            api_key=config_entry.data[CONF_API_KEY], http_client=get_async_client(hass)
-        )
 
     def _map_exception(self, err: Exception) -> Exception:
         """Map Anthropic API exceptions to Home Assistant exceptions."""
@@ -120,8 +101,3 @@ class AnthropicCoordinator(DynamicIntervalDataUpdateCoordinator[None]):
             await self.client.models.list(timeout=10.0)
         except anthropic.AnthropicError as err:
             raise self._map_exception(err)  # noqa: B904
-
-    @callback
-    def async_set_update_error(self, err: Exception) -> None:
-        """Manually set an error."""
-        super().async_set_update_error(self._map_exception(err))

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -67,3 +67,12 @@ class AnthropicCoordinator(DataUpdateCoordinator[None]):
             raise ConfigEntryAuthFailed(err.message or str(err)) from err
         except anthropic.APIError as err:
             raise UpdateFailed(err.message or str(err)) from err
+
+    def mark_connection_error(self) -> None:
+        """Mark the connection as having an error and reschedule background check."""
+        self.update_interval = UPDATE_INTERVAL_DISCONNECTED
+        if self.last_update_success:
+            self.last_update_success = False
+            self.async_update_listeners()
+            if self._listeners and not self.hass.is_stopping:
+                self._schedule_refresh()

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -42,16 +42,6 @@ class AnthropicCoordinator(DataUpdateCoordinator[None]):
         )
 
     @callback
-    def _schedule_refresh(self) -> None:
-        """Schedule the next refresh based on the current update interval."""
-        self.update_interval = (
-            UPDATE_INTERVAL_CONNECTED
-            if self.last_update_success
-            else UPDATE_INTERVAL_DISCONNECTED
-        )
-        super()._schedule_refresh()
-
-    @callback
     def async_set_updated_data(self, data: None) -> None:
         """Manually update data, notify listeners and update refresh interval."""
         self.update_interval = UPDATE_INTERVAL_CONNECTED
@@ -60,7 +50,9 @@ class AnthropicCoordinator(DataUpdateCoordinator[None]):
     async def async_update_data(self) -> None:
         """Fetch data from the API."""
         try:
+            self.update_interval = UPDATE_INTERVAL_DISCONNECTED
             await self.client.models.list(timeout=10.0)
+            self.update_interval = UPDATE_INTERVAL_CONNECTED
         except anthropic.APITimeoutError as err:
             raise TimeoutError(err.message or str(err)) from err
         except anthropic.AuthenticationError as err:

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -78,9 +78,7 @@ class DynamicIntervalDataUpdateCoordinator(DataUpdateCoordinator[_DataT]):
             self._schedule_refresh()
 
 
-class AnthropicCoordinator(
-    DynamicIntervalDataUpdateCoordinator[list[anthropic.types.ModelInfo]]
-):
+class AnthropicCoordinator(DynamicIntervalDataUpdateCoordinator[None]):
     """Coordinator for fetching and updating the list of available Anthropic models."""
 
     client: anthropic.AsyncAnthropic
@@ -116,10 +114,10 @@ class AnthropicCoordinator(
             exc.__suppress_context__ = True
         return exc
 
-    async def async_update_data(self) -> list[anthropic.types.ModelInfo]:
+    async def async_update_data(self) -> None:
         """Fetch data from the API."""
         try:
-            return (await self.client.models.list(timeout=10.0)).data
+            await self.client.models.list(timeout=10.0)
         except anthropic.AnthropicError as err:
             raise self._map_exception(err)  # noqa: B904
 

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -119,26 +119,11 @@ class AnthropicCoordinator(
     async def async_update_data(self) -> list[anthropic.types.ModelInfo]:
         """Fetch data from the API."""
         try:
-            data = (await self.client.models.list(timeout=10.0)).data
-            if not self.last_update_success:
-                self.logger.info("Claude API is available")
+            return (await self.client.models.list(timeout=10.0)).data
         except anthropic.AnthropicError as err:
-            if self.last_update_success:
-                self.logger.info("Claude API is unavailable")
             raise self._map_exception(err)  # noqa: B904
-
-        return data
-
-    @callback
-    def async_set_updated_data(self, data: list[anthropic.types.ModelInfo]) -> None:
-        """Manually update data, log if needed."""
-        if not self.last_update_success:
-            self.logger.info("Claude API is available")
-        super().async_set_updated_data(data)
 
     @callback
     def async_set_update_error(self, err: Exception) -> None:
         """Manually set an error."""
-        if self.last_update_success:
-            self.logger.info("Claude API is unavailable")
         super().async_set_update_error(self._map_exception(err))

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, TypeVar
 
 import anthropic
 
@@ -12,16 +12,14 @@ from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
-    UpdateFailed,
-    _DataT,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import LOGGER
 
 UPDATE_INTERVAL_CONNECTED = timedelta(hours=12)
 UPDATE_INTERVAL_DISCONNECTED = timedelta(minutes=1)
+
+_DataT = TypeVar("_DataT", default=dict[str, Any])
 
 type AnthropicConfigEntry = ConfigEntry[AnthropicCoordinator]
 

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -107,7 +107,7 @@ class AnthropicCoordinator(
         exc = err
         if isinstance(err, anthropic.APITimeoutError):
             exc = TimeoutError(message)
-        if isinstance(err, anthropic.AuthenticationError):
+        elif isinstance(err, anthropic.AuthenticationError):
             exc = ConfigEntryAuthFailed(message)
         elif isinstance(err, anthropic.APIError):
             exc = UpdateFailed(message)

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -105,13 +105,14 @@ class AnthropicCoordinator(
 
     def _map_exception(self, err: Exception) -> Exception:
         """Map Anthropic API exceptions to Home Assistant exceptions."""
+        message = getattr(err, "message", None) or str(err)
         exc = err
         if isinstance(err, anthropic.APITimeoutError):
-            exc = TimeoutError(err.message)
+            exc = TimeoutError(message)
         if isinstance(err, anthropic.AuthenticationError):
-            exc = ConfigEntryAuthFailed(err.message)
+            exc = ConfigEntryAuthFailed(message)
         elif isinstance(err, anthropic.APIError):
-            exc = UpdateFailed(err.message)
+            exc = UpdateFailed(message)
         if exc is not err:
             exc.__cause__ = err
             exc.__suppress_context__ = True
@@ -120,7 +121,7 @@ class AnthropicCoordinator(
     async def async_update_data(self) -> list[anthropic.types.ModelInfo]:
         """Fetch data from the API."""
         try:
-            data = (await self.client.models.list()).data
+            data = (await self.client.models.list(timeout=10.0)).data
             if not self.last_update_success:
                 self.logger.info("Claude API is available")
         except anthropic.AnthropicError as err:

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -1,0 +1,145 @@
+"""Coordinator for the Anthropic integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import anthropic
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    UpdateFailed,
+    _DataT,
+)
+
+from .const import LOGGER
+
+UPDATE_INTERVAL_CONNECTED = timedelta(hours=12)
+UPDATE_INTERVAL_DISCONNECTED = timedelta(minutes=1)
+
+type AnthropicConfigEntry = ConfigEntry[AnthropicCoordinator]
+
+
+class DynamicIntervalDataUpdateCoordinator(DataUpdateCoordinator[_DataT]):
+    """DataUpdateCoordinator which uses different intervals after successful and unsuccessful updates."""
+
+    def __init__(
+        self,
+        *args: Any,
+        update_interval_successful: timedelta,
+        update_interval_unsuccessful: timedelta,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(*args, **kwargs, update_interval=update_interval_successful)
+        self._update_interval_successful = update_interval_successful
+        self._update_interval_unsuccessful = update_interval_unsuccessful
+
+    @callback
+    def _schedule_refresh(self) -> None:
+        """Schedule the next refresh based on the current update interval."""
+        self.update_interval = (
+            self._update_interval_successful
+            if self.last_update_success
+            else self._update_interval_unsuccessful
+        )
+        super()._schedule_refresh()
+
+    @callback
+    def async_set_updated_data(self, data: _DataT) -> None:
+        """Manually update data, notify listeners and update refresh interval."""
+        self.update_interval = self._update_interval_successful
+        super().async_set_updated_data(data)
+
+    @callback
+    def async_set_update_error(self, err: Exception) -> None:
+        """Manually set an error and reschedule next update."""
+        super().async_set_update_error(err)
+        self.update_interval = self._update_interval_unsuccessful
+
+        if isinstance(err, UpdateFailed) and err.retry_after is not None:
+            self._retry_after = err.retry_after
+            self.logger.debug(
+                "Retry after triggered. Scheduling next update in %s second(s)",
+                err.retry_after,
+            )
+
+        if isinstance(err, ConfigEntryAuthFailed):
+            self.logger.debug("Authentication failed, reauthentication required")
+            self._async_unsub_refresh()
+            self._debounced_refresh.async_cancel()
+            if self.config_entry is not None:
+                self.config_entry.async_start_reauth(self.hass)
+        elif self._listeners and not self.hass.is_stopping:
+            self._schedule_refresh()
+
+
+class AnthropicCoordinator(
+    DynamicIntervalDataUpdateCoordinator[list[anthropic.types.ModelInfo]]
+):
+    """Coordinator for fetching and updating the list of available Anthropic models."""
+
+    client: anthropic.AsyncAnthropic
+
+    def __init__(self, hass: HomeAssistant, config_entry: AnthropicConfigEntry) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=config_entry.title,
+            update_interval_successful=UPDATE_INTERVAL_CONNECTED,
+            update_interval_unsuccessful=UPDATE_INTERVAL_DISCONNECTED,
+            update_method=self.async_update_data,
+            always_update=False,
+        )
+        self.client = anthropic.AsyncAnthropic(
+            api_key=config_entry.data[CONF_API_KEY], http_client=get_async_client(hass)
+        )
+
+    def _map_exception(self, err: Exception) -> Exception:
+        """Map Anthropic API exceptions to Home Assistant exceptions."""
+        exc = err
+        if isinstance(err, anthropic.APITimeoutError):
+            exc = TimeoutError(err.message)
+        if isinstance(err, anthropic.AuthenticationError):
+            exc = ConfigEntryAuthFailed(err.message)
+        elif isinstance(err, anthropic.APIError):
+            exc = UpdateFailed(err.message)
+        if exc is not err:
+            exc.__cause__ = err
+            exc.__suppress_context__ = True
+        return exc
+
+    async def async_update_data(self) -> list[anthropic.types.ModelInfo]:
+        """Fetch data from the API."""
+        try:
+            data = (await self.client.models.list()).data
+            if not self.last_update_success:
+                self.logger.info("Claude API is available")
+        except anthropic.AnthropicError as err:
+            if self.last_update_success:
+                self.logger.info("Claude API is unavailable")
+            raise self._map_exception(err)  # noqa: B904
+
+        return data
+
+    @callback
+    def async_set_updated_data(self, data: list[anthropic.types.ModelInfo]) -> None:
+        """Manually update data, log if needed."""
+        if not self.last_update_success:
+            self.logger.info("Claude API is available")
+        super().async_set_updated_data(data)
+
+    @callback
+    def async_set_update_error(self, err: Exception) -> None:
+        """Manually set an error."""
+        if self.last_update_success:
+            self.logger.info("Claude API is unavailable")
+        super().async_set_update_error(self._map_exception(err))

--- a/homeassistant/components/anthropic/coordinator.py
+++ b/homeassistant/components/anthropic/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import LOGGER
+from .const import DOMAIN, LOGGER
 
 UPDATE_INTERVAL_CONNECTED = timedelta(hours=12)
 UPDATE_INTERVAL_DISCONNECTED = timedelta(minutes=1)
@@ -56,9 +56,17 @@ class AnthropicCoordinator(DataUpdateCoordinator[None]):
         except anthropic.APITimeoutError as err:
             raise TimeoutError(err.message or str(err)) from err
         except anthropic.AuthenticationError as err:
-            raise ConfigEntryAuthFailed(err.message or str(err)) from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_authentication_error",
+                translation_placeholders={"message": err.message},
+            ) from err
         except anthropic.APIError as err:
-            raise UpdateFailed(err.message or str(err)) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_error",
+                translation_placeholders={"message": err.message},
+            ) from err
 
     def mark_connection_error(self) -> None:
         """Mark the connection as having an error and reschedule background check."""

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -887,10 +887,9 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                         else str(err)
                     },
                 ) from err
-            else:
-                coordinator.async_set_updated_data(coordinator.data)
 
             if not chat_log.unresponded_tool_results:
+                coordinator.async_set_updated_data(coordinator.data)
                 break
 
 

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -873,14 +873,16 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 await coordinator.async_request_refresh()
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
-                    translation_key="api_authentication_error" if isinstance(err, anthropic.AuthenticationError) else "api_error",
+                    translation_key="api_authentication_error",
                     translation_placeholders={"message": err.message},
                 ) from err
             except anthropic.APIConnectionError as err:
                 LOGGER.info("Connection error while talking to Anthropic: %s", err)
                 coordinator.mark_connection_error()
                 raise HomeAssistantError(
-                    f"Sorry, I had a problem talking to Anthropic: {err}"
+                    translation_domain=DOMAIN,
+                    translation_key="api_error",
+                    translation_placeholders={"message": err.message},
                 ) from err
             except anthropic.AnthropicError as err:
                 # Non-connection error, mark connection as healthy

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -868,12 +868,19 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                     ]
                 )
                 messages.extend(new_messages)
-            except (anthropic.APIConnectionError, anthropic.AuthenticationError) as err:
+            except anthropic.AuthenticationError as err:
+                # Trigger coordinator to confirm the auth failure and trigger the reauth flow.
                 await coordinator.async_request_refresh()
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_authentication_error" if isinstance(err, anthropic.AuthenticationError) else "api_error",
                     translation_placeholders={"message": err.message},
+                ) from err
+            except anthropic.APIConnectionError as err:
+                LOGGER.info("Connection error while talking to Anthropic: %s", err)
+                coordinator.mark_connection_error()
+                raise HomeAssistantError(
+                    f"Sorry, I had a problem talking to Anthropic: {err}"
                 ) from err
             except anthropic.AnthropicError as err:
                 # Non-connection error, mark connection as healthy

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -79,12 +79,11 @@ from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, llm
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.json import json_dumps
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 from homeassistant.util.json import JsonObjectType
 
-from . import AnthropicConfigEntry
 from .const import (
     CONF_CHAT_MODEL,
     CONF_CODE_EXECUTION,
@@ -107,6 +106,7 @@ from .const import (
     NON_THINKING_MODELS,
     UNSUPPORTED_STRUCTURED_OUTPUT_MODELS,
 )
+from .coordinator import AnthropicConfigEntry, AnthropicCoordinator
 
 # Max number of back and forth with the LLM to generate a response
 MAX_TOOL_ITERATIONS = 10
@@ -641,7 +641,7 @@ def _create_token_stats(
     }
 
 
-class AnthropicBaseLLMEntity(Entity):
+class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
     """Anthropic base LLM entity."""
 
     _attr_has_entity_name = True
@@ -649,6 +649,7 @@ class AnthropicBaseLLMEntity(Entity):
 
     def __init__(self, entry: AnthropicConfigEntry, subentry: ConfigSubentry) -> None:
         """Initialize the entity."""
+        super().__init__(entry.runtime_data)
         self.entry = entry
         self.subentry = subentry
         self._attr_unique_id = subentry.subentry_id
@@ -845,7 +846,8 @@ class AnthropicBaseLLMEntity(Entity):
         if tools:
             model_args["tools"] = tools
 
-        client = self.entry.runtime_data
+        coordinator = self.entry.runtime_data
+        client = coordinator.client
 
         # To prevent infinite loops, we limit the number of iterations
         for _iteration in range(max_iterations):
@@ -866,14 +868,16 @@ class AnthropicBaseLLMEntity(Entity):
                     ]
                 )
                 messages.extend(new_messages)
-            except anthropic.AuthenticationError as err:
-                self.entry.async_start_reauth(self.hass)
+            except (anthropic.APIConnectionError, anthropic.AuthenticationError) as err:
+                coordinator.async_set_update_error(err)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
-                    translation_key="api_authentication_error",
+                    translation_key="api_authentication_error" if isinstance(err, anthropic.AuthenticationError) else "api_error",
                     translation_placeholders={"message": err.message},
                 ) from err
             except anthropic.AnthropicError as err:
+                # Non-connection error, mark connection as healthy
+                coordinator.async_set_updated_data(coordinator.data)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_error",
@@ -883,6 +887,8 @@ class AnthropicBaseLLMEntity(Entity):
                         else str(err)
                     },
                 ) from err
+            else:
+                coordinator.async_set_updated_data(coordinator.data)
 
             if not chat_log.unresponded_tool_results:
                 break

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -869,7 +869,7 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 )
                 messages.extend(new_messages)
             except (anthropic.APIConnectionError, anthropic.AuthenticationError) as err:
-                coordinator.async_set_update_error(err)
+                await coordinator.async_request_refresh()
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_authentication_error" if isinstance(err, anthropic.AuthenticationError) else "api_error",

--- a/homeassistant/components/anthropic/entity.py
+++ b/homeassistant/components/anthropic/entity.py
@@ -877,7 +877,7 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 ) from err
             except anthropic.AnthropicError as err:
                 # Non-connection error, mark connection as healthy
-                coordinator.async_set_updated_data(coordinator.data)
+                coordinator.async_set_updated_data(None)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="api_error",
@@ -889,7 +889,7 @@ class AnthropicBaseLLMEntity(CoordinatorEntity[AnthropicCoordinator]):
                 ) from err
 
             if not chat_log.unresponded_tool_results:
-                coordinator.async_set_updated_data(coordinator.data)
+                coordinator.async_set_updated_data(None)
                 break
 
 

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -38,7 +38,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable:
-    status: done
+    status: exempt
     comment: |
       The logging is handled by DataUpdateCoordinator,
       however the logging level might be not INFO.

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -37,7 +37,11 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: done
+  log-when-unavailable:
+    status: done
+    comment: |
+      The logging is handled by DataUpdateCoordinator,
+      however the logging level might be not INFO.
   parallel-updates:
     status: exempt
     comment: |

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -35,9 +35,9 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates:
     status: exempt
     comment: |

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
     status: exempt
     comment: |
       The logging is handled by DataUpdateCoordinator,
-      however the logging level might be not INFO.
+      however the logging level might not be INFO.
   parallel-updates:
     status: exempt
     comment: |

--- a/homeassistant/components/anthropic/quality_scale.yaml
+++ b/homeassistant/components/anthropic/quality_scale.yaml
@@ -37,11 +37,7 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done
-  log-when-unavailable:
-    status: exempt
-    comment: |
-      The logging is handled by DataUpdateCoordinator,
-      however the logging level might not be INFO.
+  log-when-unavailable: done
   parallel-updates:
     status: exempt
     comment: |

--- a/homeassistant/components/anthropic/repairs.py
+++ b/homeassistant/components/anthropic/repairs.py
@@ -58,7 +58,7 @@ class ModelDeprecatedRepairFlow(RepairsFlow):
         if entry.entry_id in self._model_list_cache:
             model_list = self._model_list_cache[entry.entry_id]
         else:
-            client = entry.runtime_data
+            client = entry.runtime_data.client
             model_list = [
                 model_option
                 for model_option in await get_model_list(client)

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -4,7 +4,7 @@ import datetime
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
-from anthropic import AuthenticationError, RateLimitError
+from anthropic import RateLimitError
 from anthropic.types import (
     CitationsWebSearchResultLocation,
     CitationWebSearchResultLocationParam,
@@ -39,10 +39,8 @@ from homeassistant.components.anthropic.const import (
     CONF_WEB_SEARCH_REGION,
     CONF_WEB_SEARCH_TIMEZONE,
     CONF_WEB_SEARCH_USER_LOCATION,
-    DOMAIN,
 )
 from homeassistant.components.anthropic.entity import CitationDetails, ContentDetails
-from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -125,38 +123,6 @@ async def test_error_handling(
 
     assert result.response.response_type == intent.IntentResponseType.ERROR
     assert result.response.error_code == "unknown", result
-
-
-async def test_auth_error_handling(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_init_component,
-    mock_create_stream: AsyncMock,
-) -> None:
-    """Test reauth after authentication error during conversation."""
-    mock_create_stream.side_effect = AuthenticationError(
-        message="Invalid API key",
-        response=Response(status_code=403, request=Request(method="POST", url=URL())),
-        body=None,
-    )
-
-    result = await conversation.async_converse(
-        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
-    )
-
-    assert result.response.response_type == intent.IntentResponseType.ERROR
-    assert result.response.error_code == "unknown", result
-
-    await hass.async_block_till_done()
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-
-    flow = flows[0]
-    assert flow["step_id"] == "reauth_confirm"
-    assert flow["handler"] == DOMAIN
-    assert "context" in flow
-    assert flow["context"]["source"] == SOURCE_REAUTH
-    assert flow["context"]["entry_id"] == mock_config_entry.entry_id
 
 
 async def test_template_error(

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -1,0 +1,327 @@
+"""Tests for the Anthropic integration."""
+
+import datetime
+from unittest.mock import AsyncMock, patch
+
+from anthropic import APITimeoutError, AuthenticationError, RateLimitError
+from freezegun import freeze_time
+from httpx import URL, Request, Response
+
+from homeassistant.components import conversation
+from homeassistant.components.anthropic.const import DOMAIN
+from homeassistant.components.anthropic.coordinator import (
+    UPDATE_INTERVAL_CONNECTED,
+    UPDATE_INTERVAL_DISCONNECTED,
+    DynamicIntervalDataUpdateCoordinator,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_auth_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test reauth after authentication error during conversation."""
+    # This is an assumption of the tests, not the main code:
+    assert UPDATE_INTERVAL_DISCONNECTED < UPDATE_INTERVAL_CONNECTED
+
+    mock_create_stream.side_effect = AuthenticationError(
+        message="Invalid API key",
+        response=Response(status_code=403, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+
+    result = await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == "unknown", result
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert "context" in flow
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id
+
+
+@freeze_time("2026-02-27 12:00:00")
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_error_handling(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test making entity unavailable on connection error."""
+    mock_create_stream.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    result = await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+    assert result.response.error_code == "unknown", result
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Try again
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_create_stream.side_effect = RateLimitError(
+        message=None,
+        response=Response(status_code=429, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+
+    # Get a different error meaning the connection is restored
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check state is back to normal
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "2026-02-27T12:00:00+00:00"
+
+    # Verify the background check period
+    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    mock_model_list.assert_not_awaited()
+
+    test_time += UPDATE_INTERVAL_CONNECTED - UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    mock_model_list.assert_awaited_once()
+
+
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_check_reauth(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+) -> None:
+    """Test authentication error during background availability check."""
+    mock_model_list.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    assert mock_model_list.await_count == 0
+    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_CONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_model_list.side_effect = AuthenticationError(
+        message="Invalid API key",
+        response=Response(status_code=403, request=Request(method="POST", url=URL())),
+        body=None,
+    )
+
+    # Wait for background check to run and fail
+    test_time += UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Verify that the background check is not running anymore
+    test_time += UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    # Check that a reauth flow has been created
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert "context" in flow
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id
+
+
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_connection_restore(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+    mock_create_stream: AsyncMock,
+) -> None:
+    """Test background availability check restore on non-connectivity error."""
+    mock_create_stream.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Check initial state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unknown"
+
+    # Get timeout
+    await conversation.async_converse(
+        hass, "hello", None, Context(), agent_id="conversation.claude_conversation"
+    )
+
+    # Check new state
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    mock_model_list.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Wait for background check to run and fail
+    assert mock_model_list.await_count == 0
+    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    # Check state is still unavailable
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state == "unavailable"
+
+    # Now make the background check succeed
+    mock_model_list.side_effect = None
+    test_time += UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    # Check that state is back to normal since the error is not connectivity related
+    state = hass.states.get("conversation.claude_conversation")
+    assert state
+    assert state.state != "unavailable"
+
+    # Verify the background check period
+    test_time += UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    test_time += UPDATE_INTERVAL_CONNECTED - UPDATE_INTERVAL_DISCONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 3
+
+
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
+async def test_retry_after(
+    mock_model_list: AsyncMock,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_init_component,
+) -> None:
+    """Test that retry_after is respected."""
+    retry_after = 30
+    assert UPDATE_INTERVAL_DISCONNECTED.total_seconds() > retry_after
+
+    mock_model_list.side_effect = APITimeoutError(
+        request=Request(method="POST", url=URL()),
+    )
+
+    # Get timeout
+    assert mock_model_list.await_count == 0
+    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_CONNECTED
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 1
+
+    mock_model_list.side_effect = UpdateFailed(
+        "Test retry after", retry_after=retry_after
+    )
+
+    # Wait for retry_after and check
+    test_time += datetime.timedelta(seconds=retry_after)
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_model_list.await_count == 2
+
+    # Now test the coordinator for retry_after on async_set_update_error
+    mock_update_method = AsyncMock()
+    mock_coordinator = DynamicIntervalDataUpdateCoordinator[None](
+        hass,
+        mock_config_entry.runtime_data.logger,
+        config_entry=mock_config_entry,
+        name="test",
+        update_interval_successful=UPDATE_INTERVAL_CONNECTED,
+        update_interval_unsuccessful=UPDATE_INTERVAL_DISCONNECTED,
+        update_method=mock_update_method,
+    )
+    remove_listener = mock_coordinator.async_add_listener(lambda: None)
+    mock_config_entry._async_set_state(
+        hass, ConfigEntryState.SETUP_IN_PROGRESS, "testing"
+    )
+    await mock_coordinator.async_config_entry_first_refresh()
+    mock_config_entry._async_set_state(hass, ConfigEntryState.LOADED, "testing")
+    assert mock_coordinator.last_update_success
+    assert mock_update_method.await_count == 1
+
+    mock_coordinator.async_set_update_error(
+        UpdateFailed("Test retry after", retry_after=retry_after)
+    )
+    test_time += datetime.timedelta(seconds=retry_after)
+    async_fire_time_changed(hass, test_time)
+    await hass.async_block_till_done()
+    assert mock_update_method.await_count == 2
+
+    remove_listener()

--- a/tests/components/anthropic/test_coordinator.py
+++ b/tests/components/anthropic/test_coordinator.py
@@ -12,17 +12,17 @@ from homeassistant.components.anthropic.const import DOMAIN
 from homeassistant.components.anthropic.coordinator import (
     UPDATE_INTERVAL_CONNECTED,
     UPDATE_INTERVAL_DISCONNECTED,
-    DynamicIntervalDataUpdateCoordinator,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import intent
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
 async def test_auth_error_handling(
+    mock_model_list: AsyncMock,
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_init_component,
@@ -32,7 +32,7 @@ async def test_auth_error_handling(
     # This is an assumption of the tests, not the main code:
     assert UPDATE_INTERVAL_DISCONNECTED < UPDATE_INTERVAL_CONNECTED
 
-    mock_create_stream.side_effect = AuthenticationError(
+    mock_create_stream.side_effect = mock_model_list.side_effect = AuthenticationError(
         message="Invalid API key",
         response=Response(status_code=403, request=Request(method="POST", url=URL())),
         body=None,
@@ -262,66 +262,3 @@ async def test_connection_restore(
     async_fire_time_changed(hass, test_time)
     await hass.async_block_till_done()
     assert mock_model_list.await_count == 3
-
-
-@patch("anthropic.resources.models.AsyncModels.list", new_callable=AsyncMock)
-async def test_retry_after(
-    mock_model_list: AsyncMock,
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_init_component,
-) -> None:
-    """Test that retry_after is respected."""
-    retry_after = 30
-    assert UPDATE_INTERVAL_DISCONNECTED.total_seconds() > retry_after
-
-    mock_model_list.side_effect = APITimeoutError(
-        request=Request(method="POST", url=URL()),
-    )
-
-    # Get timeout
-    assert mock_model_list.await_count == 0
-    test_time = datetime.datetime.now(datetime.UTC) + UPDATE_INTERVAL_CONNECTED
-    async_fire_time_changed(hass, test_time)
-    await hass.async_block_till_done()
-    assert mock_model_list.await_count == 1
-
-    mock_model_list.side_effect = UpdateFailed(
-        "Test retry after", retry_after=retry_after
-    )
-
-    # Wait for retry_after and check
-    test_time += datetime.timedelta(seconds=retry_after)
-    async_fire_time_changed(hass, test_time)
-    await hass.async_block_till_done()
-    assert mock_model_list.await_count == 2
-
-    # Now test the coordinator for retry_after on async_set_update_error
-    mock_update_method = AsyncMock()
-    mock_coordinator = DynamicIntervalDataUpdateCoordinator[None](
-        hass,
-        mock_config_entry.runtime_data.logger,
-        config_entry=mock_config_entry,
-        name="test",
-        update_interval_successful=UPDATE_INTERVAL_CONNECTED,
-        update_interval_unsuccessful=UPDATE_INTERVAL_DISCONNECTED,
-        update_method=mock_update_method,
-    )
-    remove_listener = mock_coordinator.async_add_listener(lambda: None)
-    mock_config_entry._async_set_state(
-        hass, ConfigEntryState.SETUP_IN_PROGRESS, "testing"
-    )
-    await mock_coordinator.async_config_entry_first_refresh()
-    mock_config_entry._async_set_state(hass, ConfigEntryState.LOADED, "testing")
-    assert mock_coordinator.last_update_success
-    assert mock_update_method.await_count == 1
-
-    mock_coordinator.async_set_update_error(
-        UpdateFailed("Test retry after", retry_after=retry_after)
-    )
-    test_time += datetime.timedelta(seconds=retry_after)
-    async_fire_time_changed(hass, test_time)
-    await hass.async_block_till_done()
-    assert mock_update_method.await_count == 2
-
-    remove_listener()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Data Update Coordinator for availability check of Anthropic API.
The check is performed after 12 hours since the last successful response from API or after 1 minute if the last response was unsuccessful. Non-connectivity API errors are considered successful if received during conversation or ai task, but not during the automatic check.
This is an alternative approach for implementation of #164362 but using the coordinator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
