### PR TITLE
KNX: add config for `device_class` and `unit_of_measurement` for yaml number entities

### DIFF
--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -125,7 +125,11 @@ class KnxYamlNumber(_KnxNumber, KnxYamlEntity):
 
         self._attr_device_class = config.get(
             CONF_DEVICE_CLASS,
-            dpt_info["sensor_device_class"],
+            try_parse_enum(
+                # sensor device classes should, with some exceptions ("enum" etc.), align with number device classes
+                NumberDeviceClass,
+                dpt_info["sensor_device_class"],
+            ),
         )
         self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
         self._attr_mode = config[CONF_MODE]

--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -120,6 +120,15 @@ class KnxYamlNumber(_KnxNumber, KnxYamlEntity):
                 value_type=config[CONF_TYPE],
             ),
         )
+        dpt_string = self._device.sensor_value.dpt_class.dpt_number_str()
+        dpt_info = get_supported_dpts()[dpt_string]
+
+        self._attr_device_class = config.get(
+            CONF_DEVICE_CLASS,
+            dpt_info["sensor_device_class"],
+        )
+        self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
+        self._attr_mode = config[CONF_MODE]
         self._attr_native_max_value = config.get(
             NumberConf.MAX,
             self._device.sensor_value.dpt_class.value_max,
@@ -128,14 +137,16 @@ class KnxYamlNumber(_KnxNumber, KnxYamlEntity):
             NumberConf.MIN,
             self._device.sensor_value.dpt_class.value_min,
         )
-        self._attr_mode = config[CONF_MODE]
         self._attr_native_step = config.get(
             NumberConf.STEP,
             self._device.sensor_value.dpt_class.resolution,
         )
-        self._attr_entity_category = config.get(CONF_ENTITY_CATEGORY)
+        self._attr_native_unit_of_measurement = config.get(
+            CONF_UNIT_OF_MEASUREMENT,
+            dpt_info["unit"],
+        )
         self._attr_unique_id = str(self._device.sensor_value.group_address)
-        self._attr_native_unit_of_measurement = self._device.unit_of_measurement()
+
         self._device.sensor_value.value = max(0, self._attr_native_min_value)
 
 

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -20,7 +20,10 @@ from homeassistant.components.climate import FAN_OFF, HVACMode
 from homeassistant.components.cover import (
     DEVICE_CLASSES_SCHEMA as COVER_DEVICE_CLASSES_SCHEMA,
 )
-from homeassistant.components.number import NumberMode
+from homeassistant.components.number import (
+    DEVICE_CLASSES_SCHEMA as NUMBER_DEVICE_CLASSES_SCHEMA,
+    NumberMode,
+)
 from homeassistant.components.sensor import (
     CONF_STATE_CLASS as CONF_SENSOR_STATE_CLASS,
     DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,
@@ -39,6 +42,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PAYLOAD,
     CONF_TYPE,
+    CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
     Platform,
 )
@@ -787,6 +791,8 @@ class NumberSchema(KNXPlatformSchema):
                 vol.Optional(NumberConf.MAX): vol.Coerce(float),
                 vol.Optional(NumberConf.MIN): vol.Coerce(float),
                 vol.Optional(NumberConf.STEP): cv.positive_float,
+                vol.Optional(CONF_DEVICE_CLASS): NUMBER_DEVICE_CLASSES_SCHEMA,
+                vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
                 vol.Optional(CONF_ENTITY_CATEGORY): ENTITY_CATEGORIES_SCHEMA,
             }
         ),

--- a/tests/components/knx/test_dpt.py
+++ b/tests/components/knx/test_dpt.py
@@ -7,7 +7,10 @@ from homeassistant.components.knx.dpt import (
     _sensor_state_class_overrides,
     _sensor_unit_overrides,
 )
-from homeassistant.components.knx.schema import _sensor_attribute_sub_validator
+from homeassistant.components.knx.schema import (
+    _number_limit_sub_validator,
+    _sensor_attribute_sub_validator,
+)
 
 
 @pytest.mark.parametrize(
@@ -31,3 +34,9 @@ def test_dpt_default_device_classes(dpt: str) -> None:
         # UI validation works the same way, but uses different schema for config
         {"type": dpt}
     )
+    number_config = {"type": dpt}
+    if dpt.startswith("14"):
+        # DPT 14 has infinite range which isn't supported by HA
+        # this test shall still check for correct device_class and unit_of_measurement
+        number_config |= {"min": -500000, "max": 500000}
+    assert _number_limit_sub_validator(number_config)

--- a/tests/components/knx/test_number.py
+++ b/tests/components/knx/test_number.py
@@ -1,5 +1,6 @@
 """Test KNX number."""
 
+import logging
 from typing import Any
 
 import pytest
@@ -109,6 +110,44 @@ async def test_number_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) 
     await knx.receive_write(test_passive_address, (0x4E, 0xDE))
     state = hass.states.get("number.test")
     assert state.state == "9000.96"
+
+
+@pytest.mark.parametrize(
+    "attribute_config",
+    [
+        {"device_class": "energy"},  # invalid with uom of temperature DPT
+        {"device_class": "energy", "unit_of_measurement": "invalid"},
+        {"device_class": "invalid"},
+    ],
+)
+async def test_number_yaml_attribute_validation(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    knx: KNXTestKit,
+    attribute_config: dict[str, Any],
+) -> None:
+    """Test creating a number with invalid unit or device_class."""
+    with caplog.at_level(logging.ERROR):
+        await knx.setup_integration(
+            {
+                NumberSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    KNX_ADDRESS: "1/1/1",
+                    CONF_TYPE: "9.001",  # temperature 2 byte float
+                    **attribute_config,
+                }
+            }
+        )
+    assert len(caplog.messages) == 2
+    record = caplog.records[0]
+    assert record.levelname == "ERROR"
+    assert "Invalid config for 'knx': " in record.message
+
+    record = caplog.records[1]
+    assert record.levelname == "ERROR"
+    assert "Setup failed for 'knx': Invalid config." in record.message
+
+    assert hass.states.get("number.test") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add config for `device_class` and `unit_of_measurement` for yaml number entities to enable overriding DPTs defaults.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43978
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
