### PR TITLE
Fix IntesisHome outdoor_temp not reported when value is 0.0

### DIFF
--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -221,13 +221,13 @@ class IntesisAC(ClimateEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device specific state attributes."""
         attrs = {}
-        if self._outdoor_temp:
+        if self._outdoor_temp is not None:
             attrs["outdoor_temp"] = self._outdoor_temp
-        if self._power_consumption_heat:
+        if self._power_consumption_heat is not None:
             attrs["power_consumption_heat_kw"] = round(
                 self._power_consumption_heat / 1000, 1
             )
-        if self._power_consumption_cool:
+        if self._power_consumption_cool is not None:
             attrs["power_consumption_cool_kw"] = round(
                 self._power_consumption_cool / 1000, 1
             )
@@ -244,7 +244,7 @@ class IntesisAC(ClimateEntity):
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
             await self.async_set_hvac_mode(hvac_mode)
 
-        if temperature := kwargs.get(ATTR_TEMPERATURE):
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
             _LOGGER.debug("Setting %s to %s degrees", self._device_type, temperature)
             await self._controller.set_temperature(self._device_id, temperature)
             self._attr_target_temperature = temperature
@@ -271,7 +271,7 @@ class IntesisAC(ClimateEntity):
         await self._controller.set_mode(self._device_id, MAP_HVAC_MODE_TO_IH[hvac_mode])
 
         # Send the temperature again in case changing modes has changed it
-        if self._attr_target_temperature:
+        if self._attr_target_temperature is not None:
             await self._controller.set_temperature(
                 self._device_id, self._attr_target_temperature
             )


### PR DESCRIPTION
## What does this implement/fix?

Fixes the `outdoor_temp` sensor not being reported when the temperature is exactly 0.0°C.

The root cause is a Python truthiness check (`if self._outdoor_temp:`) that treats `0.0` as falsy, causing the sensor to be omitted from `extra_state_attributes`. Changed to an explicit `None` check (`if self._outdoor_temp is not None:`).

Also fixed the same truthiness bug in three other places in the same file:
- `power_consumption_heat` and `power_consumption_cool` in `extra_state_attributes` (would not report when consumption is exactly 0)
- `temperature` in `async_set_temperature` (would ignore a target temperature of 0)
- `_attr_target_temperature` in `async_set_hvac_mode` (would not resend temperature of 0 on mode change)

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented out code in this PR

Closes #164633