### PR TITLE
Fix incomplete device info in laundrify sensor

### DIFF
--- a/homeassistant/components/laundrify/sensor.py
+++ b/homeassistant/components/laundrify/sensor.py
@@ -47,7 +47,7 @@ class LaundrifyBaseSensor(SensorEntity):
     def __init__(self, device: LaundrifyDevice) -> None:
         """Initialize the sensor."""
         self._device = device
-        self._attr_device_info = self._attr_device_info = DeviceInfo(
+        self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.id)},
             name=device.name,
             manufacturer=MANUFACTURER,

--- a/homeassistant/components/laundrify/sensor.py
+++ b/homeassistant/components/laundrify/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, MANUFACTURER, MODELS
 from .coordinator import LaundrifyConfigEntry, LaundrifyUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +47,14 @@ class LaundrifyBaseSensor(SensorEntity):
     def __init__(self, device: LaundrifyDevice) -> None:
         """Initialize the sensor."""
         self._device = device
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device.id)})
+        self._attr_device_info = self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            name=device.name,
+            manufacturer=MANUFACTURER,
+            model=MODELS[device.model],
+            sw_version=device.firmwareVersion,
+            configuration_url=f"http://{device.internalIP}",
+        )
         self._attr_unique_id = f"{device.id}_{self._attr_device_class}"
 
 

--- a/homeassistant/components/laundrify/sensor.py
+++ b/homeassistant/components/laundrify/sensor.py
@@ -52,6 +52,7 @@ class LaundrifyBaseSensor(SensorEntity):
             name=device.name,
             manufacturer=MANUFACTURER,
             model=MODELS[device.model],
+            model_id=device.model,
             sw_version=device.firmwareVersion,
             configuration_url=f"http://{device.internalIP}",
         )

--- a/homeassistant/components/laundrify/sensor.py
+++ b/homeassistant/components/laundrify/sensor.py
@@ -52,7 +52,6 @@ class LaundrifyBaseSensor(SensorEntity):
             name=device.name,
             manufacturer=MANUFACTURER,
             model=MODELS[device.model],
-            model_id=device.model,
             sw_version=device.firmwareVersion,
             configuration_url=f"http://{device.internalIP}",
         )

--- a/tests/components/laundrify/test_sensor.py
+++ b/tests/components/laundrify/test_sensor.py
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def platforms() -> AsyncGenerator[None]:
     """Return the platforms to be loaded for this test."""
     with patch(
-        "homeassistant.components.homee.PLATFORMS", [Platform.SENSOR]
+        "homeassistant.components.laundrify.PLATFORMS", [Platform.SENSOR]
     ):
         yield
 

--- a/tests/components/laundrify/test_sensor.py
+++ b/tests/components/laundrify/test_sensor.py
@@ -34,7 +34,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def platforms() -> AsyncGenerator[None]:
     """Return the platforms to be loaded for this test."""
     with patch(
-        "homeassistant.components.homee.PLATFORMS", [Platform.ALARM_CONTROL_PANEL]
+        "homeassistant.components.homee.PLATFORMS", [Platform.SENSOR]
     ):
         yield
 

--- a/tests/components/laundrify/test_sensor.py
+++ b/tests/components/laundrify/test_sensor.py
@@ -1,5 +1,6 @@
 """Test the laundrify sensor platform."""
 
+from collections.abc import AsyncGenerator
 from datetime import timedelta
 import logging
 from unittest.mock import patch
@@ -19,6 +20,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
     STATE_UNKNOWN,
+    Platform,
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
@@ -26,6 +28,15 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.util import slugify
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.fixture(autouse=True)
+async def platforms() -> AsyncGenerator[None]:
+    """Return the platforms to be loaded for this test."""
+    with patch(
+        "homeassistant.components.homee.PLATFORMS", [Platform.ALARM_CONTROL_PANEL]
+    ):
+        yield
 
 
 async def test_laundrify_sensor_init(

--- a/tests/components/laundrify/test_sensor.py
+++ b/tests/components/laundrify/test_sensor.py
@@ -33,9 +33,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 @pytest.fixture(autouse=True)
 async def platforms() -> AsyncGenerator[None]:
     """Return the platforms to be loaded for this test."""
-    with patch(
-        "homeassistant.components.laundrify.PLATFORMS", [Platform.SENSOR]
-    ):
+    with patch("homeassistant.components.laundrify.PLATFORMS", [Platform.SENSOR]):
         yield
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix incomplete device info in laundrify sensor

If the binary sensor platforms loads after the sensor platform, the device is created without name etc., this PR fixes that issue

Spotted in https://github.com/home-assistant/core/pull/164728

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
