### PR TITLE
Migrate OAuth helper token request exception handling in Google Sheets

### DIFF
--- a/homeassistant/components/google_sheets/__init__.py
+++ b/homeassistant/components/google_sheets/__init__.py
@@ -7,7 +7,12 @@ import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
@@ -39,11 +44,9 @@ async def async_setup_entry(
     session = OAuth2Session(hass, entry, implementation)
     try:
         await session.async_ensure_token_valid()
-    except aiohttp.ClientResponseError as err:
-        if 400 <= err.status < 500:
-            raise ConfigEntryAuthFailed(
-                "OAuth session is not valid, reauth required"
-            ) from err
+    except OAuth2TokenRequestReauthError as err:
+        raise ConfigEntryAuthFailed("OAuth session is not valid, reauth required") from err
+    except OAuth2TokenRequestError as err:
         raise ConfigEntryNotReady from err
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/google_sheets/__init__.py
+++ b/homeassistant/components/google_sheets/__init__.py
@@ -45,7 +45,9 @@ async def async_setup_entry(
     try:
         await session.async_ensure_token_valid()
     except OAuth2TokenRequestReauthError as err:
-        raise ConfigEntryAuthFailed("OAuth session is not valid, reauth required") from err
+        raise ConfigEntryAuthFailed(
+            "OAuth session is not valid, reauth required"
+        ) from err
     except OAuth2TokenRequestError as err:
         raise ConfigEntryNotReady from err
     except aiohttp.ClientError as err:

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -4,7 +4,7 @@ from collections.abc import Awaitable, Callable, Coroutine
 import http
 import time
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
 from gspread.exceptions import APIError
@@ -17,6 +17,7 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
+from homeassistant.components.google_sheets import async_setup_entry
 from homeassistant.components.google_sheets.const import DOMAIN
 from homeassistant.components.google_sheets.services import (
     ADD_CREATED_COLUMN,
@@ -29,7 +30,14 @@ from homeassistant.components.google_sheets.services import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+    ServiceValidationError,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -197,6 +205,46 @@ async def test_expired_token_refresh_failure(
     # Verify a transient failure has occurred
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries[0].state is expected_state
+
+
+async def test_setup_oauth_reauth_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test a token refresh reauth error raises ConfigEntryAuthFailed."""
+    with (
+        patch(
+            "homeassistant.components.google_sheets.async_get_config_entry_implementation",
+            return_value=Mock(),
+        ),
+        patch(
+            "homeassistant.components.google_sheets.OAuth2Session.async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestReauthError(
+                domain=DOMAIN, request_info=Mock()
+            ),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+
+async def test_setup_oauth_transient_error(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test a token refresh transient error raises ConfigEntryNotReady."""
+    with (
+        patch(
+            "homeassistant.components.google_sheets.async_get_config_entry_implementation",
+            return_value=Mock(),
+        ),
+        patch(
+            "homeassistant.components.google_sheets.OAuth2Session.async_ensure_token_valid",
+            side_effect=OAuth2TokenRequestTransientError(
+                domain=DOMAIN, request_info=Mock()
+            ),
+        ),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -207,7 +207,7 @@ async def test_expired_token_refresh_failure(
 async def test_setup_oauth_reauth_error(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test a token refresh reauth error sets the config entry in setup error."""
+    """Test a token refresh reauth error puts the config entry in setup error state."""
     config_entry.add_to_hass(hass)
 
     assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})

--- a/tests/components/google_sheets/test_init.py
+++ b/tests/components/google_sheets/test_init.py
@@ -17,7 +17,6 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.components.google_sheets import async_setup_entry
 from homeassistant.components.google_sheets.const import DOMAIN
 from homeassistant.components.google_sheets.services import (
     ADD_CREATED_COLUMN,
@@ -31,8 +30,6 @@ from homeassistant.components.google_sheets.services import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
-    ConfigEntryNotReady,
     HomeAssistantError,
     OAuth2TokenRequestReauthError,
     OAuth2TokenRequestTransientError,
@@ -210,41 +207,59 @@ async def test_expired_token_refresh_failure(
 async def test_setup_oauth_reauth_error(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test a token refresh reauth error raises ConfigEntryAuthFailed."""
+    """Test a token refresh reauth error sets the config entry in setup error."""
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential("client-id", "client-secret"),
+        DOMAIN,
+    )
+
     with (
-        patch(
-            "homeassistant.components.google_sheets.async_get_config_entry_implementation",
-            return_value=Mock(),
-        ),
+        patch.object(config_entry, "async_start_reauth") as mock_async_start_reauth,
         patch(
             "homeassistant.components.google_sheets.OAuth2Session.async_ensure_token_valid",
             side_effect=OAuth2TokenRequestReauthError(
                 domain=DOMAIN, request_info=Mock()
             ),
         ),
-        pytest.raises(ConfigEntryAuthFailed),
     ):
-        await async_setup_entry(hass, config_entry)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_async_start_reauth.assert_called_once_with(hass)
 
 
 async def test_setup_oauth_transient_error(
     hass: HomeAssistant, config_entry: MockConfigEntry
 ) -> None:
-    """Test a token refresh transient error raises ConfigEntryNotReady."""
-    with (
-        patch(
-            "homeassistant.components.google_sheets.async_get_config_entry_implementation",
-            return_value=Mock(),
+    """Test a token refresh transient error sets the config entry to retry setup."""
+    config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential("client-id", "client-secret"),
+        DOMAIN,
+    )
+
+    with patch(
+        "homeassistant.components.google_sheets.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestTransientError(
+            domain=DOMAIN, request_info=Mock()
         ),
-        patch(
-            "homeassistant.components.google_sheets.OAuth2Session.async_ensure_token_valid",
-            side_effect=OAuth2TokenRequestTransientError(
-                domain=DOMAIN, request_info=Mock()
-            ),
-        ),
-        pytest.raises(ConfigEntryNotReady),
     ):
-        await async_setup_entry(hass, config_entry)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update `google_sheets` setup to handle the new OAuth helper exceptions raised by `OAuth2Session.async_ensure_token_valid()` in Core 2026.3:

- Catch `OAuth2TokenRequestReauthError` and raise `ConfigEntryAuthFailed`.
- Catch `OAuth2TokenRequestError` and raise `ConfigEntryNotReady`.

Also add tests to verify setup behavior for reauth and transient OAuth token refresh failures.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163461
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


