### PR TITLE
Fix electrasmart wrong current temperature (×256)

### DIFF
--- a/homeassistant/components/electrasmart/climate.py
+++ b/homeassistant/components/electrasmart/climate.py
@@ -264,9 +264,10 @@ class ElectraClimateEntity(ClimateEntity):
         self._attr_fan_mode = FAN_ELECTRA_TO_HASS[
             self._electra_ac_device.get_fan_speed()
         ]
-        self._attr_current_temperature = (
-            self._electra_ac_device.get_sensor_temperature()
-        )
+        raw_temp = self._electra_ac_device.get_sensor_temperature()
+        if raw_temp is not None and raw_temp > 100:
+            raw_temp = raw_temp >> 8
+        self._attr_current_temperature = raw_temp
         self._attr_target_temperature = self._electra_ac_device.get_temperature()
 
         self._attr_hvac_mode = (

--- a/homeassistant/components/electrasmart/climate.py
+++ b/homeassistant/components/electrasmart/climate.py
@@ -38,6 +38,8 @@ from .const import (
     PRESET_NONE,
     PRESET_SHABAT,
     SCAN_INTERVAL_SEC,
+    SENSOR_TEMP_SCALE_THRESHOLD,
+    SENSOR_TEMP_SHIFT_BITS,
     UNAVAILABLE_THRESH_SEC,
 )
 
@@ -265,8 +267,8 @@ class ElectraClimateEntity(ClimateEntity):
             self._electra_ac_device.get_fan_speed()
         ]
         raw_temp = self._electra_ac_device.get_sensor_temperature()
-        if raw_temp is not None and raw_temp > 100:
-            raw_temp = raw_temp >> 8
+        if raw_temp is not None and raw_temp > SENSOR_TEMP_SCALE_THRESHOLD:
+            raw_temp = raw_temp >> SENSOR_TEMP_SHIFT_BITS
         self._attr_current_temperature = raw_temp
         self._attr_target_temperature = self._electra_ac_device.get_temperature()
 

--- a/homeassistant/components/electrasmart/const.py
+++ b/homeassistant/components/electrasmart/const.py
@@ -11,3 +11,8 @@ CONSECUTIVE_FAILURE_THRESHOLD = 4
 UNAVAILABLE_THRESH_SEC = 120
 PRESET_NONE = "None"
 PRESET_SHABAT = "Shabat"
+
+# The Electra API returns I_RAT/I_CALC_AT telemetry values left-shifted by 8 bits
+# (×256). Raw values above this threshold are treated as unscaled and right-shifted.
+SENSOR_TEMP_SCALE_THRESHOLD = 100
+SENSOR_TEMP_SHIFT_BITS = 8

--- a/tests/components/electrasmart/test_climate.py
+++ b/tests/components/electrasmart/test_climate.py
@@ -1,0 +1,122 @@
+"""Tests for the Electra Smart climate platform."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.electrasmart.climate import ElectraClimateEntity
+
+
+@pytest.fixture
+def mock_device():
+    """Create a mock Electra AC device."""
+    device = MagicMock()
+    device.mac = "AA:BB:CC:DD:EE:FF"
+    device.name = "Test AC"
+    device.model = "Test Model"
+    device.manufactor = "Electra"
+    device.features = []
+    return device
+
+
+@pytest.fixture
+def mock_api():
+    """Create a mock Electra API."""
+    return MagicMock()
+
+
+@pytest.fixture
+def climate_entity(mock_device, mock_api):
+    """Create an ElectraClimateEntity for testing."""
+    with patch.object(ElectraClimateEntity, "__init__", lambda self, *a, **kw: None):
+        entity = ElectraClimateEntity.__new__(ElectraClimateEntity)
+        entity._electra_ac_device = mock_device
+        return entity
+
+
+def test_sensor_temperature_scaled_down(climate_entity):
+    """Test that raw temperatures above 100 are right-shifted by 8 bits."""
+    climate_entity._electra_ac_device.get_sensor_temperature.return_value = 5632
+    climate_entity._electra_ac_device.get_fan_speed.return_value = "AUTO"
+    climate_entity._electra_ac_device.get_temperature.return_value = 24
+    climate_entity._electra_ac_device.is_on.return_value = True
+    climate_entity._electra_ac_device.get_mode.return_value = "COOL"
+    climate_entity._electra_ac_device.is_horizontal_swing.return_value = False
+    climate_entity._electra_ac_device.is_vertical_swing.return_value = False
+    climate_entity._electra_ac_device.get_shabat_mode.return_value = False
+
+    with patch(
+        "homeassistant.components.electrasmart.climate.FAN_ELECTRA_TO_HASS",
+        {"AUTO": "auto"},
+    ), patch(
+        "homeassistant.components.electrasmart.climate.HVAC_MODE_ELECTRA_TO_HASS",
+        {"COOL": "cool"},
+    ):
+        climate_entity._update_device_attrs()
+
+    assert climate_entity._attr_current_temperature == 22
+
+
+def test_sensor_temperature_5888_becomes_23(climate_entity):
+    """Test that raw value 5888 becomes 23°C."""
+    climate_entity._electra_ac_device.get_sensor_temperature.return_value = 5888
+    climate_entity._electra_ac_device.get_fan_speed.return_value = "AUTO"
+    climate_entity._electra_ac_device.get_temperature.return_value = 24
+    climate_entity._electra_ac_device.is_on.return_value = True
+    climate_entity._electra_ac_device.get_mode.return_value = "COOL"
+    climate_entity._electra_ac_device.is_horizontal_swing.return_value = False
+    climate_entity._electra_ac_device.is_vertical_swing.return_value = False
+    climate_entity._electra_ac_device.get_shabat_mode.return_value = False
+
+    with patch(
+        "homeassistant.components.electrasmart.climate.FAN_ELECTRA_TO_HASS",
+        {"AUTO": "auto"},
+    ), patch(
+        "homeassistant.components.electrasmart.climate.HVAC_MODE_ELECTRA_TO_HASS",
+        {"COOL": "cool"},
+    ):
+        climate_entity._update_device_attrs()
+
+    assert climate_entity._attr_current_temperature == 23
+
+
+def test_sensor_temperature_normal_passthrough(climate_entity):
+    """Test that normal temperatures <= 100 pass through unchanged."""
+    climate_entity._electra_ac_device.get_sensor_temperature.return_value = 24
+    climate_entity._electra_ac_device.get_fan_speed.return_value = "AUTO"
+    climate_entity._electra_ac_device.get_temperature.return_value = 24
+    climate_entity._electra_ac_device.is_on.return_value = True
+    climate_entity._electra_ac_device.get_mode.return_value = "COOL"
+    climate_entity._electra_ac_device.is_horizontal_swing.return_value = False
+    climate_entity._electra_ac_device.is_vertical_swing.return_value = False
+    climate_entity._electra_ac_device.get_shabat_mode.return_value = False
+
+    with patch(
+        "homeassistant.components.electrasmart.climate.FAN_ELECTRA_TO_HASS",
+        {"AUTO": "auto"},
+    ), patch(
+        "homeassistant.components.electrasmart.climate.HVAC_MODE_ELECTRA_TO_HASS",
+        {"COOL": "cool"},
+    ):
+        climate_entity._update_device_attrs()
+
+    assert climate_entity._attr_current_temperature == 24
+
+
+def test_sensor_temperature_none_when_ac_off(climate_entity):
+    """Test that None temperature (AC off) stays None."""
+    climate_entity._electra_ac_device.get_sensor_temperature.return_value = None
+    climate_entity._electra_ac_device.get_fan_speed.return_value = "AUTO"
+    climate_entity._electra_ac_device.get_temperature.return_value = 24
+    climate_entity._electra_ac_device.is_on.return_value = False
+    climate_entity._electra_ac_device.is_horizontal_swing.return_value = False
+    climate_entity._electra_ac_device.is_vertical_swing.return_value = False
+    climate_entity._electra_ac_device.get_shabat_mode.return_value = False
+
+    with patch(
+        "homeassistant.components.electrasmart.climate.FAN_ELECTRA_TO_HASS",
+        {"AUTO": "auto"},
+    ):
+        climate_entity._update_device_attrs()
+
+    assert climate_entity._attr_current_temperature is None


### PR DESCRIPTION
## Proposed change

Fix incorrect current temperature readings in the Electra Smart integration. The Electra API returns `I_RAT` and `I_CALC_AT` telemetry values as raw integers left-shifted by 8 bits (×256). The integration stores them without converting, causing current temperature to display as e.g. 5,632°C instead of 22°C.

This PR applies a right-shift (`>> 8`) when the raw sensor temperature exceeds 100°C, which reliably indicates an unscaled value. Values ≤100 pass through unchanged.

| Raw value | Before fix | After fix |
|-----------|-----------|-----------|
| 5,632 | 5,632°C | 22°C |
| 5,888 | 5,888°C | 23°C |
| 6,144 | 6,144°C | 24°C |

A corresponding fix has been submitted upstream to the pyElectra library ([pyElectra PR#15](https://github.com/jafar-atili/pyElectra/pull/15)). This PR applies the workaround at the integration level as well, since the library maintainer appears inactive since mid-2024.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #124409, fixes #160191
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr