### PR TITLE
Add snapshot service to Proxmox VE integration

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -34,6 +34,7 @@ from .const import (
     DEFAULT_REALM,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    SERVICE_CREATE_SNAPSHOT,
 )
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
 from .services import async_setup_services, async_unload_services
@@ -147,10 +148,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
 
     entry.runtime_data = coordinator
 
-    # Register services the first time any config entry is loaded.
-    hass.data.setdefault(DOMAIN, set())
-    hass.data[DOMAIN].add(entry.entry_id)
-    if len(hass.data[DOMAIN]) == 1:
+    if not hass.services.has_service(DOMAIN, SERVICE_CREATE_SNAPSHOT):
         async_setup_services(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -187,9 +185,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) ->
 async def async_unload_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> bool:
     """Unload a config entry."""
     result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if result and DOMAIN in hass.data:
-        hass.data[DOMAIN].discard(entry.entry_id)
-        if not hass.data[DOMAIN]:
-            async_unload_services(hass)
-            del hass.data[DOMAIN]
+    if result and not hass.config_entries.async_loaded_entries(DOMAIN):
+        async_unload_services(hass)
     return result

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -36,6 +36,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
+from .services import async_setup_services, async_unload_services
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -145,6 +146,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register services the first time any config entry is loaded.
+    hass.data.setdefault(DOMAIN, set())
+    hass.data[DOMAIN].add(entry.entry_id)
+    if len(hass.data[DOMAIN]) == 1:
+        async_setup_services(hass)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -178,4 +186,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) ->
 
 async def async_unload_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    result = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if result and DOMAIN in hass.data:
+        hass.data[DOMAIN].discard(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            async_unload_services(hass)
+            del hass.data[DOMAIN]
+    return result

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -1,5 +1,15 @@
 """Constants for ProxmoxVE."""
 
+from enum import StrEnum
+
+
+class ResourceType(StrEnum):
+    """Proxmox resource types that support snapshots."""
+
+    VM = "vm"
+    CONTAINER = "container"
+
+
 DOMAIN = "proxmoxve"
 CONF_REALM = "realm"
 CONF_NODE = "node"

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -7,6 +7,8 @@ CONF_NODES = "nodes"
 CONF_VMS = "vms"
 CONF_CONTAINERS = "containers"
 
+SERVICE_CREATE_SNAPSHOT = "create_snapshot"
+
 NODE_ONLINE = "online"
 VM_CONTAINER_RUNNING = "running"
 

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -82,7 +82,7 @@
   },
   "services": {
     "create_snapshot": {
-      "service": "mdi:camera"
+      "service": "mdi:archive"
     }
   }
 }

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -79,5 +79,10 @@
         "default": "mdi:server"
       }
     }
+  },
+  "services": {
+    "create_snapshot": {
+      "service": "mdi:camera"
+    }
   }
 }

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -1,0 +1,387 @@
+"""Proxmox VE service handlers."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+import logging
+import re
+from typing import cast
+
+from proxmoxer import AuthenticationError
+from proxmoxer.core import ResourceException
+import requests
+from requests.exceptions import ConnectTimeout, ReadTimeout, SSLError
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_AREA_ID,
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    ATTR_FLOOR_ID,
+    ATTR_LABEL_ID,
+    ENTITY_MATCH_NONE,
+    __version__ as HA_VERSION,
+)
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
+
+from .const import DOMAIN, SERVICE_CREATE_SNAPSHOT
+from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Proxmox snapshot names allow alphanumeric characters, dots, hyphens, underscores.
+_SNAPSHOT_NAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+CREATE_SNAPSHOT_SCHEMA = vol.Schema(
+    {
+        vol.Optional("target"): cv.TARGET_SERVICE_FIELDS,
+        # Core merges target fields into service_data when called from Actions UI.
+        vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids_or_uuids,
+        vol.Optional(ATTR_DEVICE_ID): vol.Any(
+            ENTITY_MATCH_NONE,
+            vol.All(cv.ensure_list, [str]),
+        ),
+        vol.Optional(ATTR_AREA_ID): vol.Any(
+            ENTITY_MATCH_NONE,
+            vol.All(cv.ensure_list, [str]),
+        ),
+        vol.Optional(ATTR_FLOOR_ID): vol.Any(
+            ENTITY_MATCH_NONE,
+            vol.All(cv.ensure_list, [str]),
+        ),
+        vol.Optional(ATTR_LABEL_ID): vol.Any(
+            ENTITY_MATCH_NONE,
+            vol.All(cv.ensure_list, [str]),
+        ),
+        vol.Optional("version_entity"): cv.entity_id,
+    }
+)
+
+
+class _ResourceType(StrEnum):
+    """Proxmox resource types that support snapshots."""
+
+    VM = "vm"
+    CONTAINER = "container"
+
+
+def _sanitize_snapshot_version(version: str) -> str:
+    """Replace characters invalid in a Proxmox snapshot name with underscores."""
+    return _SNAPSHOT_NAME_RE.sub("_", version.strip())
+
+
+def _parse_device_identifier(
+    hass: HomeAssistant,
+    device: dr.DeviceEntry,
+    label: str,
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
+    """Return config entry, node name, vmid, and resource type for a Proxmox device.
+
+    Inspects the device's domain-specific identifier to determine whether it is
+    a VM (``{entry_id}_vm_{vmid}``) or LXC container
+    (``{entry_id}_container_{vmid}``), then resolves the parent node device.
+    """
+    raw_identifier = next(
+        (ident[1] for ident in device.identifiers if ident[0] == DOMAIN),
+        None,
+    )
+    if raw_identifier is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": label},
+        )
+
+    if "_vm_" in raw_identifier:
+        resource_type = _ResourceType.VM
+        entry_id, vmid_str = raw_identifier.rsplit("_vm_", 1)
+    elif "_container_" in raw_identifier:
+        resource_type = _ResourceType.CONTAINER
+        entry_id, vmid_str = raw_identifier.rsplit("_container_", 1)
+    else:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_not_vm_or_container",
+            translation_placeholders={"entity_id": label},
+        )
+
+    try:
+        vmid = int(vmid_str)
+    except ValueError:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": label},
+        ) from None
+
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if (
+        entry is None
+        or entry.domain != DOMAIN
+        or not isinstance(entry.runtime_data, ProxmoxCoordinator)
+    ):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": label},
+        )
+
+    # The parent device of every VM/container device is the Proxmox node device,
+    # and its name is the node name used in Proxmox API calls.
+    if device.via_device_id is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_not_vm_or_container",
+            translation_placeholders={"entity_id": label},
+        )
+
+    dev_reg = dr.async_get(hass)
+    node_device = dev_reg.async_get(device.via_device_id)
+    if node_device is None or node_device.name is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": label},
+        )
+
+    return cast(ProxmoxConfigEntry, entry), node_device.name, vmid, resource_type
+
+
+def _resolve_from_device(
+    hass: HomeAssistant,
+    device_id: str,
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
+    """Resolve config entry, node name, vmid, and resource type from a device ID."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get(device_id)
+    if device is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": device_id},
+        )
+    return _parse_device_identifier(hass, device, device_id)
+
+
+def _resolve_from_entity(
+    hass: HomeAssistant,
+    entity_id: str,
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
+    """Resolve config entry, node name, vmid, and resource type from an entity ID."""
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(entity_id)
+    if entity_entry is None or entity_entry.device_id is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": entity_id},
+        )
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get(entity_entry.device_id)
+    if device is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_entity",
+            translation_placeholders={"entity_id": entity_id},
+        )
+    return _parse_device_identifier(hass, device, entity_id)
+
+
+def _create_snapshot_blocking(
+    coordinator: ProxmoxCoordinator,
+    node: str,
+    vmid: int,
+    resource_type: _ResourceType,
+    snapname: str,
+    description: str,
+) -> None:
+    """Call the Proxmox snapshot API synchronously.
+
+    VMs support saving RAM state (vmstate); LXC containers do not.
+    """
+    if resource_type is _ResourceType.VM:
+        coordinator.proxmox.nodes(node).qemu(vmid).snapshot.post(
+            snapname=snapname,
+            description=description,
+            vmstate=False,
+        )
+    else:
+        coordinator.proxmox.nodes(node).lxc(vmid).snapshot.post(
+            snapname=snapname,
+            description=description,
+        )
+
+
+def _build_target(data: dict) -> dict:
+    """Merge top-level target fields and the nested ``target`` key into one dict.
+
+    Home Assistant's Actions UI merges target fields (entity_id, device_id,
+    area_id, floor_id, label_id) directly into service_data rather than nesting
+    them under a ``target`` key.  This function handles both shapes.
+    """
+    target = dict(data.get("target") or {})
+    for key in (
+        ATTR_ENTITY_ID,
+        ATTR_DEVICE_ID,
+        ATTR_AREA_ID,
+        ATTR_FLOOR_ID,
+        ATTR_LABEL_ID,
+    ):
+        if key in data and data[key] is not None:
+            target[key] = data[key]
+    return target
+
+
+async def _call_snapshot(
+    hass: HomeAssistant,
+    entry: ProxmoxConfigEntry,
+    node_name: str,
+    vmid: int,
+    resource_type: _ResourceType,
+    snapname: str,
+    description: str,
+) -> None:
+    """Run the snapshot API call and translate Proxmox exceptions to HA errors."""
+    coordinator: ProxmoxCoordinator = entry.runtime_data
+    try:
+        await hass.async_add_executor_job(
+            _create_snapshot_blocking,
+            coordinator,
+            node_name,
+            vmid,
+            resource_type,
+            snapname,
+            description,
+        )
+    except AuthenticationError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect_no_details",
+        ) from err
+    except SSLError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_auth_no_details",
+        ) from err
+    except (ConnectTimeout, ReadTimeout) as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="timeout_connect_no_details",
+        ) from err
+    except (ResourceException, requests.exceptions.ConnectionError) as err:
+        _LOGGER.warning(
+            "Snapshot failed for %s %s/%s: %s",
+            resource_type,
+            node_name,
+            vmid,
+            err,
+        )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="snapshot_failed",
+        ) from err
+
+
+async def async_create_snapshot(call: ServiceCall) -> None:
+    """Create a snapshot named ``Home_Assistant_{version}`` on a VM or container.
+
+    The snapshot name is derived from the running Home Assistant version by
+    default, or from an optional sensor entity when ``version_entity`` is set.
+    Snapshot creation is supported on both QEMU VMs and LXC containers.
+    """
+    hass = call.hass
+    target = _build_target(call.data)
+    version_entity_id: str | None = call.data.get("version_entity")
+
+    if version_entity_id:
+        state = hass.states.get(version_entity_id)
+        if state is None or state.state in ("unknown", "unavailable", ""):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="version_entity_unavailable",
+                translation_placeholders={"entity_id": version_entity_id},
+            )
+        version = state.state.strip()
+    else:
+        version = HA_VERSION
+
+    snapname = f"Home_Assistant_{_sanitize_snapshot_version(version)}"
+    description = version
+
+    # Prefer device targeting when a single device_id is provided, as it
+    # unambiguously identifies the VM or container.
+    device_ids_raw = target.get(ATTR_DEVICE_ID)
+    if device_ids_raw is not None and device_ids_raw != ENTITY_MATCH_NONE:
+        device_ids = [
+            did for did in cv.ensure_list(device_ids_raw) if did != ENTITY_MATCH_NONE
+        ]
+        if len(device_ids) > 1:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_target_single",
+            )
+        if len(device_ids) == 1:
+            entry, node_name, vmid, resource_type = _resolve_from_device(
+                hass, device_ids[0]
+            )
+            await _call_snapshot(
+                hass, entry, node_name, vmid, resource_type, snapname, description
+            )
+            _LOGGER.debug(
+                "Created snapshot %s on %s %s/%s",
+                snapname,
+                resource_type,
+                node_name,
+                vmid,
+            )
+            return
+
+    # Fall back to entity targeting; exactly one entity must be resolved.
+    ref = async_extract_referenced_entity_ids(
+        hass, TargetSelection(target), expand_group=True
+    )
+    all_entities = ref.referenced | ref.indirectly_referenced
+    if len(all_entities) != 1:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_target_single",
+        )
+
+    entity_id = next(iter(all_entities))
+    entry, node_name, vmid, resource_type = _resolve_from_entity(hass, entity_id)
+    await _call_snapshot(
+        hass, entry, node_name, vmid, resource_type, snapname, description
+    )
+    _LOGGER.debug(
+        "Created snapshot %s on %s %s/%s",
+        snapname,
+        resource_type,
+        node_name,
+        vmid,
+    )
+
+
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register Proxmox VE services."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        async_create_snapshot,
+        schema=CREATE_SNAPSHOT_SCHEMA,
+    )
+
+
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload Proxmox VE services."""
+    hass.services.async_remove(DOMAIN, SERVICE_CREATE_SNAPSHOT)

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     ATTR_FLOOR_ID,
     ATTR_LABEL_ID,
     ENTITY_MATCH_NONE,
-    __version__ as HA_VERSION,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -33,6 +32,7 @@ from homeassistant.helpers.target import (
     TargetSelection,
     async_extract_referenced_entity_ids,
 )
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, SERVICE_CREATE_SNAPSHOT
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
@@ -42,6 +42,9 @@ _LOGGER = logging.getLogger(__name__)
 # Proxmox snapshot names only allow alphanumeric characters and hyphens/underscores.
 # Dots are NOT valid despite appearing in Proxmox docs — the API rejects them.
 _SNAPSHOT_NAME_RE = re.compile(r"[^a-zA-Z0-9_-]+")
+
+# Maximum length for the base snapshot name before conflict suffix (_a … _z, 2 chars).
+_SNAPNAME_MAX_BASE_LEN = 37
 
 CREATE_SNAPSHOT_SCHEMA = vol.Schema(
     {
@@ -64,6 +67,9 @@ CREATE_SNAPSHOT_SCHEMA = vol.Schema(
             ENTITY_MATCH_NONE,
             vol.All(cv.ensure_list, [str]),
         ),
+        vol.Optional("vm_name", default=""): vol.All(cv.string, str.strip),
+        vol.Optional("snapshot_name", default=""): vol.All(cv.string, str.strip),
+        vol.Optional("description", default=""): vol.All(cv.string, str.strip),
         vol.Optional("version_entity"): cv.entity_id,
         vol.Optional("include_ram", default=False): cv.boolean,
     }
@@ -82,16 +88,49 @@ def _sanitize_snapshot_version(version: str) -> str:
     return _SNAPSHOT_NAME_RE.sub("_", version.strip())
 
 
+def _build_base_snapname(
+    snapshot_name_input: str,
+    vm_name_input: str,
+    device_name: str,
+    vmid: int,
+    version: str | None,
+    today: str,
+) -> str:
+    """Build the base snapshot name (before conflict-resolution suffix).
+
+    Priority for the name source:
+    1. User-supplied ``snapshot_name`` — used verbatim (sanitized) as the full name.
+    2. User-supplied ``vm_name`` combined with version or date.
+    3. Device registry name combined with version or date.
+    4. VM ID as string combined with version or date.
+
+    The result is truncated to ``_SNAPNAME_MAX_BASE_LEN`` characters to leave
+    room for the ``_a`` … ``_z`` conflict suffix.
+    """
+    if snapshot_name_input:
+        base = _sanitize_snapshot_version(snapshot_name_input)
+    else:
+        vm_part = _sanitize_snapshot_version(vm_name_input or device_name or str(vmid))
+        suffix = _sanitize_snapshot_version(version) if version is not None else today
+        base = f"{vm_part}_{suffix}"
+
+    if len(base) > _SNAPNAME_MAX_BASE_LEN:
+        base = base[:_SNAPNAME_MAX_BASE_LEN].rstrip("_")
+
+    return base
+
+
 def _parse_device_identifier(
     hass: HomeAssistant,
     device: dr.DeviceEntry,
     label: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
-    """Return config entry, node name, vmid, and resource type for a Proxmox device.
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+    """Return config entry, node name, vmid, resource type, and device name.
 
     Inspects the device's domain-specific identifier to determine whether it is
     a VM (``{entry_id}_vm_{vmid}``) or LXC container
     (``{entry_id}_container_{vmid}``), then resolves the parent node device.
+    The device name (fifth element) is the VM or container name from the registry.
     """
     raw_identifier = next(
         (ident[1] for ident in device.identifiers if ident[0] == DOMAIN),
@@ -156,14 +195,20 @@ def _parse_device_identifier(
             translation_placeholders={"entity_id": label},
         )
 
-    return cast(ProxmoxConfigEntry, entry), node_device.name, vmid, resource_type
+    return (
+        cast(ProxmoxConfigEntry, entry),
+        node_device.name,
+        vmid,
+        resource_type,
+        device.name or "",
+    )
 
 
 def _resolve_from_device(
     hass: HomeAssistant,
     device_id: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
-    """Resolve config entry, node name, vmid, and resource type from a device ID."""
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+    """Resolve config entry, node name, vmid, resource type, and device name from a device ID."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(device_id)
     if device is None:
@@ -178,8 +223,8 @@ def _resolve_from_device(
 def _resolve_from_entity(
     hass: HomeAssistant,
     entity_id: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType]:
-    """Resolve config entry, node name, vmid, and resource type from an entity ID."""
+) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+    """Resolve config entry, node name, vmid, resource type, and device name from an entity ID."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(entity_id)
     if entity_entry is None or entity_entry.device_id is None:
@@ -205,14 +250,30 @@ def _create_snapshot_blocking(
     node: str,
     vmid: int,
     resource_type: _ResourceType,
-    snapname: str,
+    base_snapname: str,
     description: str,
     include_ram: bool,
-) -> None:
-    """Call the Proxmox snapshot API synchronously.
+) -> str:
+    """Call the Proxmox snapshot API synchronously with conflict resolution.
 
-    VMs support saving RAM state (vmstate); LXC containers do not.
+    Lists existing snapshots and appends ``_a``, ``_b``, … if the base name is
+    already taken.  VMs support saving RAM state (vmstate); LXC containers do
+    not.  Returns the final snapshot name that was created.
     """
+    if resource_type is _ResourceType.VM:
+        existing = coordinator.proxmox.nodes(node).qemu(vmid).snapshot.get()
+    else:
+        existing = coordinator.proxmox.nodes(node).lxc(vmid).snapshot.get()
+
+    existing_names = {s["name"] for s in existing if s.get("name") != "current"}
+
+    # Try the base name first, then _a, _b, … until a free slot is found.
+    snapname = base_snapname
+    for letter in "abcdefghijklmnopqrstuvwxyz":
+        if snapname not in existing_names:
+            break
+        snapname = f"{base_snapname}_{letter}"
+
     if resource_type is _ResourceType.VM:
         _LOGGER.debug(
             "Creating VM snapshot %s on %s/%s (include_ram=%s)",
@@ -233,6 +294,8 @@ def _create_snapshot_blocking(
             snapname=snapname,
             description=description,
         )
+
+    return snapname
 
 
 def _build_target(data: dict) -> dict:
@@ -261,20 +324,23 @@ async def _call_snapshot(
     node_name: str,
     vmid: int,
     resource_type: _ResourceType,
-    snapname: str,
+    base_snapname: str,
     description: str,
     include_ram: bool,
-) -> None:
-    """Run the snapshot API call and translate Proxmox exceptions to HA errors."""
+) -> str:
+    """Run the snapshot API call and translate Proxmox exceptions to HA errors.
+
+    Returns the final snapshot name used after conflict resolution.
+    """
     coordinator: ProxmoxCoordinator = entry.runtime_data
     try:
-        await hass.async_add_executor_job(
+        return await hass.async_add_executor_job(
             _create_snapshot_blocking,
             coordinator,
             node_name,
             vmid,
             resource_type,
-            snapname,
+            base_snapname,
             description,
             include_ram,
         )
@@ -308,16 +374,23 @@ async def _call_snapshot(
 
 
 async def async_create_snapshot(call: ServiceCall) -> None:
-    """Create a snapshot named ``Home_Assistant_{version}`` on a VM or container.
+    """Create a snapshot on a VM or LXC container.
 
-    The snapshot name is derived from the running Home Assistant version by
-    default, or from an optional sensor entity when ``version_entity`` is set.
-    Snapshot creation is supported on both QEMU VMs and LXC containers.
+    The snapshot name defaults to ``{vm_name}_{YYYY_MM_DD}``, derived from the
+    device registry name and the current date.  When ``version_entity`` is set,
+    the date is replaced by the version string from that entity.  If the
+    generated name conflicts with an existing snapshot, a letter suffix
+    (``_a``, ``_b``, …) is appended automatically.
     """
     hass = call.hass
     target = _build_target(call.data)
     version_entity_id: str | None = call.data.get("version_entity")
+    vm_name_input: str = call.data["vm_name"]
+    snapshot_name_input: str = call.data["snapshot_name"]
+    description_input: str = call.data["description"]
+    include_ram: bool = call.data["include_ram"]
 
+    version: str | None = None
     if version_entity_id:
         state = hass.states.get(version_entity_id)
         if state is None or state.state in ("unknown", "unavailable", ""):
@@ -327,12 +400,13 @@ async def async_create_snapshot(call: ServiceCall) -> None:
                 translation_placeholders={"entity_id": version_entity_id},
             )
         version = state.state.strip()
-    else:
-        version = HA_VERSION
 
-    snapname = f"Home_Assistant_{_sanitize_snapshot_version(version)}"
-    description = version
-    include_ram: bool = call.data["include_ram"]
+    now = dt_util.now()
+    today = now.strftime("%Y_%m_%d")
+    description = (
+        description_input
+        or f"Snapshot triggered from Home Assistant on {now.strftime('%Y-%m-%d')}"
+    )
 
     # Prefer device targeting when a single device_id is provided, as it
     # unambiguously identifies the VM or container.
@@ -347,16 +421,24 @@ async def async_create_snapshot(call: ServiceCall) -> None:
                 translation_key="invalid_target_single",
             )
         if len(device_ids) == 1:
-            entry, node_name, vmid, resource_type = _resolve_from_device(
+            entry, node_name, vmid, resource_type, device_name = _resolve_from_device(
                 hass, device_ids[0]
             )
-            await _call_snapshot(
+            base_snapname = _build_base_snapname(
+                snapshot_name_input,
+                vm_name_input,
+                device_name,
+                vmid,
+                version,
+                today,
+            )
+            snapname = await _call_snapshot(
                 hass,
                 entry,
                 node_name,
                 vmid,
                 resource_type,
-                snapname,
+                base_snapname,
                 description,
                 include_ram,
             )
@@ -381,9 +463,26 @@ async def async_create_snapshot(call: ServiceCall) -> None:
         )
 
     entity_id = next(iter(all_entities))
-    entry, node_name, vmid, resource_type = _resolve_from_entity(hass, entity_id)
-    await _call_snapshot(
-        hass, entry, node_name, vmid, resource_type, snapname, description, include_ram
+    entry, node_name, vmid, resource_type, device_name = _resolve_from_entity(
+        hass, entity_id
+    )
+    base_snapname = _build_base_snapname(
+        snapshot_name_input,
+        vm_name_input,
+        device_name,
+        vmid,
+        version,
+        today,
+    )
+    snapname = await _call_snapshot(
+        hass,
+        entry,
+        node_name,
+        vmid,
+        resource_type,
+        base_snapname,
+        description,
+        include_ram,
     )
     _LOGGER.debug(
         "Created snapshot %s on %s %s/%s",

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
 import logging
 import re
 from typing import cast
@@ -34,7 +33,7 @@ from homeassistant.helpers.target import (
 )
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, SERVICE_CREATE_SNAPSHOT
+from .const import DOMAIN, SERVICE_CREATE_SNAPSHOT, ResourceType
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,18 +75,6 @@ CREATE_SNAPSHOT_SCHEMA = vol.Schema(
 )
 
 
-class _ResourceType(StrEnum):
-    """Proxmox resource types that support snapshots."""
-
-    VM = "vm"
-    CONTAINER = "container"
-
-
-def _sanitize_snapshot_version(version: str) -> str:
-    """Replace characters invalid in a Proxmox snapshot name with underscores."""
-    return _SNAPSHOT_NAME_RE.sub("_", version.strip())
-
-
 def _build_base_snapname(
     snapshot_name_input: str,
     vm_name_input: str,
@@ -99,7 +86,7 @@ def _build_base_snapname(
     """Build the base snapshot name (before conflict-resolution suffix).
 
     Priority for the name source:
-    1. User-supplied ``snapshot_name`` — used verbatim (sanitized) as the full name.
+    1. User-supplied ``snapshot_name`` — used as the base name (sanitized and may be truncated).
     2. User-supplied ``vm_name`` combined with version or date.
     3. Device registry name combined with version or date.
     4. VM ID as string combined with version or date.
@@ -108,10 +95,16 @@ def _build_base_snapname(
     room for the ``_a`` … ``_z`` conflict suffix.
     """
     if snapshot_name_input:
-        base = _sanitize_snapshot_version(snapshot_name_input)
+        base = _SNAPSHOT_NAME_RE.sub("_", snapshot_name_input.strip())
     else:
-        vm_part = _sanitize_snapshot_version(vm_name_input or device_name or str(vmid))
-        suffix = _sanitize_snapshot_version(version) if version is not None else today
+        vm_part = _SNAPSHOT_NAME_RE.sub(
+            "_", (vm_name_input or device_name or str(vmid)).strip()
+        )
+        suffix = (
+            _SNAPSHOT_NAME_RE.sub("_", version.strip())
+            if version is not None
+            else today
+        )
         base = f"{vm_part}_{suffix}"
 
     if len(base) > _SNAPNAME_MAX_BASE_LEN:
@@ -124,7 +117,7 @@ def _parse_device_identifier(
     hass: HomeAssistant,
     device: dr.DeviceEntry,
     label: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+) -> tuple[ProxmoxConfigEntry, str, int, ResourceType, str]:
     """Return config entry, node name, vmid, resource type, and device name.
 
     Inspects the device's domain-specific identifier to determine whether it is
@@ -144,10 +137,10 @@ def _parse_device_identifier(
         )
 
     if "_vm_" in raw_identifier:
-        resource_type = _ResourceType.VM
+        resource_type = ResourceType.VM
         entry_id, vmid_str = raw_identifier.rsplit("_vm_", 1)
     elif "_container_" in raw_identifier:
-        resource_type = _ResourceType.CONTAINER
+        resource_type = ResourceType.CONTAINER
         entry_id, vmid_str = raw_identifier.rsplit("_container_", 1)
     else:
         raise ServiceValidationError(
@@ -177,8 +170,6 @@ def _parse_device_identifier(
             translation_placeholders={"entity_id": label},
         )
 
-    # The parent device of every VM/container device is the Proxmox node device,
-    # and its name is the node name used in Proxmox API calls.
     if device.via_device_id is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -207,7 +198,7 @@ def _parse_device_identifier(
 def _resolve_from_device(
     hass: HomeAssistant,
     device_id: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+) -> tuple[ProxmoxConfigEntry, str, int, ResourceType, str]:
     """Resolve config entry, node name, vmid, resource type, and device name from a device ID."""
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get(device_id)
@@ -223,7 +214,7 @@ def _resolve_from_device(
 def _resolve_from_entity(
     hass: HomeAssistant,
     entity_id: str,
-) -> tuple[ProxmoxConfigEntry, str, int, _ResourceType, str]:
+) -> tuple[ProxmoxConfigEntry, str, int, ResourceType, str]:
     """Resolve config entry, node name, vmid, resource type, and device name from an entity ID."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(entity_id)
@@ -249,7 +240,7 @@ def _create_snapshot_blocking(
     coordinator: ProxmoxCoordinator,
     node: str,
     vmid: int,
-    resource_type: _ResourceType,
+    resource_type: ResourceType,
     base_snapname: str,
     description: str,
     include_ram: bool,
@@ -260,21 +251,28 @@ def _create_snapshot_blocking(
     already taken.  VMs support saving RAM state (vmstate); LXC containers do
     not.  Returns the final snapshot name that was created.
     """
-    if resource_type is _ResourceType.VM:
+    if resource_type is ResourceType.VM:
         existing = coordinator.proxmox.nodes(node).qemu(vmid).snapshot.get()
     else:
         existing = coordinator.proxmox.nodes(node).lxc(vmid).snapshot.get()
 
     existing_names = {s["name"] for s in existing if s.get("name") != "current"}
 
-    # Try the base name first, then _a, _b, … until a free slot is found.
+    # Try the base name first, then append _a … _z until a free slot is found.
     snapname = base_snapname
     for letter in "abcdefghijklmnopqrstuvwxyz":
         if snapname not in existing_names:
             break
         snapname = f"{base_snapname}_{letter}"
 
-    if resource_type is _ResourceType.VM:
+    if snapname in existing_names:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="snapshot_name_conflict",
+            translation_placeholders={"base_name": base_snapname},
+        )
+
+    if resource_type is ResourceType.VM:
         _LOGGER.debug(
             "Creating VM snapshot %s on %s/%s (include_ram=%s)",
             snapname,
@@ -323,7 +321,7 @@ async def _call_snapshot(
     entry: ProxmoxConfigEntry,
     node_name: str,
     vmid: int,
-    resource_type: _ResourceType,
+    resource_type: ResourceType,
     base_snapname: str,
     description: str,
     include_ram: bool,
@@ -347,12 +345,12 @@ async def _call_snapshot(
     except AuthenticationError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
-            translation_key="cannot_connect_no_details",
+            translation_key="invalid_auth_no_details",
         ) from err
     except SSLError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
-            translation_key="invalid_auth_no_details",
+            translation_key="cannot_connect_no_details",
         ) from err
     except (ConnectTimeout, ReadTimeout) as err:
         raise HomeAssistantError(

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -65,6 +65,7 @@ CREATE_SNAPSHOT_SCHEMA = vol.Schema(
             vol.All(cv.ensure_list, [str]),
         ),
         vol.Optional("version_entity"): cv.entity_id,
+        vol.Optional("include_ram", default=False): cv.boolean,
     }
 )
 
@@ -206,6 +207,7 @@ def _create_snapshot_blocking(
     resource_type: _ResourceType,
     snapname: str,
     description: str,
+    include_ram: bool,
 ) -> None:
     """Call the Proxmox snapshot API synchronously.
 
@@ -215,7 +217,7 @@ def _create_snapshot_blocking(
         coordinator.proxmox.nodes(node).qemu(vmid).snapshot.post(
             snapname=snapname,
             description=description,
-            vmstate=0,
+            vmstate=1 if include_ram else 0,
         )
     else:
         coordinator.proxmox.nodes(node).lxc(vmid).snapshot.post(
@@ -252,6 +254,7 @@ async def _call_snapshot(
     resource_type: _ResourceType,
     snapname: str,
     description: str,
+    include_ram: bool,
 ) -> None:
     """Run the snapshot API call and translate Proxmox exceptions to HA errors."""
     coordinator: ProxmoxCoordinator = entry.runtime_data
@@ -264,6 +267,7 @@ async def _call_snapshot(
             resource_type,
             snapname,
             description,
+            include_ram,
         )
     except AuthenticationError as err:
         raise HomeAssistantError(
@@ -319,6 +323,7 @@ async def async_create_snapshot(call: ServiceCall) -> None:
 
     snapname = f"Home_Assistant_{_sanitize_snapshot_version(version)}"
     description = version
+    include_ram: bool = call.data["include_ram"]
 
     # Prefer device targeting when a single device_id is provided, as it
     # unambiguously identifies the VM or container.
@@ -337,7 +342,14 @@ async def async_create_snapshot(call: ServiceCall) -> None:
                 hass, device_ids[0]
             )
             await _call_snapshot(
-                hass, entry, node_name, vmid, resource_type, snapname, description
+                hass,
+                entry,
+                node_name,
+                vmid,
+                resource_type,
+                snapname,
+                description,
+                include_ram,
             )
             _LOGGER.debug(
                 "Created snapshot %s on %s %s/%s",
@@ -362,7 +374,7 @@ async def async_create_snapshot(call: ServiceCall) -> None:
     entity_id = next(iter(all_entities))
     entry, node_name, vmid, resource_type = _resolve_from_entity(hass, entity_id)
     await _call_snapshot(
-        hass, entry, node_name, vmid, resource_type, snapname, description
+        hass, entry, node_name, vmid, resource_type, snapname, description, include_ram
     )
     _LOGGER.debug(
         "Created snapshot %s on %s %s/%s",

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -39,8 +39,9 @@ from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-# Proxmox snapshot names allow alphanumeric characters, dots, hyphens, underscores.
-_SNAPSHOT_NAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+# Proxmox snapshot names only allow alphanumeric characters and hyphens/underscores.
+# Dots are NOT valid despite appearing in Proxmox docs — the API rejects them.
+_SNAPSHOT_NAME_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 
 CREATE_SNAPSHOT_SCHEMA = vol.Schema(
     {
@@ -214,7 +215,7 @@ def _create_snapshot_blocking(
         coordinator.proxmox.nodes(node).qemu(vmid).snapshot.post(
             snapname=snapname,
             description=description,
-            vmstate=False,
+            vmstate=0,
         )
     else:
         coordinator.proxmox.nodes(node).lxc(vmid).snapshot.post(

--- a/homeassistant/components/proxmoxve/services.py
+++ b/homeassistant/components/proxmoxve/services.py
@@ -214,11 +214,20 @@ def _create_snapshot_blocking(
     VMs support saving RAM state (vmstate); LXC containers do not.
     """
     if resource_type is _ResourceType.VM:
-        coordinator.proxmox.nodes(node).qemu(vmid).snapshot.post(
-            snapname=snapname,
-            description=description,
-            vmstate=1 if include_ram else 0,
+        _LOGGER.debug(
+            "Creating VM snapshot %s on %s/%s (include_ram=%s)",
+            snapname,
+            node,
+            vmid,
+            include_ram,
         )
+        kwargs: dict[str, object] = {
+            "snapname": snapname,
+            "description": description,
+        }
+        if include_ram:
+            kwargs["vmstate"] = 1
+        coordinator.proxmox.nodes(node).qemu(vmid).snapshot.post(**kwargs)
     else:
         coordinator.proxmox.nodes(node).lxc(vmid).snapshot.post(
             snapname=snapname,

--- a/homeassistant/components/proxmoxve/services.yaml
+++ b/homeassistant/components/proxmoxve/services.yaml
@@ -1,0 +1,13 @@
+create_snapshot:
+  target:
+    entity:
+      integration: proxmoxve
+      domain:
+        - binary_sensor
+        - button
+        - sensor
+  fields:
+    version_entity:
+      selector:
+        entity:
+          domain: sensor

--- a/homeassistant/components/proxmoxve/services.yaml
+++ b/homeassistant/components/proxmoxve/services.yaml
@@ -11,3 +11,7 @@ create_snapshot:
       selector:
         entity:
           domain: sensor
+    include_ram:
+      default: false
+      selector:
+        boolean:

--- a/homeassistant/components/proxmoxve/services.yaml
+++ b/homeassistant/components/proxmoxve/services.yaml
@@ -7,6 +7,15 @@ create_snapshot:
         - button
         - sensor
   fields:
+    vm_name:
+      selector:
+        text:
+    snapshot_name:
+      selector:
+        text:
+    description:
+      selector:
+        text:
     version_entity:
       selector:
         entity:

--- a/homeassistant/components/proxmoxve/services.yaml
+++ b/homeassistant/components/proxmoxve/services.yaml
@@ -4,7 +4,6 @@ create_snapshot:
       integration: proxmoxve
       domain:
         - binary_sensor
-        - button
         - sensor
   fields:
     vm_name:

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -256,6 +256,10 @@
     "create_snapshot": {
       "description": "Creates a snapshot on a VM or LXC container. The snapshot is named using the `Home_Assistant_` prefix followed by the Home Assistant version. Use this before upgrading Home Assistant to create a restore point.",
       "fields": {
+        "include_ram": {
+          "description": "Save the VM's RAM state in the snapshot. Only applies to VMs — LXC containers do not support RAM snapshots.",
+          "name": "Include RAM"
+        },
         "version_entity": {
           "description": "Optional sensor entity that provides the version string to include in the snapshot name (for example the Version integration `Local installation` sensor). If not set, the current Home Assistant version is used.",
           "name": "Version entity"

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -194,7 +194,7 @@
       "message": "Authentication failed for the Proxmox VE instance."
     },
     "invalid_target_entity": {
-      "message": "The entity `{entity_id}` is not a valid Proxmox VE VM or container entity."
+      "message": "The selected target `{entity_id}` is not a valid Proxmox VE VM or container."
     },
     "invalid_target_not_vm_or_container": {
       "message": "The selected device is not a Proxmox VE VM or LXC container. Only VM and container devices are supported for snapshots."

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -254,15 +254,27 @@
   },
   "services": {
     "create_snapshot": {
-      "description": "Creates a snapshot on a VM or LXC container. The snapshot is named using the `Home_Assistant_` prefix followed by the Home Assistant version. Use this before upgrading Home Assistant to create a restore point.",
+      "description": "Creates a snapshot on a VM or LXC container. The snapshot name is built from the VM name and the current date. Set `version_entity` to use a version string instead of the date — useful before upgrading.",
       "fields": {
+        "description": {
+          "description": "Description stored with the snapshot. Defaults to 'Snapshot triggered from Home Assistant on YYYY-MM-DD' if left empty.",
+          "name": "Description"
+        },
         "include_ram": {
           "description": "Save the VM's RAM state in the snapshot. Only works for running VMs — stopped VMs and LXC containers do not support RAM snapshots.",
           "name": "Include RAM"
         },
+        "snapshot_name": {
+          "description": "Override the full snapshot name. If left empty, the name is built automatically from the VM name and the current date. Use only letters, numbers, underscores, and hyphens.",
+          "name": "Snapshot name"
+        },
         "version_entity": {
-          "description": "Optional sensor entity that provides the version string to include in the snapshot name (for example the Version integration `Local installation` sensor). If not set, the current Home Assistant version is used.",
+          "description": "Optional sensor entity whose state is used as the version string in the snapshot name (for example the Version integration `Local installation` sensor). If not set, the current date is used.",
           "name": "Version entity"
+        },
+        "vm_name": {
+          "description": "Name of the VM used in the snapshot name. Leave empty to use the device name from Proxmox. Spaces and special characters are automatically replaced with underscores.",
+          "name": "VM name"
         }
       },
       "name": "Create snapshot"

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -257,7 +257,7 @@
       "description": "Creates a snapshot on a VM or LXC container. The snapshot is named using the `Home_Assistant_` prefix followed by the Home Assistant version. Use this before upgrading Home Assistant to create a restore point.",
       "fields": {
         "include_ram": {
-          "description": "Save the VM's RAM state in the snapshot. Only applies to VMs — LXC containers do not support RAM snapshots.",
+          "description": "Save the VM's RAM state in the snapshot. Only works for running VMs — stopped VMs and LXC containers do not support RAM snapshots.",
           "name": "Include RAM"
         },
         "version_entity": {

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -217,6 +217,9 @@
     "snapshot_failed": {
       "message": "Creating the snapshot failed while communicating with the Proxmox VE instance."
     },
+    "snapshot_name_conflict": {
+      "message": "Could not create snapshot: all name variants for `{base_name}` are already taken."
+    },
     "ssl_error": {
       "message": "An SSL error occurred: {error}"
     },

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -257,7 +257,7 @@
   },
   "services": {
     "create_snapshot": {
-      "description": "Creates a snapshot on a VM or LXC container. The snapshot name is built from the VM name and the current date. Set `version_entity` to use a version string instead of the date — useful before upgrading.",
+      "description": "Creates a snapshot on a VM or LXC container. The snapshot name is built from the VM name and the current date. Set `Version entity` to use a version string instead of the date — useful before upgrading.",
       "fields": {
         "description": {
           "description": "Description stored with the snapshot. Defaults to 'Snapshot triggered from Home Assistant on YYYY-MM-DD' if left empty.",

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -193,6 +193,15 @@
     "invalid_auth_no_details": {
       "message": "Authentication failed for the Proxmox VE instance."
     },
+    "invalid_target_entity": {
+      "message": "The entity `{entity_id}` is not a valid Proxmox VE VM or container entity."
+    },
+    "invalid_target_not_vm_or_container": {
+      "message": "The selected device is not a Proxmox VE VM or LXC container. Only VM and container devices are supported for snapshots."
+    },
+    "invalid_target_single": {
+      "message": "You must target exactly one Proxmox VE VM or container (device or entity)."
+    },
     "no_nodes_found": {
       "message": "No active nodes were found on the Proxmox VE server."
     },
@@ -205,6 +214,9 @@
     "permissions_error": {
       "message": "Failed to retrieve Proxmox VE permissions. Please check your credentials and try again."
     },
+    "snapshot_failed": {
+      "message": "Creating the snapshot failed while communicating with the Proxmox VE instance."
+    },
     "ssl_error": {
       "message": "An SSL error occurred: {error}"
     },
@@ -213,6 +225,9 @@
     },
     "timeout_connect_no_details": {
       "message": "A timeout occurred while trying to connect to the Proxmox VE instance."
+    },
+    "version_entity_unavailable": {
+      "message": "The version entity `{entity_id}` is not available or has no version state."
     }
   },
   "issues": {
@@ -235,6 +250,18 @@
     "deprecated_yaml_import_issue_ssl_error": {
       "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your configuration, an SSL error occurred. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
       "title": "[%key:component::proxmoxve::issues::deprecated_yaml_import_issue_connect_timeout::title%]"
+    }
+  },
+  "services": {
+    "create_snapshot": {
+      "description": "Creates a snapshot on a VM or LXC container. The snapshot is named using the `Home_Assistant_` prefix followed by the Home Assistant version. Use this before upgrading Home Assistant to create a restore point.",
+      "fields": {
+        "version_entity": {
+          "description": "Optional sensor entity that provides the version string to include in the snapshot name (for example the Version integration `Local installation` sensor). If not set, the current Home Assistant version is used.",
+          "name": "Version entity"
+        }
+      },
+      "name": "Create snapshot"
     }
   }
 }

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -104,6 +104,7 @@ def mock_proxmox_client():
                     "status": vm["status"],
                 }
                 snapshot_mock = MagicMock()
+                snapshot_mock.get.return_value = []
                 snapshot_mock.post.return_value = (
                     "UPID:pve1:00000001:1234:5678ABCD:qmsnapshot:100:root@pam:"
                 )
@@ -121,6 +122,7 @@ def mock_proxmox_client():
                     "status": ct["status"],
                 }
                 snapshot_mock = MagicMock()
+                snapshot_mock.get.return_value = []
                 snapshot_mock.post.return_value = (
                     "UPID:pve1:00000001:1234:5678ABCD:lxcsnapshot:200:root@pam:"
                 )

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -103,6 +103,11 @@ def mock_proxmox_client():
                     "name": vm["name"],
                     "status": vm["status"],
                 }
+                snapshot_mock = MagicMock()
+                snapshot_mock.post.return_value = (
+                    "UPID:pve1:00000001:1234:5678ABCD:qmsnapshot:100:root@pam:"
+                )
+                resource.snapshot = snapshot_mock
                 qemu_mocks[vmid] = resource
             return qemu_mocks[vmid]
 
@@ -115,6 +120,11 @@ def mock_proxmox_client():
                     "name": ct["name"],
                     "status": ct["status"],
                 }
+                snapshot_mock = MagicMock()
+                snapshot_mock.post.return_value = (
+                    "UPID:pve1:00000001:1234:5678ABCD:lxcsnapshot:200:root@pam:"
+                )
+                resource.snapshot = snapshot_mock
                 lxc_mocks[vmid] = resource
             return lxc_mocks[vmid]
 

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -39,7 +39,7 @@ async def test_create_snapshot_vm_uses_core_version(
     sanitized = HA_VERSION.replace(".", "_")
     assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
     assert call_kwargs["description"] == HA_VERSION
-    assert call_kwargs["vmstate"] == 0
+    assert "vmstate" not in call_kwargs
 
 
 async def test_create_snapshot_vm_include_ram(
@@ -149,7 +149,7 @@ async def test_create_snapshot_by_vm_device_id(
     call_kwargs = snapshot_mock.call_args.kwargs
     sanitized = HA_VERSION.replace(".", "_")
     assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
-    assert call_kwargs["vmstate"] == 0
+    assert "vmstate" not in call_kwargs
 
 
 async def test_create_snapshot_by_container_device_id(

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from freezegun import freeze_time
+from freezegun.api import FrozenDateTimeFactory
 from proxmoxer.core import ResourceException
 import pytest
 
@@ -17,20 +17,20 @@ from . import setup_integration
 
 from tests.common import MockConfigEntry
 
-# Freeze to UTC noon on 2026-03-06 so dt_util.now() gives March 6 in all timezones.
 _FROZEN_DATETIME_UTC = "2026-03-06T12:00:00+00:00"
 _FROZEN_DATE = "2026-03-06"
 _FROZEN_DATE_SNAPNAME = "2026_03_06"
 _DEFAULT_DESCRIPTION = f"Snapshot triggered from Home Assistant on {_FROZEN_DATE}"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_vm_default_name_uses_date(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that create_snapshot on a VM builds a date-based name by default."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -48,13 +48,14 @@ async def test_create_snapshot_vm_default_name_uses_date(
     assert "vmstate" not in call_kwargs
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_vm_include_ram(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that include_ram=True passes vmstate=1 to the Proxmox API."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -68,13 +69,14 @@ async def test_create_snapshot_vm_include_ram(
     assert call_kwargs["vmstate"] == 1
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_container_default_name_uses_date(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that create_snapshot on a container builds a date-based name by default."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -92,13 +94,14 @@ async def test_create_snapshot_container_default_name_uses_date(
     assert "vmstate" not in call_kwargs
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_version_mode(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that create_snapshot uses version_entity state when provided."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     hass.states.async_set("sensor.local_version", "2026.3.0")
@@ -120,13 +123,14 @@ async def test_create_snapshot_version_mode(
     assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_custom_vm_name(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that a custom vm_name replaces the device name in the snapshot name."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -143,13 +147,14 @@ async def test_create_snapshot_custom_vm_name(
     assert call_kwargs["snapname"] == f"My_VM_{_FROZEN_DATE_SNAPNAME}"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_snapshot_name_override(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that snapshot_name is used verbatim as the full snapshot name."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -166,13 +171,14 @@ async def test_create_snapshot_snapshot_name_override(
     assert call_kwargs["snapname"] == "before_upgrade"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_description_override(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that a custom description is passed through to Proxmox."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -189,13 +195,14 @@ async def test_create_snapshot_description_override(
     assert call_kwargs["description"] == "my custom description"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_default_description(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that the default description includes the current date."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -209,16 +216,17 @@ async def test_create_snapshot_default_description(
     assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_conflict_appends_letter(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that _a is appended when the base snapshot name already exists."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
-    # Make one call to initialize the lazy qemu mock for vmid 100.
+    # Initialize the lazy qemu mock for vmid 100 before overriding its return value.
     await hass.services.async_call(
         DOMAIN,
         SERVICE_CREATE_SNAPSHOT,
@@ -241,16 +249,17 @@ async def test_create_snapshot_conflict_appends_letter(
     assert call_kwargs["snapname"] == f"{base}_a"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_conflict_multiple(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that _b is used when both base and _a are already taken."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
-    # Make one call to initialize the lazy qemu mock for vmid 100.
+    # Initialize the lazy qemu mock for vmid 100 before overriding its return value.
     await hass.services.async_call(
         DOMAIN,
         SERVICE_CREATE_SNAPSHOT,
@@ -276,13 +285,14 @@ async def test_create_snapshot_conflict_multiple(
     assert call_kwargs["snapname"] == f"{base}_b"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_by_vm_device_id(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test create_snapshot resolves correctly when targeting a VM device directly."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     dev_reg = dr.async_get(hass)
@@ -315,13 +325,14 @@ async def test_create_snapshot_by_vm_device_id(
     assert "vmstate" not in call_kwargs
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_by_container_device_id(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test create_snapshot resolves correctly when targeting a container device."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
     dev_reg = dr.async_get(hass)
@@ -402,16 +413,17 @@ async def test_create_snapshot_version_entity_unavailable(
     assert exc_info.value.translation_key == "version_entity_unavailable"
 
 
-@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_api_error(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that a Proxmox API failure raises HomeAssistantError."""
+    freezer.move_to(_FROZEN_DATETIME_UTC)
     await setup_integration(hass, mock_config_entry)
 
-    # Trigger lazy initialisation of the qemu mock for vmid 100.
+    # Initialize the lazy qemu mock for vmid 100 before injecting the side effect.
     await hass.services.async_call(
         DOMAIN,
         SERVICE_CREATE_SNAPSHOT,

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -1,0 +1,246 @@
+"""Tests for the Proxmox VE create_snapshot service."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from proxmoxer.core import ResourceException
+import pytest
+
+from homeassistant.components.proxmoxve.const import DOMAIN, SERVICE_CREATE_SNAPSHOT
+from homeassistant.const import __version__ as HA_VERSION
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_create_snapshot_vm_uses_core_version(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that create_snapshot on a VM uses the running HA version by default."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
+    snapshot_mock.assert_called_once()
+    call_kwargs = snapshot_mock.call_args.kwargs
+    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    assert call_kwargs["description"] == HA_VERSION
+    assert call_kwargs["vmstate"] is False
+
+
+async def test_create_snapshot_container_uses_core_version(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that create_snapshot on a container uses the running HA version by default."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.ct_nginx_start"}},
+        blocking=True,
+    )
+
+    snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
+    snapshot_mock.assert_called_once()
+    call_kwargs = snapshot_mock.call_args.kwargs
+    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    assert call_kwargs["description"] == HA_VERSION
+    # LXC snapshots do not accept vmstate
+    assert "vmstate" not in call_kwargs
+
+
+async def test_create_snapshot_vm_uses_version_entity(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that create_snapshot uses version_entity state when provided."""
+    await setup_integration(hass, mock_config_entry)
+
+    hass.states.async_set("sensor.local_version", "2026.3.0")
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {
+            "target": {"entity_id": "button.vm_web_start"},
+            "version_entity": "sensor.local_version",
+        },
+        blocking=True,
+    )
+
+    snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
+    snapshot_mock.assert_called_once()
+    call_kwargs = snapshot_mock.call_args.kwargs
+    assert call_kwargs["snapname"] == "Home_Assistant_2026.3.0"
+    assert call_kwargs["description"] == "2026.3.0"
+
+
+async def test_create_snapshot_by_vm_device_id(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test create_snapshot resolves correctly when targeting a VM device directly."""
+    await setup_integration(hass, mock_config_entry)
+
+    dev_reg = dr.async_get(hass)
+    vm_device = next(
+        (
+            d
+            for d in dr.async_entries_for_config_entry(
+                dev_reg, mock_config_entry.entry_id
+            )
+            if any(
+                ident[0] == DOMAIN and "_vm_" in str(ident[1])
+                for ident in d.identifiers
+            )
+        ),
+        None,
+    )
+    assert vm_device is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"device_id": vm_device.id}},
+        blocking=True,
+    )
+
+    snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
+    snapshot_mock.assert_called_once()
+    call_kwargs = snapshot_mock.call_args.kwargs
+    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    assert call_kwargs["vmstate"] is False
+
+
+async def test_create_snapshot_by_container_device_id(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test create_snapshot resolves correctly when targeting a container device."""
+    await setup_integration(hass, mock_config_entry)
+
+    dev_reg = dr.async_get(hass)
+    container_device = next(
+        (
+            d
+            for d in dr.async_entries_for_config_entry(
+                dev_reg, mock_config_entry.entry_id
+            )
+            if any(
+                ident[0] == DOMAIN and "_container_" in str(ident[1])
+                for ident in d.identifiers
+            )
+        ),
+        None,
+    )
+    assert container_device is not None
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"device_id": container_device.id}},
+        blocking=True,
+    )
+
+    snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
+    snapshot_mock.assert_called_once()
+    call_kwargs = snapshot_mock.call_args.kwargs
+    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    assert "vmstate" not in call_kwargs
+
+
+async def test_create_snapshot_invalid_target_single(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that targeting more than one entity raises ServiceValidationError."""
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SNAPSHOT,
+            {
+                "target": {
+                    "entity_id": [
+                        "button.vm_web_start",
+                        "button.vm_web_stop",
+                    ]
+                }
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "invalid_target_single"
+
+
+async def test_create_snapshot_version_entity_unavailable(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a missing version_entity raises ServiceValidationError."""
+    await setup_integration(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SNAPSHOT,
+            {
+                "target": {"entity_id": "button.vm_web_start"},
+                "version_entity": "sensor.nonexistent",
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "version_entity_unavailable"
+
+
+async def test_create_snapshot_api_error(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a Proxmox API failure raises HomeAssistantError."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Trigger lazy initialisation of the qemu mock for vmid 100.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+    mock_proxmox_client._qemu_mocks[100].snapshot.post.side_effect = ResourceException(
+        500, "Internal error", ""
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SNAPSHOT,
+            {"target": {"entity_id": "button.vm_web_start"}},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "snapshot_failed"

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -42,6 +42,25 @@ async def test_create_snapshot_vm_uses_core_version(
     assert call_kwargs["vmstate"] == 0
 
 
+async def test_create_snapshot_vm_include_ram(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that include_ram=True passes vmstate=1 to the Proxmox API."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}, "include_ram": True},
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["vmstate"] == 1
+
+
 async def test_create_snapshot_container_uses_core_version(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+from freezegun import freeze_time
 from proxmoxer.core import ResourceException
 import pytest
 
 from homeassistant.components.proxmoxve.const import DOMAIN, SERVICE_CREATE_SNAPSHOT
-from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -17,13 +17,20 @@ from . import setup_integration
 
 from tests.common import MockConfigEntry
 
+# Freeze to UTC noon on 2026-03-06 so dt_util.now() gives March 6 in all timezones.
+_FROZEN_DATETIME_UTC = "2026-03-06T12:00:00+00:00"
+_FROZEN_DATE = "2026-03-06"
+_FROZEN_DATE_SNAPNAME = "2026_03_06"
+_DEFAULT_DESCRIPTION = f"Snapshot triggered from Home Assistant on {_FROZEN_DATE}"
 
-async def test_create_snapshot_vm_uses_core_version(
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_vm_default_name_uses_date(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that create_snapshot on a VM uses the running HA version by default."""
+    """Test that create_snapshot on a VM builds a date-based name by default."""
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -36,12 +43,12 @@ async def test_create_snapshot_vm_uses_core_version(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    sanitized = HA_VERSION.replace(".", "_")
-    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
-    assert call_kwargs["description"] == HA_VERSION
+    assert call_kwargs["snapname"] == f"vm-web_{_FROZEN_DATE_SNAPNAME}"
+    assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
     assert "vmstate" not in call_kwargs
 
 
+@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_vm_include_ram(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
@@ -61,12 +68,13 @@ async def test_create_snapshot_vm_include_ram(
     assert call_kwargs["vmstate"] == 1
 
 
-async def test_create_snapshot_container_uses_core_version(
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_container_default_name_uses_date(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that create_snapshot on a container uses the running HA version by default."""
+    """Test that create_snapshot on a container builds a date-based name by default."""
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -79,14 +87,13 @@ async def test_create_snapshot_container_uses_core_version(
     snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    sanitized = HA_VERSION.replace(".", "_")
-    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
-    assert call_kwargs["description"] == HA_VERSION
-    # LXC snapshots do not accept vmstate
+    assert call_kwargs["snapname"] == f"ct-nginx_{_FROZEN_DATE_SNAPNAME}"
+    assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
     assert "vmstate" not in call_kwargs
 
 
-async def test_create_snapshot_vm_uses_version_entity(
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_version_mode(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
@@ -109,10 +116,167 @@ async def test_create_snapshot_vm_uses_version_entity(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == "Home_Assistant_2026_3_0"
-    assert call_kwargs["description"] == "2026.3.0"
+    assert call_kwargs["snapname"] == "vm-web_2026_3_0"
+    assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
 
 
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_custom_vm_name(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a custom vm_name replaces the device name in the snapshot name."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {
+            "target": {"entity_id": "button.vm_web_start"},
+            "vm_name": "My VM",
+        },
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["snapname"] == f"My_VM_{_FROZEN_DATE_SNAPNAME}"
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_snapshot_name_override(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that snapshot_name is used verbatim as the full snapshot name."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {
+            "target": {"entity_id": "button.vm_web_start"},
+            "snapshot_name": "before_upgrade",
+        },
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["snapname"] == "before_upgrade"
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_description_override(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a custom description is passed through to Proxmox."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {
+            "target": {"entity_id": "button.vm_web_start"},
+            "description": "my custom description",
+        },
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["description"] == "my custom description"
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_default_description(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that the default description includes the current date."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["description"] == _DEFAULT_DESCRIPTION
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_conflict_appends_letter(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that _a is appended when the base snapshot name already exists."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Make one call to initialize the lazy qemu mock for vmid 100.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    base = f"vm-web_{_FROZEN_DATE_SNAPNAME}"
+    mock_proxmox_client._qemu_mocks[100].snapshot.get.return_value = [{"name": base}]
+    mock_proxmox_client._qemu_mocks[100].snapshot.post.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["snapname"] == f"{base}_a"
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
+async def test_create_snapshot_conflict_multiple(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that _b is used when both base and _a are already taken."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Make one call to initialize the lazy qemu mock for vmid 100.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    base = f"vm-web_{_FROZEN_DATE_SNAPNAME}"
+    mock_proxmox_client._qemu_mocks[100].snapshot.get.return_value = [
+        {"name": base},
+        {"name": f"{base}_a"},
+    ]
+    mock_proxmox_client._qemu_mocks[100].snapshot.post.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE_SNAPSHOT,
+        {"target": {"entity_id": "button.vm_web_start"}},
+        blocking=True,
+    )
+
+    call_kwargs = mock_proxmox_client._qemu_mocks[100].snapshot.post.call_args.kwargs
+    assert call_kwargs["snapname"] == f"{base}_b"
+
+
+@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_by_vm_device_id(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
@@ -147,11 +311,11 @@ async def test_create_snapshot_by_vm_device_id(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    sanitized = HA_VERSION.replace(".", "_")
-    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
+    assert call_kwargs["snapname"] == f"vm-web_{_FROZEN_DATE_SNAPNAME}"
     assert "vmstate" not in call_kwargs
 
 
+@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_by_container_device_id(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
@@ -186,8 +350,7 @@ async def test_create_snapshot_by_container_device_id(
     snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    sanitized = HA_VERSION.replace(".", "_")
-    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
+    assert call_kwargs["snapname"] == f"ct-nginx_{_FROZEN_DATE_SNAPNAME}"
     assert "vmstate" not in call_kwargs
 
 
@@ -239,6 +402,7 @@ async def test_create_snapshot_version_entity_unavailable(
     assert exc_info.value.translation_key == "version_entity_unavailable"
 
 
+@freeze_time(_FROZEN_DATETIME_UTC)
 async def test_create_snapshot_api_error(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,

--- a/tests/components/proxmoxve/test_services.py
+++ b/tests/components/proxmoxve/test_services.py
@@ -36,9 +36,10 @@ async def test_create_snapshot_vm_uses_core_version(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    sanitized = HA_VERSION.replace(".", "_")
+    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
     assert call_kwargs["description"] == HA_VERSION
-    assert call_kwargs["vmstate"] is False
+    assert call_kwargs["vmstate"] == 0
 
 
 async def test_create_snapshot_container_uses_core_version(
@@ -59,7 +60,8 @@ async def test_create_snapshot_container_uses_core_version(
     snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    sanitized = HA_VERSION.replace(".", "_")
+    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
     assert call_kwargs["description"] == HA_VERSION
     # LXC snapshots do not accept vmstate
     assert "vmstate" not in call_kwargs
@@ -88,7 +90,7 @@ async def test_create_snapshot_vm_uses_version_entity(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == "Home_Assistant_2026.3.0"
+    assert call_kwargs["snapname"] == "Home_Assistant_2026_3_0"
     assert call_kwargs["description"] == "2026.3.0"
 
 
@@ -126,8 +128,9 @@ async def test_create_snapshot_by_vm_device_id(
     snapshot_mock = mock_proxmox_client._qemu_mocks[100].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
-    assert call_kwargs["vmstate"] is False
+    sanitized = HA_VERSION.replace(".", "_")
+    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
+    assert call_kwargs["vmstate"] == 0
 
 
 async def test_create_snapshot_by_container_device_id(
@@ -164,7 +167,8 @@ async def test_create_snapshot_by_container_device_id(
     snapshot_mock = mock_proxmox_client._lxc_mocks[200].snapshot.post
     snapshot_mock.assert_called_once()
     call_kwargs = snapshot_mock.call_args.kwargs
-    assert call_kwargs["snapname"] == f"Home_Assistant_{HA_VERSION}"
+    sanitized = HA_VERSION.replace(".", "_")
+    assert call_kwargs["snapname"] == f"Home_Assistant_{sanitized}"
     assert "vmstate" not in call_kwargs
 
 


### PR DESCRIPTION
## Proposed change

Adds a `proxmoxve.create_snapshot` service to the Proxmox VE integration, allowing Home Assistant automations to snapshot VMs and LXC containers — particularly useful before a Home Assistant upgrade.

- **New service**: `proxmoxve.create_snapshot` targeting any proxmoxve VM or container device/entity
- **Smart naming**: snapshot name defaults to `{vm_name}_{YYYY_MM_DD}`, resolved from the device registry
- **Version mode**: set `version_entity` to a sensor (e.g. the HA version sensor) to use a version string instead of the date
- **Conflict resolution**: if the generated name already exists, appends `_a`, `_b`, … automatically
- **Override fields**: `snapshot_name` (full name override) and `description` (description override)
- **Default description**: `Snapshot triggered from Home Assistant on YYYY-MM-DD`
- **RAM snapshot support**: `include_ram: true` saves VM memory state (VMs only)
- **LXC support**: works on both QEMU VMs and LXC containers

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43966
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [ ] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/perfect-pr)
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://www.home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
  Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
  Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls) in this repository.