### PR TITLE
Fix key error in Reolink DHCP if still setting up

### DIFF
--- a/homeassistant/components/reolink/config_flow.py
+++ b/homeassistant/components/reolink/config_flow.py
@@ -159,6 +159,15 @@ class ReolinkFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle discovery via dhcp."""
         mac_address = format_mac(discovery_info.macaddress)
         existing_entry = await self.async_set_unique_id(mac_address)
+        if existing_entry and CONF_HOST not in existing_entry.data:
+            _LOGGER.debug(
+                "Reolink DHCP discovered device with MAC '%s' and IP '%s', "
+                "but existing config entry does not have host, ignoring",
+                mac_address,
+                discovery_info.ip,
+            )
+            raise AbortFlow("already_configured")
+
         if (
             existing_entry
             and CONF_PASSWORD in existing_entry.data

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -608,12 +608,7 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
     assert config_entry.data[CONF_HOST] == TEST_HOST
 
 
-async def test_dhcp_ip_update_aborted_if_no_host(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    reolink_host_class: MagicMock,
-    reolink_host: MagicMock,
-) -> None:
+async def test_dhcp_ip_update_aborted_if_no_host(hass: HomeAssistant) -> None:
     """Test dhcp discovery does not update the IP if the config entry has no host."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -608,6 +608,38 @@ async def test_dhcp_ip_update_aborted_if_wrong_mac(
     assert config_entry.data[CONF_HOST] == TEST_HOST
 
 
+async def test_dhcp_ip_update_aborted_if_no_host(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    reolink_host_class: MagicMock,
+    reolink_host: MagicMock,
+) -> None:
+    """Test dhcp discovery does not update the IP if the config entry has no host."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=format_mac(TEST_MAC),
+        data={},
+        options={
+            CONF_PROTOCOL: DEFAULT_PROTOCOL,
+        },
+        title=TEST_NVR_NAME,
+    )
+    config_entry.add_to_hass(hass)
+
+    dhcp_data = DhcpServiceInfo(
+        ip=TEST_HOST2,
+        hostname="Reolink",
+        macaddress=DHCP_FORMATTED_MAC,
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_DHCP}, data=dhcp_data
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
 @pytest.mark.parametrize(
     ("attr", "value", "expected", "host_call_list"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix key error in Reolink DHCP if another instance of the config flow is still running.
See https://github.com/home-assistant/core/issues/162864

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/162864 fixes https://github.com/home-assistant/core/issues/163156
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
