### PR TITLE
Re-introduce scan_interval to options flow and preserve YAML import value

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -140,8 +140,8 @@ async def _async_setup(hass: HomeAssistant, config: ConfigType) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) -> bool:
     """Set up Ness Alarm from a config entry."""
-    scan_interval = entry.options.get(
-        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds()
+    scan_interval = int(
+        entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds())
     )
 
     client = Client(

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -140,10 +140,14 @@ async def _async_setup(hass: HomeAssistant, config: ConfigType) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) -> bool:
     """Set up Ness Alarm from a config entry."""
+    scan_interval = entry.options.get(
+        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL.total_seconds()
+    )
+
     client = Client(
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
-        update_interval=DEFAULT_SCAN_INTERVAL.total_seconds(),
+        update_interval=scan_interval,
         infer_arming_state=entry.data.get(CONF_INFER_ARMING_STATE, False),
     )
 

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -218,6 +218,7 @@ class NessAlarmOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
+            user_input[CONF_SCAN_INTERVAL] = int(user_input[CONF_SCAN_INTERVAL])
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import (
     OptionsFlow,
     SubentryFlowResult,
 )
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL, CONF_TYPE
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, selector
 
@@ -35,6 +35,7 @@ from .const import (
     CONNECTION_TIMEOUT,
     DEFAULT_INFER_ARMING_STATE,
     DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_ZONE_TYPE,
     DOMAIN,
     POST_CONNECTION_DELAY,
@@ -198,6 +199,13 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_INFER_ARMING_STATE, DEFAULT_INFER_ARMING_STATE
                 ),
             },
+            options={
+                CONF_SCAN_INTERVAL: int(
+                    import_data.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ).total_seconds()
+                ),
+            },
             subentries=subentries,
         )
 
@@ -217,6 +225,17 @@ class NessAlarmOptionsFlowHandler(OptionsFlow):
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(
                     {
+                        vol.Required(
+                            CONF_SCAN_INTERVAL,
+                            default=int(DEFAULT_SCAN_INTERVAL.total_seconds()),
+                        ): selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=1,
+                                max=300,
+                                unit_of_measurement="seconds",
+                                mode=selector.NumberSelectorMode.BOX,
+                            )
+                        ),
                         vol.Required(CONF_SHOW_HOME_MODE, default=True): bool,
                     }
                 ),

--- a/homeassistant/components/ness_alarm/strings.json
+++ b/homeassistant/components/ness_alarm/strings.json
@@ -78,9 +78,11 @@
     "step": {
       "init": {
         "data": {
+          "scan_interval": "Scan interval",
           "show_home_mode": "Show arm home mode"
         },
         "data_description": {
+          "scan_interval": "Time in seconds between polling the alarm panel for updates.",
           "show_home_mode": "Enable this to show the arm home option on the alarm panel."
         }
       }

--- a/tests/components/ness_alarm/conftest.py
+++ b/tests/components/ness_alarm/conftest.py
@@ -59,6 +59,7 @@ def mock_nessclient():
     with patch(
         "homeassistant.components.ness_alarm.Client", new=_mock_factory, create=True
     ):
+        _mock_instance._mock_factory = _mock_factory
         yield _mock_instance
 
 

--- a/tests/components/ness_alarm/test_config_flow.py
+++ b/tests/components/ness_alarm/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Ness Alarm config flow."""
 
+from datetime import timedelta
 from types import MappingProxyType
 from unittest.mock import AsyncMock
 
@@ -18,7 +19,7 @@ from homeassistant.components.ness_alarm.const import (
     SUBENTRY_TYPE_ZONE,
 )
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER, ConfigSubentry
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -153,6 +154,7 @@ async def test_import_yaml_config(
     hass: HomeAssistant, mock_client: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:
     """Test importing YAML configuration."""
+    scan_interval = timedelta(seconds=5)
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_IMPORT},
@@ -160,6 +162,7 @@ async def test_import_yaml_config(
             CONF_HOST: "192.168.1.72",
             CONF_PORT: 4999,
             CONF_INFER_ARMING_STATE: False,
+            CONF_SCAN_INTERVAL: scan_interval,
             CONF_ZONES: [
                 {CONF_ZONE_NAME: "Garage", CONF_ZONE_ID: 1},
                 {
@@ -177,6 +180,9 @@ async def test_import_yaml_config(
         CONF_HOST: "192.168.1.72",
         CONF_PORT: 4999,
         CONF_INFER_ARMING_STATE: False,
+    }
+    assert result["options"] == {
+        CONF_SCAN_INTERVAL: 5,
     }
 
     # Check that subentries were created for zones with names preserved
@@ -422,11 +428,13 @@ async def test_options_flow(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
+            CONF_SCAN_INTERVAL: 30,
             CONF_SHOW_HOME_MODE: False,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == 30
     assert entry.options[CONF_SHOW_HOME_MODE] is False
 
 
@@ -438,7 +446,10 @@ async def test_options_flow_enable_home_mode(hass: HomeAssistant) -> None:
             CONF_HOST: "192.168.1.100",
             CONF_PORT: 1992,
         },
-        options={CONF_SHOW_HOME_MODE: False},
+        options={
+            CONF_SCAN_INTERVAL: 10,
+            CONF_SHOW_HOME_MODE: False,
+        },
     )
     entry.add_to_hass(hass)
 
@@ -446,9 +457,11 @@ async def test_options_flow_enable_home_mode(hass: HomeAssistant) -> None:
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
+            CONF_SCAN_INTERVAL: 10,
             CONF_SHOW_HOME_MODE: True,
         },
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_SCAN_INTERVAL] == 10
     assert entry.options[CONF_SHOW_HOME_MODE] is True

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -68,6 +68,14 @@ async def test_config_entry_setup(hass: HomeAssistant, mock_nessclient) -> None:
     # Alarm panel should be created
     assert hass.states.get("alarm_control_panel.alarm_panel")
 
+    # Client should be constructed with the configured scan interval
+    mock_nessclient._mock_factory.assert_called_once_with(
+        host="192.168.1.100",
+        port=1992,
+        update_interval=30,
+        infer_arming_state=False,
+    )
+
     # Client keepalive and update should be called after startup
     assert mock_nessclient.keepalive.call_count == 1
     # update is called once during setup (connection test) and once after startup

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -4,6 +4,7 @@ from types import MappingProxyType
 from unittest.mock import AsyncMock, patch
 
 from nessclient import ArmingMode, ArmingState
+import pytest
 
 from homeassistant.components import alarm_control_panel
 from homeassistant.components.alarm_control_panel import (
@@ -27,6 +28,7 @@ from homeassistant.const import (
     ATTR_STATE,
     CONF_HOST,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_TYPE,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
@@ -35,6 +37,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
@@ -48,6 +51,9 @@ async def test_config_entry_setup(hass: HomeAssistant, mock_nessclient) -> None:
         data={
             CONF_HOST: "192.168.1.100",
             CONF_PORT: 1992,
+        },
+        options={
+            CONF_SCAN_INTERVAL: 30,
         },
     )
     entry.add_to_hass(hass)
@@ -628,3 +634,63 @@ async def test_yaml_import_triggers_flow(
         )
         assert issue is not None
         assert issue.severity == "warning"
+
+
+async def test_yaml_import_connection_error_creates_issue(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test that YAML import connection error creates a repair issue."""
+    with patch(
+        "homeassistant.components.ness_alarm.config_flow.Client",
+        return_value=AsyncMock(),
+    ) as mock_client:
+        mock_client.return_value.update.side_effect = OSError("Connection refused")
+        mock_client.return_value.close = AsyncMock()
+
+        config = {
+            DOMAIN: {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 1992,
+            }
+        }
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+        # Check that no config entry was created
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 0
+
+        # Check that a domain-specific repair issue was created
+        issue = issue_registry.async_get_issue(
+            DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
+        )
+        assert issue is not None
+        assert issue.severity == "warning"
+
+
+async def test_panic_service_no_config_entry(
+    hass: HomeAssistant, mock_nessclient
+) -> None:
+    """Test panic service raises error when no config entry is loaded."""
+    # Set up integration without a config entry to register services
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_PANIC, blocking=True, service_data={ATTR_CODE: "1234"}
+        )
+
+
+async def test_aux_service_no_config_entry(
+    hass: HomeAssistant, mock_nessclient
+) -> None:
+    """Test aux service raises error when no config entry is loaded."""
+    # Set up integration without a config entry to register services
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_AUX, blocking=True, service_data={ATTR_OUTPUT_ID: 1}
+        )


### PR DESCRIPTION
## Proposed change

During the YAML-to-config-entry migration the `scan_interval` value from the YAML configuration was being dropped. It was never stored in the config entry, and `async_setup_entry` had the update interval hardcoded to 60 seconds. This meant users who had configured a custom `scan_interval` in YAML lost that setting after migration.

This PR:
- Preserves the `scan_interval` from YAML import into `entry.options` (as integer seconds)
- Adds a `scan_interval` number selector (1–300 seconds) to the options flow so users can adjust the polling interval via the UI after setup


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #164779
- This PR is related to issue: #162414
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43922
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr