### PR TITLE
Fix KNX sensor default attributes for energy and volume DPTs

### DIFF
--- a/homeassistant/components/knx/dpt.py
+++ b/homeassistant/components/knx/dpt.py
@@ -8,6 +8,7 @@ from xknx.dpt import DPTBase, DPTComplex, DPTEnum, DPTNumeric
 from xknx.dpt.dpt_16 import DPTString
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfReactiveEnergy
 
 HaDptClass = Literal["numeric", "enum", "complex", "string"]
 
@@ -36,7 +37,7 @@ def get_supported_dpts() -> Mapping[str, DPTInfo]:
             main=dpt_class.dpt_main_number,  # type: ignore[typeddict-item] # checked in xknx unit tests
             sub=dpt_class.dpt_sub_number,
             name=dpt_class.value_type,
-            unit=dpt_class.unit,
+            unit=_sensor_unit_overrides.get(dpt_number_str, dpt_class.unit),
             sensor_device_class=_sensor_device_classes.get(dpt_number_str),
             sensor_state_class=_get_sensor_state_class(ha_dpt_class, dpt_number_str),
         )
@@ -77,13 +78,13 @@ _sensor_device_classes: Mapping[str, SensorDeviceClass] = {
     "12.1200": SensorDeviceClass.VOLUME,
     "12.1201": SensorDeviceClass.VOLUME,
     "13.002": SensorDeviceClass.VOLUME_FLOW_RATE,
-    "13.010": SensorDeviceClass.ENERGY,
-    "13.012": SensorDeviceClass.REACTIVE_ENERGY,
-    "13.013": SensorDeviceClass.ENERGY,
-    "13.015": SensorDeviceClass.REACTIVE_ENERGY,
-    "13.016": SensorDeviceClass.ENERGY,
-    "13.1200": SensorDeviceClass.VOLUME,
-    "13.1201": SensorDeviceClass.VOLUME,
+    "13.010": SensorDeviceClass.ENERGY,  # DPTActiveEnergy
+    "13.012": SensorDeviceClass.REACTIVE_ENERGY,  # DPTReactiveEnergy
+    "13.013": SensorDeviceClass.ENERGY,  # DPTActiveEnergykWh
+    "13.015": SensorDeviceClass.REACTIVE_ENERGY,  # DPTReactiveEnergykVARh
+    "13.016": SensorDeviceClass.ENERGY,  # DPTActiveEnergyMWh
+    "13.1200": SensorDeviceClass.VOLUME,  # DPTDeltaVolumeLiquidLitre
+    "13.1201": SensorDeviceClass.VOLUME,  # DPTDeltaVolumeM3
     "14.010": SensorDeviceClass.AREA,
     "14.019": SensorDeviceClass.CURRENT,
     "14.027": SensorDeviceClass.VOLTAGE,
@@ -91,7 +92,7 @@ _sensor_device_classes: Mapping[str, SensorDeviceClass] = {
     "14.030": SensorDeviceClass.VOLTAGE,
     "14.031": SensorDeviceClass.ENERGY,
     "14.033": SensorDeviceClass.FREQUENCY,
-    "14.037": SensorDeviceClass.ENERGY_STORAGE,
+    "14.037": SensorDeviceClass.ENERGY_STORAGE,  # DPTHeatQuantity
     "14.039": SensorDeviceClass.DISTANCE,
     "14.051": SensorDeviceClass.WEIGHT,
     "14.056": SensorDeviceClass.POWER,
@@ -101,7 +102,7 @@ _sensor_device_classes: Mapping[str, SensorDeviceClass] = {
     "14.068": SensorDeviceClass.TEMPERATURE,
     "14.069": SensorDeviceClass.TEMPERATURE,
     "14.070": SensorDeviceClass.TEMPERATURE_DELTA,
-    "14.076": SensorDeviceClass.VOLUME,
+    "14.076": SensorDeviceClass.VOLUME,  # DPTVolume
     "14.077": SensorDeviceClass.VOLUME_FLOW_RATE,
     "14.080": SensorDeviceClass.APPARENT_POWER,
     "14.1200": SensorDeviceClass.VOLUME_FLOW_RATE,
@@ -121,15 +122,26 @@ _sensor_state_class_overrides: Mapping[str, SensorStateClass | None] = {
     "13.010": SensorStateClass.TOTAL,  # DPTActiveEnergy
     "13.011": SensorStateClass.TOTAL,  # DPTApparantEnergy
     "13.012": SensorStateClass.TOTAL,  # DPTReactiveEnergy
+    "13.013": SensorStateClass.TOTAL,  # DPTActiveEnergykWh
+    "13.015": SensorStateClass.TOTAL,  # DPTReactiveEnergykVARh
+    "13.016": SensorStateClass.TOTAL,  # DPTActiveEnergyMWh
+    "13.1200": SensorStateClass.TOTAL,  # DPTDeltaVolumeLiquidLitre
+    "13.1201": SensorStateClass.TOTAL,  # DPTDeltaVolumeM3
     "14.007": SensorStateClass.MEASUREMENT_ANGLE,  # DPTAngleDeg
-    "14.037": SensorStateClass.TOTAL,  # DPTHeatQuantity
     "14.051": SensorStateClass.TOTAL,  # DPTMass
     "14.055": SensorStateClass.MEASUREMENT_ANGLE,  # DPTPhaseAngleDeg
     "14.031": SensorStateClass.TOTAL_INCREASING,  # DPTEnergy
+    "14.076": SensorStateClass.TOTAL,  # DPTVolume
     "17.001": None,  # DPTSceneNumber
     "29.010": SensorStateClass.TOTAL,  # DPTActiveEnergy8Byte
     "29.011": SensorStateClass.TOTAL,  # DPTApparantEnergy8Byte
     "29.012": SensorStateClass.TOTAL,  # DPTReactiveEnergy8Byte
+}
+
+_sensor_unit_overrides: Mapping[str, str] = {
+    "13.012": UnitOfReactiveEnergy.VOLT_AMPERE_REACTIVE_HOUR,  # DPTReactiveEnergy (VARh in KNX)
+    "13.015": UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,  # DPTReactiveEnergykVARh (kVARh in KNX)
+    "29.012": UnitOfReactiveEnergy.VOLT_AMPERE_REACTIVE_HOUR,  # DPTReactiveEnergy8Byte (VARh in KNX)
 }
 
 

--- a/tests/components/knx/test_dpt.py
+++ b/tests/components/knx/test_dpt.py
@@ -5,6 +5,7 @@ import pytest
 from homeassistant.components.knx.dpt import (
     _sensor_device_classes,
     _sensor_state_class_overrides,
+    _sensor_unit_overrides,
 )
 from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
 
@@ -14,7 +15,10 @@ from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
     {
         *_sensor_device_classes,
         *_sensor_state_class_overrides,
-        "7",  # generic numeric DPT without specific device and state class
+        *_sensor_unit_overrides,
+        # add generic numeric DPTs without specific device and state class
+        "7",
+        "2byte_float",
     },
 )
 def test_dpt_default_device_classes(dpt) -> None:

--- a/tests/components/knx/test_dpt.py
+++ b/tests/components/knx/test_dpt.py
@@ -23,7 +23,7 @@ from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
         }
     ),
 )
-def test_dpt_default_device_classes(dpt) -> None:
+def test_dpt_default_device_classes(dpt: str) -> None:
     """Test DPT default device and state classes and unit are valid."""
     assert _sensor_attribute_sub_validator(
         # YAML sensor config - only set type for this validation

--- a/tests/components/knx/test_dpt.py
+++ b/tests/components/knx/test_dpt.py
@@ -12,14 +12,16 @@ from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
 
 @pytest.mark.parametrize(
     "dpt",
-    {
-        *_sensor_device_classes,
-        *_sensor_state_class_overrides,
-        *_sensor_unit_overrides,
-        # add generic numeric DPTs without specific device and state class
-        "7",
-        "2byte_float",
-    },
+    sorted(
+        {
+            *_sensor_device_classes,
+            *_sensor_state_class_overrides,
+            *_sensor_unit_overrides,
+            # add generic numeric DPTs without specific device and state class
+            "7",
+            "2byte_float",
+        }
+    ),
 )
 def test_dpt_default_device_classes(dpt) -> None:
     """Test DPT default device and state classes and unit are valid."""

--- a/tests/components/knx/test_dpt.py
+++ b/tests/components/knx/test_dpt.py
@@ -1,0 +1,27 @@
+"""Test KNX DPT default attributes."""
+
+import pytest
+
+from homeassistant.components.knx.dpt import (
+    _sensor_device_classes,
+    _sensor_state_class_overrides,
+)
+from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
+
+
+@pytest.mark.parametrize(
+    "dpt",
+    {
+        *_sensor_device_classes,
+        *_sensor_state_class_overrides,
+        "7",  # generic numeric DPT without specific device and state class
+    },
+)
+def test_dpt_default_device_classes(dpt) -> None:
+    """Test DPT default device and state classes and unit are valid."""
+    assert _sensor_attribute_sub_validator(
+        # YAML sensor config - only set type for this validation
+        # other keys are not required for this test
+        # UI validation works the same way, but uses different schema for config
+        {"type": dpt}
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix missing default state class for "energy" or "volume" default device class sensors (since the default for numeric DPTs is "measurement").
- Override unit of measurement of KNX `VARh` with HAs `varh` (since the "R" in KNX is uppercase and that's not covered by `AMBIGUOUS_UNITS`)
- Add validator tests so future additions don't yield issues.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
  - fixes #164795
  - fixes #164829
- This PR is related to issue: https://github.com/home-assistant/core/pull/159465
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
