### PR TITLE
Improve ProxmoxVE permissions validation

### DIFF
--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -265,7 +265,8 @@ class ProxmoxNodeButtonEntity(ProxmoxNodeEntity, ProxmoxBaseButton):
 
     async def _async_press_call(self) -> None:
         """Execute the node button action via executor."""
-        if not is_granted(self.coordinator.permissions, p_type="nodes"):
+        node_id = self._node_data.node["node"]
+        if not is_granted(self.coordinator.permissions, p_type="nodes", p_id=node_id):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="no_permission_node_power",
@@ -273,7 +274,7 @@ class ProxmoxNodeButtonEntity(ProxmoxNodeEntity, ProxmoxBaseButton):
         await self.hass.async_add_executor_job(
             self.entity_description.press_action,
             self.coordinator,
-            self._node_data.node["node"],
+            node_id,
         )
 
 
@@ -284,7 +285,8 @@ class ProxmoxVMButtonEntity(ProxmoxVMEntity, ProxmoxBaseButton):
 
     async def _async_press_call(self) -> None:
         """Execute the VM button action via executor."""
-        if not is_granted(self.coordinator.permissions, p_type="vms"):
+        vmid = self.vm_data["vmid"]
+        if not is_granted(self.coordinator.permissions, p_type="vms", p_id=vmid):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="no_permission_vm_lxc_power",
@@ -293,7 +295,7 @@ class ProxmoxVMButtonEntity(ProxmoxVMEntity, ProxmoxBaseButton):
             self.entity_description.press_action,
             self.coordinator,
             self._node_name,
-            self.vm_data["vmid"],
+            vmid,
         )
 
 
@@ -304,8 +306,9 @@ class ProxmoxContainerButtonEntity(ProxmoxContainerEntity, ProxmoxBaseButton):
 
     async def _async_press_call(self) -> None:
         """Execute the container button action via executor."""
+        vmid = self.container_data["vmid"]
         # Container power actions fall under vms
-        if not is_granted(self.coordinator.permissions, p_type="vms"):
+        if not is_granted(self.coordinator.permissions, p_type="vms", p_id=vmid):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="no_permission_vm_lxc_power",
@@ -314,5 +317,5 @@ class ProxmoxContainerButtonEntity(ProxmoxContainerEntity, ProxmoxBaseButton):
             self.entity_description.press_action,
             self.coordinator,
             self._node_name,
-            self.container_data["vmid"],
+            vmid,
         )

--- a/homeassistant/components/proxmoxve/helpers.py
+++ b/homeassistant/components/proxmoxve/helpers.py
@@ -10,14 +10,9 @@ def is_granted(
     permission: str = PERM_POWER,
 ) -> bool:
     """Validate user permissions for the given type and permission."""
-    # Most specific permission matching
-    if p_id is not None:
-        path = f"/{p_type}/{p_id}"
-        if permission in permissions.get(path, {}):
-            return permissions.get(path, {}).get(permission) == 1
-    # Type specific permission
-    path = f"/{p_type}"
-    if permission in permissions.get(path, {}):
-        return permissions.get(path, {}).get(permission) == 1
-    # Global permission
-    return permissions.get("/", {}).get(permission) == 1
+    paths = [f"/{p_type}/{p_id}", f"/{p_type}", "/"]
+    for path in paths:
+        value = permissions.get(path, {}).get(permission)
+        if value is not None:
+            return value == 1
+    return False

--- a/homeassistant/components/proxmoxve/helpers.py
+++ b/homeassistant/components/proxmoxve/helpers.py
@@ -6,8 +6,18 @@ from .const import PERM_POWER
 def is_granted(
     permissions: dict[str, dict[str, int]],
     p_type: str = "vms",
+    p_id: str | int | None = None,  # can be str for nodes
     permission: str = PERM_POWER,
 ) -> bool:
     """Validate user permissions for the given type and permission."""
+    # Most specific permission matching
+    if p_id is not None:
+        path = f"/{p_type}/{p_id}"
+        if permission in permissions.get(path, {}):
+            return permissions.get(path, {}).get(permission) == 1
+    # Type specific permission
     path = f"/{p_type}"
-    return permissions.get(path, {}).get(permission) == 1
+    if permission in permissions.get(path, {}):
+        return permissions.get(path, {}).get(permission) == 1
+    # Global permission
+    return permissions.get("/", {}).get(permission) == 1

--- a/tests/components/proxmoxve/__init__.py
+++ b/tests/components/proxmoxve/__init__.py
@@ -25,16 +25,15 @@ AUDIT_PERMISSIONS = {
 }
 
 POWER_PERMISSIONS = {
+    "/": {"VM.PowerMgmt": 1},
     "/nodes": {"VM.PowerMgmt": 1},
     "/vms": {"VM.PowerMgmt": 1},
-    "/": {
-        "VM.PowerMgmt": 1,
-    },
+    "/vms/101": {"VM.PowerMgmt": 0},
 }
 
 MERGED_PERMISSIONS = {
-    key: value | POWER_PERMISSIONS.get(key, {})
-    for key, value in AUDIT_PERMISSIONS.items()
+    key: {**AUDIT_PERMISSIONS.get(key, {}), **POWER_PERMISSIONS.get(key, {})}
+    for key in set(AUDIT_PERMISSIONS) | set(POWER_PERMISSIONS)
 }
 
 

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -75,7 +75,7 @@ def mock_proxmox_client():
             "access_ticket.json", DOMAIN
         )
 
-        # Default to PVEUser privileges
+        # Default privileges as defined
         mock_instance.access.permissions.get.return_value = MERGED_PERMISSIONS
 
         # Make a separate mock for the qemu and lxc endpoints

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -330,7 +330,7 @@ async def test_node_buttons_permission_denied_for_auditor_role(
     entity_id: str,
     translation_key: str,
 ) -> None:
-    """Test that buttons are missing when only Audit permissions exist."""
+    """Test that buttons are informing properly when only Audit permissions exist."""
     mock_proxmox_client.access.permissions.get.return_value = AUDIT_PERMISSIONS
 
     await setup_integration(hass, mock_config_entry)
@@ -343,3 +343,21 @@ async def test_node_buttons_permission_denied_for_auditor_role(
             blocking=True,
         )
     assert exc_info.value.translation_key == translation_key
+
+
+async def test_vm_buttons_denied_for_specific_vm(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that button only works on actual permissions."""
+    await setup_integration(hass, mock_config_entry)
+    mock_proxmox_client._node_mock.qemu(101)
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.vm_db_start"},
+            blocking=True,
+        )

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -330,7 +330,7 @@ async def test_node_buttons_permission_denied_for_auditor_role(
     entity_id: str,
     translation_key: str,
 ) -> None:
-    """Test that buttons are informing properly when only Audit permissions exist."""
+    """Test that buttons are raising accordingly for Auditor permissions."""
     mock_proxmox_client.access.permissions.get.return_value = AUDIT_PERMISSIONS
 
     await setup_integration(hass, mock_config_entry)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Actually check most specific path first (and act on restrictions) before picking generic paths.
While only present on `button` currently it now should work for any operation, opening the way for more dynamic matching.

Could be interpreted as bug fix as well, but opted for quality as we should work on availability based. lmk or feel free to adjust

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165850
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
