### PR TITLE
Snapcast: Fix incorrect identifier extraction in `async_join_players`

### DIFF
--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -290,17 +290,23 @@ class SnapcastClientDevice(SnapcastCoordinatorEntity, MediaPlayerEntity):
             and entity.unique_id != self.unique_id
         ]
 
+        # Get unique ID prefix for this host
+        unique_id_prefix = self.get_unique_id(self.coordinator.host_id, "")
         for client in clients:
-            # Valid entity is a snapcast client
+            # Validate entity is a snapcast client
             if not client.unique_id.startswith(CLIENT_PREFIX):
                 raise ServiceValidationError(
                     f"Entity '{client.entity_id}' is not a Snapcast client device."
                 )
 
+            # Validate client belongs to the same server
+            if not client.unique_id.startswith(unique_id_prefix):
+                raise ServiceValidationError(
+                    f"Entity '{client.entity_id}' does not belong to the same Snapcast server."
+                )
+
             # Extract client ID and join it to the current group
-            identifier = client.unique_id.removeprefix(
-                self.get_unique_id(self.coordinator.host_id, "")
-            )
+            identifier = client.unique_id.removeprefix(unique_id_prefix)
             try:
                 await self._current_group.add_client(identifier)
             except KeyError as e:

--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -303,10 +303,10 @@ class SnapcastClientDevice(SnapcastCoordinatorEntity, MediaPlayerEntity):
             )
             try:
                 await self._current_group.add_client(identifier)
-            except KeyError:
+            except KeyError as e:
                 raise ServiceValidationError(
                     f"Client with identifier '{identifier}' does not exist on the server."
-                ) from None
+                ) from e
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/snapcast/media_player.py
+++ b/homeassistant/components/snapcast/media_player.py
@@ -298,8 +298,15 @@ class SnapcastClientDevice(SnapcastCoordinatorEntity, MediaPlayerEntity):
                 )
 
             # Extract client ID and join it to the current group
-            identifier = client.unique_id.split("_")[-1]
-            await self._current_group.add_client(identifier)
+            identifier = client.unique_id.removeprefix(
+                self.get_unique_id(self.coordinator.host_id, "")
+            )
+            try:
+                await self._current_group.add_client(identifier)
+            except KeyError:
+                raise ServiceValidationError(
+                    f"Client with identifier '{identifier}' does not exist on the server."
+                ) from None
 
         self.async_write_ha_state()
 

--- a/tests/components/snapcast/test_media_player.py
+++ b/tests/components/snapcast/test_media_player.py
@@ -105,7 +105,7 @@ async def test_unjoin(
     mock_group_1.remove_client.assert_awaited_once_with(mock_client_1.identifier)
 
 
-async def test_join_exception(
+async def test_join_non_snapcast_client(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
@@ -127,7 +127,10 @@ async def test_join_exception(
         await setup_integration(hass, mock_config_entry)
         assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    with pytest.raises(ServiceValidationError):
+    with pytest.raises(
+        ServiceValidationError,
+        match=r"Entity .*? is not a Snapcast client device.",
+    ):
         await hass.services.async_call(
             MEDIA_PLAYER_DOMAIN,
             SERVICE_JOIN,
@@ -142,6 +145,48 @@ async def test_join_exception(
     mock_group_1.add_client.assert_not_awaited()
 
 
+async def test_join_different_server(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_create_server: AsyncMock,
+    mock_group_1: AsyncMock,
+) -> None:
+    """Test join service throws an exception when trying to join a Snapcast client from another server."""
+
+    # Create a dummy Snapcast client with a different unique_id prefix
+    entity_registry.async_get_or_create(
+        MEDIA_PLAYER_DOMAIN,
+        "snapcast",
+        "snapcast_client_server2_client2",
+    )
+    await hass.async_block_till_done()
+
+    # Setup and verify the integration is loaded
+    with patch("secrets.token_hex", return_value="mock_token"):
+        await setup_integration(hass, mock_config_entry)
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    with pytest.raises(
+        ServiceValidationError,
+        match=r"Entity .*? does not belong to the same Snapcast server.",
+    ):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_JOIN,
+            {
+                ATTR_ENTITY_ID: "media_player.test_client_1_snapcast_client",
+                ATTR_GROUP_MEMBERS: [
+                    "media_player.snapcast_snapcast_client_server2_client2"
+                ],
+            },
+            blocking=True,
+        )
+
+    # Ensure that the group did not attempt to add the client
+    mock_group_1.add_client.assert_not_awaited()
+
+
 async def test_join_client_key_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -152,7 +197,7 @@ async def test_join_client_key_error(
     """Test join service throws an exception when a key error is thrown."""
 
     # add_client will throw a KeyError if the client identifier is not found on the server
-    type(mock_group_1).add_client = AsyncMock(side_effect=KeyError())
+    mock_group_1.add_client = AsyncMock(side_effect=KeyError())
 
     # Setup and verify the integration is loaded
     with patch("secrets.token_hex", return_value="mock_token"):

--- a/tests/components/snapcast/test_media_player.py
+++ b/tests/components/snapcast/test_media_player.py
@@ -142,6 +142,67 @@ async def test_join_exception(
     mock_group_1.add_client.assert_not_awaited()
 
 
+async def test_join_client_key_error(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_create_server: AsyncMock,
+    mock_group_1: AsyncMock,
+) -> None:
+    """Test join service throws an exception when a key error is thrown."""
+
+    # add_client will throw a KeyError if the client identifier is not found on the server
+    type(mock_group_1).add_client = AsyncMock(side_effect=KeyError())
+
+    # Setup and verify the integration is loaded
+    with patch("secrets.token_hex", return_value="mock_token"):
+        await setup_integration(hass, mock_config_entry)
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_JOIN,
+            {
+                ATTR_ENTITY_ID: "media_player.test_client_1_snapcast_client",
+                ATTR_GROUP_MEMBERS: ["media_player.test_client_2_snapcast_client"],
+            },
+            blocking=True,
+        )
+
+    mock_group_1.add_client.assert_awaited_once()
+
+
+async def test_join_client_identifier_underscore(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_create_server: AsyncMock,
+    mock_group_1: AsyncMock,
+    mock_client_2: AsyncMock,
+) -> None:
+    """Test join service properly handles client identifiers with underscores."""
+
+    mock_client_2.identifier = "test_client_underscore"
+
+    # Setup and verify the integration is loaded
+    with patch("secrets.token_hex", return_value="mock_token"):
+        await setup_integration(hass, mock_config_entry)
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_JOIN,
+        {
+            ATTR_ENTITY_ID: "media_player.test_client_1_snapcast_client",
+            ATTR_GROUP_MEMBERS: ["media_player.test_client_2_snapcast_client"],
+        },
+        blocking=True,
+    )
+
+    mock_group_1.add_client.assert_awaited_once_with("test_client_underscore")
+
+
 async def test_stream_not_found(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix incorrect client identifier extraction in `async_join_players` when a client's unique ID has an underscore.

Snapcast client unique IDs are generated by prefixing the client's identifier. The identifier is typically a UUID or generated from a MAC address but users can change this with a command line option.

The current logic splits on underscores and takes the last item, so an identifier like 'client_something' will be split and the integration tries to add a nonexistent client 'something' which results in a KeyError.

This PR does 2 things.
1. Improve the identifier extraction by removing the exact generated unique ID prefix leaving only the original identifier.
2. Adds try/except block around `add_client` and raise a ServiceValidationError


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Here's the log when the service fails.
```
2026-03-06 18:04:53.185 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [139873682146944] Unexpected exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 279, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<7 lines>...
    )
    ^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2817, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2860, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 835, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
        hass, entity, func, data, call.context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 907, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/snapcast/media_player.py", line 302, in async_join_players
    await self._current_group.add_client(identifier)
  File "/usr/local/lib/python3.14/site-packages/snapcast/control/group.py", line 129, in add_client
    self._server.client(client_identifier).callback()
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/snapcast/control/server.py", line 279, in client
    return self._clients[client_identifier]
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'snapcast'

```

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
