### PR TITLE
Increase CalDAV connection pool size to prevent pool exhaustion

### DIFF
--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -5,6 +5,7 @@ import logging
 import caldav
 from caldav.lib.error import AuthorizationError, DAVError
 import requests
+from requests.adapters import HTTPAdapter
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -34,6 +35,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
         ssl_verify_cert=entry.data[CONF_VERIFY_SSL],
         timeout=30,
     )
+    # Increase the connection pool size to prevent
+    # "Connection pool is full, discarding connection" warnings when many
+    # calendar/todo entities poll the same CalDAV server concurrently.
+    # See: https://github.com/home-assistant/core/issues/117927
+    adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
+    client.session.mount("https://", adapter)
+    client.session.mount("http://", adapter)
     try:
         await hass.async_add_executor_job(client.principal)
     except AuthorizationError as err:

--- a/homeassistant/components/caldav/__init__.py
+++ b/homeassistant/components/caldav/__init__.py
@@ -22,6 +22,7 @@ type CalDavConfigEntry = ConfigEntry[caldav.DAVClient]
 
 _LOGGER = logging.getLogger(__name__)
 
+CONNECTION_POOL_SIZE = 20
 
 PLATFORMS: list[Platform] = [Platform.CALENDAR, Platform.TODO]
 
@@ -35,11 +36,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: CalDavConfigEntry) -> bo
         ssl_verify_cert=entry.data[CONF_VERIFY_SSL],
         timeout=30,
     )
-    # Increase the connection pool size to prevent
-    # "Connection pool is full, discarding connection" warnings when many
-    # calendar/todo entities poll the same CalDAV server concurrently.
+    # Increase the connection pool size to prevent "Connection pool is
+    # full, discarding connection" warnings when many calendar and todo
+    # entities poll the same CalDAV server concurrently. The default
+    # urllib3 pool size of 10 is easily exceeded with 10+ calendars.
     # See: https://github.com/home-assistant/core/issues/117927
-    adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
+    adapter = HTTPAdapter(
+        pool_connections=CONNECTION_POOL_SIZE, pool_maxsize=CONNECTION_POOL_SIZE
+    )
     client.session.mount("https://", adapter)
     client.session.mount("http://", adapter)
     try:

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from requests.adapters import HTTPAdapter
 
+from homeassistant.components.caldav import CONNECTION_POOL_SIZE
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -77,23 +78,25 @@ async def test_connection_pool_size(
     exceeded, causing 'Connection pool is full' warnings.
     """
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-    with patch(
-        "homeassistant.components.caldav.config_flow.caldav.DAVClient"
-    ) as mock_client:
-        mock_session = mock_client.return_value.session
+    with (
+        patch("homeassistant.components.caldav.caldav.DAVClient") as mock_client,
+        patch(
+            "homeassistant.components.caldav.HTTPAdapter",
+            wraps=HTTPAdapter,
+        ) as mock_adapter_cls,
+    ):
         await hass.config_entries.async_setup(config_entry.entry_id)
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    # Verify mount was called for both https:// and http://
-    assert mock_session.mount.call_count >= 2
-    mounted = {call[0][0]: call[0][1] for call in mock_session.mount.call_args_list}
-    assert "https://" in mounted
-    assert "http://" in mounted
+    # Verify HTTPAdapter was constructed with the expected pool size
+    mock_adapter_cls.assert_called_once_with(
+        pool_connections=CONNECTION_POOL_SIZE, pool_maxsize=CONNECTION_POOL_SIZE
+    )
 
-    # Verify the adapters have increased pool size
-    for prefix in ("https://", "http://"):
-        adapter = mounted[prefix]
-        assert isinstance(adapter, HTTPAdapter)
-        assert adapter._pool_connections == 20
-        assert adapter._pool_maxsize == 20
+    # Verify the adapter was mounted on the session for both schemes
+    mock_session = mock_client.return_value.session
+    assert mock_session.mount.call_count >= 2
+    mounted_schemes = {call[0][0] for call in mock_session.mount.call_args_list}
+    assert "https://" in mounted_schemes
+    assert "http://" in mounted_schemes

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from caldav.lib.error import AuthorizationError, DAVError
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -24,12 +25,9 @@ async def test_load_unload(
 ) -> None:
     """Test loading and unloading of the config entry."""
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-
     with patch("homeassistant.components.caldav.config_flow.caldav.DAVClient"):
         await hass.config_entries.async_setup(config_entry.entry_id)
-
     assert config_entry.state is ConfigEntryState.LOADED
-
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.NOT_LOADED
 
@@ -56,17 +54,48 @@ async def test_client_failure(
     expected_flows: list[str],
 ) -> None:
     """Test CalDAV client failures in setup."""
-
     assert config_entry.state is ConfigEntryState.NOT_LOADED
-
     with patch(
         "homeassistant.components.caldav.config_flow.caldav.DAVClient"
     ) as mock_client:
         mock_client.return_value.principal.side_effect = side_effect
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-
     assert config_entry.state == expected_state
-
     flows = hass.config_entries.flow.async_progress()
     assert [flow.get("step_id") for flow in flows] == expected_flows
+
+
+async def test_connection_pool_size(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that the connection pool size is increased for concurrent polling.
+
+    When many calendar and todo entities poll the same CalDAV server
+    concurrently, the default urllib3 connection pool size of 10 can be
+    exceeded, causing 'Connection pool is full' warnings.
+    """
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    with patch(
+        "homeassistant.components.caldav.config_flow.caldav.DAVClient"
+    ) as mock_client:
+        mock_session = mock_client.return_value.session
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Verify mount was called for both https:// and http://
+    assert mock_session.mount.call_count >= 2
+    mounted = {
+        call[0][0]: call[0][1] for call in mock_session.mount.call_args_list
+    }
+    assert "https://" in mounted
+    assert "http://" in mounted
+
+    # Verify the adapters have increased pool size
+    for prefix in ("https://", "http://"):
+        adapter = mounted[prefix]
+        assert isinstance(adapter, HTTPAdapter)
+        assert adapter._pool_connections == 20
+        assert adapter._pool_maxsize == 20

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -87,9 +87,7 @@ async def test_connection_pool_size(
 
     # Verify mount was called for both https:// and http://
     assert mock_session.mount.call_count >= 2
-    mounted = {
-        call[0][0]: call[0][1] for call in mock_session.mount.call_args_list
-    }
+    mounted = {call[0][0]: call[0][1] for call in mock_session.mount.call_args_list}
     assert "https://" in mounted
     assert "http://" in mounted
 


### PR DESCRIPTION
## Proposed change

Increases the urllib3 connection pool size on the CalDAV client session from the default 10 to 20, preventing pool exhaustion when many calendars/todo lists poll the same server concurrently.

Users with 10+ CalDAV calendars (common with iCloud) see repeated "Connection pool is full, discarding connection" warnings. The `caldav` library creates a `requests.Session` with urllib3's default `pool_maxsize=10`. Each calendar/todo entity gets a `CalDavUpdateCoordinator` that polls every 15 minutes — when they fire concurrently, the pool overflows.

After creating the `caldav.DAVClient`, this mounts an `HTTPAdapter(pool_connections=20, pool_maxsize=20)` on the session for both HTTPS and HTTP. This is the standard `requests` library mechanism for configuring pool sizes. No new dependencies — `requests` is already a dependency of `caldav` and already imported in this file.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #117927, fixes #108915, fixes #111633, fixes #105680, fixes #145886
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.