### PR TITLE
Add trigger integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1751,6 +1751,8 @@ build.json @home-assistant/supervisor
 /tests/components/transmission/ @engrbm87 @JPHutchins @andrew-codechimp
 /homeassistant/components/trend/ @jpbede
 /tests/components/trend/ @jpbede
+/homeassistant/components/trigger/ @home-assistant/core
+/tests/components/trigger/ @home-assistant/core
 /homeassistant/components/triggercmd/ @rvmey
 /tests/components/triggercmd/ @rvmey
 /homeassistant/components/tts/ @home-assistant/core

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -224,6 +224,7 @@ DEFAULT_INTEGRATIONS = {
     "scene",
     "script",
     "tag",
+    "trigger",
     "zone",
     #
     # Built-in helpers:

--- a/homeassistant/components/trigger/__init__.py
+++ b/homeassistant/components/trigger/__init__.py
@@ -1,0 +1,33 @@
+"""Integration to load trigger platforms from specific integrations."""
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.trigger import async_register_trigger_platform
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import IntegrationNotFound, async_get_integration
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.empty_config_schema("trigger")
+
+DEFAULT_TRIGGER_DOMAINS = ("door",)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up trigger platforms from specific integrations."""
+    for domain in DEFAULT_TRIGGER_DOMAINS:
+        try:
+            integration = await async_get_integration(hass, domain)
+        except IntegrationNotFound:
+            _LOGGER.debug("Integration %s not found, skipping", domain)
+            continue
+        try:
+            platform = await integration.async_get_platform("trigger")
+        except ImportError:
+            _LOGGER.debug("Integration %s does not provide a trigger platform", domain)
+            continue
+        await async_register_trigger_platform(hass, domain, platform)
+
+    return True

--- a/homeassistant/components/trigger/manifest.json
+++ b/homeassistant/components/trigger/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "trigger",
+  "name": "Trigger",
+  "codeowners": ["@home-assistant/core"],
+  "documentation": "https://www.home-assistant.io/integrations/trigger",
+  "integration_type": "system",
+  "quality_scale": "internal"
+}

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -165,7 +165,7 @@ async def async_setup(hass: HomeAssistant) -> None:
     )
 
     await async_process_integration_platforms(
-        hass, "trigger", _register_trigger_platform, wait_for_platforms=True
+        hass, "trigger", async_register_trigger_platform, wait_for_platforms=True
     )
 
 
@@ -184,7 +184,7 @@ def async_subscribe_platform_events(
     return remove_subscription
 
 
-async def _register_trigger_platform(
+async def async_register_trigger_platform(
     hass: HomeAssistant, integration_domain: str, platform: TriggerProtocol
 ) -> None:
     """Register a trigger platform and notify listeners.

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -116,6 +116,7 @@ NO_IOT_CLASS = [
     "tag",
     "timer",
     "trace",
+    "trigger",
     "web_rtc",
     "webhook",
     "websocket_api",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2152,6 +2152,7 @@ NO_QUALITY_SCALE = [
     "tag",
     "timer",
     "trace",
+    "trigger",
     "usage_prediction",
     "web_rtc",
     "webhook",

--- a/tests/components/trigger/__init__.py
+++ b/tests/components/trigger/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the trigger integration."""

--- a/tests/components/trigger/test_init.py
+++ b/tests/components/trigger/test_init.py
@@ -1,0 +1,66 @@
+"""Test trigger integration setup."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.trigger import DEFAULT_TRIGGER_DOMAINS
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def test_setup_registers_trigger_platform(hass: HomeAssistant) -> None:
+    """Test that setup registers trigger platforms from available integrations."""
+    mock_platform = AsyncMock()
+    mock_integration = AsyncMock(
+        async_get_platform=AsyncMock(return_value=mock_platform),
+    )
+
+    with (
+        patch(
+            "homeassistant.components.trigger.async_get_integration",
+            return_value=mock_integration,
+        ),
+        patch(
+            "homeassistant.components.trigger.async_register_trigger_platform",
+        ) as mock_register,
+    ):
+        assert await async_setup_component(hass, "trigger", {})
+
+        assert mock_register.call_count == len(DEFAULT_TRIGGER_DOMAINS)
+        for domain in DEFAULT_TRIGGER_DOMAINS:
+            mock_register.assert_any_call(hass, domain, mock_platform)
+
+
+async def test_setup_skips_missing_integrations(hass: HomeAssistant) -> None:
+    """Test that setup skips integrations that don't exist."""
+    with (
+        patch(
+            "homeassistant.components.trigger.DEFAULT_TRIGGER_DOMAINS",
+            ("non_existent",),
+        ),
+        patch(
+            "homeassistant.components.trigger.async_register_trigger_platform",
+        ) as mock_register,
+    ):
+        assert await async_setup_component(hass, "trigger", {})
+        mock_register.assert_not_called()
+
+
+async def test_setup_skips_integrations_without_trigger_platform(
+    hass: HomeAssistant,
+) -> None:
+    """Test that setup skips integrations without a trigger platform."""
+    mock_integration = AsyncMock(
+        async_get_platform=AsyncMock(side_effect=ImportError),
+    )
+    with (
+        patch(
+            "homeassistant.components.trigger.async_get_integration",
+            return_value=mock_integration,
+        ),
+        patch(
+            "homeassistant.components.trigger.async_register_trigger_platform",
+        ) as mock_register,
+    ):
+        assert await async_setup_component(hass, "trigger", {})
+        mock_integration.async_get_platform.assert_called_with("trigger")
+        mock_register.assert_not_called()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add trigger integration.

There is a request to always show specific triggers in the frontend, even if the corresponding entities don't exist at all yet and their integrations are therefore not loaded.

The `trigger` integration is added to solve that problem cleanly, without excessive messing with bootstrap, integration loading, entity integrations, etc.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
