### PR TITLE
Get program from base program option at Home Connect

### DIFF
--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -312,6 +312,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
             case EventType.NOTIFY:
                 settings = self.data.settings
                 events = self.data.events
+                program_update_event_value = None
                 for event in event_message.data.items:
                     event_key = event.key
                     if event_key in SettingKey.__members__.values():  # type: ignore[comparison-overlap]
@@ -330,11 +331,13 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                             EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
                             EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
                         ) and isinstance(event_value, str):
-                            await self.update_options(
-                                event_key,
-                                ProgramKey(event_value),
-                            )
+                            program_update_event_value = ProgramKey(event_value)
                         events[event_key] = event
+                # Process program update after all events to ensure
+                # BSH_COMMON_OPTION_BASE_PROGRAM event is available for
+                # favorite program resolution
+                if program_update_event_value:
+                    await self.update_options(program_update_event_value)
                 self._call_event_listener(event_message)
 
             case EventType.EVENT:
@@ -439,7 +442,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
 
         return self.data
 
-    async def get_appliance_data(self) -> None:
+    async def get_appliance_data(self) -> None:  # pylint: disable=too-many-nested-blocks
         """Get appliance data."""
         appliance = self.data.info
         self.device_registry.async_get_or_create(
@@ -493,7 +496,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
         programs = []
         events = {}
         options = {}
-        if appliance.type in APPLIANCES_WITH_PROGRAMS:
+        if appliance.type in APPLIANCES_WITH_PROGRAMS:  # pylint: disable=too-many-nested-blocks
             try:
                 all_programs = await self.client.get_all_programs(appliance.ha_id)
             except TooManyRequestsError:
@@ -529,6 +532,17 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                         )
                         current_program_key = program.key
                         program_options = program.options
+                        if (
+                            current_program_key == ProgramKey.BSH_COMMON_FAVORITE_001
+                            and program_options
+                        ):
+                            # The API doesn't allow to fetch the options from the favorite program.
+                            # We can attempt to get the base program and get the options
+                            for option in program_options:
+                                if option.key == OptionKey.BSH_COMMON_BASE_PROGRAM:
+                                    current_program_key = ProgramKey(option.value)
+                                    break
+
                 if current_program_key:
                     options = await self.get_options_definitions(current_program_key)
                     for option in program_options or []:
@@ -595,15 +609,24 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
             )
             return {}
 
-    async def update_options(
-        self, event_key: EventKey, program_key: ProgramKey
-    ) -> None:
+    async def update_options(self, program_key: ProgramKey) -> None:
         """Update options for appliance."""
         options = self.data.options
         events = self.data.events
         options_to_notify = options.copy()
         options.clear()
-        options.update(await self.get_options_definitions(program_key))
+        if (
+            program_key == ProgramKey.BSH_COMMON_FAVORITE_001
+            and (event := events.get(EventKey.BSH_COMMON_OPTION_BASE_PROGRAM))
+            and isinstance(event.value, str)
+        ):
+            # The API doesn't allow to fetch the options from the favorite program.
+            # We can attempt to get the base program and get the options
+            resolved_program_key = ProgramKey(event.value)
+        else:
+            resolved_program_key = program_key
+
+        options.update(await self.get_options_definitions(resolved_program_key))
 
         for option in options.values():
             option_value = option.constraints.default if option.constraints else None

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -442,7 +442,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
 
         return self.data
 
-    async def get_appliance_data(self) -> None:  # pylint: disable=too-many-nested-blocks
+    async def get_appliance_data(self) -> None:
         """Get appliance data."""
         appliance = self.data.info
         self.device_registry.async_get_or_create(

--- a/homeassistant/components/home_connect/select.py
+++ b/homeassistant/components/home_connect/select.py
@@ -430,10 +430,23 @@ class HomeConnectProgramSelectEntity(HomeConnectEntity, SelectEntity):
     def update_native_value(self) -> None:
         """Set the program value."""
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
-        self._attr_current_option = (
-            PROGRAMS_TRANSLATION_KEYS_MAP.get(ProgramKey(event_value))
+        program_key = (
+            ProgramKey(event_value)
             if event and isinstance(event_value := event.value, str)
             else None
+        )
+        if (
+            program_key == ProgramKey.BSH_COMMON_FAVORITE_001
+            and (
+                base_program_event := self.appliance.events.get(
+                    EventKey.BSH_COMMON_OPTION_BASE_PROGRAM
+                )
+            )
+            and isinstance(base_program_event.value, str)
+        ):
+            program_key = ProgramKey(base_program_event.value)
+        self._attr_current_option = (
+            PROGRAMS_TRANSLATION_KEYS_MAP.get(program_key) if program_key else None
         )
 
     async def async_select_option(self, option: str) -> None:

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aiohomeconnect.model import (
     ArrayOfEvents,
     ArrayOfHomeAppliances,
+    ArrayOfPrograms,
     ArrayOfSettings,
     ArrayOfStatus,
     Event,
@@ -27,6 +28,7 @@ from aiohomeconnect.model.error import (
     TooManyRequestsError,
     UnauthorizedError,
 )
+from aiohomeconnect.model.program import Option, OptionKey, Program, ProgramKey
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -197,11 +199,7 @@ async def test_coordinator_failure_refresh_and_stream(
     assert state.state != STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize(
-    "appliance",
-    ["Dishwasher"],
-    indirect=True,
-)
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
 async def test_coordinator_not_fetching_on_disconnected_appliance(
     client: MagicMock,
     config_entry: MockConfigEntry,
@@ -887,4 +885,104 @@ async def test_other_errors_while_updating_appliance(
     assert any(
         record.levelname == log_level and re.search(string_in_log, record.message)
         for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize("array_of_programs_param", ["active", "selected"])
+async def test_fetch_base_program_options_when_active_favorite_program(
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    array_of_programs_param: str,
+) -> None:
+    """Test usage of base program option.
+
+    Test that when the favorite program is active or selected,
+    the options are fetched from the base program.
+    """
+    client.get_all_programs = AsyncMock(
+        return_value=ArrayOfPrograms(
+            programs=[],
+            **{
+                array_of_programs_param: Program(
+                    key=ProgramKey.BSH_COMMON_FAVORITE_001,
+                    options=[
+                        Option(
+                            OptionKey.BSH_COMMON_BASE_PROGRAM,
+                            ProgramKey.DISHCARE_DISHWASHER_ECO_50.value,
+                        )
+                    ],
+                ),
+            },
+        )
+    )
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    client.get_available_program.assert_awaited_once_with(
+        appliance.ha_id, program_key=ProgramKey.DISHCARE_DISHWASHER_ECO_50
+    )
+
+
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(
+    "event_key",
+    [
+        EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+        EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+    ],
+)
+async def test_fetch_base_program_options_when_favorite_program_event(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    event_key: EventKey,
+) -> None:
+    """Test usage of base program option on event.
+
+    Test that when a program event does report favorite program,
+    the options are fetched from the base program.
+    """
+    appliance_ha_id = appliance.ha_id
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    client.get_available_program.reset_mock()
+    await client.add_events(
+        [
+            EventMessage(
+                appliance_ha_id,
+                EventType.NOTIFY,
+                data=ArrayOfEvents(
+                    [
+                        Event(
+                            key=event_key,
+                            raw_key=event_key.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=ProgramKey.BSH_COMMON_FAVORITE_001.value,
+                        ),
+                        Event(
+                            key=EventKey.BSH_COMMON_OPTION_BASE_PROGRAM,
+                            raw_key=EventKey.BSH_COMMON_OPTION_BASE_PROGRAM.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=ProgramKey.DISHCARE_DISHWASHER_ECO_50.value,
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+    await hass.async_block_till_done()
+
+    client.get_available_program.assert_awaited_once_with(
+        appliance.ha_id, program_key=ProgramKey.DISHCARE_DISHWASHER_ECO_50
     )

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -1214,8 +1214,8 @@ async def test_use_base_program_on_favorite_program(
     """Test that base program is used.
 
     Assert that when the favorite program is active/selected,
-    use the base program if present to set the value of the entity,
-    if not present, it should be None.
+    use the base program if present to set the value of the entity;
+    if not present, the state should be unknown.
     """
     client.get_all_programs = AsyncMock(
         return_value=ArrayOfPrograms(

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -29,6 +29,8 @@ from aiohomeconnect.model.program import (
     EnumerateProgram,
     EnumerateProgramConstraints,
     Execution,
+    Option,
+    Program,
     ProgramDefinitionConstraints,
     ProgramDefinitionOption,
 )
@@ -1174,3 +1176,68 @@ async def test_favorite_001_program_not_exposed_as_option(
     entity_state = hass.states.get("select.dishwasher_selected_program")
     assert entity_state
     assert entity_state.attributes[ATTR_OPTIONS] == []
+
+
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(
+    ("array_of_programs_param", "entity_id"),
+    [
+        ("active", "select.dishwasher_active_program"),
+        ("selected", "select.dishwasher_selected_program"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("options", "expected_state"),
+    [
+        (
+            [
+                Option(
+                    OptionKey.BSH_COMMON_BASE_PROGRAM,
+                    ProgramKey.DISHCARE_DISHWASHER_ECO_50.value,
+                )
+            ],
+            "dishcare_dishwasher_program_eco_50",
+        ),
+        (None, STATE_UNKNOWN),
+    ],
+)
+async def test_use_base_program_on_favorite_program(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    array_of_programs_param: str,
+    entity_id: str,
+    options: list[Option] | None,
+    expected_state: str,
+) -> None:
+    """Test that base program is used.
+
+    Assert that when the favorite program is active/selected,
+    use the base program if present to set the value of the entity,
+    if not present, it should be None.
+    """
+    client.get_all_programs = AsyncMock(
+        return_value=ArrayOfPrograms(
+            programs=[
+                EnumerateProgram(
+                    key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
+                    raw_key=ProgramKey.DISHCARE_DISHWASHER_ECO_50.value,
+                    constraints=EnumerateProgramConstraints(
+                        execution=Execution.SELECT_AND_START,
+                    ),
+                ),
+            ],
+            **{
+                array_of_programs_param: Program(
+                    key=ProgramKey.BSH_COMMON_FAVORITE_001,
+                    options=options,
+                ),
+            },
+        )
+    )
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert hass.states.is_state(entity_id, expected_state)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When favorite program is used, it can have the base program option. This PR does changes to use that information to fetch the options related to the base program and set the selected/active program entities values when favorite program is used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
