### PR TITLE
Fix teslemetry time_of_use service tariff double-wrapping

### DIFF
--- a/homeassistant/components/teslemetry/services.py
+++ b/homeassistant/components/teslemetry/services.py
@@ -309,9 +309,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         config = async_get_config_for_device(hass, device)
         site = async_get_energy_site_for_entry(hass, device, config)
 
-        resp = await handle_command(
-            site.api.time_of_use_settings(call.data[ATTR_TOU_SETTINGS])
-        )
+        tou_settings = call.data[ATTR_TOU_SETTINGS]
+        # Unwrap tariff_content_v2 if user included it, since the SDK adds this wrapper
+        if "tariff_content_v2" in tou_settings:
+            tou_settings = tou_settings["tariff_content_v2"]
+
+        resp = await handle_command(site.api.time_of_use_settings(tou_settings))
         if "error" in resp:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/tests/components/teslemetry/test_services.py
+++ b/tests/components/teslemetry/test_services.py
@@ -206,11 +206,29 @@ async def test_services(
             SERVICE_TIME_OF_USE,
             {
                 CONF_DEVICE_ID: energy_device,
-                ATTR_TOU_SETTINGS: {},
+                ATTR_TOU_SETTINGS: {"utility": "test"},
             },
             blocking=True,
         )
-        set_time_of_use.assert_called_once()
+        set_time_of_use.assert_called_once_with({"utility": "test"})
+
+    # Test that tariff_content_v2 wrapper is unwrapped before passing to SDK
+    with patch(
+        "tesla_fleet_api.teslemetry.EnergySite.time_of_use_settings",
+        return_value=COMMAND_OK,
+    ) as set_time_of_use:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_TIME_OF_USE,
+            {
+                CONF_DEVICE_ID: energy_device,
+                ATTR_TOU_SETTINGS: {
+                    "tariff_content_v2": {"utility": "test"},
+                },
+            },
+            blocking=True,
+        )
+        set_time_of_use.assert_called_once_with({"utility": "test"})
 
     with patch(
         "tesla_fleet_api.teslemetry.Vehicle.add_charge_schedule",


### PR DESCRIPTION
## Proposed change

The `teslemetry.time_of_use` service was passing user-provided settings directly to the Python SDK's `time_of_use_settings()` method. However, the SDK already wraps the settings parameter in `{"tou_settings": {"tariff_content_v2": settings}}` before sending to the Tesla API. Users following the Tesla API documentation naturally pass `{"tariff_content_v2": {...}}` as the `tou_settings` service field, resulting in double-wrapped `tariff_content_v2` keys. The API interprets this invalid structure as empty settings, wiping the user's tariff plan.

This fix unwraps `tariff_content_v2` if present before passing to the SDK, correctly handling both wrapped and unwrapped user input.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr