### PR TITLE
Enhance GV5140 test to assert temperature and humidity sensors

### DIFF
--- a/tests/components/govee_ble/test_sensor.py
+++ b/tests/components/govee_ble/test_sensor.py
@@ -165,7 +165,7 @@ async def test_gvh5178_multi_sensor(hass: HomeAssistant) -> None:
 
 
 async def test_gv5140(hass: HomeAssistant) -> None:
-    """Test setting up creates the sensors for a device with CO2."""
+    """Test CO2, temperature and humidity sensors for a GV5140 device."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="AA:BB:CC:DD:EE:FF",
@@ -179,6 +179,20 @@ async def test_gv5140(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info(hass, GV5140_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 3
+
+    temp_sensor = hass.states.get("sensor.5140eeff_temperature")
+    temp_sensor_attributes = temp_sensor.attributes
+    assert temp_sensor.state == "21.6"
+    assert temp_sensor_attributes[ATTR_FRIENDLY_NAME] == "5140EEFF Temperature"
+    assert temp_sensor_attributes[ATTR_UNIT_OF_MEASUREMENT] == "°C"
+    assert temp_sensor_attributes[ATTR_STATE_CLASS] == "measurement"
+
+    humidity_sensor = hass.states.get("sensor.5140eeff_humidity")
+    humidity_sensor_attributes = humidity_sensor.attributes
+    assert humidity_sensor.state == "67.8"
+    assert humidity_sensor_attributes[ATTR_FRIENDLY_NAME] == "5140EEFF Humidity"
+    assert humidity_sensor_attributes[ATTR_UNIT_OF_MEASUREMENT] == "%"
+    assert humidity_sensor_attributes[ATTR_STATE_CLASS] == "measurement"
 
     co2_sensor = hass.states.get("sensor.5140eeff_carbon_dioxide")
     co2_sensor_attributes = co2_sensor.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

● Enhance GV5140 test to assert temperature and humidity sensors                                                                                                                                                                                

A comment on the related PR I authored https://github.com/home-assistant/core/pull/164365#discussion_r2874459961 suggested that we enhance the unit tests to cover all the sensors. The `test_gv5140` test previously only asserted the CO2 sensor. This extends it to also verify the temperature (21.6 °C) and humidity (67.8 %) sensors that the GV5140 device reports, ensuring all three sensors exposed by the device are covered. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
