### PR TITLE
Restore handling of is active input for chromecast

### DIFF
--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -804,8 +804,22 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
     @property
     def state(self) -> MediaPlayerState | None:
         """Return the state of the player."""
-        # The lovelace app loops media to prevent timing out, don't show that
+        if (chromecast := self._chromecast) is None or (
+            cast_status := self.cast_status
+        ) is None:
+            # Not connected to any chromecast, or not yet got any status
+            return None
+
+        if (
+            chromecast.cast_type == pychromecast.const.CAST_TYPE_CHROMECAST
+            and not chromecast.ignore_cec
+            and cast_status.is_active_input is False
+        ):
+            # The display interface for the device has been turned off or switched away
+            return MediaPlayerState.OFF
+
         if self.app_id == CAST_APP_ID_HOMEASSISTANT_LOVELACE:
+            # The lovelace app loops media to prevent timing out, don't show that
             return MediaPlayerState.PLAYING
 
         if (media_status := self._media_status()[0]) is not None:
@@ -822,16 +836,12 @@ class CastMediaPlayerEntity(CastDevice, MediaPlayerEntity):
             # Some apps don't report media status, show the player as playing
             return MediaPlayerState.PLAYING
 
-        if self.app_id is not None and self.app_id != pychromecast.config.APP_BACKDROP:
-            # We have an active app
-            return MediaPlayerState.IDLE
-
-        if self._chromecast is not None and self._chromecast.is_idle:
-            # If library consider us idle, that is our off state
-            # it takes HDMI status into account for cast devices.
+        if self.app_id in (pychromecast.IDLE_APP_ID, None):
+            # We have no active app or the home screen app. This is
+            # same app as APP_BACKDROP.
             return MediaPlayerState.OFF
 
-        return None
+        return MediaPlayerState.IDLE
 
     @property
     def media_content_id(self) -> str | None:

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -68,7 +68,7 @@ def get_fake_chromecast(info: ChromecastInfo):
     mock = MagicMock(uuid=info.uuid)
     mock.app_id = None
     mock.media_controller.status = None
-    mock.is_idle = True
+    mock.ignore_cec = False
     return mock
 
 
@@ -888,7 +888,6 @@ async def test_entity_cast_status(
     assert not state.attributes.get("is_volume_muted")
 
     chromecast.app_id = "1234"
-    chromecast.is_idle = False
     cast_status = MagicMock()
     cast_status.volume_level = 0.5
     cast_status.volume_muted = False
@@ -1601,7 +1600,6 @@ async def test_entity_media_states(
 
     # App id updated, but no media status
     chromecast.app_id = app_id
-    chromecast.is_idle = False
     cast_status = MagicMock()
     cast_status_cb(cast_status)
     await hass.async_block_till_done()
@@ -1644,7 +1642,6 @@ async def test_entity_media_states(
 
     # App no longer running
     chromecast.app_id = pychromecast.IDLE_APP_ID
-    chromecast.is_idle = True
     cast_status = MagicMock()
     cast_status_cb(cast_status)
     await hass.async_block_till_done()
@@ -1653,7 +1650,6 @@ async def test_entity_media_states(
 
     # No cast status
     chromecast.app_id = None
-    chromecast.is_idle = False
     cast_status_cb(None)
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
@@ -1721,18 +1717,68 @@ async def test_entity_media_states_lovelace_app(
 
     chromecast.app_id = pychromecast.IDLE_APP_ID
     media_status.player_is_idle = False
-    chromecast.is_idle = True
     media_status_cb(media_status)
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state.state == "off"
 
     chromecast.app_id = None
-    chromecast.is_idle = False
+    cast_status_cb(None)
     media_status_cb(media_status)
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state.state == "unknown"
+
+
+async def test_entity_media_states_active_input(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test various entity media states when the lovelace app is active."""
+    entity_id = "media_player.speaker"
+
+    info = get_fake_chromecast_info()
+
+    chromecast, _ = await async_setup_media_player_cast(hass, info)
+    chromecast.cast_type = pychromecast.const.CAST_TYPE_CHROMECAST
+    cast_status_cb, conn_status_cb, _ = get_status_callbacks(chromecast)
+
+    chromecast.app_id = "84912283"
+    cast_status = MagicMock()
+
+    connection_status = MagicMock()
+    connection_status.status = "CONNECTED"
+    conn_status_cb(connection_status)
+    await hass.async_block_till_done()
+
+    # Unknown input status
+    cast_status.is_active_input = None
+    cast_status_cb(cast_status)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "idle"
+
+    # Active input status
+    cast_status.is_active_input = True
+    cast_status_cb(cast_status)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == "idle"
+
+    # Inactive input status
+    cast_status.is_active_input = False
+    cast_status_cb(cast_status)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+    # Inactive input status, but ignored
+    chromecast.ignore_cec = True
+    cast_status_cb(cast_status)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "idle"
 
 
 async def test_group_media_states(
@@ -2404,7 +2450,6 @@ async def test_entity_media_states_active_app_reported_idle(
 
     # Scenario: Custom App is running (e.g. DashCast), but device reports is_idle=True
     chromecast.app_id = "84912283"  # Example Custom App ID
-    chromecast.is_idle = True  # Device thinks it's idle/standby
 
     # Trigger a status update
     cast_status = MagicMock()
@@ -2417,7 +2462,6 @@ async def test_entity_media_states_active_app_reported_idle(
 
     # Scenario: Backdrop (Screensaver) is running. Should still be OFF.
     chromecast.app_id = pychromecast.config.APP_BACKDROP
-    chromecast.is_idle = True
 
     cast_status_cb(cast_status)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The changes in https://github.com/home-assistant/core/pull/160819 once again broke handling of is_active_input which is buried in the is_idle property of the chromecast object.

Refactor the code to avoid relying on this confusingly named property (is_idle) and explicitly check for turned of displays before other checks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160819 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
