### PR TITLE
Add MAC filter option to ruckus integration

### DIFF
--- a/homeassistant/components/ruckus_unleashed/config_flow.py
+++ b/homeassistant/components/ruckus_unleashed/config_flow.py
@@ -1,23 +1,37 @@
 """Config flow for Ruckus integration."""
 
+from __future__ import annotations
+
 from collections.abc import Mapping
 import logging
+import operator
 from typing import Any
 
 from aioruckus import AjaxSession, SystemStat
 from aioruckus.exceptions import AuthenticationError, SchemaError
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .const import (
+    API_CLIENT_HOSTNAME,
     API_MESH_NAME,
     API_SYS_SYSINFO,
     API_SYS_SYSINFO_SERIAL,
+    CONF_MAC_FILTER,
     DOMAIN,
+    KEY_SYS_CLIENTS,
     KEY_SYS_SERIAL,
     KEY_SYS_TITLE,
 )
@@ -63,6 +77,15 @@ class RuckusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ruckus."""
 
     VERSION = 1
+    MINOR_VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> RuckusOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return RuckusOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -107,6 +130,59 @@ class RuckusConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
         return await self.async_step_user()
+
+
+class RuckusOptionsFlowHandler(OptionsFlowWithReload):
+    """Handle Ruckus options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            new_filter: list[str] = user_input.get(CONF_MAC_FILTER, [])
+
+            # Remove entities for devices no longer in the allow-list
+            if new_filter:
+                entity_registry = er.async_get(self.hass)
+                for reg_entry in er.async_entries_for_config_entry(
+                    entity_registry, self.config_entry.entry_id
+                ):
+                    if (
+                        reg_entry.domain == DEVICE_TRACKER_DOMAIN
+                        and reg_entry.unique_id not in new_filter
+                    ):
+                        entity_registry.async_remove(reg_entry.entity_id)
+
+            return self.async_create_entry(data={CONF_MAC_FILTER: new_filter})
+
+        coordinator = self.config_entry.runtime_data
+        current_filter: list[str] = self.config_entry.options.get(CONF_MAC_FILTER, [])
+
+        # Build client dict from active clients
+        clients: dict[str, str] = {
+            mac: f"{client[API_CLIENT_HOSTNAME]} ({mac})"
+            for mac, client in coordinator.data[KEY_SYS_CLIENTS].items()
+        }
+
+        # Preserve previously selected but now-offline clients
+        clients |= {
+            mac: f"Unknown ({mac})" for mac in current_filter if mac not in clients
+        }
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_MAC_FILTER,
+                        default=current_filter,
+                    ): cv.multi_select(
+                        dict(sorted(clients.items(), key=operator.itemgetter(1)))
+                    ),
+                }
+            ),
+        )
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/ruckus_unleashed/const.py
+++ b/homeassistant/components/ruckus_unleashed/const.py
@@ -6,6 +6,8 @@ DOMAIN = "ruckus_unleashed"
 PLATFORMS = [Platform.DEVICE_TRACKER]
 SCAN_INTERVAL = 30
 
+CONF_MAC_FILTER = "mac_filter"
+
 MANUFACTURER = "Ruckus"
 
 COORDINATOR = "coordinator"

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import API_CLIENT_HOSTNAME, API_CLIENT_IP, DOMAIN, KEY_SYS_CLIENTS
+from .const import API_CLIENT_HOSTNAME, API_CLIENT_IP, CONF_MAC_FILTER, KEY_SYS_CLIENTS
 from .coordinator import RuckusDataUpdateCoordinator, RuckusUnleashedConfigEntry
 
 _LOGGER = logging.getLogger(__package__)
@@ -26,26 +26,33 @@ async def async_setup_entry(
 
     tracked: set[str] = set()
 
+    mac_filter: list[str] = entry.options.get(CONF_MAC_FILTER, [])
+
     @callback
     def router_update():
         """Update the values of the router."""
-        add_new_entities(coordinator, async_add_entities, tracked)
+        add_new_entities(coordinator, async_add_entities, tracked, mac_filter)
 
     router_update()
 
     entry.async_on_unload(coordinator.async_add_listener(router_update))
 
     registry = er.async_get(hass)
-    restore_entities(registry, coordinator, entry, async_add_entities, tracked)
+    restore_entities(
+        registry, coordinator, entry, async_add_entities, tracked, mac_filter
+    )
 
 
 @callback
-def add_new_entities(coordinator, async_add_entities, tracked):
+def add_new_entities(coordinator, async_add_entities, tracked, mac_filter):
     """Add new tracker entities from the router."""
     new_tracked = []
 
     for mac in coordinator.data[KEY_SYS_CLIENTS]:
         if mac in tracked:
+            continue
+
+        if mac_filter and mac not in mac_filter:
             continue
 
         device = coordinator.data[KEY_SYS_CLIENTS][mac]
@@ -63,14 +70,16 @@ def restore_entities(
     entry: RuckusUnleashedConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
     tracked: set[str],
+    mac_filter: list[str],
 ) -> None:
     """Restore clients that are not a part of active clients list."""
     missing: list[RuckusDevice] = []
 
     for entity in registry.entities.get_entries_for_config_entry_id(entry.entry_id):
         if (
-            entity.platform == DOMAIN
+            entity.platform == entry.domain
             and entity.unique_id not in coordinator.data[KEY_SYS_CLIENTS]
+            and (not mac_filter or entity.unique_id in mac_filter)
         ):
             missing.append(
                 RuckusDevice(coordinator, entity.unique_id, entity.original_name)

--- a/homeassistant/components/ruckus_unleashed/device_tracker.py
+++ b/homeassistant/components/ruckus_unleashed/device_tracker.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
 
     tracked: set[str] = set()
 
-    mac_filter: list[str] = entry.options.get(CONF_MAC_FILTER, [])
+    mac_filter: set[str] = set(entry.options.get(CONF_MAC_FILTER, []))
 
     @callback
     def router_update():
@@ -70,7 +70,7 @@ def restore_entities(
     entry: RuckusUnleashedConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
     tracked: set[str],
-    mac_filter: list[str],
+    mac_filter: set[str],
 ) -> None:
     """Restore clients that are not a part of active clients list."""
     missing: list[RuckusDevice] = []

--- a/homeassistant/components/ruckus_unleashed/strings.json
+++ b/homeassistant/components/ruckus_unleashed/strings.json
@@ -22,5 +22,17 @@
         }
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "mac_filter": "Clients to track"
+        },
+        "data_description": {
+          "mac_filter": "Select specific clients to track. If none are selected, all clients will be tracked."
+        }
+      }
+    }
   }
 }

--- a/tests/components/ruckus_unleashed/__init__.py
+++ b/tests/components/ruckus_unleashed/__init__.py
@@ -73,24 +73,36 @@ TEST_CLIENT = {
     API_CLIENT_AP_MAC: DEFAULT_AP_INFO[0][API_AP_MAC],
 }
 
+TEST_CLIENT_2_ENTITY_ID = "device_tracker.ruckus_test_device_2"
+TEST_CLIENT_2 = {
+    API_CLIENT_IP: "1.1.1.3",
+    API_CLIENT_MAC: "11:22:33:44:55:66",
+    API_CLIENT_HOSTNAME: "Ruckus Test Device 2",
+    API_CLIENT_AP_MAC: DEFAULT_AP_INFO[0][API_AP_MAC],
+}
+
 DEFAULT_TITLE = DEFAULT_MESH_INFO[API_MESH_NAME]
 DEFAULT_UNIQUEID = DEFAULT_SYSTEM_INFO[API_SYS_SYSINFO][API_SYS_SYSINFO_SERIAL]
 
 
-def mock_config_entry() -> MockConfigEntry:
+def mock_config_entry(
+    options: dict | None = None,
+) -> MockConfigEntry:
     """Return a Ruckus mock config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         title=DEFAULT_TITLE,
         unique_id=DEFAULT_UNIQUEID,
         data=CONFIG,
-        options=None,
+        options=options,
     )
 
 
-async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
+async def init_integration(
+    hass: HomeAssistant, options: dict | None = None
+) -> MockConfigEntry:
     """Set up the Ruckus integration in Home Assistant."""
-    entry = mock_config_entry()
+    entry = mock_config_entry(options=options)
     entry.add_to_hass(hass)
     # Make device tied to other integration so device tracker entities get enabled
     other_config_entry = MockConfigEntry()

--- a/tests/components/ruckus_unleashed/test_config_flow.py
+++ b/tests/components/ruckus_unleashed/test_config_flow.py
@@ -13,20 +13,25 @@ from aioruckus.exceptions import AuthenticationError
 
 from homeassistant import config_entries
 from homeassistant.components.ruckus_unleashed.const import (
+    API_CLIENT_MAC,
     API_SYS_SYSINFO,
     API_SYS_SYSINFO_SERIAL,
+    CONF_MAC_FILTER,
     DOMAIN,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import utcnow
 
 from . import (
     CONFIG,
     DEFAULT_SYSTEM_INFO,
     DEFAULT_TITLE,
+    TEST_CLIENT,
     RuckusAjaxApiPatchContext,
+    init_integration,
     mock_config_entry,
 )
 
@@ -319,3 +324,120 @@ async def test_form_duplicate_error(hass: HomeAssistant) -> None:
 
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test options flow shows form and accepts selection."""
+    entry = await init_integration(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    # Verify selecting the active client works
+    with RuckusAjaxApiPatchContext():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC_FILTER: [TEST_CLIENT[API_CLIENT_MAC]]},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MAC_FILTER] == [TEST_CLIENT[API_CLIENT_MAC]]
+
+
+async def test_options_flow_offline_clients_preserved(hass: HomeAssistant) -> None:
+    """Test previously selected but now-offline clients remain selectable."""
+    offline_mac = "FF:EE:DD:CC:BB:AA"
+    entry = await init_integration(hass)
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_MAC_FILTER: [offline_mac]}
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+
+    # Verify the offline MAC is still a valid option by submitting it
+    with RuckusAjaxApiPatchContext():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC_FILTER: [offline_mac]},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MAC_FILTER] == [offline_mac]
+
+
+async def test_options_flow_removes_deselected_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that deselected devices have their entities removed."""
+    entry = await init_integration(hass)
+
+    # Verify entity exists for TEST_CLIENT
+    assert entity_registry.async_get_entity_id(
+        "device_tracker", DOMAIN, TEST_CLIENT[API_CLIENT_MAC]
+    )
+
+    # Set a filter that excludes TEST_CLIENT by selecting a different MAC.
+    # We add both the active client and a previously-selected offline MAC to
+    # the current options so both appear in the multi-select.
+    offline_mac = "FF:EE:DD:CC:BB:AA"
+    hass.config_entries.async_update_entry(
+        entry,
+        options={CONF_MAC_FILTER: [TEST_CLIENT[API_CLIENT_MAC], offline_mac]},
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with RuckusAjaxApiPatchContext():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC_FILTER: [offline_mac]},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+
+    # TEST_CLIENT entity should be removed since it's not in the new filter
+    assert not entity_registry.async_get_entity_id(
+        "device_tracker", DOMAIN, TEST_CLIENT[API_CLIENT_MAC]
+    )
+
+
+async def test_options_flow_clear_filter_keeps_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that clearing the filter does not remove entities."""
+    entry = await init_integration(hass)
+
+    # Verify entity exists
+    assert entity_registry.async_get_entity_id(
+        "device_tracker", DOMAIN, TEST_CLIENT[API_CLIENT_MAC]
+    )
+
+    # Set a filter first
+    hass.config_entries.async_update_entry(
+        entry,
+        options={CONF_MAC_FILTER: [TEST_CLIENT[API_CLIENT_MAC]]},
+    )
+
+    # Now clear the filter (empty = track all)
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    with RuckusAjaxApiPatchContext():
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_MAC_FILTER: []},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MAC_FILTER] == []
+
+    # Entity should NOT be removed when going back to track-all
+    assert entity_registry.async_get_entity_id(
+        "device_tracker", DOMAIN, TEST_CLIENT[API_CLIENT_MAC]
+    )

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -6,22 +6,29 @@ from unittest.mock import AsyncMock
 from aioruckus.const import ERROR_CONNECT_EOF, ERROR_LOGIN_INCORRECT
 from aioruckus.exceptions import AuthenticationError
 
-from homeassistant.components.ruckus_unleashed.const import DOMAIN
+from homeassistant.components.ruckus_unleashed.const import (
+    API_CLIENT_MAC,
+    CONF_MAC_FILTER,
+    DOMAIN,
+)
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.util import utcnow
 
 from . import (
     DEFAULT_UNIQUEID,
+    TEST_CLIENT,
+    TEST_CLIENT_2,
+    TEST_CLIENT_2_ENTITY_ID,
     TEST_CLIENT_ENTITY_ID,
     RuckusAjaxApiPatchContext,
     init_integration,
     mock_config_entry,
 )
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_client_connected(hass: HomeAssistant) -> None:
@@ -106,3 +113,96 @@ async def test_restoring_clients(
     device = hass.states.get(TEST_CLIENT_ENTITY_ID)
     assert device is not None
     assert device.state == STATE_NOT_HOME
+
+
+async def test_mac_filter_tracks_only_allowed(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that only allowed MACs are tracked when filter is set."""
+    entry = mock_config_entry(options={CONF_MAC_FILTER: [TEST_CLIENT[API_CLIENT_MAC]]})
+    entry.add_to_hass(hass)
+
+    # Create device registry entries so entities get enabled
+    other_config_entry = MockConfigEntry()
+    other_config_entry.add_to_hass(hass)
+    for client in (TEST_CLIENT, TEST_CLIENT_2):
+        device_registry.async_get_or_create(
+            name="Device from other integration",
+            config_entry_id=other_config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, client[API_CLIENT_MAC])},
+        )
+
+    with RuckusAjaxApiPatchContext(
+        active_clients=[TEST_CLIENT, TEST_CLIENT_2],
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # TEST_CLIENT should be tracked
+    assert hass.states.get(TEST_CLIENT_ENTITY_ID) is not None
+
+    # TEST_CLIENT_2 should NOT be tracked (not in filter)
+    assert hass.states.get(TEST_CLIENT_2_ENTITY_ID) is None
+
+
+async def test_empty_mac_filter_tracks_all(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that an empty filter tracks all clients."""
+    entry = mock_config_entry(options={CONF_MAC_FILTER: []})
+    entry.add_to_hass(hass)
+
+    # Create device registry entries so entities get enabled
+    other_config_entry = MockConfigEntry()
+    other_config_entry.add_to_hass(hass)
+    for client in (TEST_CLIENT, TEST_CLIENT_2):
+        device_registry.async_get_or_create(
+            name="Device from other integration",
+            config_entry_id=other_config_entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, client[API_CLIENT_MAC])},
+        )
+
+    with RuckusAjaxApiPatchContext(
+        active_clients=[TEST_CLIENT, TEST_CLIENT_2],
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Both clients should be tracked
+    assert hass.states.get(TEST_CLIENT_ENTITY_ID) is not None
+    assert hass.states.get(TEST_CLIENT_2_ENTITY_ID) is not None
+
+
+async def test_mac_filter_restore_respects_filter(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that restore_entities respects the MAC filter."""
+    entry = mock_config_entry(options={CONF_MAC_FILTER: [TEST_CLIENT[API_CLIENT_MAC]]})
+    entry.add_to_hass(hass)
+
+    # Pre-create entities for both clients (simulating previously tracked)
+    entity_registry.async_get_or_create(
+        "device_tracker",
+        DOMAIN,
+        TEST_CLIENT[API_CLIENT_MAC],
+        suggested_object_id="ruckus_test_device",
+        config_entry=entry,
+    )
+    entity_registry.async_get_or_create(
+        "device_tracker",
+        DOMAIN,
+        TEST_CLIENT_2[API_CLIENT_MAC],
+        suggested_object_id="ruckus_test_device_2",
+        config_entry=entry,
+    )
+
+    # Start with no active clients so restore_entities runs
+    with RuckusAjaxApiPatchContext(active_clients=[]):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # TEST_CLIENT should be restored (in filter)
+    assert hass.states.get(TEST_CLIENT_ENTITY_ID) is not None
+
+    # TEST_CLIENT_2 should NOT be restored (not in filter)
+    assert hass.states.get(TEST_CLIENT_2_ENTITY_ID) is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds some general code quality improvements and also adds a new optional option for the ruckus integration to allow selecting the devices to track from a pre-populated list.

This improves performance by only tracking a small number of devices and not every client on the network, allowing the integration to be used on larger networks where it would have struggled before.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/43887

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
