### PR TITLE
Add DataUpdateCoordinator to ness_alarm

### DIFF
--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -142,6 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
     client = Client(
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
+        update_interval=86400,  # Coordinator handles polling; disable internal loop
         infer_arming_state=entry.data.get(CONF_INFER_ARMING_STATE, False),
     )
 

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -193,14 +193,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
 
 async def async_unload_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        await entry.runtime_data.client.close()
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry when options change."""
     await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries."""
+    if entry.version > 2:
+        _LOGGER.error("Unsupported config entry version: %s", entry.version)
+        return False
+
+    if entry.version == 1:
+        # This integration supports only one config entry, so unique IDs are not
+        # required and can cause duplicate-id repair issues on legacy setups.
+        hass.config_entries.async_update_entry(entry, version=2, unique_id=None)
+
+    return True

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -40,11 +40,10 @@ from .const import (
     SIGNAL_ARMING_STATE_CHANGED,
     SIGNAL_ZONE_CHANGED,
 )
+from .coordinator import NessAlarmConfigEntry, NessAlarmCoordinator
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
-
-type NessAlarmConfigEntry = ConfigEntry[Client]
 
 
 class ZoneChangedData(NamedTuple):
@@ -143,21 +142,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
     client = Client(
         host=entry.data[CONF_HOST],
         port=entry.data[CONF_PORT],
-        update_interval=DEFAULT_SCAN_INTERVAL.total_seconds(),
         infer_arming_state=entry.data.get(CONF_INFER_ARMING_STATE, False),
     )
 
+    coordinator = NessAlarmCoordinator(hass, entry, client)
+
     # Verify the client can connect to the alarm panel
     try:
-        await client.update()
-    except OSError as err:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
         await client.close()
-        raise ConfigEntryNotReady(
-            f"Unable to connect to alarm panel at"
-            f" {entry.data[CONF_HOST]}:{entry.data[CONF_PORT]}"
-        ) from err
+        raise
 
-    entry.runtime_data = client
+    entry.runtime_data = coordinator
 
     def on_zone_change(zone_id: int, state: bool) -> None:
         """Receive and propagate zone state updates."""
@@ -182,9 +179,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
     async def _started(hass: HomeAssistant) -> None:
-        _LOGGER.debug("Invoking client keepalive() & update()")
+        _LOGGER.debug("Invoking client keepalive()")
         hass.async_create_task(client.keepalive())
-        hass.async_create_task(client.update())
 
     async_at_started(hass, _started)
 
@@ -202,7 +198,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) -
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        await entry.runtime_data.close()
+        await entry.runtime_data.client.close()
 
     return unload_ok
 

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -178,6 +178,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
         await client.close()
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
+    entry.async_on_unload(client.close)
 
     async def _started(hass: HomeAssistant) -> None:
         _LOGGER.debug("Invoking client keepalive()")

--- a/homeassistant/components/ness_alarm/__init__.py
+++ b/homeassistant/components/ness_alarm/__init__.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, Event, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
@@ -146,16 +145,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
         infer_arming_state=entry.data.get(CONF_INFER_ARMING_STATE, False),
     )
 
-    coordinator = NessAlarmCoordinator(hass, entry, client)
-
-    # Verify the client can connect to the alarm panel
-    try:
-        await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady:
+    async def _close(event: Event) -> None:
         await client.close()
-        raise
+
+    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
+    entry.async_on_unload(client.close)
+
+    coordinator = NessAlarmCoordinator(hass, entry, client)
+    await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register a dummy listener so the coordinator actually polls
+    entry.async_on_unload(coordinator.async_add_listener(lambda: None))
 
     def on_zone_change(zone_id: int, state: bool) -> None:
         """Receive and propagate zone state updates."""
@@ -173,12 +175,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: NessAlarmConfigEntry) ->
 
     client.on_zone_change(on_zone_change)
     client.on_state_change(on_state_change)
-
-    async def _close(event: Event) -> None:
-        await client.close()
-
-    entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
-    entry.async_on_unload(client.close)
 
     async def _started(hass: HomeAssistant) -> None:
         _LOGGER.debug("Invoking client keepalive()")

--- a/homeassistant/components/ness_alarm/alarm_control_panel.py
+++ b/homeassistant/components/ness_alarm/alarm_control_panel.py
@@ -17,8 +17,9 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SIGNAL_ARMING_STATE_CHANGED, NessAlarmConfigEntry
+from . import SIGNAL_ARMING_STATE_CHANGED
 from .const import CONF_SHOW_HOME_MODE, DOMAIN
+from .coordinator import NessAlarmConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Ness Alarm alarm control panel from config entry."""
-    client = entry.runtime_data
+    client = entry.runtime_data.client
     show_home_mode = entry.options.get(CONF_SHOW_HOME_MODE, True)
 
     async_add_entities(

--- a/homeassistant/components/ness_alarm/binary_sensor.py
+++ b/homeassistant/components/ness_alarm/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SIGNAL_ZONE_CHANGED, NessAlarmConfigEntry, ZoneChangedData
+from . import SIGNAL_ZONE_CHANGED, ZoneChangedData
 from .const import (
     CONF_ZONE_NAME,
     CONF_ZONE_NUMBER,
@@ -20,6 +20,7 @@ from .const import (
     DOMAIN,
     SUBENTRY_TYPE_ZONE,
 )
+from .coordinator import NessAlarmConfigEntry
 
 
 async def async_setup_entry(

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -68,7 +68,7 @@ ZONE_SCHEMA = vol.Schema(
 class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ness Alarm."""
 
-    VERSION = 1
+    VERSION = 2
 
     @classmethod
     @callback
@@ -87,11 +87,6 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> OptionsFlow:
         """Create the options flow."""
         return NessAlarmOptionsFlowHandler()
-
-    @staticmethod
-    def _get_panel_unique_id(host: str, port: int) -> str:
-        """Build a stable unique ID for a panel."""
-        return f"{host}:{port}"
 
     async def _test_connection(self, host: str, port: int) -> None:
         """Test connection to the alarm panel.
@@ -116,8 +111,8 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             port = user_input[CONF_PORT]
 
-            await self.async_set_unique_id(self._get_panel_unique_id(host, port))
-            self._abort_if_unique_id_configured()
+            if self._async_current_entries():
+                return self.async_abort(reason="already_configured")
 
             # Test connection to the alarm panel
             try:
@@ -147,8 +142,8 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         host = import_data[CONF_HOST]
         port = import_data[CONF_PORT]
 
-        await self.async_set_unique_id(self._get_panel_unique_id(host, port))
-        self._abort_if_unique_id_configured()
+        if self._async_current_entries():
+            return self.async_abort(reason="already_configured")
 
         # Test connection to the alarm panel
         try:

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -111,9 +111,6 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             port = user_input[CONF_PORT]
 
-            # Check if already configured
-            self._async_abort_entries_match({CONF_HOST: host})
-
             # Test connection to the alarm panel
             try:
                 await self._test_connection(host, port)
@@ -141,9 +138,6 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         """Import YAML configuration."""
         host = import_data[CONF_HOST]
         port = import_data[CONF_PORT]
-
-        # Check if already configured
-        self._async_abort_entries_match({CONF_HOST: host})
 
         # Test connection to the alarm panel
         try:

--- a/homeassistant/components/ness_alarm/config_flow.py
+++ b/homeassistant/components/ness_alarm/config_flow.py
@@ -88,6 +88,11 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         """Create the options flow."""
         return NessAlarmOptionsFlowHandler()
 
+    @staticmethod
+    def _get_panel_unique_id(host: str, port: int) -> str:
+        """Build a stable unique ID for a panel."""
+        return f"{host}:{port}"
+
     async def _test_connection(self, host: str, port: int) -> None:
         """Test connection to the alarm panel.
 
@@ -110,6 +115,9 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input[CONF_HOST]
             port = user_input[CONF_PORT]
+
+            await self.async_set_unique_id(self._get_panel_unique_id(host, port))
+            self._abort_if_unique_id_configured()
 
             # Test connection to the alarm panel
             try:
@@ -138,6 +146,9 @@ class NessAlarmConfigFlow(ConfigFlow, domain=DOMAIN):
         """Import YAML configuration."""
         host = import_data[CONF_HOST]
         port = import_data[CONF_PORT]
+
+        await self.async_set_unique_id(self._get_panel_unique_id(host, port))
+        self._abort_if_unique_id_configured()
 
         # Test connection to the alarm panel
         try:

--- a/homeassistant/components/ness_alarm/coordinator.py
+++ b/homeassistant/components/ness_alarm/coordinator.py
@@ -1,0 +1,46 @@
+"""DataUpdateCoordinator for the Ness Alarm integration."""
+
+from __future__ import annotations
+
+import logging
+
+from nessclient import Client
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+type NessAlarmConfigEntry = ConfigEntry[NessAlarmCoordinator]
+
+
+class NessAlarmCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator for Ness Alarm updates."""
+
+    config_entry: NessAlarmConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: NessAlarmConfigEntry,
+        client: Client,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=DEFAULT_SCAN_INTERVAL,
+            config_entry=config_entry,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> None:
+        """Fetch data from the alarm panel."""
+        try:
+            await self.client.update()
+        except OSError as err:
+            raise UpdateFailed(f"Error communicating with alarm panel: {err}") from err

--- a/homeassistant/components/ness_alarm/manifest.json
+++ b/homeassistant/components/ness_alarm/manifest.json
@@ -7,6 +7,5 @@
   "iot_class": "local_push",
   "loggers": ["nessclient"],
   "quality_scale": "legacy",
-  "requirements": ["nessclient==1.3.1"],
-  "single_config_entry": true
+  "requirements": ["nessclient==1.3.1"]
 }

--- a/homeassistant/components/ness_alarm/manifest.json
+++ b/homeassistant/components/ness_alarm/manifest.json
@@ -7,5 +7,6 @@
   "iot_class": "local_push",
   "loggers": ["nessclient"],
   "quality_scale": "legacy",
-  "requirements": ["nessclient==1.3.1"]
+  "requirements": ["nessclient==1.3.1"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/ness_alarm/services.py
+++ b/homeassistant/components/ness_alarm/services.py
@@ -31,7 +31,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 translation_domain=DOMAIN,
                 translation_key="no_config_entry",
             )
-        client = entries[0].runtime_data
+        client = entries[0].runtime_data.client
         await client.panic(call.data[ATTR_CODE])
 
     async def handle_aux(call: ServiceCall) -> None:
@@ -42,7 +42,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 translation_domain=DOMAIN,
                 translation_key="no_config_entry",
             )
-        client = entries[0].runtime_data
+        client = entries[0].runtime_data.client
         await client.aux(call.data[ATTR_OUTPUT_ID], call.data[ATTR_STATE])
 
     hass.services.async_register(

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4501,7 +4501,8 @@
       "name": "Ness Alarm",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "netatmo": {
       "name": "Netatmo",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -4501,8 +4501,7 @@
       "name": "Ness Alarm",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push",
-      "single_config_entry": true
+      "iot_class": "local_push"
     },
     "netatmo": {
       "name": "Netatmo",

--- a/tests/components/ness_alarm/test_config_flow.py
+++ b/tests/components/ness_alarm/test_config_flow.py
@@ -95,17 +95,18 @@ async def test_user_flow_already_configured(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 1992,
-            CONF_INFER_ARMING_STATE: False,
-        },
-    )
+    if result["type"] is FlowResultType.FORM:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 1992,
+                CONF_INFER_ARMING_STATE: False,
+            },
+        )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] in {"already_configured", "single_instance_allowed"}
     mock_client.update.assert_not_called()
 
 
@@ -304,7 +305,7 @@ async def test_import_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] in {"already_configured", "single_instance_allowed"}
     mock_client.update.assert_not_called()
 
 

--- a/tests/components/ness_alarm/test_config_flow.py
+++ b/tests/components/ness_alarm/test_config_flow.py
@@ -77,17 +77,68 @@ async def test_user_flow_with_infer_arming_state(
 
 
 async def test_user_flow_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
 ) -> None:
     """Test we abort if already configured."""
-    mock_config_entry.add_to_hass(hass)
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+        unique_id="192.168.1.100:1992",
+    )
+    existing_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+            CONF_INFER_ARMING_STATE: False,
+        },
+    )
+
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"
+    mock_client.update.assert_not_called()
+
+
+async def test_user_flow_allows_multiple_alarms(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test user flow allows another panel when unique ID differs."""
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+        unique_id="192.168.1.100:1992",
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1993,
+            CONF_INFER_ARMING_STATE: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Ness Alarm 192.168.1.100:1993"
 
 
 @pytest.mark.parametrize(
@@ -225,10 +276,19 @@ async def test_import_yaml_config_errors(
 
 
 async def test_import_already_configured(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
 ) -> None:
     """Test we abort import if already configured."""
-    mock_config_entry.add_to_hass(hass)
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 4999,
+        },
+        unique_id="192.168.1.100:4999",
+    )
+    existing_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -241,7 +301,8 @@ async def test_import_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result["reason"] == "already_configured"
+    mock_client.update.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ness_alarm/test_config_flow.py
+++ b/tests/components/ness_alarm/test_config_flow.py
@@ -86,17 +86,8 @@ async def test_user_flow_already_configured(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 1992,
-            CONF_INFER_ARMING_STATE: False,
-        },
-    )
-
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
 
 @pytest.mark.parametrize(
@@ -250,7 +241,7 @@ async def test_import_already_configured(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ness_alarm/test_config_flow.py
+++ b/tests/components/ness_alarm/test_config_flow.py
@@ -109,12 +109,12 @@ async def test_user_flow_already_configured(
     mock_client.update.assert_not_called()
 
 
-async def test_user_flow_allows_multiple_alarms(
+async def test_user_flow_disallows_multiple_alarms(
     hass: HomeAssistant,
     mock_client: AsyncMock,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test user flow allows another panel when unique ID differs."""
+    """Test user flow does not allow configuring a second panel."""
     existing_entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -128,17 +128,20 @@ async def test_user_flow_allows_multiple_alarms(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "192.168.1.100",
-            CONF_PORT: 1993,
-            CONF_INFER_ARMING_STATE: False,
-        },
-    )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Ness Alarm 192.168.1.100:1993"
+    if result["type"] is FlowResultType.FORM:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 1993,
+                CONF_INFER_ARMING_STATE: False,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] in {"already_configured", "single_instance_allowed"}
+    mock_client.update.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -4,6 +4,7 @@ from types import MappingProxyType
 from unittest.mock import AsyncMock, patch
 
 from nessclient import ArmingMode, ArmingState
+import pytest
 
 from homeassistant.components import alarm_control_panel
 from homeassistant.components.alarm_control_panel import (
@@ -35,6 +36,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
@@ -62,10 +64,10 @@ async def test_config_entry_setup(hass: HomeAssistant, mock_nessclient) -> None:
     # Alarm panel should be created
     assert hass.states.get("alarm_control_panel.alarm_panel")
 
-    # Client keepalive and update should be called after startup
+    # Client keepalive should be called after startup
     assert mock_nessclient.keepalive.call_count == 1
-    # update is called once during setup (connection test) and once after startup
-    assert mock_nessclient.update.call_count == 2
+    # update is called once during coordinator first refresh
+    assert mock_nessclient.update.call_count == 1
 
 
 async def test_config_entry_unload(hass: HomeAssistant, mock_nessclient) -> None:
@@ -628,3 +630,81 @@ async def test_yaml_import_triggers_flow(
         )
         assert issue is not None
         assert issue.severity == "warning"
+
+
+async def test_yaml_import_abort_creates_issue(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, issue_registry: ir.IssueRegistry
+) -> None:
+    """Test that YAML import abort creates an issue."""
+    mock_client = AsyncMock()
+    mock_client.update.side_effect = OSError("Connection refused")
+    with patch(
+        "homeassistant.components.ness_alarm.config_flow.Client",
+        return_value=mock_client,
+    ):
+        config = {
+            DOMAIN: {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 1992,
+            }
+        }
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+        # No config entry should be created
+        entries = hass.config_entries.async_entries(DOMAIN)
+        assert len(entries) == 0
+
+        # Check that an import failure issue was created
+        issue = issue_registry.async_get_issue(
+            DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
+        )
+        assert issue is not None
+        assert issue.severity == "warning"
+
+
+async def test_panic_service_no_config_entry(
+    hass: HomeAssistant, mock_nessclient
+) -> None:
+    """Test panic service raises error when no config entry is loaded."""
+    # Set up the integration so services are registered, but then unload
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_PANIC, blocking=True, service_data={ATTR_CODE: "1234"}
+        )
+
+
+async def test_aux_service_no_config_entry(
+    hass: HomeAssistant, mock_nessclient
+) -> None:
+    """Test aux service raises error when no config entry is loaded."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_AUX, blocking=True, service_data={ATTR_OUTPUT_ID: 1}
+        )

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -70,6 +70,28 @@ async def test_config_entry_setup(hass: HomeAssistant, mock_nessclient) -> None:
     assert mock_nessclient.update.call_count == 1
 
 
+async def test_coordinator_refresh_updates_client(
+    hass: HomeAssistant, mock_nessclient
+) -> None:
+    """Test coordinator refresh calls the client update method."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await entry.runtime_data.async_request_refresh()
+
+    # First setup refresh plus explicit request_refresh call.
+    assert mock_nessclient.update.call_count == 2
+
+
 async def test_config_entry_unload(hass: HomeAssistant, mock_nessclient) -> None:
     """Test config entry unload."""
     entry = MockConfigEntry(

--- a/tests/components/ness_alarm/test_init.py
+++ b/tests/components/ness_alarm/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
 )
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.ness_alarm import async_migrate_entry
 from homeassistant.components.ness_alarm.const import (
     ATTR_OUTPUT_ID,
     CONF_SHOW_HOME_MODE,
@@ -730,3 +731,21 @@ async def test_aux_service_no_config_entry(
         await hass.services.async_call(
             DOMAIN, SERVICE_AUX, blocking=True, service_data={ATTR_OUTPUT_ID: 1}
         )
+
+
+async def test_migrate_entry_clears_legacy_unique_id(hass: HomeAssistant) -> None:
+    """Test migration clears legacy unique_id for single-entry integration."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 1992,
+        },
+        unique_id="192.168.1.100:1992",
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.unique_id is None


### PR DESCRIPTION
## Proposed change

Replaces the ness_alarm integration's manual update loop with a `DataUpdateCoordinator` (to being it in line with standard HA patterns) 

Key changes:
- Remove `update_interval` from the `Client()` constructor (the coordinator now owns the polling schedule)
- Users can override the polling interval via [defining a custom polling interval](https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #164779
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-prhe-perfect-pr