### PR TITLE
fix(daikin): udpate switch on to match switch off.

### DIFF
--- a/homeassistant/components/daikin/switch.py
+++ b/homeassistant/components/daikin/switch.py
@@ -116,7 +116,7 @@ class DaikinToggleSwitch(DaikinEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the zone on."""
-        await self.device.set({})
+        await self.device.set({DAIKIN_ATTR_MODE: "on"})
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/tests/components/daikin/test_switch.py
+++ b/tests/components/daikin/test_switch.py
@@ -1,0 +1,88 @@
+"""Tests for the Daikin switch platform."""
+
+from __future__ import annotations
+
+from homeassistant.components.daikin.const import DOMAIN, KEY_MAC
+from homeassistant.components.daikin.switch import DAIKIN_ATTR_MODE
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import ZoneDevice, configure_zone_device
+
+from tests.common import MockConfigEntry
+
+HOST = "127.0.0.1"
+
+
+async def _async_setup_daikin(
+    hass: HomeAssistant, zone_device: ZoneDevice
+) -> MockConfigEntry:
+    """Set up a Daikin config entry with a mocked library device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=zone_device.mac,
+        data={CONF_HOST: HOST, KEY_MAC: zone_device.mac},
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return config_entry
+
+
+def _zone_entity_id(
+    entity_registry: er.EntityRegistry, zone_device: ZoneDevice, zone_id: int
+) -> str | None:
+    """Return the entity id for a zone climate unique id."""
+    return entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN,
+        DOMAIN,
+        f"{zone_device.mac}-toggle",
+    )
+
+
+async def test_device_state_off(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, zone_device: ZoneDevice
+) -> None:
+    """Setting a switch should update the state of the device."""
+    # Arrange
+    configure_zone_device(zone_device, zones=[["Living", "1", 22]])
+    await _async_setup_daikin(hass, zone_device)
+    entity_id = _zone_entity_id(entity_registry, zone_device, 0)
+    assert entity_id is not None
+    assert zone_device._mode != "off"
+
+    # Act
+    await hass.services.async_call(
+        "switch", "turn_off", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Assert
+    zone_device.set.assert_awaited_once_with({DAIKIN_ATTR_MODE: "off"})
+    assert zone_device._mode == "off"
+    assert hass.states.get(entity_id).state == "off"
+
+
+async def test_device_state_on(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, zone_device: ZoneDevice
+) -> None:
+    """Setting a switch should update the state of the device."""
+    # Arrange
+    configure_zone_device(zone_device, zones=[["Living", "1", 22]], mode="off")
+    await _async_setup_daikin(hass, zone_device)
+    entity_id = _zone_entity_id(entity_registry, zone_device, 0)
+    assert entity_id is not None
+    assert zone_device._mode == "off"
+
+    # Act
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Assert
+    zone_device.set.assert_awaited_once_with({DAIKIN_ATTR_MODE: "on"})
+    assert zone_device._mode == "on"
+    assert hass.states.get(entity_id).state == "on"


### PR DESCRIPTION
This fixes https://github.com/home-assistant/core/issues/164712

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
