### PR TITLE
Tesla Fleet: fix malformed energy live response handling

### DIFF
--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -176,7 +176,7 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
         self.update_interval = ENERGY_INTERVAL
 
         try:
-            raw_data = (await self.api.live_status())["response"]
+            data = (await self.api.live_status())["response"]
         except RateLimited as e:
             if isinstance(e.data, dict) and "after" in e.data:
                 LOGGER.warning(
@@ -193,15 +193,13 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
-        if not isinstance(raw_data, dict):
+        if not isinstance(data, dict):
             LOGGER.debug(
                 "%s got unexpected live status response type: %s",
                 self.name,
-                type(raw_data).__name__,
+                type(data).__name__,
             )
             return self.data
-
-        data = raw_data
 
         # Convert Wall Connectors from array to dict
         wall_connectors = data.get("wall_connectors")

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -176,7 +176,7 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
         self.update_interval = ENERGY_INTERVAL
 
         try:
-            data = (await self.api.live_status())["response"]
+            raw_data = (await self.api.live_status())["response"]
         except RateLimited as e:
             if isinstance(e.data, dict) and "after" in e.data:
                 LOGGER.warning(
@@ -193,9 +193,24 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
+        if not isinstance(raw_data, dict):
+            LOGGER.debug(
+                "%s got unexpected live status response type: %s",
+                self.name,
+                type(raw_data).__name__,
+            )
+            return self.data
+
+        data = raw_data
+
         # Convert Wall Connectors from array to dict
+        wall_connectors = data.get("wall_connectors")
+        if not isinstance(wall_connectors, list):
+            wall_connectors = []
         data["wall_connectors"] = {
-            wc["din"]: wc for wc in (data.get("wall_connectors") or [])
+            wc["din"]: wc
+            for wc in wall_connectors
+            if isinstance(wc, dict) and "din" in wc
         }
 
         self.updated_once = True

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -41,7 +41,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 
 from . import setup_platform
 from .conftest import create_config_entry
-from .const import VEHICLE_ASLEEP, VEHICLE_DATA_ALT
+from .const import LIVE_STATUS, VEHICLE_ASLEEP, VEHICLE_DATA_ALT
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -350,6 +350,23 @@ async def test_energy_live_refresh_error(
     mock_live_status.side_effect = side_effect
     await setup_platform(hass, normal_config_entry)
     assert normal_config_entry.state is state
+
+
+async def test_energy_live_refresh_bad_response(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_live_status: AsyncMock,
+) -> None:
+    """Test coordinator refresh with malformed live status payload."""
+    bad_live_status = deepcopy(LIVE_STATUS)
+    bad_live_status["response"] = "site data is unavailable"
+    mock_live_status.return_value = bad_live_status
+
+    await setup_platform(hass, normal_config_entry)
+
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state != "unavailable"
 
 
 # Test Energy Site Coordinator

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -360,6 +360,25 @@ async def test_energy_live_refresh_bad_response(
     """Test coordinator refresh with malformed live status payload."""
     bad_live_status = deepcopy(LIVE_STATUS)
     bad_live_status["response"] = "site data is unavailable"
+    mock_live_status.side_effect = None
+    mock_live_status.return_value = bad_live_status
+
+    await setup_platform(hass, normal_config_entry)
+
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state != "unavailable"
+
+
+async def test_energy_live_refresh_bad_wall_connectors(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_live_status: AsyncMock,
+) -> None:
+    """Test coordinator refresh with malformed wall connector payload."""
+    bad_live_status = deepcopy(LIVE_STATUS)
+    bad_live_status["response"]["wall_connectors"] = "site data is unavailable"
+    mock_live_status.side_effect = None
     mock_live_status.return_value = bad_live_status
 
     await setup_platform(hass, normal_config_entry)


### PR DESCRIPTION
## Proposed change
Handle malformed Tesla Fleet energy live payloads more defensively so the integration remains loaded when the API returns an unexpected `response` type. This change validates that live status `response` is a dictionary and ignores invalid `wall_connectors` entries instead of raising during coordinator refresh. A regression test covers a string `response` payload to verify setup still loads and entities do not become unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164996
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr