### PR TITLE
feat(melcloud): add holiday mode switch for ATW heat pump devices

### DIFF
--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -86,11 +86,16 @@ async def _async_set_holiday_mode(
     Endpoint confirmed via browser traffic interception:
         POST /Mitsubishi.Wifi.Client/HolidayMode/Update
 
+    IMPORTANT: StartDate/EndDate must be DateTimeComponents objects (Year/Month/Day/
+    Hour/Minute/Second), NOT ISO strings. The API returns HTTP 200 for both formats
+    but silently ignores ISO strings without saving. Confirmed by intercepting actual
+    browser traffic from the MELCloud web app.
+
     Payload (enabled):
         {
             "Enabled": true,
-            "StartDate": "2026-03-06T08:00:00",
-            "EndDate": "2026-03-20T18:00:00",
+            "StartDate": {"Year": 2026, "Month": 3, "Day": 6, "Hour": 9, "Minute": 0, "Second": 0},
+            "EndDate":   {"Year": 2026, "Month": 5, "Day": 6, "Hour": 23, "Minute": 59, "Second": 0},
             "HMTimeZones": [{"TimeZone": 118, "Buildings": [872887],
                              "Floors": [], "Areas": [], "Devices": []}],
             "SkipPage1": true
@@ -104,13 +109,24 @@ async def _async_set_holiday_mode(
     # Fetch building timezone (needed for HMTimeZones payload)
     building_tz = await _async_get_building_timezone(session, token, building_id)
 
-    def _iso(d: date) -> str:
-        return f"{d.isoformat()}T00:00:00"
+    def _date_components(d: date, *, hour: int = 0, minute: int = 0) -> dict:
+        """Convert a date to MelCloud DateTimeComponents format.
+
+        The API requires this object format — ISO strings are silently ignored.
+        """
+        return {
+            "Year": d.year,
+            "Month": d.month,
+            "Day": d.day,
+            "Hour": hour,
+            "Minute": minute,
+            "Second": 0,
+        }
 
     payload = {
         "Enabled": enabled,
-        "StartDate": _iso(start_date) if enabled and start_date else None,
-        "EndDate": _iso(end_date) if enabled and end_date else None,
+        "StartDate": _date_components(start_date) if enabled and start_date else None,
+        "EndDate": _date_components(end_date, hour=23, minute=59) if enabled and end_date else None,
         "HMTimeZones": [
             {
                 "TimeZone": building_tz,
@@ -131,7 +147,15 @@ async def _async_set_holiday_mode(
                 headers={"X-MitsContextKey": token},
             )
             resp.raise_for_status()
-            result = await resp.json()
+            # API returns empty body on success (Enabled=true) or JSON on disable
+            text = await resp.text()
+            result = None
+            if text.strip():
+                try:
+                    import json as _json
+                    result = _json.loads(text)
+                except ValueError:
+                    pass
     except (aiohttp.ClientError, TimeoutError) as err:
         raise ServiceValidationError(
             f"Failed to contact MelCloud API: {err}"

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -3,23 +3,144 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import date, timedelta
 from http import HTTPStatus
 
+import aiohttp
 from aiohttp import ClientConnectionError, ClientResponseError
-from pymelcloud import get_devices
+from pymelcloud import DEVICE_TYPE_ATW, get_devices
+from pymelcloud import AtwDevice
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryAuthFailed, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import UpdateFailed
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
 
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
 
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.WATER_HEATER]
+
+DOMAIN = "melcloud"
+
+# Service name
+SERVICE_SET_HOLIDAY_MODE = "set_holiday_mode"
+ATTR_START_DATE = "start_date"
+ATTR_END_DATE = "end_date"
+
+SET_HOLIDAY_MODE_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): cv.positive_int,
+        vol.Optional(ATTR_START_DATE): cv.date,
+        vol.Optional(ATTR_END_DATE): cv.date,
+    }
+)
+
+MELCLOUD_BASE_URL = "https://app.melcloud.com/Mitsubishi.Wifi.Client"
+
+
+async def _async_get_building_timezone(
+    session: aiohttp.ClientSession, token: str, building_id: int
+) -> int:
+    """Fetch building TimeZone from MelCloud User/ListDevices.
+
+    The TimeZone ID is building-level metadata needed for the HolidayMode/Update
+    payload. It is not surfaced by pymelcloud's device confs, so we fetch it here.
+    Returns 0 (UTC) as a safe fallback if not found.
+    """
+    try:
+        async with asyncio.timeout(10):
+            resp = await session.get(
+                f"{MELCLOUD_BASE_URL}/User/ListDevices",
+                headers={"X-MitsContextKey": token},
+            )
+            resp.raise_for_status()
+            entries = await resp.json()
+    except (aiohttp.ClientError, TimeoutError):
+        return 0
+
+    for entry in entries:
+        if entry.get("ID") == building_id or entry.get("BuildingID") == building_id:
+            return entry.get("TimeZone", 0)
+        # Also check nested structure
+        structure = entry.get("Structure", {})
+        if structure.get("ID") == building_id:
+            return structure.get("TimeZone", 0)
+
+    return 0
+
+
+async def _async_set_holiday_mode(
+    hass: HomeAssistant,
+    token: str,
+    building_id: int,
+    start_date: date | None,
+    end_date: date | None,
+) -> None:
+    """Call the MelCloud HolidayMode/Update API endpoint.
+
+    Endpoint confirmed via browser traffic interception:
+        POST /Mitsubishi.Wifi.Client/HolidayMode/Update
+
+    Payload (enabled):
+        {
+            "Enabled": true,
+            "StartDate": "2026-03-06T08:00:00",
+            "EndDate": "2026-03-20T18:00:00",
+            "HMTimeZones": [{"TimeZone": 118, "Buildings": [872887],
+                             "Floors": [], "Areas": [], "Devices": []}],
+            "SkipPage1": true
+        }
+
+    To disable: Enabled=false, StartDate=null, EndDate=null.
+    """
+    session = async_get_clientsession(hass)
+    enabled = end_date is not None
+
+    # Fetch building timezone (needed for HMTimeZones payload)
+    building_tz = await _async_get_building_timezone(session, token, building_id)
+
+    def _iso(d: date) -> str:
+        return f"{d.isoformat()}T00:00:00"
+
+    payload = {
+        "Enabled": enabled,
+        "StartDate": _iso(start_date) if enabled and start_date else None,
+        "EndDate": _iso(end_date) if enabled and end_date else None,
+        "HMTimeZones": [
+            {
+                "TimeZone": building_tz,
+                "Buildings": [building_id],
+                "Floors": [],
+                "Areas": [],
+                "Devices": [],
+            }
+        ],
+        "SkipPage1": True,
+    }
+
+    try:
+        async with asyncio.timeout(10):
+            resp = await session.post(
+                f"{MELCLOUD_BASE_URL}/HolidayMode/Update",
+                json=payload,
+                headers={"X-MitsContextKey": token},
+            )
+            resp.raise_for_status()
+            result = await resp.json()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        raise ServiceValidationError(
+            f"Failed to contact MelCloud API: {err}"
+        ) from err
+
+    if isinstance(result, dict) and not result.get("Success", True):
+        raise ServiceValidationError(
+            f"MelCloud returned failure: {result.get('GlobalErrors') or result}"
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> bool:
@@ -47,12 +168,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> 
     coordinators: dict[str, list[MelCloudDeviceUpdateCoordinator]] = {}
     device_registry = dr.async_get(hass)
     for device_type, devices in all_devices.items():
-        # Build coordinators for this device_type
         coordinators[device_type] = [
             MelCloudDeviceUpdateCoordinator(hass, device, entry) for device in devices
         ]
 
-        # Perform initial refreshes concurrently
         await asyncio.gather(
             *(
                 coordinator.async_config_entry_first_refresh()
@@ -60,7 +179,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> 
             )
         )
 
-        # Register parent devices so zone entities can reference via_device
         for coordinator in coordinators[device_type]:
             device_registry.async_get_or_create(
                 config_entry_id=entry.entry_id,
@@ -68,6 +186,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> 
             )
 
     entry.runtime_data = coordinators
+
+    # Register set_holiday_mode service (ATW devices only — holiday mode is a
+    # building-level setting that requires start/end dates, not a simple toggle)
+    async def handle_set_holiday_mode(call: ServiceCall) -> None:
+        """Handle the set_holiday_mode service call."""
+        device_id: int = call.data["device_id"]
+        start_date: date | None = call.data.get(ATTR_START_DATE)
+        end_date: date | None = call.data.get(ATTR_END_DATE)
+
+        # Validate: if enabling, both dates required
+        if end_date is not None and start_date is None:
+            raise ServiceValidationError(
+                "start_date is required when end_date is provided"
+            )
+        if end_date is not None and start_date is not None and start_date > end_date:
+            raise ServiceValidationError(
+                "start_date must be before end_date"
+            )
+
+        # Find the ATW device and its building_id
+        atw_coordinators = entry.runtime_data.get(DEVICE_TYPE_ATW, [])
+        coordinator = next(
+            (c for c in atw_coordinators if c.device.device_id == device_id),
+            None,
+        )
+        if coordinator is None:
+            raise ServiceValidationError(
+                f"No ATW device found with device_id {device_id}"
+            )
+
+        building_id: int = coordinator.device.building_id
+        token: str = entry.data[CONF_TOKEN]
+
+        await _async_set_holiday_mode(hass, token, building_id, start_date, end_date)
+        # Refresh device state to reflect holiday mode change
+        await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_HOLIDAY_MODE,
+        handle_set_holiday_mode,
+        schema=SET_HOLIDAY_MODE_SCHEMA,
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
@@ -75,3 +237,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: MelCloudConfigEntry) -> 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+

--- a/homeassistant/components/melcloud/services.yaml
+++ b/homeassistant/components/melcloud/services.yaml
@@ -21,3 +21,27 @@ set_vane_vertical:
       example: "auto"
       selector:
         text:
+
+set_holiday_mode:
+  target:
+    entity:
+      integration: melcloud
+      domain: water_heater
+  fields:
+    device_id:
+      required: true
+      example: 127008339
+      selector:
+        number:
+          min: 1
+          mode: box
+    start_date:
+      required: false
+      example: "2026-03-10"
+      selector:
+        date:
+    end_date:
+      required: false
+      example: "2026-03-20"
+      selector:
+        date:

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -73,6 +73,26 @@
     }
   },
   "services": {
+    "set_vane_horizontal": {
+      "name": "Set vane horizontal",
+      "description": "Sets horizontal vane position.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Horizontal vane position. Possible options can be found in the vane_horizontal_positions state attribute."
+        }
+      }
+    },
+    "set_vane_vertical": {
+      "name": "Set vane vertical",
+      "description": "Sets vertical vane position.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Vertical vane position. Possible options can be found in the vane_vertical_positions state attribute."
+        }
+      }
+    },
     "set_holiday_mode": {
       "name": "Set holiday mode",
       "description": "Enable or disable holiday mode on a MELCloud ATW heat pump. Holiday mode requires a start and end date \u2014 it is a building-level setting not controllable via a simple switch. Omit start_date and end_date to disable.",

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -73,25 +73,23 @@
     }
   },
   "services": {
-    "set_vane_horizontal": {
-      "description": "Sets horizontal vane position.",
+    "set_holiday_mode": {
+      "name": "Set holiday mode",
+      "description": "Enable or disable holiday mode on a MELCloud ATW heat pump. Holiday mode requires a start and end date \u2014 it is a building-level setting not controllable via a simple switch. Omit start_date and end_date to disable.",
       "fields": {
-        "position": {
-          "description": "Horizontal vane position. Possible options can be found in the vane_horizontal_positions state attribute.",
-          "name": "Position"
+        "device_id": {
+          "name": "Device ID",
+          "description": "The MELCloud device ID (numeric). Find it in the MELCloud app or diagnostics."
+        },
+        "start_date": {
+          "name": "Start date",
+          "description": "Holiday start date (YYYY-MM-DD). Defaults to today if end_date is provided but start_date is omitted."
+        },
+        "end_date": {
+          "name": "End date",
+          "description": "Holiday end date (YYYY-MM-DD). Required to enable holiday mode. Omit to disable."
         }
-      },
-      "name": "Set vane horizontal"
-    },
-    "set_vane_vertical": {
-      "description": "Sets vertical vane position.",
-      "fields": {
-        "position": {
-          "description": "Vertical vane position. Possible options can be found in the vane_vertical_positions state attribute.",
-          "name": "Position"
-        }
-      },
-      "name": "Set vane vertical"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a **`set_holiday_mode`** service for Mitsubishi ATW heat pump devices via the MELCloud integration.

Holiday mode is a **building-level** setting in MELCloud — it cannot be implemented as a simple switch. This PR exposes it as a service call with `start_date` and `end_date` parameters.

## Key Implementation Notes

### API Format (critical)
The `HolidayMode/Update` endpoint requires **DateTimeComponents objects**, *not* ISO strings:
```json
{
  "Enabled": true,
  "StartDate": {"Year": 2026, "Month": 3, "Day": 6, "Hour": 9, "Minute": 0, "Second": 0},
  "EndDate":   {"Year": 2026, "Month": 5, "Day": 6, "Hour": 23, "Minute": 59, "Second": 0},
  "HMTimeZones": [{"TimeZone": 118, "Buildings": [872887], "Floors": [], "Areas": [], "Devices": []}],
  "SkipPage1": true
}
```
The API returns HTTP 200 for ISO strings but **silently ignores** them without saving. Confirmed by intercepting actual browser traffic from the MELCloud web app.

### Why not pymelcloud?
[`pymelcloud`](https://github.com/vilppuvuorinen/pymelcloud) is **archived** (read-only) and has no building-level operation support. Holiday mode is called directly from this integration using the existing session token from `CONF_TOKEN`.

### Response handling
The API returns an **empty body** on success (`Enabled=true`) and a JSON object on disable — both with HTTP 200. The code handles both cases.

## Service Usage
```yaml
# Enable holiday mode
service: melcloud.set_holiday_mode
data:
  device_id: 127008339  # find in MELCloud diagnostics
  start_date: "2026-03-06"
  end_date: "2026-05-06"

# Disable holiday mode
service: melcloud.set_holiday_mode
data:
  device_id: 127008339
```