### PR TITLE
Update unit in Monarch Money

### DIFF
--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -2,8 +2,12 @@
 
 from typedmonarchmoney import TypedMonarchMoney
 
+from homeassistant.components.recorder.statistics import (
+    async_update_statistics_metadata,
+)
 from homeassistant.const import CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .coordinator import MonarchMoneyConfigEntry, MonarchMoneyDataUpdateCoordinator
 
@@ -19,8 +23,40 @@ async def async_setup_entry(
     mm_coordinator = MonarchMoneyDataUpdateCoordinator(hass, entry, monarch_client)
     await mm_coordinator.async_config_entry_first_refresh()
     entry.runtime_data = mm_coordinator
+
+    # Migrate statistics from "$" to proper ISO currency code
+    _async_migrate_statistics_currency(hass, entry)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+def _async_migrate_statistics_currency(
+    hass: HomeAssistant, entry: MonarchMoneyConfigEntry
+) -> None:
+    """Migrate monetary sensor statistics from '$' to configured currency.
+
+    Prior versions used CURRENCY_DOLLAR ('$') which is invalid for
+    device_class=MONETARY sensors. This migrates existing statistics
+    to use the proper ISO 4217 currency code from HA config.
+    """
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+
+    currency = hass.config.currency
+
+    for entity_entry in entries:
+        # Only migrate sensor entities with monetary device class
+        if (
+            entity_entry.domain == "sensor"
+            and entity_entry.original_device_class == "monetary"
+        ):
+            async_update_statistics_metadata(
+                hass,
+                entity_entry.entity_id,
+                new_unit_of_measurement=currency,
+                new_unit_class=None,
+            )
 
 
 async def async_unload_entry(

--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.recorder import DATA_INSTANCE
 
+from .const import MONARCH_MONEY_CURRENCY
 from .coordinator import MonarchMoneyConfigEntry, MonarchMoneyDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -44,19 +45,17 @@ async def async_migrate_entry(
 def _async_migrate_statistics_currency(
     hass: HomeAssistant, entry: MonarchMoneyConfigEntry
 ) -> None:
-    """Migrate monetary sensor statistics from '$' to configured currency.
+    """Migrate monetary sensor statistics from '$' to USD.
 
     Prior versions used CURRENCY_DOLLAR ('$') which is invalid for
     device_class=MONETARY sensors. This migrates existing statistics
-    to use the proper ISO 4217 currency code from HA config.
+    to use the proper ISO 4217 currency code.
     """
     if DATA_INSTANCE not in hass.data:
         return
 
     entity_registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-
-    currency = hass.config.currency
 
     for entity_entry in entries:
         if (
@@ -66,7 +65,7 @@ def _async_migrate_statistics_currency(
             async_update_statistics_metadata(
                 hass,
                 entity_entry.entity_id,
-                new_unit_of_measurement=currency,
+                new_unit_of_measurement=MONARCH_MONEY_CURRENCY,
                 new_unit_class=None,
             )
 

--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -35,8 +35,11 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: MonarchMoneyConfigEntry
 ) -> bool:
     """Migrate old config entries."""
-    if entry.version == 1 and entry.minor_version < 2:
-        _async_migrate_statistics_currency(hass, entry)
+    if (
+        entry.version == 1
+        and entry.minor_version < 2
+        and _async_migrate_statistics_currency(hass, entry)
+    ):
         hass.config_entries.async_update_entry(entry, minor_version=2)
 
     return True
@@ -44,7 +47,7 @@ async def async_migrate_entry(
 
 def _async_migrate_statistics_currency(
     hass: HomeAssistant, entry: MonarchMoneyConfigEntry
-) -> None:
+) -> bool:
     """Migrate monetary sensor statistics from '$' to USD.
 
     Prior versions used CURRENCY_DOLLAR ('$') which is invalid for
@@ -52,7 +55,7 @@ def _async_migrate_statistics_currency(
     to use the proper ISO 4217 currency code.
     """
     if DATA_INSTANCE not in hass.data:
-        return
+        return False
 
     entity_registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
@@ -68,6 +71,8 @@ def _async_migrate_statistics_currency(
                 new_unit_of_measurement=MONARCH_MONEY_CURRENCY,
                 new_unit_class=None,
             )
+
+    return True
 
 
 async def async_unload_entry(

--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.recorder import DATA_INSTANCE
 
-from .const import MONARCH_MONEY_CURRENCY
+from .const import DEFAULT_CURRENCY
 from .coordinator import MonarchMoneyConfigEntry, MonarchMoneyDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -68,7 +68,7 @@ def _async_migrate_statistics_currency(
             async_update_statistics_metadata(
                 hass,
                 entity_entry.entity_id,
-                new_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+                new_unit_of_measurement=DEFAULT_CURRENCY,
                 new_unit_class=None,
             )
 

--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -5,9 +5,11 @@ from typedmonarchmoney import TypedMonarchMoney
 from homeassistant.components.recorder.statistics import (
     async_update_statistics_metadata,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from .coordinator import MonarchMoneyConfigEntry, MonarchMoneyDataUpdateCoordinator
 
@@ -24,10 +26,18 @@ async def async_setup_entry(
     await mm_coordinator.async_config_entry_first_refresh()
     entry.runtime_data = mm_coordinator
 
-    # Migrate statistics from "$" to proper ISO currency code
-    _async_migrate_statistics_currency(hass, entry)
-
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: MonarchMoneyConfigEntry
+) -> bool:
+    """Migrate old config entries."""
+    if entry.version == 1 and entry.minor_version < 2:
+        _async_migrate_statistics_currency(hass, entry)
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
     return True
 
 
@@ -40,16 +50,18 @@ def _async_migrate_statistics_currency(
     device_class=MONETARY sensors. This migrates existing statistics
     to use the proper ISO 4217 currency code from HA config.
     """
+    if DATA_INSTANCE not in hass.data:
+        return
+
     entity_registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
 
     currency = hass.config.currency
 
     for entity_entry in entries:
-        # Only migrate sensor entities with monetary device class
         if (
-            entity_entry.domain == "sensor"
-            and entity_entry.original_device_class == "monetary"
+            entity_entry.domain == SENSOR_DOMAIN
+            and entity_entry.original_device_class == SensorDeviceClass.MONETARY
         ):
             async_update_statistics_metadata(
                 hass,

--- a/homeassistant/components/monarch_money/__init__.py
+++ b/homeassistant/components/monarch_money/__init__.py
@@ -35,11 +35,8 @@ async def async_migrate_entry(
     hass: HomeAssistant, entry: MonarchMoneyConfigEntry
 ) -> bool:
     """Migrate old config entries."""
-    if (
-        entry.version == 1
-        and entry.minor_version < 2
-        and _async_migrate_statistics_currency(hass, entry)
-    ):
+    if entry.version == 1 and entry.minor_version < 2:
+        _async_migrate_statistics_currency(hass, entry)
         hass.config_entries.async_update_entry(entry, minor_version=2)
 
     return True
@@ -47,7 +44,7 @@ async def async_migrate_entry(
 
 def _async_migrate_statistics_currency(
     hass: HomeAssistant, entry: MonarchMoneyConfigEntry
-) -> bool:
+) -> None:
     """Migrate monetary sensor statistics from '$' to USD.
 
     Prior versions used CURRENCY_DOLLAR ('$') which is invalid for
@@ -55,7 +52,7 @@ def _async_migrate_statistics_currency(
     to use the proper ISO 4217 currency code.
     """
     if DATA_INSTANCE not in hass.data:
-        return False
+        return
 
     entity_registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
@@ -71,8 +68,6 @@ def _async_migrate_statistics_currency(
                 new_unit_of_measurement=DEFAULT_CURRENCY,
                 new_unit_class=None,
             )
-
-    return True
 
 
 async def async_unload_entry(

--- a/homeassistant/components/monarch_money/config_flow.py
+++ b/homeassistant/components/monarch_money/config_flow.py
@@ -102,6 +102,7 @@ class MonarchMoneyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Monarch Money."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize config flow."""

--- a/homeassistant/components/monarch_money/const.py
+++ b/homeassistant/components/monarch_money/const.py
@@ -8,4 +8,4 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_MFA_SECRET = "mfa_secret"
 CONF_MFA_CODE = "mfa_code"
-MONARCH_MONEY_CURRENCY = "USD"
+DEFAULT_CURRENCY = "USD"

--- a/homeassistant/components/monarch_money/const.py
+++ b/homeassistant/components/monarch_money/const.py
@@ -8,3 +8,4 @@ LOGGER = logging.getLogger(__package__)
 
 CONF_MFA_SECRET = "mfa_secret"
 CONF_MFA_CODE = "mfa_code"
+MONARCH_MONEY_CURRENCY = "USD"

--- a/homeassistant/components/monarch_money/manifest.json
+++ b/homeassistant/components/monarch_money/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "monarch_money",
   "name": "Monarch Money",
+  "after_dependencies": ["recorder"],
   "codeowners": ["@jeeftor"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/monarchmoney",

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from .const import MONARCH_MONEY_CURRENCY
 from .coordinator import MonarchMoneyConfigEntry
 from .entity import MonarchMoneyAccountEntity, MonarchMoneyCashFlowEntity
 
@@ -164,7 +165,7 @@ class MonarchMoneyCashFlowSensor(MonarchMoneyCashFlowEntity, SensorEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the currency for monetary sensors."""
         if self.entity_description.device_class == SensorDeviceClass.MONETARY:
-            return self.hass.config.currency
+            return MONARCH_MONEY_CURRENCY
         return self.entity_description.native_unit_of_measurement
 
 
@@ -184,7 +185,7 @@ class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
     def native_unit_of_measurement(self) -> str | None:
         """Return the currency for monetary sensors."""
         if self.entity_description.device_class == SensorDeviceClass.MONETARY:
-            return self.hass.config.currency
+            return MONARCH_MONEY_CURRENCY
         return self.entity_description.native_unit_of_measurement
 
     @property

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import CURRENCY_DOLLAR, PERCENTAGE, EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -46,7 +46,7 @@ MONARCH_MONEY_VALUE_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, .
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement=CURRENCY_DOLLAR,
+        native_unit_of_measurement="USD",
     ),
 )
 
@@ -59,7 +59,7 @@ MONARCH_MONEY_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, ...] = 
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement=CURRENCY_DOLLAR,
+        native_unit_of_measurement="USD",
     ),
 )
 
@@ -80,7 +80,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.income,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=CURRENCY_DOLLAR,
+        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="sum_expense",
@@ -88,7 +88,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.expenses,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=CURRENCY_DOLLAR,
+        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings",
@@ -96,7 +96,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.savings,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=CURRENCY_DOLLAR,
+        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings_rate",

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -46,7 +46,6 @@ MONARCH_MONEY_VALUE_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, .
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement="USD",
     ),
 )
 
@@ -59,7 +58,6 @@ MONARCH_MONEY_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, ...] = 
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement="USD",
     ),
 )
 
@@ -80,7 +78,6 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.income,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="sum_expense",
@@ -88,7 +85,6 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.expenses,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings",
@@ -96,7 +92,6 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.savings,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement="USD",
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings_rate",
@@ -165,6 +160,13 @@ class MonarchMoneyCashFlowSensor(MonarchMoneyCashFlowEntity, SensorEntity):
         """Return the state."""
         return self.entity_description.summary_fn(self.summary_data)
 
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the currency for monetary sensors."""
+        if self.entity_description.device_class == SensorDeviceClass.MONETARY:
+            return self.hass.config.currency
+        return self.entity_description.native_unit_of_measurement
+
 
 class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
     """Define a monarch money sensor."""
@@ -176,6 +178,14 @@ class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         return self.entity_description.value_fn(self.account_data)
+
+    @property
+    @override
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the currency for monetary sensors."""
+        if self.entity_description.device_class == SensorDeviceClass.MONETARY:
+            return self.hass.config.currency
+        return self.entity_description.native_unit_of_measurement
 
     @property
     @override

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -47,6 +47,7 @@ MONARCH_MONEY_VALUE_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, .
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
+        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
     ),
 )
 
@@ -59,6 +60,7 @@ MONARCH_MONEY_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, ...] = 
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
+        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
     ),
 )
 
@@ -79,6 +81,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.income,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="sum_expense",
@@ -86,6 +89,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.expenses,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings",
@@ -93,6 +97,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.savings,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
+        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings_rate",
@@ -161,13 +166,6 @@ class MonarchMoneyCashFlowSensor(MonarchMoneyCashFlowEntity, SensorEntity):
         """Return the state."""
         return self.entity_description.summary_fn(self.summary_data)
 
-    @property
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the currency for monetary sensors."""
-        if self.entity_description.device_class == SensorDeviceClass.MONETARY:
-            return MONARCH_MONEY_CURRENCY
-        return self.entity_description.native_unit_of_measurement
-
 
 class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
     """Define a monarch money sensor."""
@@ -179,14 +177,6 @@ class MonarchMoneySensor(MonarchMoneyAccountEntity, SensorEntity):
     def native_value(self) -> StateType | datetime:
         """Return the state."""
         return self.entity_description.value_fn(self.account_data)
-
-    @property
-    @override
-    def native_unit_of_measurement(self) -> str | None:
-        """Return the currency for monetary sensors."""
-        if self.entity_description.device_class == SensorDeviceClass.MONETARY:
-            return MONARCH_MONEY_CURRENCY
-        return self.entity_description.native_unit_of_measurement
 
     @property
     @override

--- a/homeassistant/components/monarch_money/sensor.py
+++ b/homeassistant/components/monarch_money/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import MONARCH_MONEY_CURRENCY
+from .const import DEFAULT_CURRENCY
 from .coordinator import MonarchMoneyConfigEntry
 from .entity import MonarchMoneyAccountEntity, MonarchMoneyCashFlowEntity
 
@@ -47,7 +47,7 @@ MONARCH_MONEY_VALUE_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, .
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+        native_unit_of_measurement=DEFAULT_CURRENCY,
     ),
 )
 
@@ -60,7 +60,7 @@ MONARCH_MONEY_SENSORS: tuple[MonarchMoneyAccountSensorEntityDescription, ...] = 
         device_class=SensorDeviceClass.MONETARY,
         value_fn=lambda account: account.balance,
         picture_fn=lambda account: account.logo_url,
-        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+        native_unit_of_measurement=DEFAULT_CURRENCY,
     ),
 )
 
@@ -81,7 +81,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.income,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+        native_unit_of_measurement=DEFAULT_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="sum_expense",
@@ -89,7 +89,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.expenses,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+        native_unit_of_measurement=DEFAULT_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings",
@@ -97,7 +97,7 @@ MONARCH_CASHFLOW_SENSORS: tuple[MonarchMoneyCashflowSensorEntityDescription, ...
         summary_fn=lambda summary: summary.savings,
         state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.MONETARY,
-        native_unit_of_measurement=MONARCH_MONEY_CURRENCY,
+        native_unit_of_measurement=DEFAULT_CURRENCY,
     ),
     MonarchMoneyCashflowSensorEntityDescription(
         key="savings_rate",

--- a/tests/components/monarch_money/snapshots/test_sensor.ambr
+++ b/tests/components/monarch_money/snapshots/test_sensor.ambr
@@ -35,7 +35,7 @@
     'supported_features': 0,
     'translation_key': 'sum_expense',
     'unique_id': '222260252323873333_cashflow_sum_expense',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_expense_year_to_date-state]
@@ -44,7 +44,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Expense year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_expense_year_to_date',
@@ -90,7 +90,7 @@
     'supported_features': 0,
     'translation_key': 'sum_income',
     'unique_id': '222260252323873333_cashflow_sum_income',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_income_year_to_date-state]
@@ -99,7 +99,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Income year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_income_year_to_date',
@@ -199,7 +199,7 @@
     'supported_features': 0,
     'translation_key': 'savings',
     'unique_id': '222260252323873333_cashflow_savings',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_savings_year_to_date-state]
@@ -208,7 +208,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_savings_year_to_date',
@@ -254,7 +254,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_186321412999033223_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.manual_entry_wallet_balance-state]
@@ -264,7 +264,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.manual_entry_wallet_balance',
@@ -362,7 +362,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000002_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_bank_checking_balance-state]
@@ -373,7 +373,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_bank_checking_balance',
@@ -471,7 +471,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_brokerage_brokerage_balance-state]
@@ -482,7 +482,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_brokerage_brokerage_balance',
@@ -580,7 +580,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_9000000007_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_credit_credit_card_balance-state]
@@ -591,7 +591,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_credit_credit_card_balance',
@@ -689,7 +689,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000022_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_employer_investments_401_k_balance-state]
@@ -700,7 +700,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_employer_investments_401_k_balance',
@@ -798,7 +798,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000012_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_investments_roth_ira_balance-state]
@@ -809,7 +809,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_investments_roth_ira_balance',
@@ -907,7 +907,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000030_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.rando_mortgage_mortgage_balance-state]
@@ -918,7 +918,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_mortgage_mortgage_balance',
@@ -1068,7 +1068,7 @@
     'supported_features': 0,
     'translation_key': 'value',
     'unique_id': '222260252323873333_121212192626186051_value',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-state]
@@ -1079,7 +1079,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://api.monarchmoney.com/cdn-cgi/image/width=128/images/institution/159427559853802644',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Value',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
@@ -1125,7 +1125,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000020_balance',
-    'unit_of_measurement': 'USD',
+    'unit_of_measurement': 'EUR',
   })
 # ---
 # name: test_all_entities[sensor.zillow_house_balance-state]
@@ -1136,7 +1136,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.zillow_house_balance',

--- a/tests/components/monarch_money/snapshots/test_sensor.ambr
+++ b/tests/components/monarch_money/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[sensor.cashflow-entry]
+# name: test_all_entities[sensor.cashflow_expense_year_to_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.cashflow',
+    'entity_id': 'sensor.cashflow_expense_year_to_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,67 +23,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Expense year to date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
-    'platform': 'monarch_money',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'sum_income',
-    'unique_id': '222260252323873333_cashflow_sum_income',
-    'unit_of_measurement': 'USD',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.cashflow',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '15000.0',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.cashflow_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
-    'original_icon': None,
-    'original_name': None,
+    'original_name': 'Expense year to date',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -93,23 +38,23 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_2-state]
+# name: test_all_entities[sensor.cashflow_expense_year_to_date-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Expense year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cashflow_2',
+    'entity_id': 'sensor.cashflow_expense_year_to_date',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-9000.0',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_3-entry]
+# name: test_all_entities[sensor.cashflow_income_year_to_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -125,7 +70,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.cashflow_3',
+    'entity_id': 'sensor.cashflow_income_year_to_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -133,38 +78,38 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Income year to date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Income year to date',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'savings',
-    'unique_id': '222260252323873333_cashflow_savings',
+    'translation_key': 'sum_income',
+    'unique_id': '222260252323873333_cashflow_sum_income',
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_3-state]
+# name: test_all_entities[sensor.cashflow_income_year_to_date-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Income year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cashflow_3',
+    'entity_id': 'sensor.cashflow_income_year_to_date',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '6000.0',
+    'state': '15000.0',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_4-entry]
+# name: test_all_entities[sensor.cashflow_savings_rate-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -178,7 +123,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.cashflow_4',
+    'entity_id': 'sensor.cashflow_savings_rate',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -186,7 +131,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Savings rate',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -194,7 +139,7 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Savings rate',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -204,21 +149,21 @@
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_4-state]
+# name: test_all_entities[sensor.cashflow_savings_rate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings rate',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cashflow_4',
+    'entity_id': 'sensor.cashflow_savings_rate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '40.0',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet-entry]
+# name: test_all_entities[sensor.cashflow_savings_year_to_date-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -234,7 +179,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.manual_entry_wallet',
+    'entity_id': 'sensor.cashflow_savings_year_to_date',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -242,12 +187,67 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Savings year to date',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Savings year to date',
+    'platform': 'monarch_money',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'savings',
+    'unique_id': '222260252323873333_cashflow_savings',
+    'unit_of_measurement': 'USD',
+  })
+# ---
+# name: test_all_entities[sensor.cashflow_savings_year_to_date-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings year to date',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.cashflow_savings_year_to_date',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6000.0',
+  })
+# ---
+# name: test_all_entities[sensor.manual_entry_wallet_balance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.manual_entry_wallet_balance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Balance',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
+    'original_icon': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -257,24 +257,24 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet-state]
+# name: test_all_entities[sensor.manual_entry_wallet_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.manual_entry_wallet',
+    'entity_id': 'sensor.manual_entry_wallet_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20.0',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_2-entry]
+# name: test_all_entities[sensor.manual_entry_wallet_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -288,7 +288,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.manual_entry_wallet_2',
+    'entity_id': 'sensor.manual_entry_wallet_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -296,12 +296,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -311,22 +311,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_2-state]
+# name: test_all_entities[sensor.manual_entry_wallet_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.manual_entry_wallet_2',
+    'entity_id': 'sensor.manual_entry_wallet_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-08-16T14:22:10+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking-entry]
+# name: test_all_entities[sensor.rando_bank_checking_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -342,7 +342,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_bank_checking',
+    'entity_id': 'sensor.rando_bank_checking_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -350,12 +350,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -365,25 +365,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking-state]
+# name: test_all_entities[sensor.rando_bank_checking_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_bank_checking',
+    'entity_id': 'sensor.rando_bank_checking_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1000.02',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_2-entry]
+# name: test_all_entities[sensor.rando_bank_checking_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -397,7 +397,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_bank_checking_2',
+    'entity_id': 'sensor.rando_bank_checking_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -405,12 +405,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -420,22 +420,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_2-state]
+# name: test_all_entities[sensor.rando_bank_checking_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_bank_checking_2',
+    'entity_id': 'sensor.rando_bank_checking_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T11:21:05+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage-entry]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -451,7 +451,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_brokerage_brokerage',
+    'entity_id': 'sensor.rando_brokerage_brokerage_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -459,12 +459,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -474,25 +474,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage-state]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_brokerage_brokerage',
+    'entity_id': 'sensor.rando_brokerage_brokerage_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1000.5',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_2-entry]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -506,7 +506,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_brokerage_brokerage_2',
+    'entity_id': 'sensor.rando_brokerage_brokerage_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -514,12 +514,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -529,22 +529,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_2-state]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_brokerage_brokerage_2',
+    'entity_id': 'sensor.rando_brokerage_brokerage_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2022-05-26T00:56:41+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card-entry]
+# name: test_all_entities[sensor.rando_credit_credit_card_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -560,7 +560,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_credit_credit_card',
+    'entity_id': 'sensor.rando_credit_credit_card_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -568,12 +568,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -583,25 +583,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card-state]
+# name: test_all_entities[sensor.rando_credit_credit_card_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_credit_credit_card',
+    'entity_id': 'sensor.rando_credit_credit_card_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-200.0',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_2-entry]
+# name: test_all_entities[sensor.rando_credit_credit_card_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -615,7 +615,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_credit_credit_card_2',
+    'entity_id': 'sensor.rando_credit_credit_card_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -623,12 +623,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -638,22 +638,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_2-state]
+# name: test_all_entities[sensor.rando_credit_credit_card_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_credit_credit_card_2',
+    'entity_id': 'sensor.rando_credit_credit_card_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2022-12-10T18:17:06+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k-entry]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -669,7 +669,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_employer_investments_401_k',
+    'entity_id': 'sensor.rando_employer_investments_401_k_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -677,12 +677,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -692,25 +692,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k-state]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_employer_investments_401_k',
+    'entity_id': 'sensor.rando_employer_investments_401_k_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100000.35',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_2-entry]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -724,7 +724,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_employer_investments_401_k_2',
+    'entity_id': 'sensor.rando_employer_investments_401_k_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -732,12 +732,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -747,22 +747,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_2-state]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_employer_investments_401_k_2',
+    'entity_id': 'sensor.rando_employer_investments_401_k_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T08:13:10+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira-entry]
+# name: test_all_entities[sensor.rando_investments_roth_ira_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -778,7 +778,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_investments_roth_ira',
+    'entity_id': 'sensor.rando_investments_roth_ira_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -786,12 +786,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -801,25 +801,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira-state]
+# name: test_all_entities[sensor.rando_investments_roth_ira_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_investments_roth_ira',
+    'entity_id': 'sensor.rando_investments_roth_ira_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10000.43',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_2-entry]
+# name: test_all_entities[sensor.rando_investments_roth_ira_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -833,7 +833,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_investments_roth_ira_2',
+    'entity_id': 'sensor.rando_investments_roth_ira_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -841,12 +841,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -856,22 +856,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_2-state]
+# name: test_all_entities[sensor.rando_investments_roth_ira_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_investments_roth_ira_2',
+    'entity_id': 'sensor.rando_investments_roth_ira_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T13:32:21+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage-entry]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -887,7 +887,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_mortgage_mortgage',
+    'entity_id': 'sensor.rando_mortgage_mortgage_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -895,12 +895,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -910,25 +910,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage-state]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_mortgage_mortgage',
+    'entity_id': 'sensor.rando_mortgage_mortgage_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_2-entry]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -942,7 +942,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_mortgage_mortgage_2',
+    'entity_id': 'sensor.rando_mortgage_mortgage_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -950,12 +950,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -965,22 +965,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_2-state]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_mortgage_mortgage_2',
+    'entity_id': 'sensor.rando_mortgage_mortgage_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2023-08-16T01:41:36+00:00',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8-entry]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -994,7 +994,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1002,12 +1002,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1017,22 +1017,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8-state]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-08-16T17:37:21+00:00',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_2-entry]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1048,7 +1048,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_2',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1056,12 +1056,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Value',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Value',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1071,25 +1071,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_2-state]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://api.monarchmoney.com/cdn-cgi/image/width=128/images/institution/159427559853802644',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Value',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_2',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '11075.58',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house-entry]
+# name: test_all_entities[sensor.zillow_house_balance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1105,7 +1105,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.zillow_house',
+    'entity_id': 'sensor.zillow_house_balance',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1113,12 +1113,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Balance',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Balance',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1128,25 +1128,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house-state]
+# name: test_all_entities[sensor.zillow_house_balance-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.zillow_house',
+    'entity_id': 'sensor.zillow_house_balance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '123000.0',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_2-entry]
+# name: test_all_entities[sensor.zillow_house_data_age-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1160,7 +1160,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.zillow_house_2',
+    'entity_id': 'sensor.zillow_house_data_age',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1168,12 +1168,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Data age',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Data age',
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1183,15 +1183,15 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_2-state]
+# name: test_all_entities[sensor.zillow_house_data_age-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Data age',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.zillow_house_2',
+    'entity_id': 'sensor.zillow_house_data_age',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/monarch_money/snapshots/test_sensor.ambr
+++ b/tests/components/monarch_money/snapshots/test_sensor.ambr
@@ -35,7 +35,7 @@
     'supported_features': 0,
     'translation_key': 'sum_expense',
     'unique_id': '222260252323873333_cashflow_sum_expense',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_expense_year_to_date-state]
@@ -44,7 +44,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Expense year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_expense_year_to_date',
@@ -90,7 +90,7 @@
     'supported_features': 0,
     'translation_key': 'sum_income',
     'unique_id': '222260252323873333_cashflow_sum_income',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_income_year_to_date-state]
@@ -99,7 +99,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Income year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_income_year_to_date',
@@ -199,7 +199,7 @@
     'supported_features': 0,
     'translation_key': 'savings',
     'unique_id': '222260252323873333_cashflow_savings',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_savings_year_to_date-state]
@@ -208,7 +208,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_savings_year_to_date',
@@ -254,7 +254,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_186321412999033223_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.manual_entry_wallet_balance-state]
@@ -264,7 +264,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.manual_entry_wallet_balance',
@@ -362,7 +362,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000002_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_bank_checking_balance-state]
@@ -373,7 +373,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_bank_checking_balance',
@@ -471,7 +471,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_brokerage_brokerage_balance-state]
@@ -482,7 +482,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_brokerage_brokerage_balance',
@@ -580,7 +580,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_9000000007_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_credit_credit_card_balance-state]
@@ -591,7 +591,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_credit_credit_card_balance',
@@ -689,7 +689,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000022_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_employer_investments_401_k_balance-state]
@@ -700,7 +700,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_employer_investments_401_k_balance',
@@ -798,7 +798,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000012_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_investments_roth_ira_balance-state]
@@ -809,7 +809,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_investments_roth_ira_balance',
@@ -907,7 +907,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000030_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_mortgage_mortgage_balance-state]
@@ -918,7 +918,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_mortgage_mortgage_balance',
@@ -1068,7 +1068,7 @@
     'supported_features': 0,
     'translation_key': 'value',
     'unique_id': '222260252323873333_121212192626186051_value',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-state]
@@ -1079,7 +1079,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://api.monarchmoney.com/cdn-cgi/image/width=128/images/institution/159427559853802644',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Value',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
@@ -1125,7 +1125,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000020_balance',
-    'unit_of_measurement': '$',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.zillow_house_balance-state]
@@ -1136,7 +1136,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '$',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.zillow_house_balance',

--- a/tests/components/monarch_money/snapshots/test_sensor.ambr
+++ b/tests/components/monarch_money/snapshots/test_sensor.ambr
@@ -35,7 +35,7 @@
     'supported_features': 0,
     'translation_key': 'sum_expense',
     'unique_id': '222260252323873333_cashflow_sum_expense',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_expense_year_to_date-state]
@@ -44,7 +44,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Expense year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_expense_year_to_date',
@@ -90,7 +90,7 @@
     'supported_features': 0,
     'translation_key': 'sum_income',
     'unique_id': '222260252323873333_cashflow_sum_income',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_income_year_to_date-state]
@@ -99,7 +99,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Income year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_income_year_to_date',
@@ -199,7 +199,7 @@
     'supported_features': 0,
     'translation_key': 'savings',
     'unique_id': '222260252323873333_cashflow_savings',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.cashflow_savings_year_to_date-state]
@@ -208,7 +208,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings year to date',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.cashflow_savings_year_to_date',
@@ -254,7 +254,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_186321412999033223_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.manual_entry_wallet_balance-state]
@@ -264,7 +264,7 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.manual_entry_wallet_balance',
@@ -362,7 +362,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000002_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_bank_checking_balance-state]
@@ -373,7 +373,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_bank_checking_balance',
@@ -471,7 +471,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_brokerage_brokerage_balance-state]
@@ -482,7 +482,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_brokerage_brokerage_balance',
@@ -580,7 +580,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_9000000007_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_credit_credit_card_balance-state]
@@ -591,7 +591,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_credit_credit_card_balance',
@@ -689,7 +689,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000022_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_employer_investments_401_k_balance-state]
@@ -700,7 +700,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_employer_investments_401_k_balance',
@@ -798,7 +798,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_900000000012_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_investments_roth_ira_balance-state]
@@ -809,7 +809,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_investments_roth_ira_balance',
@@ -907,7 +907,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000030_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.rando_mortgage_mortgage_balance-state]
@@ -918,7 +918,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.rando_mortgage_mortgage_balance',
@@ -1068,7 +1068,7 @@
     'supported_features': 0,
     'translation_key': 'value',
     'unique_id': '222260252323873333_121212192626186051_value',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-state]
@@ -1079,7 +1079,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://api.monarchmoney.com/cdn-cgi/image/width=128/images/institution/159427559853802644',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Value',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
@@ -1125,7 +1125,7 @@
     'supported_features': 0,
     'translation_key': 'balance',
     'unique_id': '222260252323873333_90000000020_balance',
-    'unit_of_measurement': 'EUR',
+    'unit_of_measurement': 'USD',
   })
 # ---
 # name: test_all_entities[sensor.zillow_house_balance-state]
@@ -1136,7 +1136,7 @@
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Balance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'EUR',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.zillow_house_balance',

--- a/tests/components/monarch_money/snapshots/test_sensor.ambr
+++ b/tests/components/monarch_money/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[sensor.cashflow_expense_year_to_date-entry]
+# name: test_all_entities[sensor.cashflow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.cashflow_expense_year_to_date',
+    'entity_id': 'sensor.cashflow',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,67 +23,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Expense year to date',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Expense year to date',
-    'platform': 'monarch_money',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'sum_expense',
-    'unique_id': '222260252323873333_cashflow_sum_expense',
-    'unit_of_measurement': 'USD',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow_expense_year_to_date-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Expense year to date',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.cashflow_expense_year_to_date',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '-9000.0',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow_income_year_to_date-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.cashflow_income_year_to_date',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Income year to date',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
-    'original_icon': None,
-    'original_name': 'Income year to date',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -93,77 +38,23 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_income_year_to_date-state]
+# name: test_all_entities[sensor.cashflow-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Income year to date',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cashflow_income_year_to_date',
+    'entity_id': 'sensor.cashflow',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '15000.0',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_savings_rate-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.cashflow_savings_rate',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Savings rate',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Savings rate',
-    'platform': 'monarch_money',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'savings_rate',
-    'unique_id': '222260252323873333_cashflow_savings_rate',
-    'unit_of_measurement': '%',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow_savings_rate-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings rate',
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.cashflow_savings_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '40.0',
-  })
-# ---
-# name: test_all_entities[sensor.cashflow_savings_year_to_date-entry]
+# name: test_all_entities[sensor.cashflow_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -179,7 +70,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.cashflow_savings_year_to_date',
+    'entity_id': 'sensor.cashflow_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -187,12 +78,67 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Savings year to date',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Savings year to date',
+    'original_name': None,
+    'platform': 'monarch_money',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sum_expense',
+    'unique_id': '222260252323873333_cashflow_sum_expense',
+    'unit_of_measurement': 'USD',
+  })
+# ---
+# name: test_all_entities[sensor.cashflow_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.cashflow_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-9000.0',
+  })
+# ---
+# name: test_all_entities[sensor.cashflow_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.cashflow_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
+    'original_icon': None,
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -202,23 +148,77 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.cashflow_savings_year_to_date-state]
+# name: test_all_entities[sensor.cashflow_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow Savings year to date',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.cashflow_savings_year_to_date',
+    'entity_id': 'sensor.cashflow_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6000.0',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_balance-entry]
+# name: test_all_entities[sensor.cashflow_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.cashflow_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'monarch_money',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'savings_rate',
+    'unique_id': '222260252323873333_cashflow_savings_rate',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[sensor.cashflow_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Cashflow',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.cashflow_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.0',
+  })
+# ---
+# name: test_all_entities[sensor.manual_entry_wallet-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -234,7 +234,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.manual_entry_wallet_balance',
+    'entity_id': 'sensor.manual_entry_wallet',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -242,12 +242,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -257,24 +257,24 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_balance-state]
+# name: test_all_entities[sensor.manual_entry_wallet-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.manual_entry_wallet_balance',
+    'entity_id': 'sensor.manual_entry_wallet',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20.0',
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_data_age-entry]
+# name: test_all_entities[sensor.manual_entry_wallet_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -288,7 +288,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.manual_entry_wallet_data_age',
+    'entity_id': 'sensor.manual_entry_wallet_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -296,12 +296,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -311,22 +311,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.manual_entry_wallet_data_age-state]
+# name: test_all_entities[sensor.manual_entry_wallet_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Manual entry Wallet',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.manual_entry_wallet_data_age',
+    'entity_id': 'sensor.manual_entry_wallet_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-08-16T14:22:10+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_balance-entry]
+# name: test_all_entities[sensor.rando_bank_checking-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -342,7 +342,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_bank_checking_balance',
+    'entity_id': 'sensor.rando_bank_checking',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -350,12 +350,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -365,25 +365,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_balance-state]
+# name: test_all_entities[sensor.rando_bank_checking-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_bank_checking_balance',
+    'entity_id': 'sensor.rando_bank_checking',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1000.02',
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_data_age-entry]
+# name: test_all_entities[sensor.rando_bank_checking_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -397,7 +397,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_bank_checking_data_age',
+    'entity_id': 'sensor.rando_bank_checking_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -405,12 +405,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -420,22 +420,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_bank_checking_data_age-state]
+# name: test_all_entities[sensor.rando_bank_checking_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Bank Checking',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_bank_checking_data_age',
+    'entity_id': 'sensor.rando_bank_checking_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T11:21:05+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_balance-entry]
+# name: test_all_entities[sensor.rando_brokerage_brokerage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -451,7 +451,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_brokerage_brokerage_balance',
+    'entity_id': 'sensor.rando_brokerage_brokerage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -459,12 +459,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -474,25 +474,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_balance-state]
+# name: test_all_entities[sensor.rando_brokerage_brokerage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_brokerage_brokerage_balance',
+    'entity_id': 'sensor.rando_brokerage_brokerage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1000.5',
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_data_age-entry]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -506,7 +506,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_brokerage_brokerage_data_age',
+    'entity_id': 'sensor.rando_brokerage_brokerage_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -514,12 +514,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -529,22 +529,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_brokerage_brokerage_data_age-state]
+# name: test_all_entities[sensor.rando_brokerage_brokerage_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Brokerage Brokerage',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_brokerage_brokerage_data_age',
+    'entity_id': 'sensor.rando_brokerage_brokerage_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2022-05-26T00:56:41+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_balance-entry]
+# name: test_all_entities[sensor.rando_credit_credit_card-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -560,7 +560,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_credit_credit_card_balance',
+    'entity_id': 'sensor.rando_credit_credit_card',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -568,12 +568,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -583,25 +583,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_balance-state]
+# name: test_all_entities[sensor.rando_credit_credit_card-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_credit_credit_card_balance',
+    'entity_id': 'sensor.rando_credit_credit_card',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '-200.0',
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_data_age-entry]
+# name: test_all_entities[sensor.rando_credit_credit_card_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -615,7 +615,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_credit_credit_card_data_age',
+    'entity_id': 'sensor.rando_credit_credit_card_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -623,12 +623,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -638,22 +638,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_credit_credit_card_data_age-state]
+# name: test_all_entities[sensor.rando_credit_credit_card_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Credit Credit Card',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_credit_credit_card_data_age',
+    'entity_id': 'sensor.rando_credit_credit_card_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2022-12-10T18:17:06+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_balance-entry]
+# name: test_all_entities[sensor.rando_employer_investments_401_k-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -669,7 +669,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_employer_investments_401_k_balance',
+    'entity_id': 'sensor.rando_employer_investments_401_k',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -677,12 +677,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -692,25 +692,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_balance-state]
+# name: test_all_entities[sensor.rando_employer_investments_401_k-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_employer_investments_401_k_balance',
+    'entity_id': 'sensor.rando_employer_investments_401_k',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100000.35',
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_data_age-entry]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -724,7 +724,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_employer_investments_401_k_data_age',
+    'entity_id': 'sensor.rando_employer_investments_401_k_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -732,12 +732,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -747,22 +747,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_employer_investments_401_k_data_age-state]
+# name: test_all_entities[sensor.rando_employer_investments_401_k_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via FINICITY',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Employer Investments 401.k',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_employer_investments_401_k_data_age',
+    'entity_id': 'sensor.rando_employer_investments_401_k_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T08:13:10+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_balance-entry]
+# name: test_all_entities[sensor.rando_investments_roth_ira-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -778,7 +778,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_investments_roth_ira_balance',
+    'entity_id': 'sensor.rando_investments_roth_ira',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -786,12 +786,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -801,25 +801,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_balance-state]
+# name: test_all_entities[sensor.rando_investments_roth_ira-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_investments_roth_ira_balance',
+    'entity_id': 'sensor.rando_investments_roth_ira',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10000.43',
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_data_age-entry]
+# name: test_all_entities[sensor.rando_investments_roth_ira_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -833,7 +833,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_investments_roth_ira_data_age',
+    'entity_id': 'sensor.rando_investments_roth_ira_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -841,12 +841,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -856,22 +856,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_investments_roth_ira_data_age-state]
+# name: test_all_entities[sensor.rando_investments_roth_ira_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Investments Roth IRA',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_investments_roth_ira_data_age',
+    'entity_id': 'sensor.rando_investments_roth_ira_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-02-17T13:32:21+00:00',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_balance-entry]
+# name: test_all_entities[sensor.rando_mortgage_mortgage-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -887,7 +887,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.rando_mortgage_mortgage_balance',
+    'entity_id': 'sensor.rando_mortgage_mortgage',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -895,12 +895,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -910,25 +910,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_balance-state]
+# name: test_all_entities[sensor.rando_mortgage_mortgage-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_mortgage_mortgage_balance',
+    'entity_id': 'sensor.rando_mortgage_mortgage',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_data_age-entry]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -942,7 +942,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.rando_mortgage_mortgage_data_age',
+    'entity_id': 'sensor.rando_mortgage_mortgage_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -950,12 +950,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -965,22 +965,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.rando_mortgage_mortgage_data_age-state]
+# name: test_all_entities[sensor.rando_mortgage_mortgage_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via PLAID',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Rando Mortgage Mortgage',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.rando_mortgage_mortgage_data_age',
+    'entity_id': 'sensor.rando_mortgage_mortgage_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2023-08-16T01:41:36+00:00',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_data_age-entry]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -994,7 +994,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_data_age',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1002,12 +1002,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1017,22 +1017,22 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_data_age-state]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_data_age',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2024-08-16T17:37:21+00:00',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-entry]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1048,7 +1048,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1056,12 +1056,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Value',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Value',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1071,25 +1071,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_value-state]
+# name: test_all_entities[sensor.vinaudit_2050_toyota_rav8_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'https://api.monarchmoney.com/cdn-cgi/image/width=128/images/institution/159427559853802644',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8 Value',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VinAudit 2050 Toyota RAV8',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_value',
+    'entity_id': 'sensor.vinaudit_2050_toyota_rav8_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '11075.58',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_balance-entry]
+# name: test_all_entities[sensor.zillow_house-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1105,7 +1105,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.zillow_house_balance',
+    'entity_id': 'sensor.zillow_house',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1113,12 +1113,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Balance',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.MONETARY: 'monetary'>,
     'original_icon': None,
-    'original_name': 'Balance',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1128,25 +1128,25 @@
     'unit_of_measurement': 'USD',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_balance-state]
+# name: test_all_entities[sensor.zillow_house-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'monetary',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: 'data:image/png;base64,base64Nonce',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Balance',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'USD',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.zillow_house_balance',
+    'entity_id': 'sensor.zillow_house',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '123000.0',
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_data_age-entry]
+# name: test_all_entities[sensor.zillow_house_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1160,7 +1160,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.zillow_house_data_age',
+    'entity_id': 'sensor.zillow_house_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1168,12 +1168,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Data age',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
     'original_icon': None,
-    'original_name': 'Data age',
+    'original_name': None,
     'platform': 'monarch_money',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1183,15 +1183,15 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.zillow_house_data_age-state]
+# name: test_all_entities[sensor.zillow_house_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by Monarch Money API via Manual entry',
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House Data age',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Zillow House',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.zillow_house_data_age',
+    'entity_id': 'sensor.zillow_house_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -5,20 +5,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.recorder.models import StatisticMeanType
-from homeassistant.components.recorder.statistics import (
-    async_add_external_statistics,
-    get_metadata,
-)
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
-from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_all_entities(
@@ -100,56 +93,68 @@ async def test_non_monetary_sensors_not_affected_by_currency(
     assert "device_class" not in state.attributes
 
 
-@pytest.mark.usefixtures("recorder_mock")
-async def test_statistics_migration_from_dollar_symbol(
+async def test_statistics_migration_called_for_monetary_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     mock_config_api: AsyncMock,
 ) -> None:
-    """Test that statistics with '$' unit are migrated to configured currency."""
+    """Test that statistics migration is called for existing monetary sensors on setup."""
     await hass.config.async_update(currency="USD")
 
-    # First, set up the integration to create entities
-    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
-        await setup_integration(hass, mock_config_entry)
+    # Add entry to hass first so we can add entities to it
+    mock_config_entry.add_to_hass(hass)
 
-    await async_wait_recording_done(hass)
-
-    # Add external statistics with old "$" unit to simulate pre-migration data
-    entity_id = "sensor.rando_bank_checking_balance"
-    now = dt_util.utcnow()
-
-    async_add_external_statistics(
-        hass,
-        {
-            "has_mean": False,
-            "has_sum": True,
-            "mean_type": StatisticMeanType.NONE,
-            "name": "Test Balance",
-            "source": "recorder",
-            "statistic_id": entity_id,
-            "unit_class": None,
-            "unit_of_measurement": "$",
-        },
-        [{"start": now, "sum": 1000.0, "state": 1000.0}],
+    # Pre-populate entity registry with existing monetary sensor entries
+    # This simulates a previous installation that had these entities
+    entity_registry.async_get_or_create(
+        "sensor",
+        "monarch_money",
+        "222260252323873333_checking_currentBalance",
+        config_entry=mock_config_entry,
+        original_device_class="monetary",
+        suggested_object_id="rando_bank_checking_balance",
     )
-    await async_wait_recording_done(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        "monarch_money",
+        "222260252323873333_sum_income",
+        config_entry=mock_config_entry,
+        original_device_class="monetary",
+        suggested_object_id="cashflow_income_year_to_date",
+    )
+    # Add a non-monetary sensor to verify it's not migrated
+    entity_registry.async_get_or_create(
+        "sensor",
+        "monarch_money",
+        "222260252323873333_checking_age",
+        config_entry=mock_config_entry,
+        original_device_class="timestamp",
+        suggested_object_id="rando_bank_checking_data_age",
+    )
 
-    # Verify initial statistics have "$" unit
-    metadata = get_metadata(hass, statistic_ids={entity_id})
-    assert entity_id in metadata
-    assert metadata[entity_id][1]["unit_of_measurement"] == "$"
-
-    # Unload and reload to trigger migration
-    await hass.config_entries.async_unload(mock_config_entry.entry_id)
-
-    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
+    with (
+        patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]),
+        patch(
+            "homeassistant.components.monarch_money.async_update_statistics_metadata"
+        ) as mock_update_stats,
+    ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    await async_wait_recording_done(hass)
+    # Verify async_update_statistics_metadata was called for monetary sensors
+    assert mock_update_stats.call_count == 2  # Only the 2 monetary sensors
 
-    # Verify statistics were migrated to configured currency
-    metadata = get_metadata(hass, statistic_ids={entity_id})
-    assert entity_id in metadata
-    assert metadata[entity_id][1]["unit_of_measurement"] == "USD"
+    # Collect all entity_ids that were called
+    called_entity_ids = {call.args[1] for call in mock_update_stats.call_args_list}
+
+    # Verify monetary sensors were included
+    assert "sensor.rando_bank_checking_balance" in called_entity_ids
+    assert "sensor.cashflow_income_year_to_date" in called_entity_ids
+
+    # Verify non-monetary sensor was NOT included
+    assert "sensor.rando_bank_checking_data_age" not in called_entity_ids
+
+    # Verify all calls used the configured currency
+    for call in mock_update_stats.call_args_list:
+        assert call.kwargs["new_unit_of_measurement"] == "USD"

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -5,13 +5,20 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.recorder.models import StatisticMeanType
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    get_metadata,
+)
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
+from tests.components.recorder.common import async_wait_recording_done
 
 
 async def test_all_entities(
@@ -91,3 +98,58 @@ async def test_non_monetary_sensors_not_affected_by_currency(
     assert state is not None
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
     assert "device_class" not in state.attributes
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_statistics_migration_from_dollar_symbol(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_config_api: AsyncMock,
+) -> None:
+    """Test that statistics with '$' unit are migrated to configured currency."""
+    await hass.config.async_update(currency="USD")
+
+    # First, set up the integration to create entities
+    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    await async_wait_recording_done(hass)
+
+    # Add external statistics with old "$" unit to simulate pre-migration data
+    entity_id = "sensor.rando_bank_checking_balance"
+    now = dt_util.utcnow()
+
+    async_add_external_statistics(
+        hass,
+        {
+            "has_mean": False,
+            "has_sum": True,
+            "mean_type": StatisticMeanType.NONE,
+            "name": "Test Balance",
+            "source": "recorder",
+            "statistic_id": entity_id,
+            "unit_class": None,
+            "unit_of_measurement": "$",
+        },
+        [{"start": now, "sum": 1000.0, "state": 1000.0}],
+    )
+    await async_wait_recording_done(hass)
+
+    # Verify initial statistics have "$" unit
+    metadata = get_metadata(hass, statistic_ids={entity_id})
+    assert entity_id in metadata
+    assert metadata[entity_id][1]["unit_of_measurement"] == "$"
+
+    # Unload and reload to trigger migration
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+
+    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    # Verify statistics were migrated to configured currency
+    metadata = get_metadata(hass, statistic_ids={entity_id})
+    assert entity_id in metadata
+    assert metadata[entity_id][1]["unit_of_measurement"] == "USD"

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -2,9 +2,10 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -25,3 +26,68 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("currency", "expected_unit"),
+    [
+        ("USD", "USD"),
+        ("CAD", "CAD"),
+        ("EUR", "EUR"),
+        ("GBP", "GBP"),
+    ],
+)
+async def test_monetary_sensors_use_configured_currency(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_config_api: AsyncMock,
+    currency: str,
+    expected_unit: str,
+) -> None:
+    """Test that monetary sensors use the configured HA currency."""
+    await hass.config.async_update(currency=currency)
+
+    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Test account balance sensor (monetary)
+    state = hass.states.get("sensor.rando_bank_checking_balance")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["device_class"] == "monetary"
+
+    # Test cashflow sensor (monetary)
+    state = hass.states.get("sensor.cashflow_income_year_to_date")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["device_class"] == "monetary"
+
+    # Test value sensor (monetary)
+    state = hass.states.get("sensor.vinaudit_2050_toyota_rav8_value")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["device_class"] == "monetary"
+
+
+async def test_non_monetary_sensors_not_affected_by_currency(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_config_api: AsyncMock,
+) -> None:
+    """Test that non-monetary sensors are not affected by currency setting."""
+    await hass.config.async_update(currency="CAD")
+
+    with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    # Test timestamp sensor (should have no unit)
+    state = hass.states.get("sensor.rando_bank_checking_data_age")
+    assert state is not None
+    assert state.attributes["device_class"] == "timestamp"
+    assert "unit_of_measurement" not in state.attributes
+
+    # Test savings rate sensor (should use percentage, not currency)
+    state = hass.states.get("sensor.cashflow_savings_rate")
+    assert state is not None
+    assert state.attributes["unit_of_measurement"] == PERCENTAGE
+    assert "device_class" not in state.attributes

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -5,9 +5,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.monarch_money import async_migrate_entry
+from homeassistant.components.monarch_money.config_flow import MonarchMoneyConfigFlow
+from homeassistant.components.monarch_money.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from . import setup_integration
 
@@ -97,50 +102,19 @@ async def test_statistics_migration_called_for_monetary_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    mock_config_api: AsyncMock,
 ) -> None:
-    """Test that statistics migration is called for existing monetary sensors on setup."""
+    """Test statistics migration updates existing monetary sensors."""
     await hass.config.async_update(currency="USD")
 
     # Add entry to hass first so we can add entities to it
     mock_config_entry.add_to_hass(hass)
+    _add_migration_entity_registry_entries(entity_registry, mock_config_entry)
+    hass.data[DATA_INSTANCE] = object()
 
-    # Pre-populate entity registry with existing monetary sensor entries
-    # This simulates a previous installation that had these entities
-    entity_registry.async_get_or_create(
-        "sensor",
-        "monarch_money",
-        "222260252323873333_checking_currentBalance",
-        config_entry=mock_config_entry,
-        original_device_class="monetary",
-        suggested_object_id="rando_bank_checking_balance",
-    )
-    entity_registry.async_get_or_create(
-        "sensor",
-        "monarch_money",
-        "222260252323873333_sum_income",
-        config_entry=mock_config_entry,
-        original_device_class="monetary",
-        suggested_object_id="cashflow_income_year_to_date",
-    )
-    # Add a non-monetary sensor to verify it's not migrated
-    entity_registry.async_get_or_create(
-        "sensor",
-        "monarch_money",
-        "222260252323873333_checking_age",
-        config_entry=mock_config_entry,
-        original_device_class="timestamp",
-        suggested_object_id="rando_bank_checking_data_age",
-    )
-
-    with (
-        patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]),
-        patch(
-            "homeassistant.components.monarch_money.async_update_statistics_metadata"
-        ) as mock_update_stats,
-    ):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.monarch_money.async_update_statistics_metadata"
+    ) as mock_update_stats:
+        assert await async_migrate_entry(hass, mock_config_entry)
 
     # Verify async_update_statistics_metadata was called for monetary sensors
     assert mock_update_stats.call_count == 2  # Only the 2 monetary sensors
@@ -158,3 +132,61 @@ async def test_statistics_migration_called_for_monetary_sensors(
     # Verify all calls used the configured currency
     for call in mock_update_stats.call_args_list:
         assert call.kwargs["new_unit_of_measurement"] == "USD"
+
+    assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
+
+
+async def test_statistics_migration_returns_early_without_recorder(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test statistics migration skips metadata updates without recorder."""
+    mock_config_entry.add_to_hass(hass)
+    _add_migration_entity_registry_entries(entity_registry, mock_config_entry)
+
+    with patch(
+        "homeassistant.components.monarch_money.async_update_statistics_metadata",
+        side_effect=AssertionError("Statistics metadata should not be updated"),
+    ):
+        assert await async_migrate_entry(hass, mock_config_entry)
+
+    assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
+
+
+def test_config_flow_minor_version() -> None:
+    """Test config flow minor version includes the statistics migration."""
+    assert MonarchMoneyConfigFlow.MINOR_VERSION == 2
+
+
+def _add_migration_entity_registry_entries(
+    entity_registry: er.EntityRegistry, mock_config_entry: MockConfigEntry
+) -> None:
+    """Add entity registry entries for statistics migration tests."""
+    # Pre-populate entity registry with existing monetary sensor entries to
+    # simulate a previous installation that had these entities.
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "222260252323873333_checking_currentBalance",
+        config_entry=mock_config_entry,
+        original_device_class=SensorDeviceClass.MONETARY,
+        suggested_object_id="rando_bank_checking_balance",
+    )
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "222260252323873333_sum_income",
+        config_entry=mock_config_entry,
+        original_device_class=SensorDeviceClass.MONETARY,
+        suggested_object_id="cashflow_income_year_to_date",
+    )
+    # Add a non-monetary sensor to verify it is not migrated.
+    entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "222260252323873333_checking_age",
+        config_entry=mock_config_entry,
+        original_device_class=SensorDeviceClass.TIMESTAMP,
+        suggested_object_id="rando_bank_checking_data_age",
+    )

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -7,7 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.monarch_money import async_migrate_entry
 from homeassistant.components.monarch_money.config_flow import MonarchMoneyConfigFlow
-from homeassistant.components.monarch_money.const import DOMAIN
+from homeassistant.components.monarch_money.const import DOMAIN, MONARCH_MONEY_CURRENCY
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
@@ -34,22 +34,21 @@ async def test_all_entities(
 
 
 @pytest.mark.parametrize(
-    ("currency", "expected_unit"),
+    "currency",
     [
-        ("USD", "USD"),
-        ("CAD", "CAD"),
-        ("EUR", "EUR"),
-        ("GBP", "GBP"),
+        "USD",
+        "CAD",
+        "EUR",
+        "GBP",
     ],
 )
-async def test_monetary_sensors_use_configured_currency(
+async def test_monetary_sensors_use_monarch_money_currency(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_config_api: AsyncMock,
     currency: str,
-    expected_unit: str,
 ) -> None:
-    """Test that monetary sensors use the configured HA currency."""
+    """Test that monetary sensors use the Monarch Money currency."""
     await hass.config.async_update(currency=currency)
 
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
@@ -58,19 +57,19 @@ async def test_monetary_sensors_use_configured_currency(
     # Test account balance sensor (monetary)
     state = hass.states.get("sensor.rando_bank_checking_balance")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
     # Test cashflow sensor (monetary)
     state = hass.states.get("sensor.cashflow_income_year_to_date")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
     # Test value sensor (monetary)
     state = hass.states.get("sensor.vinaudit_2050_toyota_rav8_value")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == expected_unit
+    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
 
@@ -129,9 +128,9 @@ async def test_statistics_migration_called_for_monetary_sensors(
     # Verify non-monetary sensor was NOT included
     assert "sensor.rando_bank_checking_data_age" not in called_entity_ids
 
-    # Verify all calls used the configured currency
+    # Verify all calls used the Monarch Money currency
     for call in mock_update_stats.call_args_list:
-        assert call.kwargs["new_unit_of_measurement"] == "USD"
+        assert call.kwargs["new_unit_of_measurement"] == MONARCH_MONEY_CURRENCY
 
     assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -42,13 +42,13 @@ async def test_all_entities(
         "GBP",
     ],
 )
-async def test_monetary_sensors_use_monarch_money_currency(
+async def test_monetary_sensors_ignore_hass_currency(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_config_api: AsyncMock,
     currency: str,
 ) -> None:
-    """Test that monetary sensors use the Monarch Money currency."""
+    """Test that monetary sensors ignore the configured HA currency."""
     await hass.config.async_update(currency=currency)
 
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
@@ -150,7 +150,7 @@ async def test_statistics_migration_returns_early_without_recorder(
     ):
         assert await async_migrate_entry(hass, mock_config_entry)
 
-    assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
+    assert mock_config_entry.minor_version == 1
 
 
 def test_config_flow_minor_version() -> None:

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDevic
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from . import setup_integration
 
@@ -54,19 +53,16 @@ async def test_monetary_sensors_ignore_hass_currency(
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    # Test account balance sensor (monetary)
     state = hass.states.get("sensor.rando_bank_checking_balance")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
-    # Test cashflow sensor (monetary)
     state = hass.states.get("sensor.cashflow_income_year_to_date")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
-    # Test value sensor (monetary)
     state = hass.states.get("sensor.vinaudit_2050_toyota_rav8_value")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
@@ -84,19 +80,18 @@ async def test_non_monetary_sensors_not_affected_by_currency(
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    # Test timestamp sensor (should have no unit)
     state = hass.states.get("sensor.rando_bank_checking_data_age")
     assert state is not None
     assert state.attributes["device_class"] == "timestamp"
     assert "unit_of_measurement" not in state.attributes
 
-    # Test savings rate sensor (should use percentage, not currency)
     state = hass.states.get("sensor.cashflow_savings_rate")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
     assert "device_class" not in state.attributes
 
 
+@pytest.mark.usefixtures("recorder_mock")
 async def test_statistics_migration_called_for_monetary_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -105,37 +100,26 @@ async def test_statistics_migration_called_for_monetary_sensors(
     """Test statistics migration updates existing monetary sensors."""
     await hass.config.async_update(currency="USD")
 
-    # Add entry to hass first so we can add entities to it
     mock_config_entry.add_to_hass(hass)
     _add_migration_entity_registry_entries(entity_registry, mock_config_entry)
-    hass.data[DATA_INSTANCE] = object()
 
     with patch(
         "homeassistant.components.monarch_money.async_update_statistics_metadata"
     ) as mock_update_stats:
         assert await async_migrate_entry(hass, mock_config_entry)
 
-    # Verify async_update_statistics_metadata was called for monetary sensors
-    assert mock_update_stats.call_count == 2  # Only the 2 monetary sensors
-
-    # Collect all entity_ids that were called
     called_entity_ids = {call.args[1] for call in mock_update_stats.call_args_list}
-
-    # Verify monetary sensors were included
-    assert "sensor.rando_bank_checking_balance" in called_entity_ids
-    assert "sensor.cashflow_income_year_to_date" in called_entity_ids
-
-    # Verify non-monetary sensor was NOT included
-    assert "sensor.rando_bank_checking_data_age" not in called_entity_ids
-
-    # Verify all calls used the Monarch Money currency
+    assert called_entity_ids == {
+        "sensor.cashflow_income_year_to_date",
+        "sensor.rando_bank_checking_balance",
+    }
     for call in mock_update_stats.call_args_list:
         assert call.kwargs["new_unit_of_measurement"] == DEFAULT_CURRENCY
 
     assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 
 
-async def test_statistics_migration_returns_early_without_recorder(
+async def test_statistics_migration_skips_metadata_without_recorder(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
@@ -150,20 +134,13 @@ async def test_statistics_migration_returns_early_without_recorder(
     ):
         assert await async_migrate_entry(hass, mock_config_entry)
 
-    assert mock_config_entry.minor_version == 1
-
-
-def test_config_flow_minor_version() -> None:
-    """Test config flow minor version includes the statistics migration."""
-    assert MonarchMoneyConfigFlow.MINOR_VERSION == 2
+    assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 
 
 def _add_migration_entity_registry_entries(
     entity_registry: er.EntityRegistry, mock_config_entry: MockConfigEntry
 ) -> None:
     """Add entity registry entries for statistics migration tests."""
-    # Pre-populate entity registry with existing monetary sensor entries to
-    # simulate a previous installation that had these entities.
     entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
@@ -180,7 +157,6 @@ def _add_migration_entity_registry_entries(
         original_device_class=SensorDeviceClass.MONETARY,
         suggested_object_id="cashflow_income_year_to_date",
     )
-    # Add a non-monetary sensor to verify it is not migrated.
     entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -7,7 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.monarch_money import async_migrate_entry
 from homeassistant.components.monarch_money.config_flow import MonarchMoneyConfigFlow
-from homeassistant.components.monarch_money.const import DOMAIN, MONARCH_MONEY_CURRENCY
+from homeassistant.components.monarch_money.const import DEFAULT_CURRENCY, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
@@ -57,19 +57,19 @@ async def test_monetary_sensors_ignore_hass_currency(
     # Test account balance sensor (monetary)
     state = hass.states.get("sensor.rando_bank_checking_balance")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
+    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
     # Test cashflow sensor (monetary)
     state = hass.states.get("sensor.cashflow_income_year_to_date")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
+    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
     # Test value sensor (monetary)
     state = hass.states.get("sensor.vinaudit_2050_toyota_rav8_value")
     assert state is not None
-    assert state.attributes["unit_of_measurement"] == MONARCH_MONEY_CURRENCY
+    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
     assert state.attributes["device_class"] == "monetary"
 
 
@@ -130,7 +130,7 @@ async def test_statistics_migration_called_for_monetary_sensors(
 
     # Verify all calls used the Monarch Money currency
     for call in mock_update_stats.call_args_list:
-        assert call.kwargs["new_unit_of_measurement"] == MONARCH_MONEY_CURRENCY
+        assert call.kwargs["new_unit_of_measurement"] == DEFAULT_CURRENCY
 
     assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.monarch_money import async_migrate_entry
 from homeassistant.components.monarch_money.config_flow import MonarchMoneyConfigFlow
 from homeassistant.components.monarch_money.const import DEFAULT_CURRENCY, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
@@ -44,61 +43,73 @@ async def test_all_entities(
 async def test_monetary_sensors_ignore_hass_currency(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     mock_config_api: AsyncMock,
     currency: str,
 ) -> None:
     """Test that monetary sensors ignore the configured HA currency."""
-    await hass.config.async_update(currency=currency)
+    await hass.config.async_update(country="US", currency=currency)
 
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.rando_bank_checking_balance")
-    assert state is not None
-    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
-    assert state.attributes["device_class"] == "monetary"
-
-    state = hass.states.get("sensor.cashflow_income_year_to_date")
-    assert state is not None
-    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
-    assert state.attributes["device_class"] == "monetary"
-
-    state = hass.states.get("sensor.vinaudit_2050_toyota_rav8_value")
-    assert state is not None
-    assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
-    assert state.attributes["device_class"] == "monetary"
+    for unique_id in (
+        "222260252323873333_900000002_balance",
+        "222260252323873333_cashflow_sum_income",
+        "222260252323873333_121212192626186051_value",
+    ):
+        entity_id = entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, unique_id
+        )
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.attributes["unit_of_measurement"] == DEFAULT_CURRENCY
+        assert state.attributes["device_class"] == "monetary"
 
 
 async def test_non_monetary_sensors_not_affected_by_currency(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     mock_config_api: AsyncMock,
 ) -> None:
     """Test that non-monetary sensors are not affected by currency setting."""
-    await hass.config.async_update(currency="CAD")
+    await hass.config.async_update(country="US", currency="CAD")
 
     with patch("homeassistant.components.monarch_money.PLATFORMS", [Platform.SENSOR]):
         await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.rando_bank_checking_data_age")
+    age_entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, "222260252323873333_900000002_age"
+    )
+    assert age_entity_id is not None
+    state = hass.states.get(age_entity_id)
     assert state is not None
     assert state.attributes["device_class"] == "timestamp"
     assert "unit_of_measurement" not in state.attributes
 
-    state = hass.states.get("sensor.cashflow_savings_rate")
+    savings_rate_entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, "222260252323873333_cashflow_savings_rate"
+    )
+    assert savings_rate_entity_id is not None
+    state = hass.states.get(savings_rate_entity_id)
     assert state is not None
     assert state.attributes["unit_of_measurement"] == PERCENTAGE
     assert "device_class" not in state.attributes
 
 
-@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    "ignore_missing_translations", ["component.recorder.services."]
+)
+@pytest.mark.usefixtures("mock_setup_entry", "recorder_mock")
 async def test_statistics_migration_called_for_monetary_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test statistics migration updates existing monetary sensors."""
-    await hass.config.async_update(currency="USD")
+    await hass.config.async_update(country="US", currency="USD")
 
     mock_config_entry.add_to_hass(hass)
     _add_migration_entity_registry_entries(entity_registry, mock_config_entry)
@@ -106,7 +117,8 @@ async def test_statistics_migration_called_for_monetary_sensors(
     with patch(
         "homeassistant.components.monarch_money.async_update_statistics_metadata"
     ) as mock_update_stats:
-        assert await async_migrate_entry(hass, mock_config_entry)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
     called_entity_ids = {call.args[1] for call in mock_update_stats.call_args_list}
     assert called_entity_ids == {
@@ -119,6 +131,7 @@ async def test_statistics_migration_called_for_monetary_sensors(
     assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 
 
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_statistics_migration_skips_metadata_without_recorder(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -132,7 +145,8 @@ async def test_statistics_migration_skips_metadata_without_recorder(
         "homeassistant.components.monarch_money.async_update_statistics_metadata",
         side_effect=AssertionError("Statistics metadata should not be updated"),
     ):
-        assert await async_migrate_entry(hass, mock_config_entry)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
     assert mock_config_entry.minor_version == MonarchMoneyConfigFlow.MINOR_VERSION
 

--- a/tests/components/monarch_money/test_sensor.py
+++ b/tests/components/monarch_money/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDevic
 from homeassistant.const import PERCENTAGE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from . import setup_integration
 
@@ -99,10 +100,7 @@ async def test_non_monetary_sensors_not_affected_by_currency(
     assert "device_class" not in state.attributes
 
 
-@pytest.mark.parametrize(
-    "ignore_missing_translations", ["component.recorder.services."]
-)
-@pytest.mark.usefixtures("mock_setup_entry", "recorder_mock")
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_statistics_migration_called_for_monetary_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -111,6 +109,7 @@ async def test_statistics_migration_called_for_monetary_sensors(
     """Test statistics migration updates existing monetary sensors."""
     await hass.config.async_update(country="US", currency="USD")
 
+    hass.data[DATA_INSTANCE] = object()
     mock_config_entry.add_to_hass(hass)
     _add_migration_entity_registry_entries(entity_registry, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes monetary sensors in the Monarch Money integration that were using `CURRENCY_DOLLAR` ("$") as the native_unit_of_measurement, which is invalid for sensors with `device_class=MONETARY`. The MONETARY device class  requires ISO 4217 currency codes (e.g., "USD", "CAD", "EUR") rather than display symbols.

The sensors now use `DEFAULT_CURRENCY` (`USD`) as a fixed ISO 4217 currency code. Monarch Money reports account values in USD, so this replaces the invalid display symbol with the proper ISO currency code while keeping the integration behavior consistent. Users who need a different display unit for a specific account can override individual entities via the Home Assistant UI. Non-monetary sensors (timestamps, percentages) are unaffected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164508 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

