### PR TITLE
Migrate netgear to use runtime_data

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -138,7 +138,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         coordinator_traffic=coordinator_traffic_meter,
         coordinator_speed=coordinator_speed_test,
         coordinator_firmware=coordinator_firmware,
-        coordinator_util=coordinator_utilization,
+        coordinator_utilization=coordinator_utilization,
         coordinator_link=coordinator_link,
     )
 

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -6,24 +6,14 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT, CONF_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    KEY_COORDINATOR,
-    KEY_COORDINATOR_FIRMWARE,
-    KEY_COORDINATOR_LINK,
-    KEY_COORDINATOR_SPEED,
-    KEY_COORDINATOR_TRAFFIC,
-    KEY_COORDINATOR_UTIL,
-    KEY_ROUTER,
-    PLATFORMS,
-)
+from .const import PLATFORMS
+from .coordinator import NetgearConfigEntry, NetgearRuntimeData
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -34,7 +24,7 @@ SPEED_TEST_INTERVAL = timedelta(hours=2)
 SCAN_INTERVAL_FIRMWARE = timedelta(hours=5)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> bool:
     """Set up Netgear component."""
     router = NetgearRouter(hass, entry)
     try:
@@ -58,8 +48,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             router.port,
             router.ssl,
         )
-
-    hass.data.setdefault(DOMAIN, {})
 
     async def async_update_devices() -> bool:
         """Fetch data from the router."""
@@ -144,31 +132,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator_utilization.async_config_entry_first_refresh()
     await coordinator_link.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = {
-        KEY_ROUTER: router,
-        KEY_COORDINATOR: coordinator,
-        KEY_COORDINATOR_TRAFFIC: coordinator_traffic_meter,
-        KEY_COORDINATOR_SPEED: coordinator_speed_test,
-        KEY_COORDINATOR_FIRMWARE: coordinator_firmware,
-        KEY_COORDINATOR_UTIL: coordinator_utilization,
-        KEY_COORDINATOR_LINK: coordinator_link,
-    }
+    entry.runtime_data = NetgearRuntimeData(
+        router=router,
+        coordinator=coordinator,
+        coordinator_traffic=coordinator_traffic_meter,
+        coordinator_speed=coordinator_speed_test,
+        coordinator_firmware=coordinator_firmware,
+        coordinator_util=coordinator_utilization,
+        coordinator_link=coordinator_link,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
+    router = entry.runtime_data.router
 
     if not router.track_devices:
         router_id = None
@@ -193,10 +176,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+    hass: HomeAssistant, config_entry: NetgearConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
     """Remove a device from a config entry."""
-    router = hass.data[DOMAIN][config_entry.entry_id][KEY_ROUTER]
+    router = config_entry.runtime_data.router
 
     device_mac = None
     for connection in device_entry.connections:

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -57,7 +57,7 @@ class NetgearRouterButtonEntity(NetgearRouterCoordinatorEntity, ButtonEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: DataUpdateCoordinator[bool],
         router: NetgearRouter,
         entity_description: NetgearButtonEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -9,13 +9,12 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .coordinator import NetgearConfigEntry
 from .entity import NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -39,12 +38,12 @@ BUTTONS = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up button for Netgear component."""
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    router = entry.runtime_data.router
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(
         NetgearRouterButtonEntity(coordinator, router, entity_description)
         for entity_description in BUTTONS
@@ -58,7 +57,7 @@ class NetgearRouterButtonEntity(NetgearRouterCoordinatorEntity, ButtonEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[Any],
         router: NetgearRouter,
         entity_description: NetgearButtonEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/const.py
+++ b/homeassistant/components/netgear/const.py
@@ -16,14 +16,6 @@ PLATFORMS = [
 
 CONF_CONSIDER_HOME = "consider_home"
 
-KEY_ROUTER = "router"
-KEY_COORDINATOR = "coordinator"
-KEY_COORDINATOR_TRAFFIC = "coordinator_traffic"
-KEY_COORDINATOR_SPEED = "coordinator_speed"
-KEY_COORDINATOR_FIRMWARE = "coordinator_firmware"
-KEY_COORDINATOR_UTIL = "coordinator_utilization"
-KEY_COORDINATOR_LINK = "coordinator_link"
-
 DEFAULT_CONSIDER_HOME = timedelta(seconds=180)
 DEFAULT_NAME = "Netgear router"
 

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -1,0 +1,27 @@
+"""Models for the Netgear integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .router import NetgearRouter
+
+
+@dataclass
+class NetgearRuntimeData:
+    """Runtime data for the Netgear integration."""
+
+    router: NetgearRouter
+    coordinator: DataUpdateCoordinator[bool]
+    coordinator_traffic: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_speed: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_firmware: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_util: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_link: DataUpdateCoordinator[dict[str, Any] | None]
+
+
+type NetgearConfigEntry = ConfigEntry[NetgearRuntimeData]

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -20,7 +20,7 @@ class NetgearRuntimeData:
     coordinator_traffic: DataUpdateCoordinator[dict[str, Any] | None]
     coordinator_speed: DataUpdateCoordinator[dict[str, Any] | None]
     coordinator_firmware: DataUpdateCoordinator[dict[str, Any] | None]
-    coordinator_util: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_utilization: DataUpdateCoordinator[dict[str, Any] | None]
     coordinator_link: DataUpdateCoordinator[dict[str, Any] | None]
 
 

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
@@ -58,7 +57,7 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: DataUpdateCoordinator[bool],
         router: NetgearRouter,
         device: dict,
     ) -> None:

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.device_tracker import ScannerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DEVICE_ICONS, DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .const import DEVICE_ICONS
+from .coordinator import NetgearConfigEntry
 from .entity import NetgearDeviceEntity
 from .router import NetgearRouter
 
@@ -19,12 +20,12 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for Netgear component."""
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    router = entry.runtime_data.router
+    coordinator = entry.runtime_data.coordinator
     tracked = set()
 
     @callback
@@ -56,7 +57,10 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
     _attr_has_entity_name = False
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+        self,
+        coordinator: DataUpdateCoordinator[Any],
+        router: NetgearRouter,
+        device: dict,
     ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator, router, device)

--- a/homeassistant/components/netgear/entity.py
+++ b/homeassistant/components/netgear/entity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import Any
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
@@ -24,7 +25,10 @@ class NetgearDeviceEntity(CoordinatorEntity):
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, router: NetgearRouter, device: dict
+        self,
+        coordinator: DataUpdateCoordinator[Any],
+        router: NetgearRouter,
+        device: dict,
     ) -> None:
         """Initialize a Netgear device."""
         super().__init__(coordinator)
@@ -90,7 +94,7 @@ class NetgearRouterCoordinatorEntity(NetgearRouterEntity, CoordinatorEntity):
     """Base class for a Netgear router entity."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator, router: NetgearRouter
+        self, coordinator: DataUpdateCoordinator[Any], router: NetgearRouter
     ) -> None:
         """Initialize a Netgear device."""
         CoordinatorEntity.__init__(self, coordinator)

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -270,7 +270,7 @@ async def async_setup_entry(
     entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up device tracker for Netgear component."""
+    """Set up Netgear sensors from a config entry."""
     router = entry.runtime_data.router
     coordinator = entry.runtime_data.coordinator
     coordinator_traffic = entry.runtime_data.coordinator_traffic

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -275,7 +275,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     coordinator_traffic = entry.runtime_data.coordinator_traffic
     coordinator_speed = entry.runtime_data.coordinator_speed
-    coordinator_utilization = entry.runtime_data.coordinator_util
+    coordinator_utilization = entry.runtime_data.coordinator_utilization
     coordinator_link = entry.runtime_data.coordinator_link
 
     async_add_entities(

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -15,7 +16,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
@@ -28,15 +28,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    KEY_COORDINATOR,
-    KEY_COORDINATOR_LINK,
-    KEY_COORDINATOR_SPEED,
-    KEY_COORDINATOR_TRAFFIC,
-    KEY_COORDINATOR_UTIL,
-    KEY_ROUTER,
-)
+from .coordinator import NetgearConfigEntry
 from .entity import NetgearDeviceEntity, NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -275,16 +267,16 @@ SENSOR_LINK_TYPES = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for Netgear component."""
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
-    coordinator_traffic = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_TRAFFIC]
-    coordinator_speed = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_SPEED]
-    coordinator_utilization = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_UTIL]
-    coordinator_link = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_LINK]
+    router = entry.runtime_data.router
+    coordinator = entry.runtime_data.coordinator
+    coordinator_traffic = entry.runtime_data.coordinator_traffic
+    coordinator_speed = entry.runtime_data.coordinator_speed
+    coordinator_utilization = entry.runtime_data.coordinator_util
+    coordinator_link = entry.runtime_data.coordinator_link
 
     async_add_entities(
         NetgearRouterSensorEntity(coordinator, router, description)
@@ -334,7 +326,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[Any],
         router: NetgearRouter,
         device: dict,
         attribute: str,
@@ -373,7 +365,7 @@ class NetgearRouterSensorEntity(NetgearRouterCoordinatorEntity, RestoreSensor):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[Any],
         router: NetgearRouter,
         entity_description: NetgearSensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -365,7 +365,7 @@ class NetgearRouterSensorEntity(NetgearRouterCoordinatorEntity, RestoreSensor):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: DataUpdateCoordinator[dict[str, Any] | None],
         router: NetgearRouter,
         entity_description: NetgearSensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -148,7 +148,7 @@ class NetgearAllowBlock(NetgearDeviceEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: DataUpdateCoordinator[bool],
         router: NetgearRouter,
         device: dict,
         entity_description: SwitchEntityDescription,

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -9,13 +9,12 @@ from typing import Any
 from pynetgear import ALLOW, BLOCK
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR, KEY_ROUTER
+from .coordinator import NetgearConfigEntry
 from .entity import NetgearDeviceEntity, NetgearRouterEntity
 from .router import NetgearRouter
 
@@ -100,11 +99,11 @@ ROUTER_SWITCH_TYPES = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up switches for Netgear component."""
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
+    router = entry.runtime_data.router
 
     async_add_entities(
         NetgearRouterSwitchEntity(router, description)
@@ -112,7 +111,7 @@ async def async_setup_entry(
     )
 
     # Entities per network device
-    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR]
+    coordinator = entry.runtime_data.coordinator
     tracked = set()
 
     @callback
@@ -149,7 +148,7 @@ class NetgearAllowBlock(NetgearDeviceEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[Any],
         router: NetgearRouter,
         device: dict,
         entity_description: SwitchEntityDescription,

--- a/homeassistant/components/netgear/update.py
+++ b/homeassistant/components/netgear/update.py
@@ -10,12 +10,11 @@ from homeassistant.components.update import (
     UpdateEntity,
     UpdateEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, KEY_COORDINATOR_FIRMWARE, KEY_ROUTER
+from .coordinator import NetgearConfigEntry
 from .entity import NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -24,12 +23,12 @@ LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: NetgearConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up update entities for Netgear component."""
-    router = hass.data[DOMAIN][entry.entry_id][KEY_ROUTER]
-    coordinator = hass.data[DOMAIN][entry.entry_id][KEY_COORDINATOR_FIRMWARE]
+    router = entry.runtime_data.router
+    coordinator = entry.runtime_data.coordinator_firmware
     entities = [NetgearUpdateEntity(coordinator, router)]
 
     async_add_entities(entities)
@@ -43,7 +42,7 @@ class NetgearUpdateEntity(NetgearRouterCoordinatorEntity, UpdateEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: DataUpdateCoordinator[Any],
         router: NetgearRouter,
     ) -> None:
         """Initialize a Netgear device."""

--- a/homeassistant/components/netgear/update.py
+++ b/homeassistant/components/netgear/update.py
@@ -42,7 +42,7 @@ class NetgearUpdateEntity(NetgearRouterCoordinatorEntity, UpdateEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: DataUpdateCoordinator[dict[str, Any] | None],
         router: NetgearRouter,
     ) -> None:
         """Initialize a Netgear device."""


### PR DESCRIPTION
## Proposed change

Replace the legacy `hass.data[DOMAIN][entry.entry_id]` dictionary pattern in the `netgear` integration with the modern `entry.runtime_data` approach, using a typed dataclass and a `ConfigEntry` type alias.

A new `coordinator.py` module is introduced with:
- `NetgearRuntimeData` — a dataclass holding the `NetgearRouter` instance and the six `DataUpdateCoordinator` instances (devices, traffic, speed, firmware, utilization, link status)
- `type NetgearConfigEntry = ConfigEntry[NetgearRuntimeData]` — a typed config entry alias

All platform modules (`device_tracker`, `sensor`, `switch`, `button`, `update`) and `__init__.py` are updated to use `entry.runtime_data` instead of `hass.data` lookups. The now-unused `KEY_*` string constants are removed from `const.py`.

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr