### PR TITLE
Allow the creation of multi-domain triggers

### DIFF
--- a/homeassistant/components/alarm_control_panel/trigger.py
+++ b/homeassistant/components/alarm_control_panel/trigger.py
@@ -44,7 +44,7 @@ def make_entity_state_trigger_required_features(
     class CustomTrigger(EntityStateTriggerRequiredFeatures):
         """Trigger for entity state changes."""
 
-        _domain = domain
+        _domains = {domain}
         _to_states = {to_state}
         _required_features = required_features
 

--- a/homeassistant/components/binary_sensor/trigger.py
+++ b/homeassistant/components/binary_sensor/trigger.py
@@ -24,7 +24,7 @@ class BinarySensorOnOffTrigger(EntityTargetStateTriggerBase):
     """Class for binary sensor on/off triggers."""
 
     _device_class: BinarySensorDeviceClass | None
-    _domain: str = DOMAIN
+    _domains = {DOMAIN}
 
     def entity_filter(self, entities: set[str]) -> set[str]:
         """Filter entities of this domain."""

--- a/homeassistant/components/button/trigger.py
+++ b/homeassistant/components/button/trigger.py
@@ -14,7 +14,7 @@ from . import DOMAIN
 class ButtonPressedTrigger(EntityTriggerBase):
     """Trigger for button entity presses."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _schema = ENTITY_STATE_TRIGGER_SCHEMA
 
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:

--- a/homeassistant/components/climate/trigger.py
+++ b/homeassistant/components/climate/trigger.py
@@ -43,7 +43,7 @@ HVAC_MODE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST.extend
 class HVACModeChangedTrigger(EntityTargetStateTriggerBase):
     """Trigger for entity state changes."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _schema = HVAC_MODE_CHANGED_TRIGGER_SCHEMA
 
     def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:

--- a/homeassistant/components/light/trigger.py
+++ b/homeassistant/components/light/trigger.py
@@ -23,7 +23,7 @@ def _convert_uint8_to_percentage(value: Any) -> float:
 class BrightnessChangedTrigger(EntityNumericalStateAttributeChangedTriggerBase):
     """Trigger for brightness changed."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _attribute = ATTR_BRIGHTNESS
 
     _converter = staticmethod(_convert_uint8_to_percentage)
@@ -34,7 +34,7 @@ class BrightnessCrossedThresholdTrigger(
 ):
     """Trigger for brightness crossed threshold."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _attribute = ATTR_BRIGHTNESS
     _converter = staticmethod(_convert_uint8_to_percentage)
 

--- a/homeassistant/components/scene/trigger.py
+++ b/homeassistant/components/scene/trigger.py
@@ -14,7 +14,7 @@ from . import DOMAIN
 class SceneActivatedTrigger(EntityTriggerBase):
     """Trigger for scene entity activations."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _schema = ENTITY_STATE_TRIGGER_SCHEMA
 
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:

--- a/homeassistant/components/text/trigger.py
+++ b/homeassistant/components/text/trigger.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 class TextChangedTrigger(EntityTriggerBase):
     """Trigger for text entity when its content changes."""
 
-    _domain = DOMAIN
+    _domains = {DOMAIN}
     _schema = ENTITY_STATE_TRIGGER_SCHEMA
 
     def is_valid_state(self, state: State) -> bool:

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -386,7 +386,7 @@ class EntityTriggerBase(Trigger):
         )
 
     def entity_filter(self, entities: set[str]) -> set[str]:
-        """Filter entities of this domain."""
+        """Filter entities of these domains."""
         return {
             entity_id
             for entity_id in entities

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -336,7 +336,7 @@ ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST = ENTITY_STATE_TRIGGER_SCHEMA.extend(
 class EntityTriggerBase(Trigger):
     """Trigger for entity state changes."""
 
-    _domain: str
+    _domains: set[str]
     _schema: vol.Schema = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST
 
     @override
@@ -390,7 +390,7 @@ class EntityTriggerBase(Trigger):
         return {
             entity_id
             for entity_id in entities
-            if split_entity_id(entity_id)[0] == self._domain
+            if split_entity_id(entity_id)[0] in self._domains
         }
 
     @override
@@ -792,7 +792,7 @@ def make_entity_target_state_trigger(
     class CustomTrigger(EntityTargetStateTriggerBase):
         """Trigger for entity state changes."""
 
-        _domain = domain
+        _domains = {domain}
         _to_states = to_states_set
 
     return CustomTrigger
@@ -806,7 +806,7 @@ def make_entity_transition_trigger(
     class CustomTrigger(EntityTransitionTriggerBase):
         """Trigger for conditional entity state changes."""
 
-        _domain = domain
+        _domains = {domain}
         _from_states = from_states
         _to_states = to_states
 
@@ -821,7 +821,7 @@ def make_entity_origin_state_trigger(
     class CustomTrigger(EntityOriginStateTriggerBase):
         """Trigger for entity "from state" changes."""
 
-        _domain = domain
+        _domains = {domain}
         _from_state = from_state
 
     return CustomTrigger
@@ -835,7 +835,7 @@ def make_entity_numerical_state_attribute_changed_trigger(
     class CustomTrigger(EntityNumericalStateAttributeChangedTriggerBase):
         """Trigger for numerical state attribute changes."""
 
-        _domain = domain
+        _domains = {domain}
         _attribute = attribute
 
     return CustomTrigger
@@ -849,7 +849,7 @@ def make_entity_numerical_state_attribute_crossed_threshold_trigger(
     class CustomTrigger(EntityNumericalStateAttributeCrossedThresholdTriggerBase):
         """Trigger for numerical state attribute changes."""
 
-        _domain = domain
+        _domains = {domain}
         _attribute = attribute
 
     return CustomTrigger
@@ -863,7 +863,7 @@ def make_entity_target_state_attribute_trigger(
     class CustomTrigger(EntityTargetStateAttributeTriggerBase):
         """Trigger for entity state changes."""
 
-        _domain = domain
+        _domains = {domain}
         _attribute = attribute
         _attribute_to_state = to_state
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adjusts the `EntityTriggerBase` base class to accept a set of strings for domains to listen on, which allows us later to define multi-domain triggers.
All current derived trigger classes (_under the helper module, as also within the platforms_) and their creation helper methods got updated, too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
