### PR TITLE
Prevent cloud account linking without My Home Assistant

### DIFF
--- a/homeassistant/components/cloud/account_link.py
+++ b/homeassistant/components/cloud/account_link.py
@@ -13,6 +13,7 @@ from hass_nabucasa import account_link
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_entry_oauth2_flow, event
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DATA_CLOUD, DOMAIN
 
@@ -38,6 +39,24 @@ async def async_provide_implementation(
     hass: HomeAssistant, domain: str
 ) -> list[config_entry_oauth2_flow.AbstractOAuth2Implementation]:
     """Provide an implementation for a domain."""
+    # Cloud account linking requires My Home Assistant for the OAuth callback
+    # redirect. Without it, the callback from account-link.nabucasa.com fails.
+    if "my" not in hass.config.components:
+        _LOGGER.warning(
+            "Cloud account linking unavailable for %s: "
+            "My Home Assistant is not configured",
+            domain,
+        )
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "my_not_configured_account_link",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="my_not_configured_account_link",
+        )
+        return []
+
     services = await _get_services(hass)
 
     for service in services:

--- a/homeassistant/components/cloud/strings.json
+++ b/homeassistant/components/cloud/strings.json
@@ -42,6 +42,10 @@
       },
       "title": "A deprecated voice was used"
     },
+    "my_not_configured_account_link": {
+      "description": "Cloud account linking is unavailable because [My Home Assistant](https://my.home-assistant.io) is not configured. The OAuth callback from Home Assistant Cloud requires My Home Assistant to redirect back to your local instance. To fix this, set up My Home Assistant or use application credentials instead.",
+      "title": "Cloud account linking unavailable"
+    },
     "legacy_subscription": {
       "fix_flow": {
         "abort": {

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -13,7 +13,7 @@ from homeassistant.components.cloud import account_link
 from homeassistant.components.cloud.const import DATA_CLOUD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import config_entry_oauth2_flow
+from homeassistant.helpers import config_entry_oauth2_flow, issue_registry as ir
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed, mock_platform
@@ -43,6 +43,32 @@ def flow_handler(
         yield TestFlowHandler
 
 
+async def test_provide_implementation_without_my(hass: HomeAssistant) -> None:
+    """Test that cloud implementation is not provided without My Home Assistant."""
+    account_link.async_setup(hass)
+
+    # Ensure "my" is not loaded
+    assert "my" not in hass.config.components
+
+    with patch(
+        "homeassistant.components.cloud.account_link._get_services",
+        return_value=[
+            {"service": "test", "min_version": "0.1.0"},
+        ],
+    ):
+        implementations = await config_entry_oauth2_flow.async_get_implementations(
+            hass, "test"
+        )
+
+    assert "cloud" not in implementations
+
+    # Verify a repair issue was created
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue("cloud", "my_not_configured_account_link")
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+
+
 async def test_setup_provide_implementation(hass: HomeAssistant) -> None:
     """Test that we provide implementations."""
     legacy_entry = MockConfigEntry(
@@ -57,6 +83,7 @@ async def test_setup_provide_implementation(hass: HomeAssistant) -> None:
     )
     none_cloud_entry.add_to_hass(hass)
     legacy_entry.add_to_hass(hass)
+    hass.config.components.add("my")
     account_link.async_setup(hass)
 
     with (


### PR DESCRIPTION
## Summary

- Skip `CloudOAuth2Implementation` when the `my` component is not loaded, preventing broken OAuth flows via `account-link.nabucasa.com`
- Log a warning when cloud account linking is unavailable due to missing My Home Assistant
- Create a repair issue to guide users toward configuring My Home Assistant or using application credentials

## Background

When Home Assistant Cloud is active and an OAuth integration (like Miele) is set up, the OAuth flow is routed through `account-link.nabucasa.com`. This callback path requires My Home Assistant to handle the redirect back to the local instance. Without it, the callback fails with a 503 error and users get no helpful feedback.

Related issue: #163132

## Test plan

- [x] `pytest tests/components/cloud/test_account_link.py` — all 5 tests pass
- [x] New test `test_provide_implementation_without_my` verifies:
  - No cloud implementation is offered when `my` is not loaded
  - A repair issue with severity WARNING is created
- [x] Existing tests updated to load `my` component where cloud implementations are expected
- [x] `pylint` and `mypy` pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)