### PR TITLE
Hive: Fix bug in config flow for authentication and device registration

### DIFF
--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 from apyhiveapi import Auth
@@ -25,8 +26,6 @@ from homeassistant.core import callback
 
 from . import HiveConfigEntry
 from .const import CONF_CODE, CONF_DEVICE_NAME, CONFIG_ENTRY_VERSION, DOMAIN
-
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,11 +70,12 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             except HiveApiError:
                 errors["base"] = "no_internet_available"
 
-            if (auth_result := self.tokens.get("AuthenticationResult")) and auth_result.get("NewDeviceMetadata"):
+            if (
+                auth_result := self.tokens.get("AuthenticationResult")
+            ) and auth_result.get("NewDeviceMetadata"):
                 _LOGGER.debug("Login successful, New device detected.")
                 self.device_registration = True
                 return await self.async_step_configuration()
-
 
             if self.tokens.get("ChallengeName") == "SMS_MFA":
                 _LOGGER.debug("Login successful, SMS 2FA required")
@@ -83,7 +83,9 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_2fa()
 
             if not errors:
-                _LOGGER.debug("Login successful, no new device detected, no 2FA required")
+                _LOGGER.debug(
+                    "Login successful, no new device detected, no 2FA required"
+                )
                 # Complete the entry.
                 try:
                     return await self.async_setup_hive_entry()
@@ -163,7 +165,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                 self._get_reauth_entry(),
                 title=self.data["username"],
                 data=self.data,
-                reason="reauth_successful", 
+                reason="reauth_successful",
             )
         return self.async_create_entry(title=self.data["username"], data=self.data)
 

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -71,7 +71,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_internet_available"
 
             if (
-                auth_result := self.tokens.get("AuthenticationResult")
+                auth_result := self.tokens.get("AuthenticationResult", {})
             ) and auth_result.get("NewDeviceMetadata"):
                 _LOGGER.debug("Login successful, New device detected")
                 self.device_registration = True

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -39,7 +39,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the config flow."""
         self.data: dict[str, Any] = {}
-        self.tokens: dict[str, str] = {}
+        self.tokens: dict[str, Any] = {}
         self.device_registration: bool = False
         self.device_name = "Home Assistant"
 
@@ -73,7 +73,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             if (
                 auth_result := self.tokens.get("AuthenticationResult")
             ) and auth_result.get("NewDeviceMetadata"):
-                _LOGGER.debug("Login successful, New device detected.")
+                _LOGGER.debug("Login successful, New device detected")
                 self.device_registration = True
                 return await self.async_step_configuration()
 

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -26,6 +26,10 @@ from homeassistant.core import callback
 from . import HiveConfigEntry
 from .const import CONF_CODE, CONF_DEVICE_NAME, CONFIG_ENTRY_VERSION, DOMAIN
 
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
 
 class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Hive config flow."""
@@ -67,11 +71,19 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             except HiveApiError:
                 errors["base"] = "no_internet_available"
 
+            if (auth_result := self.tokens.get("AuthenticationResult")) and auth_result.get("NewDeviceMetadata"):
+                _LOGGER.debug("Login successful, New device detected.")
+                self.device_registration = True
+                return await self.async_step_configuration()
+
+
             if self.tokens.get("ChallengeName") == "SMS_MFA":
+                _LOGGER.debug("Login successful, SMS 2FA required")
                 # Complete SMS 2FA.
                 return await self.async_step_2fa()
 
             if not errors:
+                _LOGGER.debug("Login successful, no new device detected, no 2FA required")
                 # Complete the entry.
                 try:
                     return await self.async_setup_hive_entry()
@@ -103,6 +115,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "no_internet_available"
 
             if not errors:
+                _LOGGER.debug("2FA successful")
                 if self.source == SOURCE_REAUTH:
                     return await self.async_setup_hive_entry()
                 self.device_registration = True
@@ -119,10 +132,11 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if user_input:
             if self.device_registration:
+                _LOGGER.debug("Attempting to register device")
                 self.device_name = user_input["device_name"]
                 await self.hive_auth.device_registration(user_input["device_name"])
                 self.data["device_data"] = await self.hive_auth.get_device_data()
-
+                _LOGGER.debug("Device registration successful")
             try:
                 return await self.async_setup_hive_entry()
             except UnknownHiveError:
@@ -142,13 +156,14 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             raise UnknownHiveError
 
         # Setup the config entry
+        _LOGGER.debug("Setting up Hive entry")
         self.data["tokens"] = self.tokens
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(
                 self._get_reauth_entry(),
                 title=self.data["username"],
                 data=self.data,
-                reason="reauth_successful",
+                reason="reauth_successful", 
             )
         return self.async_create_entry(title=self.data["username"], data=self.data)
 
@@ -160,6 +175,7 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
             CONF_USERNAME: entry_data[CONF_USERNAME],
             CONF_PASSWORD: entry_data[CONF_PASSWORD],
         }
+        _LOGGER.debug("Reauthenticating user")
         return await self.async_step_user(data)
 
     @staticmethod

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -74,6 +74,94 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
+async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
+    """Test user flow with no 2FA required and device registration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.hive.config_flow.Auth.login",
+        return_value={
+            "ChallengeName": "SUCCESS",
+            "AuthenticationResult": {
+                "RefreshToken": "mock-refresh-token",
+                "AccessToken": "mock-access-token",
+                "NewDeviceMetadata": {
+                    "DeviceGroupKey": "mock-device-group-key",
+                    "DeviceKey": "mock-device-key",
+                },
+            },
+        },
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+            },
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "configuration"
+    assert result2["errors"] == {}
+
+    with (
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.device_registration",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.hive.config_flow.Auth.get_device_data",
+            return_value=[
+                "mock-device-group-key",
+                "mock-device-key",
+                "mock-device-password",
+            ],
+        ),
+        patch(
+            "homeassistant.components.hive.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_DEVICE_NAME: DEVICE_NAME,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == USERNAME
+    assert result3["data"] == {
+        CONF_USERNAME: USERNAME,
+        CONF_PASSWORD: PASSWORD,
+        "tokens": {
+            "AuthenticationResult": {
+                "AccessToken": "mock-access-token",
+                "RefreshToken": "mock-refresh-token",
+                "NewDeviceMetadata": {
+                    "DeviceGroupKey": "mock-device-group-key",
+                    "DeviceKey": "mock-device-key",
+                },
+            },
+            "ChallengeName": "SUCCESS",
+        },
+        "device_data": [
+            "mock-device-group-key",
+            "mock-device-key",
+            "mock-device-password",
+        ],
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
 async def test_user_flow_2fa(hass: HomeAssistant) -> None:
     """Test user flow with 2FA."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
…egistration steps

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Fix issue where user logs in with registered device and doesnt require SMS step up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
