### PR TITLE
Add per entity service to Notify for compatability issues

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -135,6 +135,7 @@ class NotifyEntity(RestoreEntity):
     _attr_device_class: None
     _attr_state: None = None
     __last_notified_isoformat: str | None = None
+    __service_name: str | None = None
 
     @cached_property
     @final
@@ -154,6 +155,37 @@ class NotifyEntity(RestoreEntity):
         state = await self.async_get_last_state()
         if state is not None and state.state not in (STATE_UNAVAILABLE, None):
             self.__set_state(state.state)
+
+        # Register individual per entity services for backwards compatibility
+        if self.entity_id and self.entity_id.startswith(f"{DOMAIN}."):
+            self.__service_name = self.entity_id[len(DOMAIN) + 1 :]
+
+            async def _async_notify_service_handler(service_call: ServiceCall) -> None:
+                """Handle the notify service call for this entity."""
+                # Extract message and optional title to match entity service behavior
+                kwargs = {ATTR_MESSAGE: service_call.data[ATTR_MESSAGE]}
+                if ATTR_TITLE in service_call.data:
+                    kwargs[ATTR_TITLE] = service_call.data[ATTR_TITLE]
+                await self._async_send_message(**kwargs)
+
+            # Only register if not already registered
+            if not self.hass.services.has_service(DOMAIN, self.__service_name):
+                self.hass.services.async_register(
+                    DOMAIN,
+                    self.__service_name,
+                    _async_notify_service_handler,
+                    schema=NOTIFY_SERVICE_SCHEMA,
+                )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Call when the notify entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+
+        # Unregister individual service when entity is removed
+        if self.__service_name and self.hass.services.has_service(
+            DOMAIN, self.__service_name
+        ):
+            self.hass.services.async_remove(DOMAIN, self.__service_name)
 
     @final
     async def _async_send_message(self, **kwargs: Any) -> None:

--- a/tests/components/notify/test_init.py
+++ b/tests/components/notify/test_init.py
@@ -267,3 +267,53 @@ async def test_name(hass: HomeAssistant, config_flow_fixture: None) -> None:
     state = hass.states.get(entity3.entity_id)
     assert state
     assert state.attributes == {"supported_features": NotifyEntityFeature(0)}
+
+
+async def test_per_entity_service_registration(
+    hass: HomeAssistant, config_flow_fixture: None
+) -> None:
+    """Test that individual services are registered for each notify entity."""
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=help_async_setup_entry_init,
+            async_unload_entry=help_async_unload_entry,
+        ),
+    )
+
+    entity = MockNotifyEntity(name="test_notifier", entity_id="notify.test_notifier")
+    # Reset any previous mock calls
+    entity.send_message_mock_calls.reset_mock()
+
+    setup_test_component_platform(hass, DOMAIN, [entity], from_config_entry=True)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify the individual service is registered
+    assert hass.services.has_service(DOMAIN, "test_notifier")
+
+    # Test calling the individual service (like alerts do)
+    await hass.services.async_call(
+        DOMAIN,
+        "test_notifier",
+        {
+            notify.ATTR_MESSAGE: "Test via individual service",
+            notify.ATTR_TITLE: "Alert Title",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    entity.send_message_mock_calls.assert_called_once_with(
+        "Test via individual service", title="Alert Title"
+    )
+
+    # Test unloading removes the service
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert not hass.services.has_service(DOMAIN, "test_notifier")


### PR DESCRIPTION
## Proposed change

Add per entitiy services for the new Notify platform that is replacing the legacy BaseNotificationService

This fixes a compatibility issue with telegram bot deprecation described in the attached issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164855
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
