### PR TITLE
Remove dispatcher pattern and use options properties in Vizio

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pyvizio.api.apps import AppConfig, find_app_name
 from pyvizio.const import APP_HOME, INPUT_APPS, NO_APP_RUNNING, UNKNOWN_APP
 
@@ -14,10 +16,6 @@ from homeassistant.components.media_player import (
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_EXCLUDE, CONF_INCLUDE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -122,9 +120,7 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         self._available_inputs: list[str] = []
         self._available_apps: list[str] = []
 
-        self._volume_step = config_entry.options[CONF_VOLUME_STEP]
         self._all_apps = apps_coordinator.data if apps_coordinator else None
-        self._conf_apps = config_entry.options.get(CONF_APPS, {})
         self._additional_app_configs = config_entry.data.get(CONF_APPS, {}).get(
             CONF_ADDITIONAL_CONFIGS, []
         )
@@ -141,6 +137,16 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         self._attr_unique_id = unique_id
         self._attr_device_class = device_class
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
+
+    @property
+    def _volume_step(self) -> int:
+        """Return the configured volume step."""
+        return self._config_entry.options[CONF_VOLUME_STEP]
+
+    @property
+    def _conf_apps(self) -> dict:
+        """Return the configured app filter options."""
+        return self._config_entry.options.get(CONF_APPS, {})
 
     def _apps_list(self, apps: list[str]) -> list[str]:
         """Return process apps list based on configured filters."""
@@ -225,22 +231,6 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
             additional_app["name"] for additional_app in self._additional_app_configs
         ]
 
-    @staticmethod
-    async def _async_send_update_options_signal(
-        hass: HomeAssistant, config_entry: VizioConfigEntry
-    ) -> None:
-        """Send update event when Vizio config entry is updated."""
-        # Move this method to component level if another entity ever gets added for a
-        # single config entry.
-        # See here: https://github.com/home-assistant/core/pull/30653#discussion_r366426121
-        async_dispatcher_send(hass, config_entry.entry_id, config_entry)
-
-    async def _async_update_options(self, config_entry: VizioConfigEntry) -> None:
-        """Update options if the update signal comes from this entity."""
-        self._volume_step = config_entry.options[CONF_VOLUME_STEP]
-        # Update so that CONF_ADDITIONAL_CONFIGS gets retained for imports
-        self._conf_apps.update(config_entry.options.get(CONF_APPS, {}))
-
     async def async_update_setting(
         self, setting_type: str, setting_name: str, new_value: int | str
     ) -> None:
@@ -259,19 +249,10 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         # Process initial coordinator data
         self._handle_coordinator_update()
 
-        # Register callback for when config entry is updated.
-        self.async_on_remove(
-            self._config_entry.add_update_listener(
-                self._async_send_update_options_signal
-            )
-        )
+        async def _async_write_state(*_: Any) -> None:
+            self.async_write_ha_state()
 
-        # Register callback for update event
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass, self._config_entry.entry_id, self._async_update_options
-            )
-        )
+        self.async_on_remove(self._config_entry.add_update_listener(_async_write_state))
 
         if not (apps_coordinator := self._apps_coordinator):
             return

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -250,7 +250,7 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         self._handle_coordinator_update()
 
         async def _async_write_state(*_: Any) -> None:
-            self.async_write_ha_state()
+            self._handle_coordinator_update()
 
         self.async_on_remove(self._config_entry.add_update_listener(_async_write_state))
 


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

Simplify the Vizio media player's options update mechanism:

- Remove the dispatcher roundtrip (`_async_send_update_options_signal` → `async_dispatcher_send` → `async_dispatcher_connect` → `_async_update_options`) and replace with a direct `add_update_listener` callback that recomputes entity state via `_handle_coordinator_update()`
- Remove the `async_dispatcher_connect`, `async_dispatcher_send` imports (no longer used)
- Replace cached `_volume_step` and `_conf_apps` instance fields with `@property` methods that read directly from `config_entry.options`, ensuring option changes are always reflected without needing a separate update handler

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr