### PR TITLE
Set device classes and measurement units for Smarla

### DIFF
--- a/homeassistant/components/smarla/number.py
+++ b/homeassistant/components/smarla/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -32,6 +33,7 @@ NUMBERS: list[SmarlaNumberEntityDescription] = [
         native_max_value=100,
         native_min_value=0,
         native_step=1,
+        native_unit_of_measurement=PERCENTAGE,
         mode=NumberMode.SLIDER,
     ),
 ]

--- a/homeassistant/components/smarla/sensor.py
+++ b/homeassistant/components/smarla/sensor.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pysmarlaapi.federwiege.services.classes import Property
 
 from homeassistant.components.sensor import (
+    SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
@@ -35,6 +36,7 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         property="oscillation",
         multiple=True,
         value_pos=0,
+        device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.MILLIMETERS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -45,6 +47,7 @@ SENSORS: list[SmarlaSensorEntityDescription] = [
         property="oscillation",
         multiple=True,
         value_pos=1,
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MILLISECONDS,
         state_class=SensorStateClass.MEASUREMENT,
     ),

--- a/homeassistant/components/smarla/switch.py
+++ b/homeassistant/components/smarla/switch.py
@@ -5,7 +5,11 @@ from typing import Any
 
 from pysmarlaapi.federwiege.services.classes import Property
 
-from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -26,12 +30,14 @@ SWITCHES: list[SmarlaSwitchEntityDescription] = [
         name=None,
         service="babywiege",
         property="swing_active",
+        device_class=SwitchDeviceClass.SWITCH,
     ),
     SmarlaSwitchEntityDescription(
         key="smart_mode",
         translation_key="smart_mode",
         service="babywiege",
         property="smart_mode",
+        device_class=SwitchDeviceClass.SWITCH,
     ),
 ]
 

--- a/tests/components/smarla/snapshots/test_number.ambr
+++ b/tests/components/smarla/snapshots/test_number.ambr
@@ -37,7 +37,7 @@
     'supported_features': 0,
     'translation_key': 'intensity',
     'unique_id': 'ABCD-intensity',
-    'unit_of_measurement': None,
+    'unit_of_measurement': '%',
   })
 # ---
 # name: test_entities[number.smarla_intensity-state]
@@ -48,6 +48,7 @@
       'min': 0,
       'mode': <NumberMode.SLIDER: 'slider'>,
       'step': 1,
+      'unit_of_measurement': '%',
     }),
     'context': <ANY>,
     'entity_id': 'number.smarla_intensity',

--- a/tests/components/smarla/snapshots/test_sensor.ambr
+++ b/tests/components/smarla/snapshots/test_sensor.ambr
@@ -76,8 +76,11 @@
     'name': None,
     'object_id_base': 'Amplitude',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
     'original_icon': None,
     'original_name': 'Amplitude',
     'platform': 'smarla',
@@ -92,6 +95,7 @@
 # name: test_entities[sensor.smarla_amplitude-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'distance',
       'friendly_name': 'Smarla Amplitude',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
@@ -129,8 +133,11 @@
     'name': None,
     'object_id_base': 'Period',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
     'original_name': 'Period',
     'platform': 'smarla',
@@ -145,6 +152,7 @@
 # name: test_entities[sensor.smarla_period-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'duration',
       'friendly_name': 'Smarla Period',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,

--- a/tests/components/smarla/snapshots/test_switch.ambr
+++ b/tests/components/smarla/snapshots/test_switch.ambr
@@ -23,7 +23,7 @@
     'object_id_base': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
     'original_icon': None,
     'original_name': None,
     'platform': 'smarla',
@@ -38,6 +38,7 @@
 # name: test_entities[switch.smarla-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'switch',
       'friendly_name': 'Smarla',
     }),
     'context': <ANY>,
@@ -72,7 +73,7 @@
     'object_id_base': 'Smart Mode',
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
     'original_icon': None,
     'original_name': 'Smart Mode',
     'platform': 'smarla',
@@ -87,6 +88,7 @@
 # name: test_entities[switch.smarla_smart_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'switch',
       'friendly_name': 'Smarla Smart Mode',
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Set appropriate device classes for entities and set native unit of the intensity entity to percentage.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
