### PR TITLE
Bump ZHA to 1.0.1

### DIFF
--- a/homeassistant/components/zha/cover.py
+++ b/homeassistant/components/zha/cover.py
@@ -67,8 +67,12 @@ class ZhaCover(ZHAEntity, CoverEntity):
                 self.entity_data.entity.info_object.device_class
             )
 
+    @staticmethod
+    def _convert_supported_features(
+        zha_features: ZHACoverEntityFeature,
+    ) -> CoverEntityFeature:
+        """Convert ZHA cover features to HA cover features."""
         features = CoverEntityFeature(0)
-        zha_features: ZHACoverEntityFeature = self.entity_data.entity.supported_features
 
         if ZHACoverEntityFeature.OPEN in zha_features:
             features |= CoverEntityFeature.OPEN
@@ -87,7 +91,13 @@ class ZhaCover(ZHAEntity, CoverEntity):
         if ZHACoverEntityFeature.SET_TILT_POSITION in zha_features:
             features |= CoverEntityFeature.SET_TILT_POSITION
 
-        self._attr_supported_features = features
+        return features
+
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Return the supported features."""
+        zha_features: ZHACoverEntityFeature = self.entity_data.entity.supported_features
+        return self._convert_supported_features(zha_features)
 
     @property
     def is_closed(self) -> bool | None:

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==1.0.0", "serialx==0.6.2"],
+  "requirements": ["zha==1.0.1", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3350,7 +3350,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.0.0
+zha==1.0.1
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2823,7 +2823,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.0.0
+zha==1.0.1
 
 # homeassistant.components.zinvolt
 zinvolt==0.3.0

--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -22,6 +22,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
     SERVICE_STOP_COVER,
     SERVICE_STOP_COVER_TILT,
+    CoverEntityFeature,
     CoverState,
 )
 from homeassistant.components.zha.helpers import (
@@ -332,6 +333,70 @@ async def test_cover(
         assert cluster.request.call_args[1]["expect_reply"] is True
 
 
+async def test_cover_supported_features_runtime_update(
+    hass: HomeAssistant,
+    setup_zha: Callable[..., Coroutine[None]],
+    zigpy_device_mock: Callable[..., Device],
+) -> None:
+    """Test ZHA cover supported features update at runtime."""
+    await setup_zha()
+    gateway = get_zha_gateway(hass)
+    gateway_proxy: ZHAGatewayProxy = get_zha_gateway_proxy(hass)
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_PROFILE: zha.PROFILE_ID,
+                SIG_EP_TYPE: zha.DeviceType.WINDOW_COVERING_DEVICE,
+                SIG_EP_INPUT: [closures.WindowCovering.cluster_id],
+                SIG_EP_OUTPUT: [],
+            }
+        },
+    )
+    cluster = zigpy_device.endpoints[1].window_covering
+    cluster.PLUGGED_ATTR_READS = {
+        WCAttrs.current_position_lift_percentage.name: 0,
+        WCAttrs.current_position_tilt_percentage.name: 100,
+        WCAttrs.window_covering_type.name: WCT.Tilt_blind_tilt_and_lift,
+        WCAttrs.config_status.name: WCCS(~WCCS.Open_up_commands_reversed),
+    }
+    update_attribute_cache(cluster)
+
+    gateway.get_or_create_device(zigpy_device)
+    await gateway.async_device_initialized(zigpy_device)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    zha_device_proxy: ZHADeviceProxy = gateway_proxy.get_device_proxy(zigpy_device.ieee)
+    entity_id = find_entity_id(Platform.COVER, zha_device_proxy, hass)
+    assert entity_id is not None
+
+    await async_update_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
+
+    await send_attributes_report(
+        hass, cluster, {WCAttrs.window_covering_type.id: WCT.Tilt_blind_tilt_only}
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["supported_features"] == (
+        CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
+
+
 async def test_cover_failures(
     hass: HomeAssistant,
     setup_zha: Callable[..., Coroutine[None]],
@@ -369,11 +434,25 @@ async def test_cover_failures(
     assert entity_id is not None
 
     # test that the state has changed from unavailable to closed
-    await send_attributes_report(hass, cluster, {0: 0, 8: 100, 1: 1})
+    await send_attributes_report(
+        hass,
+        cluster,
+        {
+            WCAttrs.current_position_lift_percentage.id: 100,
+            WCAttrs.current_position_tilt_percentage.id: 100,
+        },
+    )
     assert hass.states.get(entity_id).state == CoverState.CLOSED
 
     # test that it opens
-    await send_attributes_report(hass, cluster, {0: 1, 8: 0, 1: 100})
+    await send_attributes_report(
+        hass,
+        cluster,
+        {
+            WCAttrs.current_position_lift_percentage.id: 0,
+            WCAttrs.current_position_tilt_percentage.id: 0,
+        },
+    )
     assert hass.states.get(entity_id).state == CoverState.OPEN
 
     # close from UI


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [1.0.1](https://github.com/zigpy/zha/releases/tag/1.0.1) (full diff: https://github.com/zigpy/zha/compare/1.0.0...1.0.1).
These dependency upgrades are bundled with it: 

- `zigpy` [1.1.0](https://github.com/zigpy/zigpy/releases/tag/1.1.0)
full diff: https://github.com/zigpy/zigpy/compare/1.0.0...1.1.0

- `zha-quirks` [1.0.1](https://github.com/zigpy/zha-device-handlers/releases/tag/1.0.1)
full diff: https://github.com/zigpy/zha-device-handlers/compare/1.0.0...1.0.1

A quick overview of the changes in this ZHA release:
- An issue was fixed where certain Telink-based Sonoff devices were unable to complete an OTA upgrade
- An issue was fixed where Sonoff plugs showed positive power consumption values whilst off
- An issue was fixed where the Ubisys covering window type entity required a restart to affect the cover entity
  - Due to the ZHA change, this also required a change in HA and to an existing test, both done here
  - As the change can't be separated without affecting cover functionality, the test for the fix was also added
- An issue was fixed where "Xiaomi attribute report multiple valid interpretations" was logged a lot
- An issue was fixed where Hue sensors were not showing timeout configuration entities

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/164251, fixes https://github.com/home-assistant/core/issues/158061
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
