### PR TITLE
Bump aiohomeconnect to 0.30.0

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -1,7 +1,5 @@
 """Constants for the Home Connect integration."""
 
-from typing import cast
-
 from aiohomeconnect.model import EventKey, OptionKey, ProgramKey, SettingKey, StatusKey
 
 from homeassistant.const import UnitOfTemperature, UnitOfTime, UnitOfVolume
@@ -76,9 +74,9 @@ AFFECTS_TO_SELECTED_PROGRAM = "selected_program"
 
 
 TRANSLATION_KEYS_PROGRAMS_MAP = {
-    bsh_key_to_translation_key(program.value): cast(ProgramKey, program)
+    bsh_key_to_translation_key(program.value): program
     for program in ProgramKey
-    if program != ProgramKey.UNKNOWN
+    if program not in (ProgramKey.UNKNOWN, ProgramKey.BSH_COMMON_FAVORITE_001)
 }
 
 PROGRAMS_TRANSLATION_KEYS_MAP = {

--- a/homeassistant/components/home_connect/manifest.json
+++ b/homeassistant/components/home_connect/manifest.json
@@ -23,6 +23,6 @@
   "iot_class": "cloud_push",
   "loggers": ["aiohomeconnect"],
   "quality_scale": "platinum",
-  "requirements": ["aiohomeconnect==0.28.0"],
+  "requirements": ["aiohomeconnect==0.30.0"],
   "zeroconf": ["_homeconnect._tcp.local."]
 }

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -403,8 +403,7 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
         self._attr_options = [
             PROGRAMS_TRANSLATION_KEYS_MAP[program.key]
             for program in self.appliance.programs
-            if program.key
-            not in (ProgramKey.UNKNOWN, ProgramKey.BSH_COMMON_FAVORITE_001)
+            if program.key in PROGRAMS_TRANSLATION_KEYS_MAP
             and (
                 program.constraints is None
                 or program.constraints.execution

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -403,7 +403,8 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
         self._attr_options = [
             PROGRAMS_TRANSLATION_KEYS_MAP[program.key]
             for program in self.appliance.programs
-            if program.key != ProgramKey.UNKNOWN
+            if program.key
+            not in (ProgramKey.UNKNOWN, ProgramKey.BSH_COMMON_FAVORITE_001)
             and (
                 program.constraints is None
                 or program.constraints.execution

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -279,7 +279,7 @@ aioharmony==0.5.3
 aiohasupervisor==0.3.3
 
 # homeassistant.components.home_connect
-aiohomeconnect==0.28.0
+aiohomeconnect==0.30.0
 
 # homeassistant.components.homekit_controller
 aiohomekit==3.2.20

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -267,7 +267,7 @@ aioharmony==0.5.3
 aiohasupervisor==0.3.3
 
 # homeassistant.components.home_connect
-aiohomeconnect==0.28.0
+aiohomeconnect==0.30.0
 
 # homeassistant.components.homekit_controller
 aiohomekit==3.2.20

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -1145,3 +1145,32 @@ async def test_restore_option_entity(
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
     assert not state.attributes.get(ATTR_RESTORED)
+
+
+async def test_favorite_001_program_not_exposed_as_option(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+) -> None:
+    """Test that favorite 001 program is not exposed as an option."""
+    client.get_all_programs = AsyncMock(
+        return_value=ArrayOfPrograms(
+            [
+                EnumerateProgram(
+                    key=ProgramKey.BSH_COMMON_FAVORITE_001,
+                    raw_key=ProgramKey.BSH_COMMON_FAVORITE_001.value,
+                    constraints=EnumerateProgramConstraints(
+                        execution=Execution.SELECT_AND_START,
+                    ),
+                ),
+            ]
+        )
+    )
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entity_state = hass.states.get("select.dishwasher_selected_program")
+    assert entity_state
+    assert entity_state.attributes[ATTR_OPTIONS] == []

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -4,11 +4,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import MagicMock
 
-from aiohomeconnect.model import HomeAppliance, SettingKey
+from aiohomeconnect.model import HomeAppliance, ProgramKey, SettingKey
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.home_connect.const import DOMAIN
+from homeassistant.components.home_connect.utils import bsh_key_to_translation_key
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -266,3 +268,34 @@ async def test_services_exception(
         match=SERVICE_VALIDATION_ERROR_MAPPING[service_name],
     ):
         await hass.services.async_call(**service_call)
+
+
+async def test_not_possible_to_use_favorite_program(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+) -> None:
+    """Raise a ValueError when trying to use a favorite program."""
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "HA_ID")},
+    )
+
+    with pytest.raises(MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_program_and_options",
+            {
+                "device_id": device_entry.id,
+                "affects_to": "selected_program",
+                "program": bsh_key_to_translation_key(
+                    ProgramKey.BSH_COMMON_FAVORITE_001
+                ),
+            },
+            blocking=True,
+        )

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -277,7 +277,7 @@ async def test_not_possible_to_use_favorite_program(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
 ) -> None:
-    """Raise a ValueError when trying to use a favorite program."""
+    """Raise a MultipleInvalid when trying to use a favorite program."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -294,7 +294,7 @@ async def test_not_possible_to_use_favorite_program(
                 "device_id": device_entry.id,
                 "affects_to": "selected_program",
                 "program": bsh_key_to_translation_key(
-                    ProgramKey.BSH_COMMON_FAVORITE_001
+                    ProgramKey.BSH_COMMON_FAVORITE_001.value
                 ),
             },
             blocking=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump aiohomeconnect to version 0.30.0
https://github.com/MartinHjelmare/aiohomeconnect/compare/v0.28.0...v0.30.0

Also, I'm not exposing a new key (BSH_COMMON_FAVORITE_001) that it has been added from this dependency update, but it raises issues on the API, so it is better to avoid exposing it.

In a future PR, we will add some features related to that favorite program.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
