### PR TITLE
Bump reolink-aio to 0.19.1

### DIFF
--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.19.0"]
+  "requirements": ["reolink-aio==0.19.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2796,7 +2796,7 @@ renault-api==0.5.5
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.19.0
+reolink-aio==0.19.1
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2368,7 +2368,7 @@ renault-api==0.5.5
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.19.0
+reolink-aio==0.19.1
 
 # homeassistant.components.rflink
 rflink==0.0.67


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink-aio to 0.19.1:
**Bug fixes:**
- Add ptzType 6, which means supporting only pan tilt on battery cams (https://github.com/starkillerOG/reolink_aio/pull/157)
- [Recognize floodlight mode 6 as "adaptive"](https://github.com/starkillerOG/reolink_aio/commit/0d2ac7316a4c9874fac07743eb9a2543b721cf76)
- [Fix UnexpectedDataError in baichuan get_ability_info for NVRs](https://github.com/starkillerOG/reolink_aio/commit/8383d18dbfee7cc2e62eb1d514e62f75a39b6dc2)

**Optimizations:**
- [Do not retry or use baichuan fallback when camera offline](https://github.com/starkillerOG/reolink_aio/commit/b9cb0f64f52484a76cf33693ce2ea780c5c98922)
- [Bump down "could not verify a working RTSP url" from error to warning](https://github.com/starkillerOG/reolink_aio/commit/a57d95cb4ea1c7d0be96e69f519ed8a9ef3c29f8)

**New Contributors**
* @zkw13 made their first contribution in https://github.com/starkillerOG/reolink_aio/pull/157

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.19.0...0.19.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/162971 fixes https://github.com/starkillerOG/reolink_aio/issues/154
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
