### PR TITLE
Fix for #164973 & #165041 (Keep sensor data after restart)

### DIFF
--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -7,8 +7,8 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, Self, cast
 
-from homeassistant.const import ATTR_RESTORED, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant, State, callback, valid_entity_id
+from homeassistant.const import ATTR_RESTORED, EVENT_HOMEASSISTANT_FINAL_WRITE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback, valid_entity_id
 from homeassistant.exceptions import HomeAssistantError, UnsupportedStorageVersionError
 from homeassistant.util import dt as dt_util
 from homeassistant.util.hass_dict import HassKey
@@ -126,6 +126,7 @@ class RestoreStateData:
         )
         self.last_states: dict[str, StoredState] = {}
         self.entities: dict[str, RestoreEntity] = {}
+        self._cancel_interval_dump: CALLBACK_TYPE = lambda: None
 
     def set_load_empty(self) -> None:
         """Set the store to load empty and become read-only."""
@@ -134,6 +135,7 @@ class RestoreStateData:
     async def async_setup(self) -> None:
         """Set up up the instance of this data helper."""
         await self.async_load()
+        self.async_setup_final_write_dump()
 
         @callback
         def hass_start(hass: HomeAssistant) -> None:
@@ -222,7 +224,7 @@ class RestoreStateData:
 
     @callback
     def async_setup_dump(self, *args: Any) -> None:
-        """Set up the restore state listeners."""
+        """Set up the startup and periodic restore state dumps."""
 
         async def _async_dump_states(*_: Any) -> None:
             await self.async_dump_states()
@@ -241,14 +243,19 @@ class RestoreStateData:
             STATE_DUMP_INTERVAL,
             name="RestoreStateData dump states",
         )
+        self._cancel_interval_dump = cancel_interval
 
-        async def _async_dump_states_at_stop(*_: Any) -> None:
-            cancel_interval()
+    @callback
+    def async_setup_final_write_dump(self) -> None:
+        """Set up the shutdown restore state dump."""
+
+        async def _async_dump_states_at_final_write(*_: Any) -> None:
+            self._cancel_interval_dump()
             await self.async_dump_states()
 
-        # Dump states when stopping hass
         self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_dump_states_at_stop
+            EVENT_HOMEASSISTANT_FINAL_WRITE,
+            _async_dump_states_at_final_write,
         )
 
     @callback

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -253,6 +253,8 @@ class RestoreStateData:
             self._cancel_interval_dump()
             await self.async_dump_states()
 
+        # Final write runs after integrations remove entities, so last_states
+        # collected during shutdown are included in the persisted snapshot.
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_FINAL_WRITE,
             _async_dump_states_at_final_write,

--- a/tests/helpers/test_restore_state.py
+++ b/tests/helpers/test_restore_state.py
@@ -6,7 +6,11 @@ import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_FINAL_WRITE,
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import CoreState, HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
@@ -129,6 +133,14 @@ async def test_periodic_write(hass: HomeAssistant) -> None:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
 
+    assert not mock_write_data.called
+
+    with patch(
+        "homeassistant.helpers.restore_state.Store.async_save"
+    ) as mock_write_data:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+
     assert mock_write_data.called
 
     with patch(
@@ -194,6 +206,15 @@ async def test_save_persistent_states(hass: HomeAssistant) -> None:
     ) as mock_write_data:
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
+
+    assert not mock_write_data.called
+
+    with patch(
+        "homeassistant.helpers.restore_state.Store.async_save"
+    ) as mock_write_data:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+
     # Verify normal shutdown
     assert mock_write_data.called
 
@@ -251,6 +272,73 @@ async def test_hass_starting(hass: HomeAssistant) -> None:
 
     # Assert that this session states were written
     assert mock_write_data.called
+
+
+async def test_hass_final_write_before_start(hass: HomeAssistant) -> None:
+    """Test that we persist states if Home Assistant stops before start."""
+    hass.set_state(CoreState.not_running)
+
+    data = async_get(hass)
+    await hass.async_block_till_done()
+    await data.store.async_save([])
+
+    hass.data.pop(DATA_RESTORE_STATE)
+    await async_load(hass)
+
+    platform = MockEntityPlatform(hass, domain="input_boolean")
+    entity = RestoreEntity()
+    entity.hass = hass
+    entity.entity_id = "input_boolean.b1"
+    await platform.async_add_entities([entity])
+
+    hass.states.async_set(entity.entity_id, "on")
+
+    with patch(
+        "homeassistant.helpers.restore_state.Store.async_save"
+    ) as mock_write_data:
+        hass.set_state(CoreState.final_write)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+
+    assert mock_write_data.called
+    written_states = mock_write_data.mock_calls[0][1][0]
+    assert len(written_states) == 1
+    state = json_round_trip(written_states[0])
+    assert state["state"]["entity_id"] == entity.entity_id
+    assert state["state"]["state"] == "on"
+
+
+async def test_hass_final_write_after_entity_removed(hass: HomeAssistant) -> None:
+    """Test that final write persists states captured during entity removal."""
+    data = async_get(hass)
+    await hass.async_block_till_done()
+    await data.store.async_save([])
+
+    hass.data.pop(DATA_RESTORE_STATE)
+    await async_load(hass)
+
+    platform = MockEntityPlatform(hass, domain="input_boolean")
+    entity = RestoreEntity()
+    entity.hass = hass
+    entity.entity_id = "input_boolean.b1"
+    await platform.async_add_entities([entity])
+
+    hass.states.async_set(entity.entity_id, "on")
+    await entity.async_remove()
+
+    with patch(
+        "homeassistant.helpers.restore_state.Store.async_save"
+    ) as mock_write_data:
+        hass.set_state(CoreState.final_write)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+
+    assert mock_write_data.called
+    written_states = mock_write_data.mock_calls[0][1][0]
+    assert len(written_states) == 1
+    state = json_round_trip(written_states[0])
+    assert state["state"]["entity_id"] == entity.entity_id
+    assert state["state"]["state"] == "on"
 
 
 async def test_dump_data(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a restart persistence regression affecting RestoreEntity-based helpers such as integration sensors and utility_meter sensors.
The root cause was in the shared restore-state lifecycle. Restore-state snapshots were being persisted too early during shutdown, before all entities had finished removing and updating their final last_states. 
This change moves restore-state persistence to the final write phase and registers that shutdown persistence as soon as restore-state is initialized. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164973 & #165041
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
