### PR TITLE
Add exception handling to media source in Radio Browser integration

### DIFF
--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import mimetypes
 
+from aiodns.error import DNSError
 import pycountry
-from radios import FilterBy, Order, RadioBrowser, Station
+from radios import FilterBy, Order, RadioBrowser, RadioBrowserError, Station
 
-from homeassistant.components.media_player import MediaClass, MediaType
+from homeassistant.components.media_player import BrowseError, MediaClass, MediaType
 from homeassistant.components.media_source import (
     BrowseMediaSource,
     MediaSource,
@@ -55,9 +56,20 @@ class RadioMediaSource(MediaSource):
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve selected Radio station to a streaming URL."""
-        radios = self.radios
-
-        station = await radios.station(uuid=item.identifier)
+        try:
+            radios = self.radios
+        except AttributeError as e:
+            raise Unresolvable(
+                translation_domain=DOMAIN,
+                translation_key="config_entry_not_ready",
+            ) from e
+        try:
+            station = await radios.station(uuid=item.identifier)
+        except (DNSError, RadioBrowserError) as e:
+            raise Unresolvable(
+                translation_domain=DOMAIN,
+                translation_key="radio_browser_error",
+            ) from e
         if not station:
             raise Unresolvable("Radio station is no longer available")
 
@@ -74,25 +86,37 @@ class RadioMediaSource(MediaSource):
         item: MediaSourceItem,
     ) -> BrowseMediaSource:
         """Return media."""
-        radios = self.radios
+        try:
+            radios = self.radios
+        except AttributeError as e:
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="config_entry_not_ready",
+            ) from e
 
-        return BrowseMediaSource(
-            domain=DOMAIN,
-            identifier=None,
-            media_class=MediaClass.CHANNEL,
-            media_content_type=MediaType.MUSIC,
-            title=self.entry.title,
-            can_play=False,
-            can_expand=True,
-            children_media_class=MediaClass.DIRECTORY,
-            children=[
-                *await self._async_build_popular(radios, item),
-                *await self._async_build_by_tag(radios, item),
-                *await self._async_build_by_language(radios, item),
-                *await self._async_build_local(radios, item),
-                *await self._async_build_by_country(radios, item),
-            ],
-        )
+        try:
+            return BrowseMediaSource(
+                domain=DOMAIN,
+                identifier=None,
+                media_class=MediaClass.CHANNEL,
+                media_content_type=MediaType.MUSIC,
+                title=self.entry.title,
+                can_play=False,
+                can_expand=True,
+                children_media_class=MediaClass.DIRECTORY,
+                children=[
+                    *await self._async_build_popular(radios, item),
+                    *await self._async_build_by_tag(radios, item),
+                    *await self._async_build_by_language(radios, item),
+                    *await self._async_build_local(radios, item),
+                    *await self._async_build_by_country(radios, item),
+                ],
+            )
+        except (DNSError, RadioBrowserError) as e:
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="radio_browser_error",
+            ) from e
 
     @callback
     @staticmethod

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -16,6 +16,7 @@ from homeassistant.components.media_source import (
     PlayMedia,
     Unresolvable,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util.location import vincenty
 
@@ -56,13 +57,13 @@ class RadioMediaSource(MediaSource):
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve selected Radio station to a streaming URL."""
-        try:
-            radios = self.radios
-        except AttributeError as e:
+
+        if self.entry.state != ConfigEntryState.LOADED:
             raise Unresolvable(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",
-            ) from e
+            )
+        radios = self.radios
         try:
             station = await radios.station(uuid=item.identifier)
         except (DNSError, RadioBrowserError) as e:
@@ -86,13 +87,13 @@ class RadioMediaSource(MediaSource):
         item: MediaSourceItem,
     ) -> BrowseMediaSource:
         """Return media."""
-        try:
-            radios = self.radios
-        except AttributeError as e:
+
+        if self.entry.state != ConfigEntryState.LOADED:
             raise BrowseError(
                 translation_domain=DOMAIN,
                 translation_key="config_entry_not_ready",
-            ) from e
+            )
+        radios = self.radios
 
         try:
             return BrowseMediaSource(

--- a/homeassistant/components/radio_browser/strings.json
+++ b/homeassistant/components/radio_browser/strings.json
@@ -5,5 +5,13 @@
         "description": "Do you want to add Radio Browser to Home Assistant?"
       }
     }
+  },
+  "exceptions": {
+    "config_entry_not_ready": {
+      "message": "Radio Browser integration is not ready"
+    },
+    "radio_browser_error": {
+      "message": "Error occurred while communicating with the Radio Browser API"
+    }
   }
 }

--- a/homeassistant/components/radio_browser/strings.json
+++ b/homeassistant/components/radio_browser/strings.json
@@ -11,7 +11,7 @@
       "message": "Radio Browser integration is not ready"
     },
     "radio_browser_error": {
-      "message": "Error occurred while communicating with the Radio Browser API"
+      "message": "Error occurred while communicating with Radio Browser"
     }
   }
 }

--- a/tests/components/radio_browser/conftest.py
+++ b/tests/components/radio_browser/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant.components.radio_browser.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -39,9 +40,14 @@ async def init_integration(
 ) -> MockConfigEntry:
     """Set up the Radio Browser integration for testing."""
     mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    with patch(
+        "homeassistant.components.radio_browser.RadioBrowser",
+        autospec=True,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+
+    assert mock_config_entry.state == ConfigEntryState.LOADED
 
     return mock_config_entry
 

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -1,14 +1,19 @@
 """Tests for radio_browser media_source."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
+from aiodns.error import DNSError
 import pytest
-from radios import FilterBy, Order
+from radios import FilterBy, Order, RadioBrowserError
 
 from homeassistant.components import media_source
+from homeassistant.components.media_player import BrowseError
 from homeassistant.components.radio_browser.media_source import async_get_media_source
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 DOMAIN = "radio_browser"
 
@@ -71,3 +76,113 @@ async def test_browsing_local(
     assert other_browse is not None
     assert other_browse.title == "My Radios"
     assert len(other_browse.children) == 0
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [DNSError, RadioBrowserError],
+)
+async def test_browsing_exceptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """Test browsing exceptions."""
+
+    with patch(
+        "homeassistant.components.radio_browser.RadioBrowser",
+        autospec=True,
+    ) as mock_browser:
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.LOADED
+
+        mock_browser.return_value.stations.side_effect = exception
+        with pytest.raises(BrowseError) as exc_info:
+            await media_source.async_browse_media(
+                hass, f"{media_source.URI_SCHEME}{DOMAIN}/popular"
+            )
+        assert exc_info.value.translation_key == "radio_browser_error"
+
+
+async def test_browsing_not_ready(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test browsing config entry not ready."""
+
+    with patch(
+        "homeassistant.components.radio_browser.RadioBrowser",
+        autospec=True,
+    ) as mock_browser:
+        mock_browser.return_value.stats.side_effect = RadioBrowserError
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+        with pytest.raises(BrowseError) as exc_info:
+            await media_source.async_browse_media(
+                hass, f"{media_source.URI_SCHEME}{DOMAIN}/popular"
+            )
+        assert exc_info.value.translation_key == "config_entry_not_ready"
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [DNSError, RadioBrowserError],
+)
+async def test_resolve_media_exceptions(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+) -> None:
+    """Test resolving media exceptions."""
+
+    with patch(
+        "homeassistant.components.radio_browser.RadioBrowser",
+        autospec=True,
+    ) as mock_browser:
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.LOADED
+
+        mock_browser.return_value.station.side_effect = exception
+        with pytest.raises(media_source.Unresolvable) as exc_info:
+            await media_source.async_resolve_media(
+                hass, f"{media_source.URI_SCHEME}{DOMAIN}/123456", None
+            )
+        assert exc_info.value.translation_key == "radio_browser_error"
+
+
+async def test_resolve_media_not_ready(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test resolving media config entry not ready."""
+
+    with patch(
+        "homeassistant.components.radio_browser.RadioBrowser",
+        autospec=True,
+    ) as mock_browser:
+        mock_browser.return_value.stats.side_effect = RadioBrowserError
+        mock_config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+
+        with pytest.raises(media_source.Unresolvable) as exc_info:
+            await media_source.async_resolve_media(
+                hass, f"{media_source.URI_SCHEME}{DOMAIN}/123456", None
+            )
+        assert exc_info.value.translation_key == "config_entry_not_ready"


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Radio Browser was down and I noticed that the media browser did not handle exceptions when the config entry is not loaded or when a connection error occurs. It just displayed `Unknown error`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
