### PR TITLE
Handle boolean charging state in Tessie sensor

### DIFF
--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -58,6 +58,15 @@ def minutes_to_datetime(value: StateType) -> datetime | None:
     return None
 
 
+def charge_state_to_option(value: StateType) -> str | None:
+    """Convert Tessie charge state to the enum option."""
+    if isinstance(value, str):
+        return TessieChargeStates.get(value)
+    if isinstance(value, bool):
+        return TessieChargeStates["Charging" if value else "Stopped"]
+    return None
+
+
 @dataclass(frozen=True, kw_only=True)
 class TessieSensorEntityDescription(SensorEntityDescription):
     """Describes Tessie Sensor entity."""
@@ -71,7 +80,7 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
         key="charge_state_charging_state",
         options=list(TessieChargeStates.values()),
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda value: TessieChargeStates[cast(str, value)],
+        value_fn=charge_state_to_option,
     ),
     TessieSensorEntityDescription(
         key="charge_state_usable_battery_level",

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -4,11 +4,27 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.tessie.sensor import charge_state_to_option
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import StateType
 
 from .common import assert_entities, setup_platform
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Charging", "charging"),
+        (True, "charging"),
+        (False, "stopped"),
+        ("Unexpected", None),
+    ],
+)
+def test_charge_state_to_option(value: StateType, expected: str | None) -> None:
+    """Test charge state conversion for enum sensor values."""
+    assert charge_state_to_option(value) == expected
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Summary
- add a safe converter for `charge_state_charging_state` in the Tessie sensor platform
- map boolean values to Tessie enum options (`true -> charging`, `false -> stopped`)
- keep string mappings and gracefully ignore unexpected values
- add regression tests for string, boolean, and unknown values

## Testing
- `pytest tests/components/tessie -q`

Closes #165169
