### PR TITLE
Move WattTime coordinator to separate module

### DIFF
--- a/homeassistant/components/watttime/__init__.py
+++ b/homeassistant/components/watttime/__init__.py
@@ -2,28 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
 from aiowatttime import Client
-from aiowatttime.emissions import RealTimeEmissionsResponseType
 from aiowatttime.errors import InvalidCredentialsError, WattTimeError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    Platform,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER
-
-DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
+from .coordinator import WattTimeCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
@@ -42,27 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.error("Error while authenticating with WattTime: %s", err)
         return False
 
-    async def async_update_data() -> RealTimeEmissionsResponseType:
-        """Get the latest realtime emissions data."""
-        try:
-            return await client.emissions.async_get_realtime_emissions(
-                entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE]
-            )
-        except InvalidCredentialsError as err:
-            raise ConfigEntryAuthFailed("Invalid username/password") from err
-        except WattTimeError as err:
-            raise UpdateFailed(
-                f"Error while requesting data from WattTime: {err}"
-            ) from err
-
-    coordinator = DataUpdateCoordinator(
-        hass,
-        LOGGER,
-        config_entry=entry,
-        name=entry.title,
-        update_interval=DEFAULT_UPDATE_INTERVAL,
-        update_method=async_update_data,
-    )
+    coordinator = WattTimeCoordinator(hass, entry, client)
 
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/watttime/coordinator.py
+++ b/homeassistant/components/watttime/coordinator.py
@@ -1,0 +1,55 @@
+"""Coordinator for the WattTime integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from aiowatttime import Client
+from aiowatttime.emissions import RealTimeEmissionsResponseType
+from aiowatttime.errors import InvalidCredentialsError, WattTimeError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER
+
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
+
+
+class WattTimeCoordinator(DataUpdateCoordinator[RealTimeEmissionsResponseType]):
+    """Coordinator for WattTime data updates."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        client: Client,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=DEFAULT_UPDATE_INTERVAL,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> RealTimeEmissionsResponseType:
+        """Get the latest realtime emissions data."""
+        try:
+            return await self.client.emissions.async_get_realtime_emissions(
+                self.config_entry.data[CONF_LATITUDE],
+                self.config_entry.data[CONF_LONGITUDE],
+            )
+        except InvalidCredentialsError as err:
+            raise ConfigEntryAuthFailed("Invalid username/password") from err
+        except WattTimeError as err:
+            raise UpdateFailed(
+                f"Error while requesting data from WattTime: {err}"
+            ) from err

--- a/homeassistant/components/watttime/diagnostics.py
+++ b/homeassistant/components/watttime/diagnostics.py
@@ -14,9 +14,9 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_BALANCING_AUTHORITY, CONF_BALANCING_AUTHORITY_ABBREV, DOMAIN
+from .coordinator import WattTimeCoordinator
 
 CONF_TITLE = "title"
 
@@ -37,7 +37,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: WattTimeCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     return async_redact_data(
         {

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -22,12 +22,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_BALANCING_AUTHORITY, CONF_BALANCING_AUTHORITY_ABBREV, DOMAIN
+from .coordinator import WattTimeCoordinator
 
 ATTR_BALANCING_AUTHORITY = "balancing_authority"
 
@@ -67,14 +65,14 @@ async def async_setup_entry(
     )
 
 
-class RealtimeEmissionsSensor(CoordinatorEntity, SensorEntity):
+class RealtimeEmissionsSensor(CoordinatorEntity[WattTimeCoordinator], SensorEntity):
     """Define a realtime emissions sensor."""
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator,
+        coordinator: WattTimeCoordinator,
         entry: ConfigEntry,
         description: SensorEntityDescription,
     ) -> None:


### PR DESCRIPTION
## Breaking changes

<!--
  If your PR contains a breaking change for existing users, it is important to tell them what breaks, how to make it work again and why we did this. This piece of text is published with the release notes, so it helps if you write it towards our users, not us.
  Note: Remove this section if this PR does not contain a breaking change.
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Move the `DataUpdateCoordinator` inline logic from `__init__.py` into a dedicated `WattTimeCoordinator` class in a new `coordinator.py` module. This follows the standard HA integration structure. The update method closure is replaced by `_async_update_data`, and `config_entry` is narrowed to non-optional via a class-level annotation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
