### PR TITLE
Migrate Tuya lights to kelvin

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -665,8 +665,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     _white_color_mode = ColorMode.COLOR_TEMP
     _fixed_color_mode: ColorMode | None = None
-    _attr_min_color_temp_kelvin = 2000  # 500 Mireds
-    _attr_max_color_temp_kelvin = 6500  # 153 Mireds
+    _attr_min_color_temp_kelvin = MIN_KELVIN
+    _attr_max_color_temp_kelvin = MAX_KELVIN
 
     def __init__(
         self,

--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -33,7 +33,6 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util import color as color_util
 from homeassistant.util.json import json_loads_object
 
 from . import TuyaConfigEntry
@@ -130,7 +129,7 @@ class _ColorTempWrapper(DPCodeIntegerWrapper):
         """Init DPCodeIntegerWrapper."""
         super().__init__(dpcode, type_information)
         self._remap_helper = RemapHelper.from_type_information(
-            type_information, MIN_MIREDS, MAX_MIREDS
+            type_information, MIN_KELVIN, MAX_KELVIN
         )
 
     def read_device_status(self, device: CustomerDevice) -> Any | None:
@@ -138,17 +137,11 @@ class _ColorTempWrapper(DPCodeIntegerWrapper):
         if (temperature := device.status.get(self.dpcode)) is None:
             return None
 
-        return color_util.color_temperature_mired_to_kelvin(
-            self._remap_helper.remap_value_to(temperature, reverse=True)
-        )
+        return round(self._remap_helper.remap_value_to(temperature))
 
     def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
         """Convert a Home Assistant value (Kelvin) back to a raw device value."""
-        return round(
-            self._remap_helper.remap_value_from(
-                color_util.color_temperature_kelvin_to_mired(value), reverse=True
-            )
-        )
+        return round(self._remap_helper.remap_value_from(value))
 
 
 DEFAULT_H_TYPE = RemapHelper(source_min=1, source_max=360, target_min=0, target_max=360)
@@ -200,8 +193,8 @@ class _ColorDataWrapper(DPCodeJsonWrapper):
         )
 
 
-MAX_MIREDS = 500  # 2000 K
-MIN_MIREDS = 153  # 6500 K
+MIN_KELVIN = 2000  # 500 mireds
+MAX_KELVIN = 6500  # 153 mireds
 
 
 class FallbackColorDataMode(StrEnum):

--- a/tests/components/tuya/snapshots/test_light.ambr
+++ b/tests/components/tuya/snapshots/test_light.ambr
@@ -1856,26 +1856,26 @@
     'attributes': ReadOnlyDict({
       'brightness': 255,
       'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
-      'color_temp_kelvin': 3508,
+      'color_temp_kelvin': 4788,
       'friendly_name': 'Ieskas',
       'hs_color': tuple(
-        27.165,
-        44.6,
+        26.83,
+        22.201,
       ),
       'max_color_temp_kelvin': 6500,
       'min_color_temp_kelvin': 2000,
       'rgb_color': tuple(
         255,
-        193,
-        141,
+        224,
+        198,
       ),
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
       ]),
       'supported_features': <LightEntityFeature: 0>,
       'xy_color': tuple(
-        0.453,
-        0.374,
+        0.38,
+        0.353,
       ),
     }),
     'context': <ANY>,
@@ -2792,18 +2792,18 @@
     'attributes': ReadOnlyDict({
       'brightness': 241,
       'color_mode': <ColorMode.COLOR_TEMP: 'color_temp'>,
-      'color_temp_kelvin': 3832,
+      'color_temp_kelvin': 5100,
       'friendly_name': 'Plafond bureau ',
       'hs_color': tuple(
-        26.903,
-        38.001,
+        27.117,
+        17.902,
       ),
       'max_color_temp_kelvin': 6500,
       'min_color_temp_kelvin': 2000,
       'rgb_color': tuple(
         255,
-        202,
-        158,
+        230,
+        209,
       ),
       'supported_color_modes': list([
         <ColorMode.COLOR_TEMP: 'color_temp'>,
@@ -2811,8 +2811,8 @@
       ]),
       'supported_features': <LightEntityFeature: 0>,
       'xy_color': tuple(
-        0.43,
         0.368,
+        0.349,
       ),
     }),
     'context': <ANY>,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we have a a double inversion:
- we take a Tuya range value (0...1000)
- we invert-map it to mired range (500...153) using inverted remap_helper
- we re-invert it into a Kelvin range (2000...6500) using `color_util`

This simplifies the code so that we map directly the Tuya range to a Kelvin range without the double-inversion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
