### PR TITLE
Add optional mobile ID support to Ituran config flow

### DIFF
--- a/homeassistant/components/ituran/config_flow.py
+++ b/homeassistant/components/ituran/config_flow.py
@@ -45,17 +45,27 @@ class IturanConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
+
+        data_schema = STEP_USER_DATA_SCHEMA
+        if self.show_advanced_options:
+            data_schema = data_schema.extend({vol.Optional(CONF_MOBILE_ID): str})
+
         errors: dict[str, str] = {}
         if user_input is not None:
             await self.async_set_unique_id(user_input[CONF_ID_OR_PASSPORT])
             if self.source != SOURCE_REAUTH:
                 self._abort_if_unique_id_configured()
 
-            ituran = Ituran(
+            args = [
                 user_input[CONF_ID_OR_PASSPORT],
                 user_input[CONF_PHONE_NUMBER],
-            )
-            user_input[CONF_MOBILE_ID] = ituran.mobile_id
+            ]
+            if user_input.get(CONF_MOBILE_ID):
+                args.append(user_input[CONF_MOBILE_ID])
+
+            ituran = Ituran(*args)
+            if not user_input.get(CONF_MOBILE_ID):
+                user_input[CONF_MOBILE_ID] = ituran.mobile_id
             try:
                 authenticated = await ituran.is_authenticated()
                 if not authenticated:
@@ -77,7 +87,7 @@ class IturanConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_otp()
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=data_schema, errors=errors
         )
 
     async def async_step_otp(

--- a/homeassistant/components/ituran/strings.json
+++ b/homeassistant/components/ituran/strings.json
@@ -26,11 +26,13 @@
       "user": {
         "data": {
           "id_or_passport": "ID or passport number",
-          "phone_number": "Mobile phone number"
+          "phone_number": "Mobile phone number",
+          "mobile_id": "Mobile ID (Password)"
         },
         "data_description": {
           "id_or_passport": "The government ID or passport number provided when registering with Ituran.",
-          "phone_number": "The mobile phone number provided when registering with Ituran. A one-time password will be sent to this mobile number."
+          "phone_number": "The mobile phone number provided when registering with Ituran. A one-time password will be sent to this mobile number.",
+          "mobile_id": "Optional. The mobile ID from your Ituran mobile app. Does not require a one-time password and allows using both this integration and the mobile app simultaneously."
         }
       }
     }

--- a/tests/components/ituran/test_config_flow.py
+++ b/tests/components/ituran/test_config_flow.py
@@ -79,6 +79,34 @@ async def test_full_user_flow(
     await __do_successful_otp_step(hass, result, mock_ituran)
 
 
+async def test_full_user_flow_with_mobile_id(
+    hass: HomeAssistant, mock_ituran: AsyncMock, mock_setup_entry: AsyncMock
+) -> None:
+    """Test the full user configuration flow with mobile_id provided."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER, "show_advanced_options": True},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ID_OR_PASSPORT: MOCK_CONFIG_DATA[CONF_ID_OR_PASSPORT],
+            CONF_PHONE_NUMBER: MOCK_CONFIG_DATA[CONF_PHONE_NUMBER],
+            CONF_MOBILE_ID: MOCK_CONFIG_DATA[CONF_MOBILE_ID],
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "otp"
+    assert result["errors"] == {}
+
+    await __do_successful_otp_step(hass, result, mock_ituran)
+
+
 async def test_invalid_auth(
     hass: HomeAssistant, mock_ituran: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for providing an optional [mobile_id](cci:1://file:///Users/aviram/code/homeassistant/core/tests/components/ituran/test_config_flow.py:81:0-106:61) parameter during the setup of the Ituran integration.
Providing the [mobile_id](cci:1://file:///Users/aviram/code/homeassistant/core/tests/components/ituran/test_config_flow.py:81:0-106:61) allows users to run both the Home Assistant integration and the native Ituran mobile app simultaneously without the sessions invalidating each other. Because retrieving the [mobile_id](cci:1://file:///Users/aviram/code/homeassistant/core/tests/components/ituran/test_config_flow.py:81:0-106:61) is a highly technical process for the end user, this field is purposefully exposed only when "Advanced Mode" is enabled in the user's Home Assistant profile. It defaults back to the `pyituran` generated ID otherwise (the original behavior).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/orgs/home-assistant/discussions/3037
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/3037
- Link to documentation pull request: TODO(aviram): update link
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
