### PR TITLE
Add reauthentication flow to Ghost integration (Silver)

### DIFF
--- a/homeassistant/components/ghost/config_flow.py
+++ b/homeassistant/components/ghost/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from typing import Any
 
@@ -23,11 +24,63 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ADMIN_API_KEY): str,
+    }
+)
+
 
 class GhostConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ghost."""
 
     VERSION = 1
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauth confirmation."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            admin_api_key = user_input[CONF_ADMIN_API_KEY]
+
+            if ":" not in admin_api_key:
+                errors["base"] = "invalid_api_key"
+            else:
+                try:
+                    await self._validate_credentials(
+                        reauth_entry.data[CONF_API_URL], admin_api_key
+                    )
+                except GhostAuthError:
+                    errors["base"] = "invalid_auth"
+                except GhostError:
+                    errors["base"] = "cannot_connect"
+                except Exception:
+                    _LOGGER.exception("Unexpected error during Ghost reauth")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_update_reload_and_abort(
+                        reauth_entry,
+                        data_updates=user_input,
+                    )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "title": reauth_entry.title,
+                "docs_url": "https://account.ghost.org/?r=settings/integrations/new",
+            },
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/ghost/manifest.json
+++ b/homeassistant/components/ghost/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aioghost"],
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["aioghost==0.4.0"]
 }

--- a/homeassistant/components/ghost/quality_scale.yaml
+++ b/homeassistant/components/ghost/quality_scale.yaml
@@ -38,7 +38,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: done
 
   # Gold

--- a/homeassistant/components/ghost/strings.json
+++ b/homeassistant/components/ghost/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "This Ghost site is already configured."
+      "already_configured": "This Ghost site is already configured.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "Failed to connect to Ghost. Please check your URL.",
@@ -10,6 +11,16 @@
       "unknown": "An unexpected error occurred."
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "admin_api_key": "[%key:component::ghost::config::step::user::data::admin_api_key%]"
+        },
+        "data_description": {
+          "admin_api_key": "[%key:component::ghost::config::step::user::data_description::admin_api_key%]"
+        },
+        "description": "Your API key for {title} is invalid. [Create a new integration key]({docs_url}) to reauthenticate.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "user": {
         "data": {
           "admin_api_key": "Admin API key",

--- a/tests/components/ghost/test_config_flow.py
+++ b/tests/components/ghost/test_config_flow.py
@@ -16,6 +16,10 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from .conftest import API_KEY, API_URL, SITE_UUID
 
+from tests.common import MockConfigEntry
+
+NEW_API_KEY = "new_key_id:new_key_secret"
+
 
 @pytest.mark.usefixtures("mock_setup_entry")
 async def test_form_user(hass: HomeAssistant, mock_ghost_api: AsyncMock) -> None:
@@ -138,3 +142,88 @@ async def test_form_errors_can_recover(
         CONF_API_URL: API_URL,
         CONF_ADMIN_API_KEY: API_KEY,
     }
+
+
+@pytest.mark.usefixtures("mock_ghost_api", "mock_setup_entry")
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ADMIN_API_KEY: NEW_API_KEY},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_ADMIN_API_KEY] == NEW_API_KEY
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error_key"),
+    [
+        (GhostAuthError("Invalid API key"), "invalid_auth"),
+        (GhostConnectionError("Connection failed"), "cannot_connect"),
+        (RuntimeError("Unexpected"), "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reauth_flow_errors_can_recover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ghost_api: AsyncMock,
+    side_effect: Exception,
+    error_key: str,
+) -> None:
+    """Test reauth flow errors and recovery."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    mock_ghost_api.get_site.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ADMIN_API_KEY: NEW_API_KEY},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error_key}
+
+    mock_ghost_api.get_site.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ADMIN_API_KEY: NEW_API_KEY},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_ADMIN_API_KEY] == NEW_API_KEY
+    assert len(hass.config_entries.async_entries()) == 1
+
+
+async def test_reauth_flow_invalid_api_key_format(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauth flow with invalid API key format."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ADMIN_API_KEY: "invalid-no-colon"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_api_key"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adding Ghost integration re-auth flow as the last missing requirement to bring it up to Silver status. This change has been modeled after other integrations, like Withings, to match the same structure and patterns. Has been tested against production Ghost instances during dev, by revoking and regenerating API keys, and works cleanly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
