### PR TITLE
Support Z-Wave Hoppe eHandle tilt sensor

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -401,6 +401,11 @@ async def async_setup_entry(
                     or int(state_key) in info.entity_description.states
                 )
             )
+        elif (
+            isinstance(info, NewZwaveDiscoveryInfo)
+            and info.entity_class is ZWaveBooleanBinarySensor
+        ):
+            entities.append(ZWaveBooleanBinarySensor(config_entry, driver, info))
         elif isinstance(info, NewZwaveDiscoveryInfo):
             pass  # other entity classes are not migrated yet
         elif info.platform_hint == "notification":
@@ -481,12 +486,16 @@ class ZWaveBooleanBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         self,
         config_entry: ZwaveJSConfigEntry,
         driver: Driver,
-        info: ZwaveDiscoveryInfo,
+        info: ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo,
     ) -> None:
         """Initialize a ZWaveBooleanBinarySensor entity."""
         super().__init__(config_entry, driver, info)
 
-        # Entity class attributes
+        if isinstance(info, NewZwaveDiscoveryInfo):
+            # Entity name and description are set from the discovery schema.
+            return
+
+        # Entity class attributes for old-style discovery.
         self._attr_name = self.generate_name(include_value_name=True)
         primary_value = self.info.primary_value
         if description := BOOLEAN_SENSOR_MAPPINGS.get(
@@ -578,6 +587,27 @@ class ZWaveConfigParameterBinarySensor(ZWaveBooleanBinarySensor):
 
 
 DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    NewZWaveDiscoverySchema(
+        # Hoppe eHandle ConnectSense (0x0313:0x0701:0x0002) - window tilt sensor.
+        # The window tilt state is exposed as a binary sensor that is disabled by default
+        # instead of a notification sensor. We enable that sensor and give it a name
+        # that is more consistent with the other window related entities.
+        platform=Platform.BINARY_SENSOR,
+        manufacturer_id={0x0313},
+        product_id={0x0002},
+        product_type={0x0701},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SENSOR_BINARY},
+            property={"Tilt"},
+            type={ValueType.BOOLEAN},
+        ),
+        entity_description=BinarySensorEntityDescription(
+            key="window_door_is_tilted",
+            name="Window/door is tilted",
+            device_class=BinarySensorDeviceClass.WINDOW,
+        ),
+        entity_class=ZWaveBooleanBinarySensor,
+    ),
     NewZWaveDiscoverySchema(
         platform=Platform.BINARY_SENSOR,
         primary_value=ZWaveValueDiscoverySchema(

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -583,6 +583,15 @@ def nabu_casa_zwa2_legacy_state_fixture() -> NodeDataType:
     )
 
 
+@pytest.fixture(name="hoppe_ehandle_connectsense_state")
+def hoppe_ehandle_connectsense_state_fixture() -> NodeDataType:
+    """Load node state fixture data for Hoppe eHandle ConnectSense."""
+    return cast(
+        NodeDataType,
+        load_json_object_fixture("hoppe_ehandle_connectsense_state.json", DOMAIN),
+    )
+
+
 # model fixtures
 
 
@@ -1457,5 +1466,15 @@ def nabu_casa_zwa2_legacy_fixture(
 ) -> Node:
     """Load node for Nabu Casa ZWA-2 (legacy firmware)."""
     node = Node(client, nabu_casa_zwa2_legacy_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="hoppe_ehandle_connectsense")
+def hoppe_ehandle_connectsense_fixture(
+    client: MagicMock, hoppe_ehandle_connectsense_state: NodeDataType
+) -> Node:
+    """Load node for Hoppe eHandle ConnectSense."""
+    node = Node(client, hoppe_ehandle_connectsense_state)
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/hoppe_ehandle_connectsense_state.json
+++ b/tests/components/zwave_js/fixtures/hoppe_ehandle_connectsense_state.json
@@ -1,0 +1,324 @@
+{
+  "nodeId": 20,
+  "index": 0,
+  "installerIcon": 3079,
+  "userIcon": 3079,
+  "status": 1,
+  "ready": true,
+  "isListening": false,
+  "isRouting": true,
+  "isSecure": true,
+  "manufacturerId": 787,
+  "productId": 2,
+  "productType": 1793,
+  "firmwareVersion": "1.1.0",
+  "zwavePlusVersion": 2,
+  "deviceConfig": {
+    "filename": "/data/db/devices/0x0313/e0400z-ef.json",
+    "isEmbedded": true,
+    "manufacturer": "Hoppe",
+    "manufacturerId": 787,
+    "label": "E0400Z-EF",
+    "description": "eHandle ConnectSense",
+    "devices": [
+      {
+        "productType": 1793,
+        "productId": 2
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false,
+    "associations": {},
+    "paramInformation": {
+      "_map": {}
+    }
+  },
+  "label": "E0400Z-EF",
+  "interviewAttempts": 1,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 6,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing End Node"
+    },
+    "generic": {
+      "key": 7,
+      "label": "Notification Sensor"
+    },
+    "specific": {
+      "key": 1,
+      "label": "Notification Sensor"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x0313:0x0701:0x0002:1.1.0",
+  "statistics": {
+    "commandsTX": 285,
+    "commandsRX": 468,
+    "commandsDroppedRX": 10,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0,
+    "rtt": 32.4,
+    "lastSeen": "2026-03-03T18:31:30.589Z",
+    "rssi": -39,
+    "lwr": {
+      "protocolDataRate": 3,
+      "repeaters": [],
+      "rssi": -40,
+      "repeaterRSSI": []
+    }
+  },
+  "highestSecurityClass": 1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "lastSeen": "2026-03-03T13:42:01.894Z",
+  "protocol": 0,
+  "sdkVersion": "7.15.4",
+  "values": [
+    {
+      "commandClass": 48,
+      "commandClassName": "Binary Sensor",
+      "property": "Tilt",
+      "propertyName": "Tilt",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Sensor state (Tilt)",
+        "ccSpecific": {
+          "sensorType": 11
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": false
+    },
+    {
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Door state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Door state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Door state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "22": "Window/door is open",
+          "23": "Window/door is closed",
+          "5632": "Window/door is open in regular position",
+          "5633": "Window/door is open in tilt position"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 23
+    },
+    {
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Door state (simple)",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Door state (simple)",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Door state (simple)",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "22": "Window/door is open",
+          "23": "Window/door is closed"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 23
+    },
+    {
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 787
+    },
+    {
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1793
+    },
+    {
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 2
+    },
+    {
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "level",
+      "propertyName": "level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Battery level",
+        "min": 0,
+        "max": 100,
+        "unit": "%",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 100
+    },
+    {
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": ["1.1"]
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 20,
+      "index": 0,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing End Node"
+        },
+        "generic": {
+          "key": 7,
+          "label": "Notification Sensor"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Notification Sensor"
+        }
+      },
+      "commandClasses": [
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 48,
+          "name": "Binary Sensor",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 113,
+          "name": "Notification",
+          "version": 8,
+          "isSecure": true
+        },
+        {
+          "id": 132,
+          "name": "Wake Up",
+          "version": 2,
+          "isSecure": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -476,3 +476,24 @@ async def test_smoke_co_notification_sensors(
     assert state.state == STATE_ON, (
         f"Expected smoke diagnostic state to be 'on', got '{state.state}'"
     )
+
+
+async def test_hoppe_ehandle_connectsense(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hoppe_ehandle_connectsense: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test Hoppe eHandle ConnectSense tilt sensor is discovered as a window sensor."""
+    entity_id = "binary_sensor.ehandle_connectsense_window_door_is_tilted"
+    state = hass.states.get(entity_id)
+    assert state is not None, (
+        "Window/door is tilted sensor should be enabled by default"
+    )
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.original_name == "Window/door is tilted"
+    assert entry.original_device_class == BinarySensorDeviceClass.WINDOW
+    assert entry.disabled_by is None, "Entity should be enabled by default"

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -7,7 +7,6 @@ import pytest
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.components.number import (
@@ -580,26 +579,3 @@ async def test_nabu_casa_zwa2_legacy(
     assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
         "The LED should have the correct friendly name"
     )
-
-
-@pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR]])
-async def test_hoppe_ehandle_connectsense(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    client: MagicMock,
-    hoppe_ehandle_connectsense: Node,
-    integration: MockConfigEntry,
-) -> None:
-    """Test Hoppe eHandle ConnectSense tilt sensor is discovered as a window sensor."""
-    entity_id = "binary_sensor.ehandle_connectsense_window_door_is_tilted"
-    state = hass.states.get(entity_id)
-    assert state is not None, (
-        "Window/door is tilted sensor should be enabled by default"
-    )
-    assert state.state == STATE_OFF
-
-    entry = entity_registry.async_get(entity_id)
-    assert entry is not None
-    assert entry.original_name == "Window/door is tilted"
-    assert entry.original_device_class == BinarySensorDeviceClass.WINDOW
-    assert entry.disabled_by is None, "Entity should be enabled by default"

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -7,6 +7,7 @@ import pytest
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode
 from homeassistant.components.number import (
@@ -579,3 +580,26 @@ async def test_nabu_casa_zwa2_legacy(
     assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
         "The LED should have the correct friendly name"
     )
+
+
+@pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR]])
+async def test_hoppe_ehandle_connectsense(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    hoppe_ehandle_connectsense: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test Hoppe eHandle ConnectSense tilt sensor is discovered as a window sensor."""
+    entity_id = "binary_sensor.ehandle_connectsense_window_door_is_tilted"
+    state = hass.states.get(entity_id)
+    assert state is not None, (
+        "Window/door is tilted sensor should be enabled by default"
+    )
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.original_name == "Window/door is tilted"
+    assert entry.original_device_class == BinarySensorDeviceClass.WINDOW
+    assert entry.disabled_by is None, "Entity should be enabled by default"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The [Hoppe ConnectSense eHandle](https://www.hoppe.com/de-de/produkt/1001338351/amsterdam-efenstergriffe-connectsense?C_TECH_ID=755&C_GRT_ID=200) has a tilt sensor, which is not exposed using the Notification CC, but a (legacy) Binary Sensor that is disabled by default. The default name is also inconsistent with the other sensor entities.

This PR enables the tilt sensor entity by default and aligns its name with the existing Door/Window notification sensor entities. Unlike most of those, this tilt sensor entity actually works though:
<img width="320" height="102" alt="grafik" src="https://github.com/user-attachments/assets/e4235527-9daa-4b7e-b1b3-f4b2f30f212b" />




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards. - **I'm not super familiar with the new Z-Wave discovery schema, so I'll need some input whether this approach is correct or not.**

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
