### PR TITLE
Add base NetgearDataCoordinator to netgear

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -12,7 +12,12 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import PLATFORMS
-from .coordinator import NetgearConfigEntry, NetgearDataCoordinator, NetgearRuntimeData
+from .coordinator import (
+    NetgearConfigEntry,
+    NetgearDataCoordinator,
+    NetgearFirmwareCoordinator,
+    NetgearRuntimeData,
+)
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -20,7 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=30)
 SPEED_TEST_INTERVAL = timedelta(hours=2)
-SCAN_INTERVAL_FIRMWARE = timedelta(hours=5)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> bool:
@@ -62,10 +66,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         """Fetch data from the router."""
         return await router.async_get_speed_test()
 
-    async def async_check_firmware() -> dict[str, Any] | None:
-        """Check for new firmware of the router."""
-        return await router.async_check_new_firmware()
-
     async def async_update_utilization() -> dict[str, Any] | None:
         """Fetch data from the router."""
         return await router.async_get_utilization()
@@ -99,14 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_update_speed_test,
         update_interval=SPEED_TEST_INTERVAL,
     )
-    coordinator_firmware = NetgearDataCoordinator(
-        hass,
-        router,
-        entry,
-        name="Firmware",
-        update_method=async_check_firmware,
-        update_interval=SCAN_INTERVAL_FIRMWARE,
-    )
+    coordinator_firmware = NetgearFirmwareCoordinator(hass, router, entry)
     coordinator_utilization = NetgearDataCoordinator(
         hass,
         router,

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -10,10 +10,9 @@ from homeassistant.const import CONF_PORT, CONF_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import PLATFORMS
-from .coordinator import NetgearConfigEntry, NetgearRuntimeData
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator, NetgearRuntimeData
 from .errors import CannotLoginException
 from .router import NetgearRouter
 
@@ -76,57 +75,57 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         return await router.async_get_link_status()
 
     # Create update coordinators
-    coordinator = DataUpdateCoordinator(
+    coordinator_tracker = NetgearDataCoordinator[bool](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Devices",
+        router,
+        entry,
+        name="Devices",
         update_method=async_update_devices,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_traffic_meter = DataUpdateCoordinator(
+    coordinator_traffic_meter = NetgearDataCoordinator[dict[str, Any] | None](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Traffic meter",
+        router,
+        entry,
+        name="Traffic meter",
         update_method=async_update_traffic_meter,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_speed_test = DataUpdateCoordinator(
+    coordinator_speed_test = NetgearDataCoordinator[dict[str, Any] | None](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Speed test",
+        router,
+        entry,
+        name="Speed test",
         update_method=async_update_speed_test,
         update_interval=SPEED_TEST_INTERVAL,
     )
-    coordinator_firmware = DataUpdateCoordinator(
+    coordinator_firmware = NetgearDataCoordinator[dict[str, Any] | None](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Firmware",
+        router,
+        entry,
+        name="Firmware",
         update_method=async_check_firmware,
         update_interval=SCAN_INTERVAL_FIRMWARE,
     )
-    coordinator_utilization = DataUpdateCoordinator(
+    coordinator_utilization = NetgearDataCoordinator[dict[str, Any] | None](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Utilization",
+        router,
+        entry,
+        name="Utilization",
         update_method=async_update_utilization,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_link = DataUpdateCoordinator(
+    coordinator_link = NetgearDataCoordinator[dict[str, Any] | None](
         hass,
-        _LOGGER,
-        config_entry=entry,
-        name=f"{router.device_name} Ethernet Link Status",
+        router,
+        entry,
+        name="Ethernet Link Status",
         update_method=async_check_link_status,
         update_interval=SCAN_INTERVAL,
     )
 
     if router.track_devices:
-        await coordinator.async_config_entry_first_refresh()
+        await coordinator_tracker.async_config_entry_first_refresh()
     await coordinator_traffic_meter.async_config_entry_first_refresh()
     await coordinator_firmware.async_config_entry_first_refresh()
     await coordinator_utilization.async_config_entry_first_refresh()
@@ -134,7 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
 
     entry.runtime_data = NetgearRuntimeData(
         router=router,
-        coordinator=coordinator,
+        coordinator_tracker=coordinator_tracker,
         coordinator_traffic=coordinator_traffic_meter,
         coordinator_speed=coordinator_speed_test,
         coordinator_firmware=coordinator_firmware,

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         return await router.async_get_link_status()
 
     # Create update coordinators
-    coordinator_tracker = NetgearDataCoordinator[bool](
+    coordinator_tracker = NetgearDataCoordinator(
         hass,
         router,
         entry,
@@ -83,7 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_update_devices,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_traffic_meter = NetgearDataCoordinator[dict[str, Any] | None](
+    coordinator_traffic_meter = NetgearDataCoordinator(
         hass,
         router,
         entry,
@@ -91,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_update_traffic_meter,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_speed_test = NetgearDataCoordinator[dict[str, Any] | None](
+    coordinator_speed_test = NetgearDataCoordinator(
         hass,
         router,
         entry,
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_update_speed_test,
         update_interval=SPEED_TEST_INTERVAL,
     )
-    coordinator_firmware = NetgearDataCoordinator[dict[str, Any] | None](
+    coordinator_firmware = NetgearDataCoordinator(
         hass,
         router,
         entry,
@@ -107,7 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_check_firmware,
         update_interval=SCAN_INTERVAL_FIRMWARE,
     )
-    coordinator_utilization = NetgearDataCoordinator[dict[str, Any] | None](
+    coordinator_utilization = NetgearDataCoordinator(
         hass,
         router,
         entry,
@@ -115,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         update_method=async_update_utilization,
         update_interval=SCAN_INTERVAL,
     )
-    coordinator_link = NetgearDataCoordinator[dict[str, Any] | None](
+    coordinator_link = NetgearDataCoordinator(
         hass,
         router,
         entry,

--- a/homeassistant/components/netgear/button.py
+++ b/homeassistant/components/netgear/button.py
@@ -12,9 +12,8 @@ from homeassistant.components.button import (
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .coordinator import NetgearConfigEntry
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
 from .entity import NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -43,9 +42,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up button for Netgear component."""
     router = entry.runtime_data.router
-    coordinator = entry.runtime_data.coordinator
+    coordinator_tracker = entry.runtime_data.coordinator_tracker
     async_add_entities(
-        NetgearRouterButtonEntity(coordinator, router, entity_description)
+        NetgearRouterButtonEntity(coordinator_tracker, router, entity_description)
         for entity_description in BUTTONS
     )
 
@@ -57,7 +56,7 @@ class NetgearRouterButtonEntity(NetgearRouterCoordinatorEntity, ButtonEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[bool],
+        coordinator: NetgearDataCoordinator[bool],
         router: NetgearRouter,
         entity_description: NetgearButtonEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -57,4 +57,3 @@ class NetgearDataCoordinator[T](DataUpdateCoordinator[T]):
             update_interval=update_interval,
             update_method=update_method,
         )
-        self.router = router

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from datetime import timedelta
+import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .router import NetgearRouter
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -16,12 +22,39 @@ class NetgearRuntimeData:
     """Runtime data for the Netgear integration."""
 
     router: NetgearRouter
-    coordinator: DataUpdateCoordinator[bool]
-    coordinator_traffic: DataUpdateCoordinator[dict[str, Any] | None]
-    coordinator_speed: DataUpdateCoordinator[dict[str, Any] | None]
-    coordinator_firmware: DataUpdateCoordinator[dict[str, Any] | None]
-    coordinator_utilization: DataUpdateCoordinator[dict[str, Any] | None]
-    coordinator_link: DataUpdateCoordinator[dict[str, Any] | None]
+    coordinator_tracker: NetgearDataCoordinator[bool]
+    coordinator_traffic: NetgearDataCoordinator[dict[str, Any] | None]
+    coordinator_speed: NetgearDataCoordinator[dict[str, Any] | None]
+    coordinator_firmware: NetgearDataCoordinator[dict[str, Any] | None]
+    coordinator_utilization: NetgearDataCoordinator[dict[str, Any] | None]
+    coordinator_link: NetgearDataCoordinator[dict[str, Any] | None]
 
 
 type NetgearConfigEntry = ConfigEntry[NetgearRuntimeData]
+
+
+class NetgearDataCoordinator[T](DataUpdateCoordinator[T]):
+    """Base coordinator for Netgear."""
+
+    config_entry: NetgearConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        router: NetgearRouter,
+        entry: NetgearConfigEntry,
+        *,
+        name: str,
+        update_interval: timedelta,
+        update_method: Callable[[], Coroutine[Any, Any, T]],
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=f"{router.device_name} {name}",
+            update_interval=update_interval,
+            update_method=update_method,
+        )
+        self.router = router

--- a/homeassistant/components/netgear/coordinator.py
+++ b/homeassistant/components/netgear/coordinator.py
@@ -16,6 +16,8 @@ from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL_FIRMWARE = timedelta(hours=5)
+
 
 @dataclass
 class NetgearRuntimeData:
@@ -25,7 +27,7 @@ class NetgearRuntimeData:
     coordinator_tracker: NetgearDataCoordinator[bool]
     coordinator_traffic: NetgearDataCoordinator[dict[str, Any] | None]
     coordinator_speed: NetgearDataCoordinator[dict[str, Any] | None]
-    coordinator_firmware: NetgearDataCoordinator[dict[str, Any] | None]
+    coordinator_firmware: NetgearFirmwareCoordinator
     coordinator_utilization: NetgearDataCoordinator[dict[str, Any] | None]
     coordinator_link: NetgearDataCoordinator[dict[str, Any] | None]
 
@@ -46,7 +48,7 @@ class NetgearDataCoordinator[T](DataUpdateCoordinator[T]):
         *,
         name: str,
         update_interval: timedelta,
-        update_method: Callable[[], Coroutine[Any, Any, T]],
+        update_method: Callable[[], Coroutine[Any, Any, T]] | None = None,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -57,3 +59,24 @@ class NetgearDataCoordinator[T](DataUpdateCoordinator[T]):
             update_interval=update_interval,
             update_method=update_method,
         )
+        self.router = router
+
+
+class NetgearFirmwareCoordinator(NetgearDataCoordinator[dict[str, Any] | None]):
+    """Coordinator for Netgear firmware updates."""
+
+    def __init__(
+        self, hass: HomeAssistant, router: NetgearRouter, entry: NetgearConfigEntry
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            router,
+            entry,
+            name="Firmware",
+            update_interval=SCAN_INTERVAL_FIRMWARE,
+        )
+
+    async def _async_update_data(self) -> dict[str, Any] | None:
+        """Check for new firmware of the router."""
+        return await self.router.async_check_new_firmware()

--- a/homeassistant/components/netgear/device_tracker.py
+++ b/homeassistant/components/netgear/device_tracker.py
@@ -7,10 +7,9 @@ import logging
 from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DEVICE_ICONS
-from .coordinator import NetgearConfigEntry
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
 from .entity import NetgearDeviceEntity
 from .router import NetgearRouter
 
@@ -24,13 +23,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up device tracker for Netgear component."""
     router = entry.runtime_data.router
-    coordinator = entry.runtime_data.coordinator
+    coordinator_tracker = entry.runtime_data.coordinator_tracker
     tracked = set()
 
     @callback
     def new_device_callback() -> None:
         """Add new devices if needed."""
-        if not coordinator.data:
+        if not coordinator_tracker.data:
             return
 
         new_entities = []
@@ -39,14 +38,16 @@ async def async_setup_entry(
             if mac in tracked:
                 continue
 
-            new_entities.append(NetgearScannerEntity(coordinator, router, device))
+            new_entities.append(
+                NetgearScannerEntity(coordinator_tracker, router, device)
+            )
             tracked.add(mac)
 
         async_add_entities(new_entities)
 
-    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
+    entry.async_on_unload(coordinator_tracker.async_add_listener(new_device_callback))
 
-    coordinator.data = True
+    coordinator_tracker.data = True
     new_device_callback()
 
 
@@ -57,7 +58,7 @@ class NetgearScannerEntity(NetgearDeviceEntity, ScannerEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[bool],
+        coordinator: NetgearDataCoordinator[bool],
         router: NetgearRouter,
         device: dict,
     ) -> None:

--- a/homeassistant/components/netgear/entity.py
+++ b/homeassistant/components/netgear/entity.py
@@ -10,12 +10,10 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import NetgearDataCoordinator
 from .router import NetgearRouter
 
 
@@ -26,7 +24,7 @@ class NetgearDeviceEntity(CoordinatorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: NetgearDataCoordinator[Any],
         router: NetgearRouter,
         device: dict,
     ) -> None:
@@ -94,7 +92,7 @@ class NetgearRouterCoordinatorEntity(NetgearRouterEntity, CoordinatorEntity):
     """Base class for a Netgear router entity."""
 
     def __init__(
-        self, coordinator: DataUpdateCoordinator[Any], router: NetgearRouter
+        self, coordinator: NetgearDataCoordinator[Any], router: NetgearRouter
     ) -> None:
         """Initialize a Netgear device."""
         CoordinatorEntity.__init__(self, coordinator)

--- a/homeassistant/components/netgear/entity.py
+++ b/homeassistant/components/netgear/entity.py
@@ -88,12 +88,12 @@ class NetgearRouterEntity(Entity):
         )
 
 
-class NetgearRouterCoordinatorEntity(NetgearRouterEntity, CoordinatorEntity):
+class NetgearRouterCoordinatorEntity[T: NetgearDataCoordinator[Any]](
+    NetgearRouterEntity, CoordinatorEntity[T]
+):
     """Base class for a Netgear router entity."""
 
-    def __init__(
-        self, coordinator: NetgearDataCoordinator[Any], router: NetgearRouter
-    ) -> None:
+    def __init__(self, coordinator: T, router: NetgearRouter) -> None:
         """Initialize a Netgear device."""
         CoordinatorEntity.__init__(self, coordinator)
         NetgearRouterEntity.__init__(self, router)

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -26,10 +26,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .coordinator import NetgearConfigEntry
-from .entity import NetgearDeviceEntity, NetgearRouterCoordinatorEntity
+from .entity import (
+    NetgearDataCoordinator,
+    NetgearDeviceEntity,
+    NetgearRouterCoordinatorEntity,
+)
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
@@ -272,7 +275,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Netgear sensors from a config entry."""
     router = entry.runtime_data.router
-    coordinator = entry.runtime_data.coordinator
+    coordinator_tracker = entry.runtime_data.coordinator_tracker
     coordinator_traffic = entry.runtime_data.coordinator_traffic
     coordinator_speed = entry.runtime_data.coordinator_speed
     coordinator_utilization = entry.runtime_data.coordinator_utilization
@@ -298,7 +301,7 @@ async def async_setup_entry(
     @callback
     def new_device_callback() -> None:
         """Add new devices if needed."""
-        if not coordinator.data:
+        if not coordinator_tracker.data:
             return
 
         new_entities: list[NetgearSensorEntity] = []
@@ -308,16 +311,16 @@ async def async_setup_entry(
                 continue
 
             new_entities.extend(
-                NetgearSensorEntity(coordinator, router, device, attribute)
+                NetgearSensorEntity(coordinator_tracker, router, device, attribute)
                 for attribute in sensors
             )
             tracked.add(mac)
 
         async_add_entities(new_entities)
 
-    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
+    entry.async_on_unload(coordinator_tracker.async_add_listener(new_device_callback))
 
-    coordinator.data = True
+    coordinator_tracker.data = True
     new_device_callback()
 
 
@@ -326,7 +329,7 @@ class NetgearSensorEntity(NetgearDeviceEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[Any],
+        coordinator: NetgearDataCoordinator[Any],
         router: NetgearRouter,
         device: dict,
         attribute: str,
@@ -365,7 +368,7 @@ class NetgearRouterSensorEntity(NetgearRouterCoordinatorEntity, RestoreSensor):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[dict[str, Any] | None],
+        coordinator: NetgearDataCoordinator[dict[str, Any] | None],
         router: NetgearRouter,
         entity_description: NetgearSensorEntityDescription,
     ) -> None:

--- a/homeassistant/components/netgear/sensor.py
+++ b/homeassistant/components/netgear/sensor.py
@@ -27,12 +27,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .coordinator import NetgearConfigEntry
-from .entity import (
-    NetgearDataCoordinator,
-    NetgearDeviceEntity,
-    NetgearRouterCoordinatorEntity,
-)
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
+from .entity import NetgearDeviceEntity, NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -12,10 +12,9 @@ from homeassistant.components.switch import SwitchEntity, SwitchEntityDescriptio
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .coordinator import NetgearConfigEntry
-from .entity import NetgearDeviceEntity, NetgearRouterEntity
+from .entity import NetgearDataCoordinator, NetgearDeviceEntity, NetgearRouterEntity
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,14 +110,14 @@ async def async_setup_entry(
     )
 
     # Entities per network device
-    coordinator = entry.runtime_data.coordinator
+    coordinator_tracker = entry.runtime_data.coordinator_tracker
     tracked = set()
 
     @callback
     def new_device_callback() -> None:
         """Add new devices if needed."""
         new_entities = []
-        if not coordinator.data:
+        if not coordinator_tracker.data:
             return
 
         for mac, device in router.devices.items():
@@ -127,7 +126,9 @@ async def async_setup_entry(
 
             new_entities.extend(
                 [
-                    NetgearAllowBlock(coordinator, router, device, entity_description)
+                    NetgearAllowBlock(
+                        coordinator_tracker, router, device, entity_description
+                    )
                     for entity_description in SWITCH_TYPES
                 ]
             )
@@ -135,9 +136,9 @@ async def async_setup_entry(
 
         async_add_entities(new_entities)
 
-    entry.async_on_unload(coordinator.async_add_listener(new_device_callback))
+    entry.async_on_unload(coordinator_tracker.async_add_listener(new_device_callback))
 
-    coordinator.data = True
+    coordinator_tracker.data = True
     new_device_callback()
 
 
@@ -148,7 +149,7 @@ class NetgearAllowBlock(NetgearDeviceEntity, SwitchEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[bool],
+        coordinator: NetgearDataCoordinator[bool],
         router: NetgearRouter,
         device: dict,
         entity_description: SwitchEntityDescription,

--- a/homeassistant/components/netgear/switch.py
+++ b/homeassistant/components/netgear/switch.py
@@ -13,8 +13,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import NetgearConfigEntry
-from .entity import NetgearDataCoordinator, NetgearDeviceEntity, NetgearRouterEntity
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
+from .entity import NetgearDeviceEntity, NetgearRouterEntity
 from .router import NetgearRouter
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/netgear/update.py
+++ b/homeassistant/components/netgear/update.py
@@ -13,7 +13,7 @@ from homeassistant.components.update import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
+from .coordinator import NetgearConfigEntry, NetgearFirmwareCoordinator
 from .entity import NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -33,7 +33,9 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class NetgearUpdateEntity(NetgearRouterCoordinatorEntity, UpdateEntity):
+class NetgearUpdateEntity(
+    NetgearRouterCoordinatorEntity[NetgearFirmwareCoordinator], UpdateEntity
+):
     """Update entity for a Netgear device."""
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
@@ -41,7 +43,7 @@ class NetgearUpdateEntity(NetgearRouterCoordinatorEntity, UpdateEntity):
 
     def __init__(
         self,
-        coordinator: NetgearDataCoordinator[dict[str, Any] | None],
+        coordinator: NetgearFirmwareCoordinator,
         router: NetgearRouter,
     ) -> None:
         """Initialize a Netgear device."""

--- a/homeassistant/components/netgear/update.py
+++ b/homeassistant/components/netgear/update.py
@@ -12,9 +12,8 @@ from homeassistant.components.update import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .coordinator import NetgearConfigEntry
+from .coordinator import NetgearConfigEntry, NetgearDataCoordinator
 from .entity import NetgearRouterCoordinatorEntity
 from .router import NetgearRouter
 
@@ -42,7 +41,7 @@ class NetgearUpdateEntity(NetgearRouterCoordinatorEntity, UpdateEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[dict[str, Any] | None],
+        coordinator: NetgearDataCoordinator[dict[str, Any] | None],
         router: NetgearRouter,
     ) -> None:
         """Initialize a Netgear device."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preliminary work for moving all coordinator declarations to coordinator module (see #164808)

- rename `NetgearRuntimeData.coordinator` => `NetgearRuntimeData.coordinator_tracker`
- ensure `config_entry` is always typed as `NetgearConfigEntry`
- prefix name with `router.device_name`
- set logger in base class
- migrate NetgearFirmwareCoordinator (other coordinators will be migrated in a follow-up PR)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
