### PR TITLE
Add binary_sensors for Rehlko load shedding

### DIFF
--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -153,7 +153,6 @@ class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
             entity_registry_enabled_default=False,
         )
         self._definition_id = definition_id
-        self._display_name = display_name
         super().__init__(
             coordinator,
             device_id,

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -20,7 +20,7 @@ from .const import (
     DEVICE_DATA_IS_CONNECTED,
     GENERATOR_DATA_DEVICE,
 )
-from .coordinator import RehlkoConfigEntry
+from .coordinator import RehlkoConfigEntry, RehlkoUpdateCoordinator
 from .entity import RehlkoEntity
 
 # Coordinator is used to centralize the data updates
@@ -73,19 +73,42 @@ async def async_setup_entry(
     """Set up the binary sensor platform."""
     homes = config_entry.runtime_data.homes
     coordinators = config_entry.runtime_data.coordinators
-    async_add_entities(
-        RehlkoBinarySensorEntity(
-            coordinators[device_data[DEVICE_DATA_ID]],
-            device_data[DEVICE_DATA_ID],
-            device_data,
-            sensor_description,
-            document_key=sensor_description.document_key,
-            connectivity_key=sensor_description.connectivity_key,
-        )
-        for home_data in homes
-        for device_data in home_data[DEVICE_DATA_DEVICES]
-        for sensor_description in BINARY_SENSORS
-    )
+    entities: list[BinarySensorEntity] = []
+
+    for home_data in homes:
+        for device_data in home_data[DEVICE_DATA_DEVICES]:
+            device_id = device_data[DEVICE_DATA_ID]
+            coordinator = coordinators[device_id]
+
+            # Add standard binary sensors
+            entities.extend(
+                RehlkoBinarySensorEntity(
+                    coordinator,
+                    device_id,
+                    device_data,
+                    sensor_description,
+                    document_key=sensor_description.document_key,
+                    connectivity_key=sensor_description.connectivity_key,
+                )
+                for sensor_description in BINARY_SENSORS
+            )
+
+            # Add loadshed binary sensors if loadshed data is available
+            if coordinator.data and "loadShed" in coordinator.data:
+                loadshed_data = coordinator.data["loadShed"]
+                if loadshed_data.get("parameters"):
+                    entities.extend(
+                        RehlkoLoadshedBinarySensorEntity(
+                            coordinator,
+                            device_id,
+                            device_data,
+                            parameter["definitionId"],
+                            parameter["displayName"],
+                        )
+                        for parameter in loadshed_data["parameters"]
+                    )
+
+    async_add_entities(entities)
 
 
 class RehlkoBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
@@ -105,4 +128,53 @@ class RehlkoBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
             self.entity_description.key,
             self._rehlko_value,
         )
+        return None
+
+
+class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
+    """Representation of a Loadshed Binary Sensor."""
+
+    def __init__(
+        self,
+        coordinator: RehlkoUpdateCoordinator,
+        device_id: int,
+        device_data: dict,
+        definition_id: int,
+        display_name: str,
+    ) -> None:
+        """Initialize the loadshed binary sensor."""
+        # Create a synthetic entity description for this loadshed parameter
+        description = BinarySensorEntityDescription(
+            key=f"loadshed_{definition_id}",
+            translation_key="loadshed_parameter",
+            icon="mdi:transmission-tower-off",
+            entity_registry_enabled_default=False,
+        )
+        self._definition_id = definition_id
+        self._display_name = display_name
+        super().__init__(
+            coordinator,
+            device_id,
+            device_data,
+            description,
+            document_key=None,
+            connectivity_key=DEVICE_DATA_IS_CONNECTED,
+        )
+        # Use translation placeholders for the dynamic display name
+        self._attr_translation_placeholders = {"display_name": display_name}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the binary sensor."""
+        if not self.coordinator.data or "loadShed" not in self.coordinator.data:
+            return None
+
+        loadshed_data = self.coordinator.data["loadShed"]
+        if not loadshed_data.get("parameters"):
+            return None
+
+        for parameter in loadshed_data["parameters"]:
+            if parameter["definitionId"] == self._definition_id:
+                return parameter.get("value")
+
         return None

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -94,19 +94,21 @@ async def async_setup_entry(
             )
 
             # Add loadshed binary sensors if loadshed data is available
-            if coordinator.data and "loadShed" in coordinator.data:
-                loadshed_data = coordinator.data["loadShed"]
-                if loadshed_data.get("parameters"):
-                    entities.extend(
-                        RehlkoLoadshedBinarySensorEntity(
-                            coordinator,
-                            device_id,
-                            device_data,
-                            parameter["definitionId"],
-                            parameter["displayName"],
-                        )
-                        for parameter in loadshed_data["parameters"]
+            if (
+                coordinator.data
+                and (loadshed_data := coordinator.data.get("loadShed"))
+                and (parameters := loadshed_data.get("parameters"))
+            ):
+                entities.extend(
+                    RehlkoLoadshedBinarySensorEntity(
+                        coordinator,
+                        device_id,
+                        device_data,
+                        parameter["definitionId"],
+                        parameter["displayName"],
                     )
+                    for parameter in parameters
+                )
 
     async_add_entities(entities)
 

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -168,15 +168,18 @@ class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
-        if not self.coordinator.data or "loadShed" not in self.coordinator.data:
+        if (
+            not self.coordinator.data
+            or not (loadshed_data := self.coordinator.data.get("loadShed"))
+            or not (parameters := loadshed_data.get("parameters"))
+        ):
             return None
 
-        loadshed_data = self.coordinator.data["loadShed"]
-        if not loadshed_data.get("parameters"):
-            return None
-
-        for parameter in loadshed_data["parameters"]:
-            if parameter["definitionId"] == self._definition_id:
-                return parameter.get("value")
-
-        return None
+        return next(
+            (
+                parameter.get("value")
+                for parameter in parameters
+                if parameter["definitionId"] == self._definition_id
+            ),
+            None,
+        )

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -149,7 +149,6 @@ class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
         description = BinarySensorEntityDescription(
             key=f"loadshed_{definition_id}",
             translation_key="loadshed_parameter",
-            icon="mdi:transmission-tower-off",
             entity_registry_enabled_default=False,
         )
         self._definition_id = definition_id

--- a/homeassistant/components/rehlko/binary_sensor.py
+++ b/homeassistant/components/rehlko/binary_sensor.py
@@ -94,10 +94,8 @@ async def async_setup_entry(
             )
 
             # Add loadshed binary sensors if loadshed data is available
-            if (
-                coordinator.data
-                and (loadshed_data := coordinator.data.get("loadShed"))
-                and (parameters := loadshed_data.get("parameters"))
+            if (loadshed_data := coordinator.data.get("loadShed")) and (
+                parameters := loadshed_data.get("parameters")
             ):
                 entities.extend(
                     RehlkoLoadshedBinarySensorEntity(
@@ -166,10 +164,8 @@ class RehlkoLoadshedBinarySensorEntity(RehlkoEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return the state of the binary sensor."""
-        if (
-            not self.coordinator.data
-            or not (loadshed_data := self.coordinator.data.get("loadShed"))
-            or not (parameters := loadshed_data.get("parameters"))
+        if not (loadshed_data := self.coordinator.data.get("loadShed")) or not (
+            parameters := loadshed_data.get("parameters")
         ):
             return None
 

--- a/homeassistant/components/rehlko/icons.json
+++ b/homeassistant/components/rehlko/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "binary_sensor": {
+      "loadshed_parameter": {
+        "default": "mdi:transmission-tower-off"
+      }
+    },
     "sensor": {
       "device_ip_address": {
         "default": "mdi:ip-network"

--- a/homeassistant/components/rehlko/strings.json
+++ b/homeassistant/components/rehlko/strings.json
@@ -36,7 +36,7 @@
         "name": "Auto run"
       },
       "loadshed_parameter": {
-        "name": "Loadshed {display_name}"
+        "name": "Load shed {display_name}"
       },
       "oil_pressure": {
         "name": "Oil pressure"

--- a/homeassistant/components/rehlko/strings.json
+++ b/homeassistant/components/rehlko/strings.json
@@ -35,6 +35,9 @@
       "auto_run": {
         "name": "Auto run"
       },
+      "loadshed_parameter": {
+        "name": "Loadshed {display_name}"
+      },
       "oil_pressure": {
         "name": "Oil pressure"
       }

--- a/tests/components/rehlko/snapshots/test_binary_sensor.ambr
+++ b/tests/components/rehlko/snapshots/test_binary_sensor.ambr
@@ -123,7 +123,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed HVAC A',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -138,7 +138,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed HVAC A',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_hvac_a',
@@ -173,7 +172,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed HVAC B',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -188,7 +187,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed HVAC B',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_hvac_b',
@@ -223,7 +221,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed Load A',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -238,7 +236,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed Load A',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_load_a',
@@ -273,7 +270,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed Load B',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -288,7 +285,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed Load B',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_load_b',
@@ -323,7 +319,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed Load C',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -338,7 +334,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed Load C',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_load_c',
@@ -373,7 +368,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:transmission-tower-off',
+    'original_icon': None,
     'original_name': 'Load shed Load D',
     'platform': 'rehlko',
     'previous_unique_id': None,
@@ -388,7 +383,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Generator 1 Load shed Load D',
-      'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.generator_1_load_shed_load_d',

--- a/tests/components/rehlko/snapshots/test_binary_sensor.ambr
+++ b/tests/components/rehlko/snapshots/test_binary_sensor.ambr
@@ -98,7 +98,7 @@
     'state': 'on',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_a-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_hvac_a-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -111,7 +111,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_a',
+    'entity_id': 'binary_sensor.generator_1_load_shed_hvac_a',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -119,12 +119,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed HVAC A',
+    'object_id_base': 'Load shed HVAC A',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed HVAC A',
+    'original_name': 'Load shed HVAC A',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -134,21 +134,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_a-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_hvac_a-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed HVAC A',
+      'friendly_name': 'Generator 1 Load shed HVAC A',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_a',
+    'entity_id': 'binary_sensor.generator_1_load_shed_hvac_a',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_b-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_hvac_b-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -161,7 +161,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_b',
+    'entity_id': 'binary_sensor.generator_1_load_shed_hvac_b',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -169,12 +169,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed HVAC B',
+    'object_id_base': 'Load shed HVAC B',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed HVAC B',
+    'original_name': 'Load shed HVAC B',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -184,21 +184,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_b-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_hvac_b-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed HVAC B',
+      'friendly_name': 'Generator 1 Load shed HVAC B',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_b',
+    'entity_id': 'binary_sensor.generator_1_load_shed_hvac_b',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_a-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_a-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -211,7 +211,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_a',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_a',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -219,12 +219,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed Load A',
+    'object_id_base': 'Load shed Load A',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed Load A',
+    'original_name': 'Load shed Load A',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -234,21 +234,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_a-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_a-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed Load A',
+      'friendly_name': 'Generator 1 Load shed Load A',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_a',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_a',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_b-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_b-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -261,7 +261,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_b',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_b',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -269,12 +269,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed Load B',
+    'object_id_base': 'Load shed Load B',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed Load B',
+    'original_name': 'Load shed Load B',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -284,21 +284,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_b-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_b-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed Load B',
+      'friendly_name': 'Generator 1 Load shed Load B',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_b',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_b',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_c-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_c-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -311,7 +311,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_c',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_c',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -319,12 +319,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed Load C',
+    'object_id_base': 'Load shed Load C',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed Load C',
+    'original_name': 'Load shed Load C',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -334,21 +334,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_c-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_c-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed Load C',
+      'friendly_name': 'Generator 1 Load shed Load C',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_c',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_c',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_d-entry]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_d-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -361,7 +361,7 @@
     'disabled_by': None,
     'domain': 'binary_sensor',
     'entity_category': None,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_d',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_d',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -369,12 +369,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Loadshed Load D',
+    'object_id_base': 'Load shed Load D',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:transmission-tower-off',
-    'original_name': 'Loadshed Load D',
+    'original_name': 'Load shed Load D',
     'platform': 'rehlko',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -384,14 +384,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[binary_sensor.generator_1_loadshed_load_d-state]
+# name: test_sensors[binary_sensor.generator_1_load_shed_load_d-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Generator 1 Loadshed Load D',
+      'friendly_name': 'Generator 1 Load shed Load D',
       'icon': 'mdi:transmission-tower-off',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.generator_1_loadshed_load_d',
+    'entity_id': 'binary_sensor.generator_1_load_shed_load_d',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/rehlko/snapshots/test_binary_sensor.ambr
+++ b/tests/components/rehlko/snapshots/test_binary_sensor.ambr
@@ -98,6 +98,306 @@
     'state': 'on',
   })
 # ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed HVAC A',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed HVAC A',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed HVAC A',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed HVAC B',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed HVAC B',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_hvac_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed HVAC B',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_hvac_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_a-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_a',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed Load A',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed Load A',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_a-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed Load A',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_a',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_b-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_b',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed Load B',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed Load B',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_b-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed Load B',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_b',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_c-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_c',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed Load C',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed Load C',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_c-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed Load C',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_c',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_d-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_d',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loadshed Load D',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:transmission-tower-off',
+    'original_name': 'Loadshed Load D',
+    'platform': 'rehlko',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loadshed_parameter',
+    'unique_id': 'myemail@email.com_12345_loadshed_6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[binary_sensor.generator_1_loadshed_load_d-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Generator 1 Loadshed Load D',
+      'icon': 'mdi:transmission-tower-off',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.generator_1_loadshed_load_d',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_sensors[binary_sensor.generator_1_oil_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/rehlko/test_binary_sensor.py
+++ b/tests/components/rehlko/test_binary_sensor.py
@@ -85,7 +85,7 @@ async def test_loadshed_binary_sensor_states(
     hvac_a_param = generator["loadShed"]["parameters"][0]
     assert hvac_a_param["displayName"] == "HVAC A"
     assert hvac_a_param["value"] is False
-    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    state = hass.states.get("binary_sensor.generator_1_load_shed_hvac_a")
     assert state.state == STATE_OFF
 
     # Change HVAC A to on (true)
@@ -93,7 +93,7 @@ async def test_loadshed_binary_sensor_states(
     freezer.tick(SCAN_INTERVAL_MINUTES)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    state = hass.states.get("binary_sensor.generator_1_load_shed_hvac_a")
     assert state.state == STATE_ON
 
     # Remove loadShed data to test unavailable state
@@ -101,7 +101,7 @@ async def test_loadshed_binary_sensor_states(
     freezer.tick(SCAN_INTERVAL_MINUTES)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    state = hass.states.get("binary_sensor.generator_1_load_shed_hvac_a")
     assert state.state == STATE_UNKNOWN
 
 

--- a/tests/components/rehlko/test_binary_sensor.py
+++ b/tests/components/rehlko/test_binary_sensor.py
@@ -18,6 +18,8 @@ from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
+pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
+
 
 @pytest.fixture(name="platform_binary_sensor", autouse=True)
 async def platform_binary_sensor_fixture():
@@ -26,7 +28,6 @@ async def platform_binary_sensor_fixture():
         yield
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/rehlko/test_binary_sensor.py
+++ b/tests/components/rehlko/test_binary_sensor.py
@@ -18,8 +18,6 @@ from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
-pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
-
 
 @pytest.fixture(name="platform_binary_sensor", autouse=True)
 async def platform_binary_sensor_fixture():
@@ -28,6 +26,7 @@ async def platform_binary_sensor_fixture():
         yield
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/rehlko/test_binary_sensor.py
+++ b/tests/components/rehlko/test_binary_sensor.py
@@ -72,6 +72,39 @@ async def test_binary_sensor_states(
     assert "engineOilPressureOk" in caplog.text
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_loadshed_binary_sensor_states(
+    hass: HomeAssistant,
+    generator: dict[str, Any],
+    mock_rehlko: AsyncMock,
+    load_rehlko_config_entry: None,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the Rehlko loadshed binary sensor state logic."""
+    # Initial state - HVAC A should be off (false)
+    hvac_a_param = generator["loadShed"]["parameters"][0]
+    assert hvac_a_param["displayName"] == "HVAC A"
+    assert hvac_a_param["value"] is False
+    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    assert state.state == STATE_OFF
+
+    # Change HVAC A to on (true)
+    hvac_a_param["value"] = True
+    freezer.tick(SCAN_INTERVAL_MINUTES)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    assert state.state == STATE_ON
+
+    # Remove loadShed data to test unavailable state
+    del generator["loadShed"]
+    freezer.tick(SCAN_INTERVAL_MINUTES)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.generator_1_loadshed_hvac_a")
+    assert state.state == STATE_UNKNOWN
+
+
 async def test_binary_sensor_connectivity_availability(
     hass: HomeAssistant,
     generator: dict[str, Any],


### PR DESCRIPTION
## Proposed change

Add load shed binary sensors to the Rehlko integration.

Load shedding allows the generator to control equipment loads during operation, either reducing initial load or phasing loads over time to prevent surge.

The sensors use user-configured display names from the generator setup, reflecting the actual equipment being controlled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164258
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
