### PR TITLE
Fix missing last_reset for Tibber accumulated cost/reward sensors

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -878,7 +878,9 @@ class TibberSensorRT(TibberSensor, CoordinatorEntity["TibberRtDataCoordinator"])
             return
         if self.entity_description.key in (
             "accumulatedConsumption",
+            "accumulatedCost",
             "accumulatedProduction",
+            "accumulatedReward",
         ):
             # Value is reset to 0 at midnight, but not always strictly increasing
             # due to hourly corrections.


### PR DESCRIPTION
## Summary

- The `accumulatedCost` and `accumulatedReward` real-time sensors reset to 0 at midnight daily, identical to `accumulatedConsumption` and `accumulatedProduction`
- Only the consumption/production sensors had `last_reset` handling in `_handle_coordinator_update`, while cost/reward were missing
- Without `last_reset`, sensors with `state_class: total` produce incorrect long-term statistics — HA interprets the midnight reset (e.g. 62 SEK → 0) as a large negative change instead of a reset, corrupting the energy dashboard

This PR adds `accumulatedCost` and `accumulatedReward` to the existing `last_reset` detection logic in `sensor.py`, so HA correctly recognizes the daily midnight reset for these monetary sensors.

## Test plan

- [ ] Verify `accumulatedCost` sensor now has `last_reset` attribute set after midnight reset
- [ ] Verify `accumulatedReward` sensor now has `last_reset` attribute set after midnight reset
- [ ] Verify energy dashboard statistics are correct across midnight boundary
- [ ] Verify no regression for `accumulatedConsumption` / `accumulatedProduction` sensors
- [ ] Run existing Tibber integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)