### PR TITLE
Add support for active power limit in Kostal Plenticore

### DIFF
--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -67,6 +67,21 @@ NUMBER_SETTINGS_DATA = [
         fmt_from="format_round",
         fmt_to="format_round_back",
     ),
+    PlenticoreNumberEntityDescription(
+        key="active_power_limitation",
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        icon="mdi:solar-power",
+        name="Active Power Limitation",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        native_max_value=10000,
+        native_min_value=0,
+        native_step=1,
+        module_id="devices:local",
+        data_id="Inverter:ActivePowerLimitation",
+        fmt_from="format_round",
+        fmt_to="format_round_back",
+    ),
 ]
 
 

--- a/homeassistant/components/kostal_plenticore/number.py
+++ b/homeassistant/components/kostal_plenticore/number.py
@@ -69,6 +69,7 @@ NUMBER_SETTINGS_DATA = [
     ),
     PlenticoreNumberEntityDescription(
         key="active_power_limitation",
+        device_class=NumberDeviceClass.POWER,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
         icon="mdi:solar-power",

--- a/tests/components/kostal_plenticore/conftest.py
+++ b/tests/components/kostal_plenticore/conftest.py
@@ -25,6 +25,7 @@ DEFAULT_SETTING_VALUES = {
         "Properties:VersionMC": "01.46",
         "Battery:MinSoc": "5",
         "Battery:MinHomeComsumption": "50",
+        "Inverter:ActivePowerLimitation": "8000",
     },
     "scb:network": {"Hostname": "scb"},
 }
@@ -47,6 +48,15 @@ DEFAULT_SETTINGS = {
             access="readwrite",
             unit="W",
             id="Battery:MinHomeComsumption",
+            type="byte",
+        ),
+        SettingsData(
+            min="0",
+            max="10000",
+            default=None,
+            access="readwrite",
+            unit="W",
+            id="Inverter:ActivePowerLimitation",
             type="byte",
         ),
     ],

--- a/tests/components/kostal_plenticore/test_diagnostics.py
+++ b/tests/components/kostal_plenticore/test_diagnostics.py
@@ -52,6 +52,7 @@ async def test_entry_diagnostics(
                 "devices:local": [
                     "min='5' max='100' default=None access='readwrite' unit='%' id='Battery:MinSoc' type='byte'",
                     "min='50' max='38000' default=None access='readwrite' unit='W' id='Battery:MinHomeComsumption' type='byte'",
+                    "min='0' max='10000' default=None access='readwrite' unit='W' id='Inverter:ActivePowerLimitation' type='byte'",
                 ],
                 "scb:network": [
                     "min='1' max='63' default=None access='readwrite' unit=None id='Hostname' type='string'"

--- a/tests/components/kostal_plenticore/test_number.py
+++ b/tests/components/kostal_plenticore/test_number.py
@@ -41,6 +41,7 @@ async def test_setup_all_entries(
     assert (
         entity_registry.async_get("number.scb_battery_min_home_consumption") is not None
     )
+    assert entity_registry.async_get("number.scb_active_power_limitation") is not None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -77,6 +78,7 @@ async def test_setup_no_entries(
 
     assert entity_registry.async_get("number.scb_battery_min_soc") is None
     assert entity_registry.async_get("number.scb_battery_min_home_consumption") is None
+    assert entity_registry.async_get("number.scb_active_power_limitation") is None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for active power limit so a user can set a limit for how much power the inverter outputs. This can be useful when electricity price is negative and we only want to output power to cover only self consumption.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR adresses this feature request: https://github.com/orgs/home-assistant/discussions/1744

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
