### PR TITLE
Add entity_id to LLM exposed entities and tool parameters

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -681,6 +681,7 @@ def _get_exposed_entities(
                     area_names.extend(area.aliases)
 
         info: dict[str, Any] = {
+            "entity_id": state.entity_id,
             "names": ", ".join(names),
             "domain": state.domain,
         }

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -597,15 +597,17 @@ class AssistAPI(API):
         if exposed_entities:
             if exposed_entities[CALENDAR_DOMAIN]:
                 names = []
-                for info in exposed_entities[CALENDAR_DOMAIN].values():
+                for entity_id, info in exposed_entities[CALENDAR_DOMAIN].items():
+                    names.append(entity_id)
                     names.extend(info["names"].split(", "))
                 tools.append(CalendarGetEventsTool(names))
 
             if exposed_domains is not None and TODO_DOMAIN in exposed_domains:
                 names = []
-                for info in exposed_entities["entities"].values():
+                for entity_id, info in exposed_entities["entities"].items():
                     if info["domain"] != TODO_DOMAIN:
                         continue
+                    names.append(entity_id)
                     names.extend(info["names"].split(", "))
                 tools.append(TodoGetItemsTool(names))
 

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -583,84 +583,106 @@ async def test_assist_api_prompt(
         )
     )
     exposed_entities_prompt = """Live Context: An overview of the areas and the devices in this smart home:
-- names: '1'
+- entity_id: light.1
+  names: '1'
   domain: light
   state: unavailable
   areas: Test Area 2
-- names: Kitchen
+- entity_id: light.kitchen
+  names: Kitchen
   domain: light
   state: 'on'
   attributes:
     temperature: '0.9'
     humidity: '65'
-- names: Living Room
+- entity_id: light.living_room
+  names: Living Room
   domain: light
   state: 'on'
   areas: Test Area, Alternative name
-- names: Test Device, my test light
+- entity_id: light.test_device
+  names: Test Device, my test light
   domain: light
   state: unavailable
   areas: Test Area, Alternative name
-- names: Test Device 2
+- entity_id: light.test_device_2
+  names: Test Device 2
   domain: light
   state: unavailable
   areas: Test Area 2
-- names: Test Device 3
+- entity_id: light.test_device_3
+  names: Test Device 3
   domain: light
   state: unavailable
   areas: Test Area 2
-- names: Test Device 4
+- entity_id: light.test_device_4
+  names: Test Device 4
   domain: light
   state: unavailable
   areas: Test Area 2
-- names: Test Service
+- entity_id: light.test_service
+  names: Test Service
   domain: light
   state: unavailable
   areas: Test Area, Alternative name
-- names: Test Service
+- entity_id: light.test_service_2
+  names: Test Service
   domain: light
   state: unavailable
   areas: Test Area, Alternative name
-- names: Test Service
+- entity_id: light.test_service_3
+  names: Test Service
   domain: light
   state: unavailable
   areas: Test Area, Alternative name
-- names: Unnamed Device
+- entity_id: light.unnamed_device
+  names: Unnamed Device
   domain: light
   state: unavailable
   areas: Test Area 2
 """
     stateless_exposed_entities_prompt = """Static Context: An overview of the areas and the devices in this smart home:
-- names: '1'
+- entity_id: light.1
+  names: '1'
   domain: light
   areas: Test Area 2
-- names: Kitchen
+- entity_id: light.kitchen
+  names: Kitchen
   domain: light
-- names: Living Room
+- entity_id: light.living_room
+  names: Living Room
   domain: light
   areas: Test Area, Alternative name
-- names: Test Device, my test light
+- entity_id: light.test_device
+  names: Test Device, my test light
   domain: light
   areas: Test Area, Alternative name
-- names: Test Device 2
+- entity_id: light.test_device_2
+  names: Test Device 2
   domain: light
   areas: Test Area 2
-- names: Test Device 3
+- entity_id: light.test_device_3
+  names: Test Device 3
   domain: light
   areas: Test Area 2
-- names: Test Device 4
+- entity_id: light.test_device_4
+  names: Test Device 4
   domain: light
   areas: Test Area 2
-- names: Test Service
+- entity_id: light.test_service
+  names: Test Service
   domain: light
   areas: Test Area, Alternative name
-- names: Test Service
+- entity_id: light.test_service_2
+  names: Test Service
   domain: light
   areas: Test Area, Alternative name
-- names: Test Service
+- entity_id: light.test_service_3
+  names: Test Service
   domain: light
   areas: Test Area, Alternative name
-- names: Unnamed Device
+- entity_id: light.unnamed_device
+  names: Unnamed Device
   domain: light
   areas: Test Area 2
 """

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1312,7 +1312,10 @@ async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
         (tool for tool in api.tools if tool.name == "calendar_get_events"), None
     )
     assert tool is not None
-    assert tool.parameters.schema["calendar"].container == ["Mock Calendar Name"]
+    assert tool.parameters.schema["calendar"].container == [
+        "calendar.test_calendar",
+        "Mock Calendar Name",
+    ]
 
     calls = async_mock_service(
         hass,
@@ -1392,6 +1395,25 @@ async def test_calendar_get_events_tool(hass: HomeAssistant) -> None:
         "end_date_time": dt_util.start_of_local_day() + timedelta(days=7),
     }
 
+    # Test using entity_id instead of name
+    tool_input = llm.ToolInput(
+        tool_name="calendar_get_events",
+        tool_args={
+            "calendar": "calendar.test_calendar",
+            "range": "today",
+        },
+    )
+    with patch("homeassistant.util.dt.now", return_value=now):
+        response = await api.async_call_tool(tool_input)
+
+    assert len(calls) == 3
+    assert calls[2].data == {
+        "entity_id": ["calendar.test_calendar"],
+        "start_date_time": now,
+        "end_date_time": dt_util.start_of_local_day() + timedelta(days=1),
+    }
+    assert response["success"] is True
+
 
 async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     """Test the todo get items tool."""
@@ -1412,7 +1434,10 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
     api = await llm.async_get_api(hass, "assist", llm_context)
     tool = next((tool for tool in api.tools if tool.name == "todo_get_items"), None)
     assert tool is not None
-    assert tool.parameters.schema["todo_list"].container == ["Mock Todo List Name"]
+    assert tool.parameters.schema["todo_list"].container == [
+        "todo.test_list",
+        "Mock Todo List Name",
+    ]
 
     calls = async_mock_service(
         hass,
@@ -1502,6 +1527,20 @@ async def test_todo_get_items_tool(hass: HomeAssistant) -> None:
         "entity_id": ["todo.test_list"],
         "status": ["needs_action", "completed"],
     }
+
+    # Test using entity_id instead of name
+    calls.clear()
+    result = await tool.async_call(
+        hass,
+        llm.ToolInput("todo_get_items", {"todo_list": "todo.test_list"}),
+        llm_context,
+    )
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": ["todo.test_list"],
+        "status": ["needs_action"],
+    }
+    assert result["success"] is True
 
 
 async def test_get_date_time_tool(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

This change enhances the LLM helper to include `entity_id` in the exposed entities context and tool parameters. Previously, only friendly names were provided to LLM tools, which could be ambiguous when multiple entities share the same name. Now both `entity_id` and friendly names are included, allowing LLM tools to accept either format.

The changes include:
1. Adding `entity_id` field to the exposed entities YAML context sent to LLMs
2. Including `entity_id` in the tool parameter containers for calendar and todo tools
3. Updating tool implementations to accept both `entity_id` and friendly names as input

This improves the reliability and flexibility of LLM tool calls by providing unambiguous entity identification.

## Type of change

- [x] New feature (which adds functionality to an existing integration)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This change is backward compatible - tools still accept friendly names as before
- Updated test expectations to reflect the new entity_id field in exposed entities
- Added test cases verifying that tools work with entity_id input

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

https://claude.ai/code/session_011Emj2coCYBA2KNiGwxeu8E