### PR TITLE
Cleanup deprecated tuya entities

### DIFF
--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1097,11 +1097,5 @@
     "action_dpcode_not_found": {
       "message": "Unable to process action as the device does not provide a corresponding function code (expected one of {expected} in {available})."
     }
-  },
-  "issues": {
-    "deprecated_entity_new_valve": {
-      "description": "The Tuya entity `{entity}` is deprecated, replaced by a new valve entity.\nPlease update your dashboards, automations and scripts, disable `{entity}` and reload the integration/restart Home Assistant to fix this issue.",
-      "title": "{name} is deprecated"
-    }
   }
 }

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 from tuya_device_handlers.device_wrapper.base import DeviceWrapper
@@ -10,34 +9,18 @@ from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.switch import (
-    DOMAIN as SWITCH_DOMAIN,
     SwitchDeviceClass,
     SwitchEntity,
     SwitchEntityDescription,
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 
 from . import TuyaConfigEntry
-from .const import DOMAIN, TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-
-
-@dataclass(frozen=True, kw_only=True)
-class TuyaDeprecatedSwitchEntityDescription(SwitchEntityDescription):
-    """Describes Tuya deprecated switch entity."""
-
-    deprecated: str
-    breaks_in_ha_version: str
-
 
 # All descriptions can be found here. Mostly the Boolean data types in the
 # default instruction set of each category end up being a Switch.
@@ -664,14 +647,6 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
-    DeviceCategory.SFKZQ: (
-        TuyaDeprecatedSwitchEntityDescription(
-            key=DPCode.SWITCH,
-            translation_key="switch",
-            deprecated="deprecated_entity_new_valve",
-            breaks_in_ha_version="2026.4.0",
-        ),
-    ),
     DeviceCategory.SGBJ: (
         SwitchEntityDescription(
             key=DPCode.MUFFLING,
@@ -937,7 +912,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up tuya sensors dynamically through tuya discovery."""
     manager = entry.runtime_data.manager
-    entity_registry = er.async_get(hass)
 
     @callback
     def async_discover_device(device_ids: list[str]) -> None:
@@ -954,12 +928,6 @@ async def async_setup_entry(
                             device, description.key, prefer_function=True
                         )
                     )
-                    and _check_deprecation(
-                        hass,
-                        device,
-                        description,
-                        entity_registry,
-                    )
                 )
 
         async_add_entities(entities)
@@ -969,55 +937,6 @@ async def async_setup_entry(
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
     )
-
-
-def _check_deprecation(
-    hass: HomeAssistant,
-    device: CustomerDevice,
-    description: SwitchEntityDescription,
-    entity_registry: er.EntityRegistry,
-) -> bool:
-    """Check entity deprecation.
-
-    Returns:
-        `True` if the entity should be created, `False` otherwise.
-    """
-    # Not deprecated, just create it
-    if not isinstance(description, TuyaDeprecatedSwitchEntityDescription):
-        return True
-
-    unique_id = f"tuya.{device.id}{description.key}"
-    entity_id = entity_registry.async_get_entity_id(SWITCH_DOMAIN, DOMAIN, unique_id)
-
-    # Deprecated and not present in registry, skip creation
-    if not entity_id or not (entity_entry := entity_registry.async_get(entity_id)):
-        return False
-
-    # Deprecated and present in registry but disabled, remove it and skip creation
-    if entity_entry.disabled:
-        entity_registry.async_remove(entity_id)
-        async_delete_issue(
-            hass,
-            DOMAIN,
-            f"deprecated_entity_{unique_id}",
-        )
-        return False
-
-    # Deprecated and present in registry and enabled, raise issue and create it
-    async_create_issue(
-        hass,
-        DOMAIN,
-        f"deprecated_entity_{unique_id}",
-        breaks_in_ha_version=description.breaks_in_ha_version,
-        is_fixable=False,
-        severity=IssueSeverity.WARNING,
-        translation_key=description.deprecated,
-        translation_placeholders={
-            "name": f"{device.name} {entity_entry.name or entity_entry.original_name}",
-            "entity": entity_id,
-        },
-    )
-    return True
 
 
 class TuyaSwitchEntity(TuyaEntity, SwitchEntity):

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -15,10 +15,9 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.components.tuya import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er
 
 from . import MockDeviceListener, check_selective_state_update, initialize_entry
 
@@ -87,57 +86,6 @@ async def test_selective_state_update(
         expected_state=expected_state,
         last_reported=last_reported,
     )
-
-
-@pytest.mark.parametrize(
-    ("preexisting_entity", "disabled_by", "expected_entity", "expected_issue"),
-    [
-        (True, None, True, True),
-        (True, er.RegistryEntryDisabler.USER, False, False),
-        (False, None, False, False),
-    ],
-)
-@pytest.mark.parametrize(
-    "mock_device_code",
-    ["sfkzq_rzklytdei8i8vo37"],
-)
-async def test_sfkzq_deprecated_switch(
-    hass: HomeAssistant,
-    mock_manager: Manager,
-    mock_config_entry: MockConfigEntry,
-    mock_device: CustomerDevice,
-    issue_registry: ir.IssueRegistry,
-    entity_registry: er.EntityRegistry,
-    preexisting_entity: bool,
-    disabled_by: er.RegistryEntryDisabler,
-    expected_entity: bool,
-    expected_issue: bool,
-) -> None:
-    """Test switch deprecation issue."""
-    original_entity_id = "switch.balkonbewasserung_switch"
-    entity_unique_id = "tuya.73ov8i8iedtylkzrqzkfsswitch"
-    if preexisting_entity:
-        suggested_id = original_entity_id.replace(f"{SWITCH_DOMAIN}.", "")
-        entity_registry.async_get_or_create(
-            SWITCH_DOMAIN,
-            DOMAIN,
-            entity_unique_id,
-            suggested_object_id=suggested_id,
-            disabled_by=disabled_by,
-        )
-
-    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
-
-    assert (
-        entity_registry.async_get(original_entity_id) is not None
-    ) is expected_entity
-    assert (
-        issue_registry.async_get_issue(
-            domain=DOMAIN,
-            issue_id=f"deprecated_entity_{entity_unique_id}",
-        )
-        is not None
-    ) is expected_issue
 
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.SWITCH])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously deprecated switch entities to control valves have been removed. Please use the valve entities.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
