### PR TITLE
Add event_start timestamp to UniFi Protect event payloads

### DIFF
--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -13,7 +13,7 @@ AUTH_RETRIES = 2
 
 ATTR_EVENT_SCORE = "event_score"
 ATTR_EVENT_ID = "event_id"
-ATTR_EVENT_START: Final = "event_start"
+ATTR_EVENT_START = "event_start"
 ATTR_WIDTH = "width"
 ATTR_HEIGHT = "height"
 ATTR_FPS = "fps"

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -13,6 +13,7 @@ AUTH_RETRIES = 2
 
 ATTR_EVENT_SCORE = "event_score"
 ATTR_EVENT_ID = "event_id"
+ATTR_EVENT_START: Final = "event_start"
 ATTR_WIDTH = "width"
 ATTR_HEIGHT = "height"
 ATTR_FPS = "fps"

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from datetime import datetime
 from typing import Any
 
 from uiprotect.data import ModelType
@@ -97,7 +98,10 @@ class ProtectDeviceRingEventEntity(EventEntityMixin, ProtectDeviceEntity, EventE
             and not self._event_already_ended(prev_event, prev_event_end)
             and event.type is EventType.RING
         ):
-            self._trigger_event(EVENT_TYPE_DOORBELL_RING, {ATTR_EVENT_ID: event.id})
+            self._trigger_event(
+                EVENT_TYPE_DOORBELL_RING,
+                {ATTR_EVENT_ID: event.id, ATTR_EVENT_START: event.start},
+            )
             self.async_write_ha_state()
 
 
@@ -204,6 +208,7 @@ class ProtectDeviceVehicleEventEntity(
     entity_description: ProtectEventEntityDescription
     _thumbnail_timer_cancel: CALLBACK_TYPE | None = None
     _latest_event_id: str | None = None
+    _latest_event_start: datetime | None = None
     _latest_thumbnails: list[EventDetectedThumbnail] | None = None
     _thumbnail_timer_due: float = 0.0  # Loop time when timer should fire
     _fired_event_id: str | None = None  # Track last fired event to prevent duplicates
@@ -289,17 +294,23 @@ class ProtectDeviceVehicleEventEntity(
             thumbnails: Pre-stored thumbnails to use. If None, fetches from
                 the current event (used when event is still active).
         """
+        event_start: datetime | None = None
         if thumbnails is None:
             # No stored thumbnails; try to get from current event
             event = self.entity_description.get_event_obj(self.device)
             if not event or event.id != event_id:
                 return
             thumbnails = self._get_vehicle_thumbnails(event)
+            event_start = event.start
+        else:
+            event_start = self._latest_event_start
 
         if not thumbnails:
             return
 
         event_data = self._build_event_data(event_id, thumbnails)
+        if event_start is not None:
+            event_data[ATTR_EVENT_START] = event_start
 
         # Prevent duplicate firing of same event with same data
         if self._fired_event_id == event_id and self._fired_event_data == event_data:
@@ -354,6 +365,7 @@ class ProtectDeviceVehicleEventEntity(
             # Store event data and extend/start the timer
             # Timer extension allows better thumbnails (with LPR) to arrive
             self._latest_event_id = event.id
+            self._latest_event_start = event.start
             self._latest_thumbnails = thumbnails
             self._thumbnail_timer_due = (
                 self.hass.loop.time() + VEHICLE_EVENT_DELAY_SECONDS

--- a/homeassistant/components/unifiprotect/event.py
+++ b/homeassistant/components/unifiprotect/event.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import async_call_at
 from . import Bootstrap
 from .const import (
     ATTR_EVENT_ID,
+    ATTR_EVENT_START,
     EVENT_TYPE_DOORBELL_RING,
     EVENT_TYPE_FINGERPRINT_IDENTIFIED,
     EVENT_TYPE_FINGERPRINT_NOT_IDENTIFIED,
@@ -123,6 +124,7 @@ class ProtectDeviceNFCEventEntity(EventEntityMixin, ProtectDeviceEntity, EventEn
         ):
             event_data = {
                 ATTR_EVENT_ID: event.id,
+                ATTR_EVENT_START: event.start,
                 KEYRINGS_USER_FULL_NAME: "",
                 KEYRINGS_ULP_ID: "",
                 KEYRINGS_USER_STATUS: "",
@@ -167,6 +169,7 @@ class ProtectDeviceFingerprintEventEntity(
         ):
             event_data = {
                 ATTR_EVENT_ID: event.id,
+                ATTR_EVENT_START: event.start,
                 KEYRINGS_USER_FULL_NAME: "",
                 KEYRINGS_ULP_ID: "",
             }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -269,6 +269,9 @@
       "doorbell": {
         "name": "[%key:component::event::entity_component::doorbell::name%]",
         "state_attributes": {
+          "event_start": {
+            "name": "Event start"
+          },
           "event_type": {
             "state": {
               "ring": "Ring"
@@ -306,6 +309,9 @@
       "vehicle": {
         "name": "Vehicle",
         "state_attributes": {
+          "event_start": {
+            "name": "Event start"
+          },
           "event_type": {
             "state": {
               "detected": "Detected"

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -279,6 +279,9 @@
       "fingerprint": {
         "name": "Fingerprint",
         "state_attributes": {
+          "event_start": {
+            "name": "Event start"
+          },
           "event_type": {
             "state": {
               "identified": "Identified",
@@ -290,6 +293,9 @@
       "nfc": {
         "name": "NFC",
         "state_attributes": {
+          "event_start": {
+            "name": "Event start"
+          },
           "event_type": {
             "state": {
               "scanned": "Scanned"

--- a/tests/components/unifiprotect/test_event.py
+++ b/tests/components/unifiprotect/test_event.py
@@ -18,6 +18,7 @@ from uiprotect.data import (
 
 from homeassistant.components.unifiprotect.const import (
     ATTR_EVENT_ID,
+    ATTR_EVENT_START,
     DEFAULT_ATTRIBUTION,
 )
 from homeassistant.components.unifiprotect.event import EVENT_DESCRIPTIONS
@@ -115,6 +116,7 @@ async def test_doorbell_ring(
     timestamp = state.state
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_ID] == "test_event_id"
+    assert state.attributes[ATTR_EVENT_START] == fixed_now - timedelta(seconds=1)
 
     event = Event(
         model=ModelType.EVENT,
@@ -245,6 +247,7 @@ async def test_doorbell_nfc_scanned(
     assert state
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_ID] == "test_event_id"
+    assert state.attributes[ATTR_EVENT_START] == fixed_now - timedelta(seconds=1)
     assert state.attributes["nfc_id"] == "test_nfc_id"
     assert state.attributes["full_name"] == test_user_full_name
 
@@ -518,6 +521,7 @@ async def test_doorbell_fingerprint_identified(
     assert state
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_ID] == "test_event_id"
+    assert state.attributes[ATTR_EVENT_START] == fixed_now - timedelta(seconds=1)
     assert state.attributes["ulp_id"] == ulp_id
     assert state.attributes["full_name"] == test_user_full_name
 
@@ -779,6 +783,7 @@ async def test_vehicle_detection_basic(
     assert state
     assert state.attributes[ATTR_ATTRIBUTION] == DEFAULT_ATTRIBUTION
     assert state.attributes[ATTR_EVENT_ID] == "test_vehicle_event_id"
+    assert state.attributes[ATTR_EVENT_START] == fixed_now - timedelta(seconds=1)
     assert state.attributes["confidence"] == 95
     assert "clock_best_wall" in state.attributes
     assert "license_plate" not in state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

All four UniFi Protect event entities (`nfc`, `fingerprint`, `doorbell`, `vehicle`) now include an `event_start` attribute in their fired event payloads, exposing the device-side timestamp from `Event.start`.

Previously only the HA-side receive time was available via `trigger.to_state.last_changed`. Automations had no way to detect delivery delays between a physical scan/detection occurring on the device and HA processing it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
