### PR TITLE
Update ness_alarm scan interval to 5 secs

### DIFF
--- a/homeassistant/components/ness_alarm/const.py
+++ b/homeassistant/components/ness_alarm/const.py
@@ -24,7 +24,7 @@ SUBENTRY_TYPE_ZONE = "zone"
 
 # Defaults
 DEFAULT_PORT = 4999
-DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
 DEFAULT_INFER_ARMING_STATE = False
 DEFAULT_ZONE_TYPE = BinarySensorDeviceClass.MOTION
 


### PR DESCRIPTION
## Proposed change

This PR is targeting 2026.3.1

Reduce the ness_alarm default scan interval from 60 seconds to 5 seconds for more responsive state updates from the alarm panel.

As mentioned within the issue attached: 

> Polling appears fixed at 60 seconds, and zone binary_sensor states (e.g. motion) can take up to ~1 minute to update/clear.

this is really not intended for an alarm panel + only binary sensors for zones, the 60s was originally carried over from being the default from the YAML

Once [#164797](https://github.com/home-assistant/core/pull/164797) is merged, users will be able to [customize the polling interval](https://www.home-assistant.io/common-tasks/general/#defining-a-custom-polling-interval) through the UI as originally intended. (will be apart of 2026.4)


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #164779
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
