### PR TITLE
Fix incompatible state class for intellifire timer_end_timestamp sensor

### DIFF
--- a/homeassistant/components/intellifire/sensor.py
+++ b/homeassistant/components/intellifire/sensor.py
@@ -97,7 +97,6 @@ INTELLIFIRE_SENSORS: tuple[IntellifireSensorEntityDescription, ...] = (
     IntellifireSensorEntityDescription(
         key="timer_end_timestamp",
         translation_key="timer_end_timestamp",
-        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=_time_remaining_to_timestamp,
     ),


### PR DESCRIPTION
Fixes #163326. The timer_end_timestamp sensor incorrectly had state_class set to MEASUREMENT, which is incompatible with device_class TIMESTAMP. Timestamp sensors should not have a state class.