### PR TITLE
Add reconfiguration flow to Indevolt integration

### DIFF
--- a/homeassistant/components/indevolt/config_flow.py
+++ b/homeassistant/components/indevolt/config_flow.py
@@ -51,6 +51,38 @@ class IndevoltConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the Indevolt device host."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        # Attempt to setup from user input
+        if user_input is not None:
+            errors, device_data = await self._async_validate_input(user_input)
+
+            if not errors and device_data:
+                await self.async_set_unique_id(device_data[CONF_SERIAL_NUMBER])
+                self._abort_if_unique_id_mismatch(reason="different_device")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates={
+                        CONF_HOST: user_input[CONF_HOST],
+                        **device_data,
+                    },
+                )
+
+        # Retrieve user input (prefilled form)
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_HOST): str}),
+                reconfigure_entry.data,
+            ),
+            errors=errors,
+        )
+
     async def _async_validate_input(
         self, user_input: dict[str, Any]
     ) -> tuple[dict[str, str], dict[str, Any] | None]:

--- a/homeassistant/components/indevolt/quality_scale.yaml
+++ b/homeassistant/components/indevolt/quality_scale.yaml
@@ -77,8 +77,7 @@ rules:
     status: todo
   icon-translations:
     status: todo
-  reconfiguration-flow:
-    status: todo
+  reconfiguration-flow: done
   repair-issues:
     status: exempt
     comment: No repair issues needed for current functionality

--- a/homeassistant/components/indevolt/strings.json
+++ b/homeassistant/components/indevolt/strings.json
@@ -2,7 +2,9 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "Failed to connect (aborted)"
+      "cannot_connect": "Failed to connect (aborted)",
+      "different_device": "The device at the new host has a different serial number. Please ensure the new host is the same device.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -10,6 +12,16 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::indevolt::config::step::user::data_description::host%]"
+        },
+        "description": "Update the connection details for your Indevolt device.",
+        "title": "Reconfigure Indevolt device"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/tests/components/indevolt/test_config_flow.py
+++ b/tests/components/indevolt/test_config_flow.py
@@ -123,6 +123,7 @@ async def test_reconfigure_flow_success(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_indevolt: AsyncMock,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test successful reconfiguration flow."""
     mock_config_entry.add_to_hass(hass)
@@ -143,9 +144,14 @@ async def test_reconfigure_flow_success(
         result["flow_id"], {CONF_HOST: new_host}
     )
 
-    # Verify entry is updated and flow is aborted
+    # Verify flow is aborted
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+
+    # Flush pending tasks
+    await hass.async_block_till_done()
+
+    # Verify entry is updated
     assert mock_config_entry.data[CONF_HOST] == new_host
     assert mock_config_entry.data[CONF_SERIAL_NUMBER] == TEST_DEVICE_SN_GEN2
 
@@ -163,6 +169,7 @@ async def test_reconfigure_flow_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_indevolt: AsyncMock,
+    mock_setup_entry: AsyncMock,
     exception: Exception,
     expected_error: str,
 ) -> None:
@@ -195,11 +202,15 @@ async def test_reconfigure_flow_error(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
 
+    # Flush pending tasks
+    await hass.async_block_till_done()
+
 
 async def test_reconfigure_flow_different_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_indevolt: AsyncMock,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test reconfigure aborts when connecting to a different device."""
     mock_config_entry.add_to_hass(hass)
@@ -228,3 +239,6 @@ async def test_reconfigure_flow_different_device(
     # Verify flow is aborted with correct reason
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "different_device"
+
+    # Flush pending tasks
+    await hass.async_block_till_done()

--- a/tests/components/indevolt/test_config_flow.py
+++ b/tests/components/indevolt/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.components.indevolt.const import (
     CONF_SERIAL_NUMBER,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_RECONFIGURE, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_MODEL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -19,20 +19,30 @@ from .conftest import TEST_DEVICE_SN_GEN2, TEST_HOST
 
 from tests.common import MockConfigEntry
 
+# Used to mock host change
+TEST_HOST_NEW = "192.168.1.200"
+
 
 async def test_user_flow_success(
     hass: HomeAssistant, mock_indevolt: AsyncMock, mock_setup_entry: AsyncMock
 ) -> None:
     """Test successful user-initiated config flow."""
+
+    # Initiate user flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+
+    # Verify correct form is returned
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    # Test config entry creation (with success)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"host": TEST_HOST}
     )
+
+    # Verify entry is created with correct data
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "INDEVOLT CMS-SF2000"
     assert result["data"] == {
@@ -62,27 +72,28 @@ async def test_user_flow_error(
 ) -> None:
     """Test connection errors in user flow."""
 
+    # Initiate user flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
     # Configure mock to raise exception
     mock_indevolt.get_config.side_effect = exception
-
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_HOST: TEST_HOST}
     )
 
+    # Verify exception is thrown with correct error message
     assert result["type"] is FlowResultType.FORM
     assert result["errors"]["base"] == expected_error
 
     # Test recovery by patching the library to work
     mock_indevolt.get_config.side_effect = None
-
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {CONF_HOST: TEST_HOST}
     )
 
+    # Verify entry is created with correct data
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "INDEVOLT CMS-SF2000"
 
@@ -93,6 +104,7 @@ async def test_user_flow_duplicate_entry(
     """Test duplicate entry aborts the flow."""
     mock_config_entry.add_to_hass(hass)
 
+    # Initiate user flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -102,5 +114,117 @@ async def test_user_flow_duplicate_entry(
         result["flow_id"], {CONF_HOST: TEST_HOST}
     )
 
+    # Verify flow is aborted with correct reason
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_indevolt: AsyncMock,
+) -> None:
+    """Test successful reconfiguration flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Initiate reconfigure flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": mock_config_entry.entry_id},
+    )
+
+    # Verify correct form is returned
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    # Mock new host input
+    new_host = TEST_HOST_NEW
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: new_host}
+    )
+
+    # Verify entry is updated and flow is aborted
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == new_host
+    assert mock_config_entry.data[CONF_SERIAL_NUMBER] == TEST_DEVICE_SN_GEN2
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (TimeoutError, "timeout"),
+        (ConnectionError, "cannot_connect"),
+        (ClientError, "cannot_connect"),
+        (Exception("Some unknown error"), "unknown"),
+    ],
+)
+async def test_reconfigure_flow_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_indevolt: AsyncMock,
+    exception: Exception,
+    expected_error: str,
+) -> None:
+    """Test connection errors in reconfigure flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Initiate reconfigure flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": mock_config_entry.entry_id},
+    )
+
+    # Configure mock to raise exception
+    mock_indevolt.get_config.side_effect = exception
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: TEST_HOST}
+    )
+
+    # Verify exception is thrown with correct error message
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == expected_error
+
+    # Test recovery by patching the library to work
+    mock_indevolt.get_config.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: TEST_HOST}
+    )
+
+    # Verify entry is created with correct data and flow is aborted
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+async def test_reconfigure_flow_different_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_indevolt: AsyncMock,
+) -> None:
+    """Test reconfigure aborts when connecting to a different device."""
+    mock_config_entry.add_to_hass(hass)
+
+    # Setup new device for configuration
+    mock_indevolt.get_config.return_value = {
+        "device": {
+            "sn": "DIFFERENT-SERIAL-99999999",
+            "type": "CMS-OTHER",
+            "generation": 1,
+            "fw": "1.0.0",
+        }
+    }
+
+    # Initiate reconfigure flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_RECONFIGURE, "entry_id": mock_config_entry.entry_id},
+    )
+
+    # Configure mock to cause host collision with different device
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: TEST_HOST_NEW}
+    )
+
+    # Verify flow is aborted with correct reason
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "different_device"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds reconfiguration flow to the Indevolt integration (incl. tests), allowing users to reconfigure the host address. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
