### PR TITLE
Ignore transient empty segments in Matter vacuum

### DIFF
--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -260,14 +260,15 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             # Ignore empty segments; some devices transiently
             # report an empty list before sending the real one.
             and (current_segments := self._current_segments)
-            and current_segments != {s.id: s for s in last_seen_segments}
         ):
-            _LOGGER.debug(
-                "Vacuum segments changed: last_seen=%s, current=%s",
-                {s.id: s for s in last_seen_segments},
-                current_segments,
-            )
-            self.async_create_segments_issue()
+            last_seen_by_id = {s.id: s for s in last_seen_segments}
+            if current_segments != last_seen_by_id:
+                _LOGGER.debug(
+                    "Vacuum segments changed: last_seen=%s, current=%s",
+                    last_seen_by_id,
+                    current_segments,
+                )
+                self.async_create_segments_issue()
 
     @callback
     def _calculate_features(self) -> None:

--- a/homeassistant/components/matter/vacuum.py
+++ b/homeassistant/components/matter/vacuum.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import IntEnum
+import logging
 from typing import TYPE_CHECKING, Any
 
 from chip.clusters import Objects as clusters
@@ -25,6 +26,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import get_matter
 from .models import MatterDiscoverySchema
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class OperationalState(IntEnum):
@@ -254,8 +257,16 @@ class MatterVacuum(MatterEntity, StateVacuumEntity):
             VacuumEntityFeature.CLEAN_AREA in self.supported_features
             and self.registry_entry is not None
             and (last_seen_segments := self.last_seen_segments) is not None
-            and self._current_segments != {s.id: s for s in last_seen_segments}
+            # Ignore empty segments; some devices transiently
+            # report an empty list before sending the real one.
+            and (current_segments := self._current_segments)
+            and current_segments != {s.id: s for s in last_seen_segments}
         ):
+            _LOGGER.debug(
+                "Vacuum segments changed: last_seen=%s, current=%s",
+                {s.id: s for s in last_seen_segments},
+                current_segments,
+            )
             self.async_create_segments_issue()
 
     @callback

--- a/tests/components/matter/test_vacuum.py
+++ b/tests/components/matter/test_vacuum.py
@@ -475,6 +475,43 @@ async def test_vacuum_clean_area_select_areas_failure(
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_vacuum_cleaner"])
+async def test_vacuum_no_issue_on_transient_empty_segments(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test that no issue is raised when device transiently reports empty segments."""
+    entity_id = "vacuum.mock_vacuum"
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+
+    entity_registry.async_update_entity_options(
+        entity_id,
+        VACUUM_DOMAIN,
+        {
+            "last_seen_segments": [
+                {
+                    "id": "7",
+                    "name": "My Location A",
+                    "group": None,
+                }
+            ]
+        },
+    )
+
+    # Simulate transient empty SupportedAreas (cluster 336, attribute 0)
+    set_node_attribute(matter_node, 1, 336, 0, [])
+    await trigger_subscription_callback(hass, matter_client)
+
+    issue_reg = ir.async_get(hass)
+    issue = issue_reg.async_get_issue(
+        VACUUM_DOMAIN, f"segments_changed_{entity_entry.id}"
+    )
+    assert issue is None
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_vacuum_cleaner"])
 async def test_vacuum_raise_segments_changed_issue(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Breaking change

## Proposed change

Some Matter vacuum devices (e.g. Roborock) transiently report an empty `SupportedAreas` list before re-sending the full set of areas. This empty list was treated as a segment change, causing a spurious repair issue to be raised every time it happened (on device reboot, which seems to happen every night as well).

This PR skips the segment-change detection when the current segments list is empty, as an empty list represents a transient device state rather than a real change. A debug log and a test for this scenario have been added.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #164652
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
