### PR TITLE
Move jvc_projector entities select domain

### DIFF
--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
@@ -118,7 +118,11 @@ async def async_migrate_entities(
             entry.unique_id,
             config_entry=config_entry,
             disabled_by=entry.disabled_by,
-            object_id_base=entry.object_id_base or split_entity_id(entry.entity_id)[1],
+            object_id_base=(
+                entry.object_id_base
+                or entry.translation_key
+                or entry.unique_id.rsplit("_", 1)[-1]
+            ),
             device_id=entry.device_id,
             entity_category=entry.entity_category,
             has_entity_name=entry.has_entity_name,

--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -115,7 +115,7 @@ async def async_migrate_entities(
             entry.unique_id,
             config_entry=config_entry,
             device_id=entry.device_id,
-            object_id_base=entry.object_id_base or entry.original_name,
+            object_id_base=entry.object_id_base,
             has_entity_name=entry.has_entity_name,
             disabled_by=entry.disabled_by,
         )

--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -101,10 +101,7 @@ async def async_migrate_entities(
         if (
             entry.platform != DOMAIN
             or entry.domain != Platform.SENSOR
-            or not any(
-                entry.unique_id.endswith(f"_{key}")
-                for key in ("hdr_processing", "picture_mode")
-            )
+            or entry.translation_key not in ("hdr_processing", "picture_mode")
         ):
             continue
 
@@ -117,17 +114,10 @@ async def async_migrate_entities(
             DOMAIN,
             entry.unique_id,
             config_entry=config_entry,
-            disabled_by=entry.disabled_by,
-            object_id_base=(
-                entry.object_id_base
-                or entry.translation_key
-                or entry.unique_id.rsplit("_", 1)[-1]
-            ),
             device_id=entry.device_id,
-            entity_category=entry.entity_category,
+            object_id_base=entry.object_id_base or entry.original_name,
             has_entity_name=entry.has_entity_name,
-            original_name=entry.original_name,
-            translation_key=entry.translation_key,
+            disabled_by=entry.disabled_by,
         )
 
         if entity_id is None:

--- a/homeassistant/components/jvc_projector/__init__.py
+++ b/homeassistant/components/jvc_projector/__init__.py
@@ -11,10 +11,12 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
 
+from .const import DOMAIN
 from .coordinator import JVCConfigEntry, JvcProjectorDataUpdateCoordinator
 
 PLATFORMS = [
@@ -77,13 +79,62 @@ async def async_migrate_entities(
     coordinator: JvcProjectorDataUpdateCoordinator,
 ) -> None:
     """Migrate old entities as needed."""
+    entity_registry = er.async_get(hass)
+
+    # Fix legacy unique_id of power binary_sensor entry. Can be removed ~2027.3+.
 
     @callback
     def _update_entry(entry: RegistryEntry) -> dict[str, str] | None:
-        """Fix unique_id of power binary_sensor entry."""
+        """Generate a new unique_id for power binary_sensor entry."""
         if entry.domain == Platform.BINARY_SENSOR and ":" not in entry.unique_id:
             if entry.unique_id.endswith("_power"):
                 return {"new_unique_id": f"{coordinator.unique_id}_power"}
         return None
 
     await async_migrate_entries(hass, config_entry.entry_id, _update_entry)
+
+    # Move legacy sensor entities that became selects. Can be removed ~2027.3+.
+
+    for entry in er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    ):
+        if (
+            entry.platform != DOMAIN
+            or entry.domain != Platform.SENSOR
+            or not any(
+                entry.unique_id.endswith(f"_{key}")
+                for key in ("hdr_processing", "picture_mode")
+            )
+        ):
+            continue
+
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SELECT, DOMAIN, entry.unique_id
+        )
+
+        new_entry = entity_registry.async_get_or_create(
+            Platform.SELECT,
+            DOMAIN,
+            entry.unique_id,
+            config_entry=config_entry,
+            disabled_by=entry.disabled_by,
+            object_id_base=entry.object_id_base or split_entity_id(entry.entity_id)[1],
+            device_id=entry.device_id,
+            entity_category=entry.entity_category,
+            has_entity_name=entry.has_entity_name,
+            original_name=entry.original_name,
+            translation_key=entry.translation_key,
+        )
+
+        if entity_id is None:
+            entity_registry.async_update_entity(
+                new_entry.entity_id,
+                area_id=entry.area_id,
+                categories=entry.categories,
+                hidden_by=entry.hidden_by,
+                icon=entry.icon,
+                labels=entry.labels,
+                name=entry.name,
+            )
+
+        entity_registry.async_remove(entry.entity_id)

--- a/homeassistant/components/jvc_projector/icons.json
+++ b/homeassistant/components/jvc_projector/icons.json
@@ -18,6 +18,9 @@
       "dynamic_control": {
         "default": "mdi:lightbulb-on-outline"
       },
+      "hdr_processing": {
+        "default": "mdi:image-filter-hdr-outline"
+      },
       "input": {
         "default": "mdi:hdmi-port"
       },
@@ -26,6 +29,9 @@
       },
       "light_power": {
         "default": "mdi:lightbulb-on-outline"
+      },
+      "picture_mode": {
+        "default": "mdi:movie-roll"
       }
     },
     "sensor": {
@@ -37,12 +43,6 @@
       },
       "hdr": {
         "default": "mdi:image-filter-hdr-outline"
-      },
-      "hdr_processing": {
-        "default": "mdi:image-filter-hdr-outline"
-      },
-      "picture_mode": {
-        "default": "mdi:movie-roll"
       },
       "power": {
         "default": "mdi:power",

--- a/homeassistant/components/jvc_projector/select.py
+++ b/homeassistant/components/jvc_projector/select.py
@@ -49,6 +49,16 @@ SELECTS: Final[tuple[JvcProjectorSelectDescription, ...]] = (
         command=cmd.Anamorphic,
         entity_registry_enabled_default=False,
     ),
+    JvcProjectorSelectDescription(
+        key="hdr_processing",
+        command=cmd.HdrProcessing,
+        entity_registry_enabled_default=False,
+    ),
+    JvcProjectorSelectDescription(
+        key="picture_mode",
+        command=cmd.PictureMode,
+        entity_registry_enabled_default=False,
+    ),
 )
 
 

--- a/homeassistant/components/jvc_projector/sensor.py
+++ b/homeassistant/components/jvc_projector/sensor.py
@@ -60,20 +60,6 @@ SENSORS: tuple[JvcProjectorSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
-    JvcProjectorSensorDescription(
-        key="hdr_processing",
-        command=cmd.HdrProcessing,
-        device_class=SensorDeviceClass.ENUM,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-    ),
-    JvcProjectorSensorDescription(
-        key="picture_mode",
-        command=cmd.PictureMode,
-        device_class=SensorDeviceClass.ENUM,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        entity_registry_enabled_default=False,
-    ),
 )
 
 

--- a/homeassistant/components/jvc_projector/strings.json
+++ b/homeassistant/components/jvc_projector/strings.json
@@ -71,6 +71,15 @@
           "off": "[%key:common::state::off%]"
         }
       },
+      "hdr_processing": {
+        "name": "HDR Processing",
+        "state": {
+          "frame-by-frame": "Frame-by-Frame",
+          "hdr10p": "HDR10+",
+          "scene-by-scene": "Scene-by-Scene",
+          "static": "Static"
+        }
+      },
       "input": {
         "name": "Input",
         "state": {
@@ -100,6 +109,23 @@
           "low": "[%key:common::state::low%]",
           "mid": "[%key:common::state::medium%]",
           "normal": "[%key:common::state::normal%]"
+        }
+      },
+      "picture_mode": {
+        "name": "Picture Mode",
+        "state": {
+          "frame-adapt-hdr": "Frame Adapt HDR",
+          "frame-adapt-hdr2": "Frame Adapt HDR2",
+          "frame-adapt-hdr3": "Frame Adapt HDR3",
+          "hdr1": "HDR1",
+          "hdr10": "HDR10",
+          "hdr10-ll": "HDR10 LL",
+          "hdr2": "HDR2",
+          "last-setting": "Last Setting",
+          "pana-pq": "Pana PQ",
+          "user-4": "User 4",
+          "user-5": "User 5",
+          "user-6": "User 6"
         }
       }
     },
@@ -134,34 +160,8 @@
           "smpte-st-2084": "SMPTE ST 2084"
         }
       },
-      "hdr_processing": {
-        "name": "HDR Processing",
-        "state": {
-          "frame-by-frame": "Frame-by-Frame",
-          "hdr10p": "HDR10+",
-          "scene-by-scene": "Scene-by-Scene",
-          "static": "Static"
-        }
-      },
       "light_time": {
         "name": "Light Time"
-      },
-      "picture_mode": {
-        "name": "Picture Mode",
-        "state": {
-          "frame-adapt-hdr": "Frame Adapt HDR",
-          "frame-adapt-hdr2": "Frame Adapt HDR2",
-          "frame-adapt-hdr3": "Frame Adapt HDR3",
-          "hdr1": "HDR1",
-          "hdr10": "HDR10",
-          "hdr10-ll": "HDR10 LL",
-          "hdr2": "HDR2",
-          "last-setting": "Last Setting",
-          "pana-pq": "Pana PQ",
-          "user-4": "User 4",
-          "user-5": "User 5",
-          "user-6": "User 6"
-        }
       },
       "power": {
         "name": "Status",

--- a/tests/components/jvc_projector/test_init.py
+++ b/tests/components/jvc_projector/test_init.py
@@ -105,6 +105,7 @@ async def test_migrate_legacy_sensor_entities_to_select(
         f"{mac}_hdr_processing",
         config_entry=mock_config_entry,
         disabled_by=None,
+        translation_key="hdr_processing",
     )
     entity_registry.async_get_or_create(
         Platform.SENSOR,
@@ -112,6 +113,7 @@ async def test_migrate_legacy_sensor_entities_to_select(
         f"{mac}_picture_mode",
         config_entry=mock_config_entry,
         disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+        translation_key="picture_mode",
     )
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/jvc_projector/test_init.py
+++ b/tests/components/jvc_projector/test_init.py
@@ -6,9 +6,9 @@ from jvcprojector import JvcProjectorAuthError, JvcProjectorTimeoutError
 
 from homeassistant.components.jvc_projector.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import format_mac
 
 from . import MOCK_MAC
@@ -87,3 +87,60 @@ async def test_config_entry_auth_error(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_migrate_legacy_sensor_entities_to_select(
+    hass: HomeAssistant,
+    mock_device: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test migration of legacy sensor entries that became selects."""
+    entity_registry = er.async_get(hass)
+    mac = format_mac(MOCK_MAC)
+    mock_config_entry.add_to_hass(hass)
+
+    legacy_hdr_entry = entity_registry.async_get_or_create(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{mac}_hdr_processing",
+        config_entry=mock_config_entry,
+        disabled_by=None,
+    )
+    entity_registry.async_get_or_create(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{mac}_picture_mode",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get(legacy_hdr_entry.entity_id) is None
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SENSOR, DOMAIN, f"{mac}_hdr_processing"
+        )
+        is None
+    )
+
+    migrated_hdr_entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, f"{mac}_hdr_processing"
+    )
+    assert migrated_hdr_entity_id is not None
+    migrated_hdr_entry = entity_registry.async_get(migrated_hdr_entity_id)
+    assert migrated_hdr_entry is not None
+    assert migrated_hdr_entry.disabled_by is None
+
+    migrated_picture_mode_entity_id = entity_registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, f"{mac}_picture_mode"
+    )
+    assert migrated_picture_mode_entity_id is not None
+    migrated_picture_mode_entry = entity_registry.async_get(
+        migrated_picture_mode_entity_id
+    )
+    assert migrated_picture_mode_entry is not None
+    assert (
+        migrated_picture_mode_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    )

--- a/tests/components/jvc_projector/test_sensor.py
+++ b/tests/components/jvc_projector/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for the JVC Projector binary sensor device."""
+"""Tests for JVC Projector sensor platform."""
 
 from datetime import timedelta
 from unittest.mock import MagicMock
@@ -12,7 +12,6 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 POWER_ID = "sensor.jvc_projector_status"
 HDR_ENTITY_ID = "sensor.jvc_projector_hdr"
-HDR_PROCESSING_ENTITY_ID = "sensor.jvc_projector_hdr_processing"
 
 
 async def test_entity_state(
@@ -34,7 +33,7 @@ async def test_enable_hdr_sensor(
     mock_device,
     mock_integration: MockConfigEntry,
 ) -> None:
-    """Test enabling the HDR select (disabled by default)."""
+    """Test enabling the HDR sensor (disabled by default)."""
 
     # Test entity is disabled initially
     entry = entity_registry.async_get(HDR_ENTITY_ID)
@@ -43,8 +42,6 @@ async def test_enable_hdr_sensor(
 
     # Enable entity
     entity_registry.async_update_entity(HDR_ENTITY_ID, disabled_by=None)
-    entity_registry.async_update_entity(HDR_PROCESSING_ENTITY_ID, disabled_by=None)
-
     # Add to hass
     await hass.config_entries.async_reload(mock_integration.entry_id)
     await hass.async_block_till_done()
@@ -65,4 +62,4 @@ async def test_enable_hdr_sensor(
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get(HDR_PROCESSING_ENTITY_ID) is not None
+    assert hass.states.get(HDR_ENTITY_ID) is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The entities `picture_mode` and `hdr_processing` introduced in 2026.3 have changed from sensor entities to select entities.

Why this changed:
  - These values are selectable modes/settings, so select is the correct entity type.
  - This gives the expected behavior in Home Assistant (clear options and mode selection support).

What this means for you:
  - The old entities `sensor.jvc_projector_picture_mode` and `sensor.jvc_projector_hdr_processing` are replaced by:
    - `select.jvc_projector_picture_mode`
    - `select.jvc_projector_hdr_processing`

If you use automations/scripts:
  - Update any references from the old `sensor.*` entity IDs to the new `select.*` IDs.
  - If you were checking state, keep using state checks but against the new `select.*` entities.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A new PictureMode and HdrProcessing sensor entity was added in 2026.3, but via a user report I just realized those should have have been select since they support updates 🤦‍♂️. This PR makes that move. By default these are disabled so its doubtful anyone was using them yet, but:

1. Adding a Breaking message to users.
2. Created a migration action in `__init__.py` to make the switch cleanly. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/43988
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
