### PR TITLE
LG Soundbar: Fix incorrect state and outdated track information 

### DIFF
--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -42,8 +42,6 @@ class LGDevice(MediaPlayerEntity):
 
     _attr_should_poll = False
     _attr_state = MediaPlayerState.OFF
-    _attr_device_on = False
-    _attr_stream_type = 0
     _attr_supported_features = (
         MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -81,6 +79,8 @@ class LGDevice(MediaPlayerEntity):
         self._treble = 0
         self._device = None
         self._support_play_control = False
+        self._device_on = False
+        self._stream_type = 0
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)}, name=host
         )
@@ -115,7 +115,7 @@ class LGDevice(MediaPlayerEntity):
             if "i_curr_func" in data:
                 self._function = data["i_curr_func"]
             if "b_powerstatus" in data:
-                self._attr_device_on = data["b_powerstatus"]
+                self._device_on = data["b_powerstatus"]
                 if data["b_powerstatus"]:
                     self._attr_state = MediaPlayerState.ON
                 else:
@@ -161,14 +161,14 @@ class LGDevice(MediaPlayerEntity):
     def _update_playinfo(self, data: dict[str, Any]) -> None:
         """Update the player info."""
         if "i_play_ctrl" in data:
-            if self._attr_device_on and self._attr_stream_type != 0:
+            if self._device_on and self._stream_type != 0:
                 if data["i_play_ctrl"] == 0:
                     self._attr_state = MediaPlayerState.PLAYING
                 else:
                     self._attr_state = MediaPlayerState.PAUSED
         if "i_stream_type" in data:
-            if self._attr_stream_type != data["i_stream_type"]:
-                self._attr_stream_type = data["i_stream_type"]
+            if self._stream_type != data["i_stream_type"]:
+                self._stream_type = data["i_stream_type"]
                 # Ask device for current play info when stream type changed.
                 self._device.get_play()
             if data["i_stream_type"] == 0:
@@ -178,7 +178,7 @@ class LGDevice(MediaPlayerEntity):
                 self._attr_media_image_url = None
                 self._attr_media_artist = None
                 self._attr_media_title = None
-                if self._attr_device_on:
+                if self._device_on:
                     self._attr_state = MediaPlayerState.ON
                 else:
                     self._attr_state = MediaPlayerState.OFF

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -161,17 +161,27 @@ class LGDevice(MediaPlayerEntity):
     def _update_playinfo(self, data: dict[str, Any]) -> None:
         """Update the player info."""
         if "i_play_ctrl" in data:
-            if self._attr_device_on:
+            if self._attr_device_on and self._attr_stream_type != 0:
                 if data["i_play_ctrl"] == 0:
                     self._attr_state = MediaPlayerState.PLAYING
                 else:
                     self._attr_state = MediaPlayerState.PAUSED
         if "i_stream_type" in data:
-            self._attr_stream_type = data["i_stream_type"]
+            if self._attr_stream_type != data["i_stream_type"]:
+                self._attr_stream_type = data["i_stream_type"]
+                # Ask device for current play info when stream type changed.
+                self._device.get_play()
             if data["i_stream_type"] == 0:
+                # If the stream type is 0 (aka the soundbar is used as an actual soundbar)
+                # the last track info should be cleared and the state should only be on or off,
+                # as all playing/paused are not applicable in this mode
                 self._attr_media_image_url = None
                 self._attr_media_artist = None
                 self._attr_media_title = None
+                if self._attr_device_on:
+                    self._attr_state = MediaPlayerState.ON
+                else:
+                    self._attr_state = MediaPlayerState.OFF
         if "s_albumart" in data:
             if data["s_albumart"].strip():
                 self._attr_media_image_url = data["s_albumart"]

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -41,7 +41,9 @@ class LGDevice(MediaPlayerEntity):
     """Representation of an LG soundbar device."""
 
     _attr_should_poll = False
-    _attr_state = MediaPlayerState.ON
+    _attr_state = MediaPlayerState.OFF
+    _attr_device_on = False
+    _attr_stream_type = 0
     _attr_supported_features = (
         MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_MUTE
@@ -113,6 +115,7 @@ class LGDevice(MediaPlayerEntity):
             if "i_curr_func" in data:
                 self._function = data["i_curr_func"]
             if "b_powerstatus" in data:
+                self._attr_device_on = data["b_powerstatus"]
                 if data["b_powerstatus"]:
                     self._attr_state = MediaPlayerState.ON
                 else:
@@ -158,16 +161,32 @@ class LGDevice(MediaPlayerEntity):
     def _update_playinfo(self, data: dict[str, Any]) -> None:
         """Update the player info."""
         if "i_play_ctrl" in data:
-            if data["i_play_ctrl"] == 0:
-                self._attr_state = MediaPlayerState.PLAYING
-            else:
-                self._attr_state = MediaPlayerState.PAUSED
+            if self._attr_device_on:
+                if data["i_play_ctrl"] == 0:
+                    self._attr_state = MediaPlayerState.PLAYING
+                else:
+                    self._attr_state = MediaPlayerState.PAUSED
+        if "i_stream_type" in data:
+            self._attr_stream_type = data["i_stream_type"]
+            if data["i_stream_type"] == 0:
+                self._attr_media_image_url = None
+                self._attr_media_artist = None
+                self._attr_media_title = None
         if "s_albumart" in data:
-            self._attr_media_image_url = data["s_albumart"]
+            if data["s_albumart"].strip():
+                self._attr_media_image_url = data["s_albumart"]
+            else:
+                self._attr_media_image_url = None
         if "s_artist" in data:
-            self._attr_media_artist = data["s_artist"]
+            if data["s_artist"].strip():
+                self._attr_media_artist = data["s_artist"]
+            else:
+                self._attr_media_artist = None
         if "s_title" in data:
-            self._attr_media_title = data["s_title"]
+            if data["s_title"].strip():
+                self._attr_media_title = data["s_title"]
+            else:
+                self._attr_media_title = None
         if "b_support_play_ctrl" in data:
             self._support_play_control = data["b_support_play_ctrl"]
 

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -183,20 +183,11 @@ class LGDevice(MediaPlayerEntity):
                 else:
                     self._attr_state = MediaPlayerState.OFF
         if "s_albumart" in data:
-            if data["s_albumart"].strip():
-                self._attr_media_image_url = data["s_albumart"]
-            else:
-                self._attr_media_image_url = None
+            self._attr_media_image_url = data["s_albumart"].strip() or None
         if "s_artist" in data:
-            if data["s_artist"].strip():
-                self._attr_media_artist = data["s_artist"]
-            else:
-                self._attr_media_artist = None
+            self._attr_media_artist = data["s_artist"].strip() or None
         if "s_title" in data:
-            if data["s_title"].strip():
-                self._attr_media_title = data["s_title"]
-            else:
-                self._attr_media_title = None
+            self._attr_media_title = data["s_title"].strip() or None
         if "b_support_play_ctrl" in data:
             self._support_play_control = data["b_support_play_ctrl"]
 

--- a/homeassistant/components/lg_soundbar/media_player.py
+++ b/homeassistant/components/lg_soundbar/media_player.py
@@ -160,12 +160,6 @@ class LGDevice(MediaPlayerEntity):
 
     def _update_playinfo(self, data: dict[str, Any]) -> None:
         """Update the player info."""
-        if "i_play_ctrl" in data:
-            if self._device_on and self._stream_type != 0:
-                if data["i_play_ctrl"] == 0:
-                    self._attr_state = MediaPlayerState.PLAYING
-                else:
-                    self._attr_state = MediaPlayerState.PAUSED
         if "i_stream_type" in data:
             if self._stream_type != data["i_stream_type"]:
                 self._stream_type = data["i_stream_type"]
@@ -182,6 +176,12 @@ class LGDevice(MediaPlayerEntity):
                     self._attr_state = MediaPlayerState.ON
                 else:
                     self._attr_state = MediaPlayerState.OFF
+        if "i_play_ctrl" in data:
+            if self._device_on and self._stream_type != 0:
+                if data["i_play_ctrl"] == 0:
+                    self._attr_state = MediaPlayerState.PLAYING
+                else:
+                    self._attr_state = MediaPlayerState.PAUSED
         if "s_albumart" in data:
             self._attr_media_image_url = data["s_albumart"].strip() or None
         if "s_artist" in data:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This should fix the incorrect state issue reported as Issue #164932 introduced with #161184.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164932 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The device should have the state
- `off` when it's off (duh),
- `on` when its on but not playing anything
-  `on` when used as a classic soundbar so it has no control over the input coming in via ARC (etc.)
-  `playing` when its playing streaming music etc via AirPlay/Spotify/etc where the soundbar can control the playback
-  `paused` when its paused while streaming music etc via AirPlay/Spotify/etc where the soundbar can control the playback
Unfortunately, the soundbar sometimes reports incorrect/nonsensical states. Therefore an additional condition was added, that the `playing` and `paused` state is only used when playing from a Google Cast/Alexa/AirPlay/Spotify/Tidal source, otherwise only the `on` and `off` states are used.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
