### PR TITLE
Minor Saunum integration improvements

### DIFF
--- a/homeassistant/components/saunum/__init__.py
+++ b/homeassistant/components/saunum/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pysaunum import SaunumClient, SaunumConnectionError
+from pysaunum import SaunumClient, SaunumConnectionError, SaunumTimeoutError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LeilSaunaConfigEntry) ->
 
     try:
         client = await SaunumClient.create(host)
-    except SaunumConnectionError as exc:
+    except (SaunumConnectionError, SaunumTimeoutError) as exc:
         raise ConfigEntryNotReady(f"Error connecting to {host}: {exc}") from exc
 
     entry.async_on_unload(client.async_close)

--- a/homeassistant/components/saunum/climate.py
+++ b/homeassistant/components/saunum/climate.py
@@ -6,7 +6,14 @@ import asyncio
 from datetime import timedelta
 from typing import Any
 
-from pysaunum import MAX_TEMPERATURE, MIN_TEMPERATURE, SaunumException
+from pysaunum import (
+    DEFAULT_DURATION,
+    DEFAULT_FAN_DURATION,
+    DEFAULT_TEMPERATURE,
+    MAX_TEMPERATURE,
+    MIN_TEMPERATURE,
+    SaunumException,
+)
 
 from homeassistant.components.climate import (
     FAN_HIGH,
@@ -149,7 +156,7 @@ class LeilSaunaClimate(LeilSaunaEntity, ClimateEntity):
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         sauna_type = self.coordinator.data.sauna_type
-        if sauna_type is not None and sauna_type in self._preset_name_map:
+        if sauna_type in self._preset_name_map:
             return self._preset_name_map[sauna_type]
         return self._preset_name_map[0]
 
@@ -242,9 +249,9 @@ class LeilSaunaClimate(LeilSaunaEntity, ClimateEntity):
 
     async def async_start_session(
         self,
-        duration: timedelta = timedelta(minutes=120),
-        target_temperature: int = 80,
-        fan_duration: timedelta = timedelta(minutes=10),
+        duration: timedelta = timedelta(minutes=DEFAULT_DURATION),
+        target_temperature: int = DEFAULT_TEMPERATURE,
+        fan_duration: timedelta = timedelta(minutes=DEFAULT_FAN_DURATION),
     ) -> None:
         """Start a sauna session with custom parameters."""
         if self.coordinator.data.door_open:

--- a/homeassistant/components/saunum/entity.py
+++ b/homeassistant/components/saunum/entity.py
@@ -1,7 +1,5 @@
 """Base entity for Saunum Leil Sauna Control Unit integration."""
 
-from __future__ import annotations
-
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -17,10 +15,9 @@ class LeilSaunaEntity(CoordinatorEntity[LeilSaunaCoordinator]):
     def __init__(self, coordinator: LeilSaunaCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-        entry_id = coordinator.config_entry.entry_id
-        self._attr_unique_id = entry_id
+
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, entry_id)},
+            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             name="Saunum Leil",
             manufacturer="Saunum",
             model="Leil Touch Panel",

--- a/homeassistant/components/saunum/entity.py
+++ b/homeassistant/components/saunum/entity.py
@@ -1,5 +1,7 @@
 """Base entity for Saunum Leil Sauna Control Unit integration."""
 
+from __future__ import annotations
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -15,9 +17,10 @@ class LeilSaunaEntity(CoordinatorEntity[LeilSaunaCoordinator]):
     def __init__(self, coordinator: LeilSaunaCoordinator) -> None:
         """Initialize the entity."""
         super().__init__(coordinator)
-
+        entry_id = coordinator.config_entry.entry_id
+        self._attr_unique_id = entry_id
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
+            identifiers={(DOMAIN, entry_id)},
             name="Saunum Leil",
             manufacturer="Saunum",
             model="Leil Touch Panel",

--- a/homeassistant/components/saunum/number.py
+++ b/homeassistant/components/saunum/number.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from pysaunum import (
+    DEFAULT_DURATION,
+    DEFAULT_FAN_DURATION,
     MAX_DURATION,
     MAX_FAN_DURATION,
     MIN_DURATION,
@@ -35,10 +37,6 @@ if TYPE_CHECKING:
 
 PARALLEL_UPDATES = 0
 
-# Default values when device returns None or invalid data
-DEFAULT_DURATION_MIN = 120
-DEFAULT_FAN_DURATION_MIN = 15
-
 
 @dataclass(frozen=True, kw_only=True)
 class LeilSaunaNumberEntityDescription(NumberEntityDescription):
@@ -59,8 +57,8 @@ NUMBERS: tuple[LeilSaunaNumberEntityDescription, ...] = (
         native_step=1,
         value_fn=lambda data: (
             duration
-            if (duration := data.sauna_duration) is not None and duration > MIN_DURATION
-            else DEFAULT_DURATION_MIN
+            if (duration := data.sauna_duration) > MIN_DURATION
+            else DEFAULT_DURATION
         ),
         set_value_fn=lambda client, value: client.async_set_sauna_duration(int(value)),
     ),
@@ -74,8 +72,8 @@ NUMBERS: tuple[LeilSaunaNumberEntityDescription, ...] = (
         native_step=1,
         value_fn=lambda data: (
             fan_dur
-            if (fan_dur := data.fan_duration) is not None and fan_dur > MIN_FAN_DURATION
-            else DEFAULT_FAN_DURATION_MIN
+            if (fan_dur := data.fan_duration) > MIN_FAN_DURATION
+            else DEFAULT_FAN_DURATION
         ),
         set_value_fn=lambda client, value: client.async_set_fan_duration(int(value)),
     ),

--- a/homeassistant/components/saunum/services.py
+++ b/homeassistant/components/saunum/services.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from pysaunum import MAX_DURATION, MAX_FAN_DURATION, MAX_TEMPERATURE, MIN_TEMPERATURE
+from pysaunum import (
+    DEFAULT_DURATION,
+    DEFAULT_FAN_DURATION,
+    DEFAULT_TEMPERATURE,
+    MAX_DURATION,
+    MAX_FAN_DURATION,
+    MAX_TEMPERATURE,
+    MIN_TEMPERATURE,
+)
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -29,17 +37,21 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_START_SESSION,
         entity_domain=CLIMATE_DOMAIN,
         schema={
-            vol.Optional(ATTR_DURATION, default=timedelta(minutes=120)): vol.All(
+            vol.Optional(
+                ATTR_DURATION, default=timedelta(minutes=DEFAULT_DURATION)
+            ): vol.All(
                 cv.time_period,
                 vol.Range(
                     min=timedelta(minutes=1),
                     max=timedelta(minutes=MAX_DURATION),
                 ),
             ),
-            vol.Optional(ATTR_TARGET_TEMPERATURE, default=80): vol.All(
+            vol.Optional(ATTR_TARGET_TEMPERATURE, default=DEFAULT_TEMPERATURE): vol.All(
                 cv.positive_int, vol.Range(min=MIN_TEMPERATURE, max=MAX_TEMPERATURE)
             ),
-            vol.Optional(ATTR_FAN_DURATION, default=timedelta(minutes=10)): vol.All(
+            vol.Optional(
+                ATTR_FAN_DURATION, default=timedelta(minutes=DEFAULT_FAN_DURATION)
+            ): vol.All(
                 cv.time_period,
                 vol.Range(
                     min=timedelta(minutes=1),

--- a/tests/components/saunum/test_number.py
+++ b/tests/components/saunum/test_number.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from unittest.mock import MagicMock
 
-from pysaunum import SaunumException
+from pysaunum import DEFAULT_DURATION, DEFAULT_FAN_DURATION, SaunumException
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -50,7 +50,7 @@ async def test_set_sauna_duration(
     # Verify initial state
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "120"
+    assert state.state == str(DEFAULT_DURATION)
 
     # Set new duration
     await hass.services.async_call(
@@ -75,7 +75,7 @@ async def test_set_fan_duration(
     # Verify initial state
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "10"
+    assert state.state == str(DEFAULT_FAN_DURATION)
 
     # Set new duration
     await hass.services.async_call(
@@ -151,13 +151,13 @@ async def test_number_with_default_duration(
     mock_config_entry: MockConfigEntry,
     mock_saunum_client: MagicMock,
 ) -> None:
-    """Test number entities use default when device returns None."""
-    # Set duration to None (device hasn't set it yet)
+    """Test number entities use default when device returns 0."""
+    # Set duration to 0 (device hasn't set it yet / sauna type default)
     base_data = mock_saunum_client.async_get_data.return_value
     mock_saunum_client.async_get_data.return_value = replace(
         base_data,
-        sauna_duration=None,
-        fan_duration=None,
+        sauna_duration=0,
+        fan_duration=0,
     )
 
     mock_config_entry.add_to_hass(hass)
@@ -167,11 +167,11 @@ async def test_number_with_default_duration(
     # Should show default values
     sauna_duration_state = hass.states.get("number.saunum_leil_sauna_duration")
     assert sauna_duration_state is not None
-    assert sauna_duration_state.state == "120"  # DEFAULT_DURATION_MIN
+    assert sauna_duration_state.state == str(DEFAULT_DURATION)
 
     fan_duration_state = hass.states.get("number.saunum_leil_fan_duration")
     assert fan_duration_state is not None
-    assert fan_duration_state.state == "15"  # DEFAULT_FAN_DURATION_MIN
+    assert fan_duration_state.state == str(DEFAULT_FAN_DURATION)
 
 
 async def test_number_with_valid_duration_from_device(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace hardcoded default values for duration, fan duration, and temperature with DEFAULT_DURATION, DEFAULT_FAN_DURATION, and DEFAULT_TEMPERATURE constants from pysaunum. Also handle SaunumTimeoutError during setup and simplify None checks where the library now returns 0 instead.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
