### PR TITLE
Skip unmapped and watchdog event types in Hikvision NVR event injection

### DIFF
--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -117,7 +117,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
                 # Map raw event type names to friendly names using SENSOR_MAP
                 mapped_events: dict[str, list[int]] = {}
                 for event_type, channels in nvr_events.items():
-                    friendly_name = SENSOR_MAP.get(event_type.lower(), event_type)
+                    event_key = event_type.lower()
+                    # Skip videoloss - used as watchdog by pyhik, not a real sensor
+                    if event_key == "videoloss":
+                        continue
+                    friendly_name = SENSOR_MAP.get(event_key)
+                    if friendly_name is None:
+                        _LOGGER.debug("Skipping unmapped event type: %s", event_type)
+                        continue
                     if friendly_name in mapped_events:
                         mapped_events[friendly_name].extend(channels)
                     else:

--- a/homeassistant/components/hikvision/__init__.py
+++ b/homeassistant/components/hikvision/__init__.py
@@ -130,7 +130,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: HikvisionConfigEntry) ->
                     else:
                         mapped_events[friendly_name] = list(channels)
                 _LOGGER.debug("Mapped NVR events: %s", mapped_events)
-                camera.inject_events(mapped_events)
+                if mapped_events:
+                    camera.inject_events(mapped_events)
             else:
                 _LOGGER.debug(
                     "No event triggers returned from %s. "

--- a/tests/components/hikvision/conftest.py
+++ b/tests/components/hikvision/conftest.py
@@ -141,5 +141,5 @@ def mock_hik_nvr(mock_hikcamera: MagicMock) -> MagicMock:
     camera = mock_hikcamera.return_value
     camera.get_type = "NVR"
     camera.current_event_states = {}
-    camera.get_event_triggers.return_value = {"Motion": [1, 2]}
+    camera.get_event_triggers.return_value = {"VMD": [1, 2]}
     return mock_hikcamera

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -121,9 +121,7 @@ async def test_setup_entry_nvr_skips_videoloss(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    mock_hik_nvr.return_value.inject_events.assert_called_once_with(
-        {"Motion": [1, 2]}
-    )
+    mock_hik_nvr.return_value.inject_events.assert_called_once_with({"Motion": [1, 2]})
 
 
 async def test_setup_entry_nvr_skips_unmapped_events(
@@ -142,9 +140,7 @@ async def test_setup_entry_nvr_skips_unmapped_events(
         await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    mock_hik_nvr.return_value.inject_events.assert_called_once_with(
-        {"Motion": [1]}
-    )
+    mock_hik_nvr.return_value.inject_events.assert_called_once_with({"Motion": [1]})
     assert "Skipping unmapped event type: audioexception" in caplog.text
 
 

--- a/tests/components/hikvision/test_init.py
+++ b/tests/components/hikvision/test_init.py
@@ -1,5 +1,6 @@
 """Test Hikvision integration setup and unload."""
 
+import logging
 from unittest.mock import MagicMock
 from xml.etree.ElementTree import ParseError
 
@@ -104,6 +105,64 @@ async def test_setup_entry_nvr_fetches_events(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     mock_hik_nvr.return_value.get_event_triggers.assert_called_once()
     mock_hik_nvr.return_value.inject_events.assert_called_once()
+
+
+async def test_setup_entry_nvr_skips_videoloss(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hik_nvr: MagicMock,
+) -> None:
+    """Test NVR event injection skips videoloss (watchdog event)."""
+    mock_hik_nvr.return_value.get_event_triggers.return_value = {
+        "VMD": [1, 2],
+        "videoloss": [1, 2, 3],
+    }
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_hik_nvr.return_value.inject_events.assert_called_once_with(
+        {"Motion": [1, 2]}
+    )
+
+
+async def test_setup_entry_nvr_skips_unmapped_events(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hik_nvr: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test NVR event injection skips events not in SENSOR_MAP."""
+    mock_hik_nvr.return_value.get_event_triggers.return_value = {
+        "VMD": [1],
+        "audioexception": [1, 2],
+    }
+
+    with caplog.at_level(logging.DEBUG):
+        await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_hik_nvr.return_value.inject_events.assert_called_once_with(
+        {"Motion": [1]}
+    )
+    assert "Skipping unmapped event type: audioexception" in caplog.text
+
+
+async def test_setup_entry_nvr_skips_all_unknown_events(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hik_nvr: MagicMock,
+) -> None:
+    """Test NVR event injection with only unknown events does not inject."""
+    mock_hik_nvr.return_value.get_event_triggers.return_value = {
+        "videoloss": [1],
+        "audioexception": [2],
+    }
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_hik_nvr.return_value.inject_events.assert_not_called()
 
 
 async def test_setup_entry_nvr_event_fetch_request_error(


### PR DESCRIPTION
## Proposed change

Filter the NVR event injection loop to skip two event types that were creating unknown sensor entities:

- `videoloss`: pyhik's `initialize()` intentionally skips this event type (used as a watchdog, not a real sensor), but the NVR injection path was not filtering it out, causing "Video Loss" entities
- `audioexception`: not present in pyhik's `SENSOR_MAP`, so it passed through as the raw string instead of being mapped to a friendly name

Now we skip `videoloss` (matching pyhik behavior) and skip any event types that don't have a mapping in `SENSOR_MAP`, logging them at debug level for troubleshooting.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #164901
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
