### PR TITLE
Fix bugs and code quality issues in Insteon integration

### DIFF
--- a/homeassistant/components/insteon/api/config.py
+++ b/homeassistant/components/insteon/api/config.py
@@ -104,7 +104,7 @@ def remove_x10_device(hass: HomeAssistant, housecode: str, unitcode: int):
     hass.config_entries.async_update_entry(entry=config_entry, options=new_options)
 
 
-def add_device_overide(hass: HomeAssistant, override: DeviceOverride):
+def add_device_override(hass: HomeAssistant, override: DeviceOverride):
     """Add an Insteon device override."""
 
     config_entry = get_insteon_config_entry(hass)
@@ -270,12 +270,13 @@ async def websocket_add_device_override(
     connection: websocket_api.connection.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Get the schema for the modem configuration."""
+    """Add a device override to the Insteon configuration."""
     override = msg[OVERRIDE]
     try:
-        add_device_overide(hass, override)
+        add_device_override(hass, override)
     except ValueError:
         connection.send_error(msg[ID], "duplicate", "Duplicate device address")
+        return
 
     connection.send_result(msg[ID])
 
@@ -293,7 +294,7 @@ async def websocket_remove_device_override(
     connection: websocket_api.connection.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Get the schema for the modem configuration."""
+    """Remove a device override from the Insteon configuration."""
     address = Address(msg[DEVICE_ADDRESS])
     remove_device_override(hass, address)
     async_dispatcher_send(hass, SIGNAL_REMOVE_DEVICE_OVERRIDE, address)

--- a/homeassistant/components/insteon/binary_sensor.py
+++ b/homeassistant/components/insteon/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Support for INSTEON dimmers via PowerLinc Modem."""
+"""Support for INSTEON binary sensors via PowerLinc Modem."""
 
 from pyinsteon.groups import (
     CO_SENSOR,

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -110,7 +110,9 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
-        return HVAC_MODES[self._insteon_device.groups[SYSTEM_MODE].value]
+        return HVAC_MODES.get(
+            self._insteon_device.groups[SYSTEM_MODE].value, HVACMode.OFF
+        )
 
     @property
     def current_temperature(self) -> float | None:
@@ -143,7 +145,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
-        return FAN_MODES[self._insteon_device.groups[FAN_MODE].value]
+        return FAN_MODES.get(self._insteon_device.groups[FAN_MODE].value)
 
     @property
     def target_humidity(self) -> int | None:
@@ -151,7 +153,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         high = self._insteon_device.groups[HUMIDITY_HIGH].value
         low = self._insteon_device.groups[HUMIDITY_LOW].value
         # May not be loaded yet so return a default if required
-        return (high + low) / 2 if high and low else None
+        return (high + low) / 2 if high is not None and low is not None else None
 
     @property
     def hvac_action(self) -> HVACAction:

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -153,7 +153,7 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         high = self._insteon_device.groups[HUMIDITY_HIGH].value
         low = self._insteon_device.groups[HUMIDITY_LOW].value
         # May not be loaded yet so return a default if required
-        return (high + low) / 2 if high is not None and low is not None else None
+        return int((high + low) / 2) if high is not None and low is not None else None
 
     @property
     def hvac_action(self) -> HVACAction:

--- a/homeassistant/components/insteon/const.py
+++ b/homeassistant/components/insteon/const.py
@@ -107,7 +107,6 @@ SIGNAL_REMOVE_DEVICE_OVERRIDE = "insteon_remove_device_override"
 SIGNAL_REMOVE_ENTITY = "insteon_remove_entity"
 SIGNAL_ADD_X10_DEVICE = "insteon_add_x10_device"
 SIGNAL_REMOVE_X10_DEVICE = "insteon_remove_x10_device"
-SIGNAL_ADD_DEFAULT_LINKS = "add_default_links"
 
 HOUSECODES = [
     "a",

--- a/homeassistant/components/insteon/cover.py
+++ b/homeassistant/components/insteon/cover.py
@@ -64,7 +64,7 @@ class InsteonCoverEntity(InsteonEntity, CoverEntity):
     @property
     def is_closed(self) -> bool:
         """Return the boolean response if the node is on."""
-        return bool(self.current_cover_position)
+        return not bool(self.current_cover_position)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""

--- a/homeassistant/components/insteon/cover.py
+++ b/homeassistant/components/insteon/cover.py
@@ -63,7 +63,7 @@ class InsteonCoverEntity(InsteonEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool:
-        """Return the boolean response if the node is on."""
+        """Return True if the cover is closed (position 0)."""
         return not bool(self.current_cover_position)
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/insteon/entity.py
+++ b/homeassistant/components/insteon/entity.py
@@ -34,7 +34,7 @@ class InsteonEntity(Entity):
     _attr_should_poll = False
 
     def __init__(self, device, group):
-        """Initialize the INSTEON binary sensor."""
+        """Initialize the INSTEON entity."""
         self._insteon_device_group = device.groups[group]
         self._insteon_device = device
 
@@ -124,10 +124,14 @@ class InsteonEntity(Entity):
             async_dispatcher_connect(self.hass, load_signal, self._async_read_aldb)
         )
         print_signal = f"{self.entity_id}_{SIGNAL_PRINT_ALDB}"
-        async_dispatcher_connect(self.hass, print_signal, self._print_aldb)
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, print_signal, self._print_aldb)
+        )
         default_links_signal = f"{self.entity_id}_{SIGNAL_ADD_DEFAULT_LINKS}"
-        async_dispatcher_connect(
-            self.hass, default_links_signal, self._async_add_default_links
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, default_links_signal, self._async_add_default_links
+            )
         )
         remove_signal = f"{self._insteon_device.address.id}_{SIGNAL_REMOVE_ENTITY}"
         self.async_on_remove(

--- a/homeassistant/components/insteon/light.py
+++ b/homeassistant/components/insteon/light.py
@@ -16,8 +16,6 @@ from .const import SIGNAL_ADD_ENTITIES
 from .entity import InsteonEntity
 from .utils import async_add_insteon_devices, async_add_insteon_entities
 
-MAX_BRIGHTNESS = 255
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -77,7 +75,7 @@ class InsteonDimmerEntity(InsteonEntity, LightEntity):
             brightness = int(kwargs[ATTR_BRIGHTNESS])
         elif self._insteon_device_group.group == 1:
             brightness = self.get_device_property(ON_LEVEL)
-        if brightness:
+        if brightness is not None:
             await self._insteon_device.async_on(
                 on_level=brightness, group=self._insteon_device_group.group
             )

--- a/homeassistant/components/insteon/switch.py
+++ b/homeassistant/components/insteon/switch.py
@@ -1,4 +1,4 @@
-"""Support for INSTEON dimmers via PowerLinc Modem."""
+"""Support for INSTEON switches via PowerLinc Modem."""
 
 from typing import Any
 


### PR DESCRIPTION
## Summary

- **[CRITICAL]** `cover.py`: Fix inverted `is_closed` logic — was returning `True` when the cover was open, inverting all cover state and automations
- **[HIGH]** `api/config.py`: Fix double WebSocket response on duplicate device override — `send_result` was always called even after `send_error`, crashing the connection
- **[HIGH]** `entity.py`: Fix dispatcher connection leaks — `print_signal` and `default_links_signal` were never unsubscribed on entity removal; wrapped with `async_on_remove`
- **[MEDIUM]** `light.py`: Fix `brightness=0` being silently discarded — `if brightness:` changed to `if brightness is not None:` so devices can be turned on at minimum level
- **[MEDIUM]** `climate.py`: Fix unsafe `HVAC_MODES[value]`/`FAN_MODES[value]` dict lookups that would crash on unexpected pyinsteon mode values; use `.get()` with safe defaults
- **[MEDIUM]** `climate.py`: Fix humidity `target_humidity` returning `None` when `high=0` or `low=0` (valid sensor readings)
- `const.py`: Remove duplicate `SIGNAL_ADD_DEFAULT_LINKS` constant
- `api/config.py`: Rename `add_device_overide` → `add_device_override` (typo); fix copy-pasted docstrings
- `light.py`: Remove unused `MAX_BRIGHTNESS = 255` constant
- `entity.py`: Fix wrong `__init__` docstring ("binary sensor" → "entity")
- `switch.py`, `binary_sensor.py`: Fix module docstrings (said "dimmers" for both)

## Test plan

- [x] All 79 existing Insteon tests pass (`pytest tests/components/insteon/ --timeout=10`)
- [x] Cover entity shows correct open/closed state in UI (closed at position 0)
- [x] Adding a duplicate device override via WebSocket returns only an error response (not error + success)
- [x] Entities removed and re-added do not accumulate duplicate dispatcher listeners