### PR TITLE
Fix 'this' variable in template options flow

### DIFF
--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -267,9 +267,13 @@ class TemplateEntity(AbstractTemplateEntity):
     def _get_this_variable(self) -> TemplateStateFromEntityId:
         """Create a this variable for the entity."""
         if self._preview_callback:
-            preview_entity_id = async_generate_entity_id(
-                self._entity_id_format, self._attr_name or "preview", hass=self.hass
-            )
+            if (
+                self.registry_entry
+                and (preview_entity_id := self.registry_entry.entity_id) is None
+            ) or not self.registry_entry:
+                preview_entity_id = async_generate_entity_id(
+                    self._entity_id_format, self._attr_name or "preview", hass=self.hass
+                )
             return TemplateStateFromEntityId(self.hass, preview_entity_id)
 
         return TemplateStateFromEntityId(self.hass, self.entity_id)

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -266,17 +266,20 @@ class TemplateEntity(AbstractTemplateEntity):
 
     def _get_this_variable(self) -> TemplateStateFromEntityId:
         """Create a this variable for the entity."""
+        entity_id = self.entity_id
         if self._preview_callback:
-            if (
-                self.registry_entry
-                and (preview_entity_id := self.registry_entry.entity_id) is None
-            ) or not self.registry_entry:
-                preview_entity_id = async_generate_entity_id(
+            # During config flow, the registry entry and entity_id will be None. In this scenario,
+            # a temporary entity_id is created.
+            # During option flow, the preview entity_id will be None, however the registry entry
+            # will contain the target entity_id.
+            if self.registry_entry:
+                entity_id = self.registry_entry.entity_id
+            else:
+                entity_id = async_generate_entity_id(
                     self._entity_id_format, self._attr_name or "preview", hass=self.hass
                 )
-            return TemplateStateFromEntityId(self.hass, preview_entity_id)
 
-        return TemplateStateFromEntityId(self.hass, self.entity_id)
+        return TemplateStateFromEntityId(self.hass, entity_id)
 
     def _render_script_variables(self) -> dict[str, Any]:
         """Render configured variables."""

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -1876,7 +1876,7 @@ async def test_preview_error(
         ),
     ],
 )
-async def test_preview_this_variable(
+async def test_preview_this_variable_config_flow(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     step_id: str,
@@ -1918,4 +1918,80 @@ async def test_preview_this_variable(
     # Verify we do not get an error and that we receive a preview state.
     msg = await client.receive_json()
     assert "error" not in msg["event"]
+    assert msg["event"]["state"] == expected_state
+
+
+@pytest.mark.parametrize(
+    ("template_type", "extra_config", "set_state", "expected_state"),
+    [
+        (
+            "sensor",
+            {},
+            "foobar",
+            "foobar",
+        ),
+        (
+            "binary_sensor",
+            {
+                "state": "{{ this.state }}",
+            },
+            "on",
+            "on",
+        ),
+    ],
+)
+async def test_preview_this_variable_options_flow(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    template_type: str,
+    extra_config: dict,
+    set_state: str,
+    expected_state: str,
+) -> None:
+    """Test 'this' variable with options flow."""
+    client = await hass_ws_client(hass)
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": template_type,
+            "state": "{{ None }}",
+            **extra_config,
+        },
+        title="My template",
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = f"{template_type}.my_template"
+    hass.states.async_set(entity_id, set_state)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{template_type}.my_template")
+    assert state.state == expected_state
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+    assert result["preview"] == "template"
+
+    await client.send_json_auto_id(
+        {
+            "type": "template/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "options_flow",
+            "user_input": {
+                "state": "{{ this.state }}",
+                **extra_config,
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+
+    msg = await client.receive_json()
     assert msg["event"]["state"] == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `this` variable was populated with fake state data when entering a template entity's option flow.  This fix appropriately grabs the correct state from the state machine when entering options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
