### PR TITLE
Handle boolean charging state in Tessie sensor

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TessieConfigEntry
 from .const import TessieState
 from .entity import TessieEnergyEntity, TessieEntity
+from .helpers import is_charging
 from .models import TessieEnergyData, TessieVehicleData
 
 PARALLEL_UPDATES = 0
@@ -44,7 +45,7 @@ VEHICLE_DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
     TessieBinarySensorEntityDescription(
         key="charge_state_charging_state",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        is_on=lambda x: x == "Charging",
+        is_on=is_charging,
         entity_registry_enabled_default=False,
     ),
     TessieBinarySensorEntityDescription(

--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -16,9 +16,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TessieConfigEntry
-from .const import TessieState
+from .const import TessieChargeStates, TessieState
 from .entity import TessieEnergyEntity, TessieEntity
-from .helpers import is_charging
+from .helpers import charge_state_to_option
 from .models import TessieEnergyData, TessieVehicleData
 
 PARALLEL_UPDATES = 0
@@ -45,7 +45,9 @@ VEHICLE_DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
     TessieBinarySensorEntityDescription(
         key="charge_state_charging_state",
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
-        is_on=is_charging,
+        is_on=lambda value: (
+            charge_state_to_option(value) == TessieChargeStates["Charging"]
+        ),
         entity_registry_enabled_default=False,
     ),
     TessieBinarySensorEntityDescription(

--- a/homeassistant/components/tessie/helpers.py
+++ b/homeassistant/components/tessie/helpers.py
@@ -7,9 +7,23 @@ from aiohttp import ClientError
 from tesla_fleet_api.exceptions import TeslaFleetError
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.typing import StateType
 
 from . import _LOGGER
-from .const import DOMAIN, TRANSLATED_ERRORS
+from .const import DOMAIN, TRANSLATED_ERRORS, TessieChargeStates
+
+
+def charge_state_to_option(value: StateType) -> str | None:
+    """Convert Tessie charging state values into enum sensor options."""
+    if isinstance(value, str):
+        return TessieChargeStates.get(
+            value, value if value in TessieChargeStates.values() else None
+        )
+    if isinstance(value, bool):
+        return (
+            TessieChargeStates["Charging"] if value else TessieChargeStates["Stopped"]
+        )
+    return None
 
 
 async def handle_command(command: Awaitable[dict[str, Any]]) -> dict[str, Any]:

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -57,6 +57,15 @@ def minutes_to_datetime(value: StateType) -> datetime | None:
     return None
 
 
+def charge_state_to_option(value: StateType) -> str | None:
+    """Convert Tessie charge state to the enum option."""
+    if isinstance(value, str):
+        return TessieChargeStates.get(value)
+    if isinstance(value, bool):
+        return TessieChargeStates["Charging" if value else "Stopped"]
+    return None
+
+
 @dataclass(frozen=True, kw_only=True)
 class TessieSensorEntityDescription(SensorEntityDescription):
     """Describes Tessie Sensor entity."""
@@ -71,7 +80,7 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
         key="charge_state_charging_state",
         options=list(TessieChargeStates.values()),
         device_class=SensorDeviceClass.ENUM,
-        value_fn=lambda value: TessieChargeStates[cast(str, value)],
+        value_fn=charge_state_to_option,
     ),
     TessieSensorEntityDescription(
         key="charge_state_usable_battery_level",

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -46,6 +46,7 @@ from .entity import (
     TessieEntity,
     TessieWallConnectorEntity,
 )
+from .helpers import charge_state_to_option
 from .models import TessieEnergyData, TessieVehicleData
 
 
@@ -54,15 +55,6 @@ def minutes_to_datetime(value: StateType) -> datetime | None:
     """Convert relative minutes into absolute datetime."""
     if isinstance(value, (int, float)) and value > 0:
         return dt_util.now() + timedelta(minutes=value)
-    return None
-
-
-def charge_state_to_option(value: StateType) -> str | None:
-    """Convert Tessie charge state to the enum option."""
-    if isinstance(value, str):
-        return TessieChargeStates.get(value)
-    if isinstance(value, bool):
-        return TessieChargeStates["Charging" if value else "Stopped"]
     return None
 
 

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.typing import StateType
 
 from . import TessieConfigEntry
 from .entity import TessieEnergyEntity, TessieEntity
-from .helpers import handle_command
+from .helpers import handle_command, is_charging_or_starting
 from .models import TessieEnergyData, TessieVehicleData
 
 
@@ -71,7 +71,7 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         unique_id="charge_state_charge_enable_request",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
-        value_func=lambda state: state in {"Starting", "Charging"},
+        value_func=is_charging_or_starting,
     ),
 )
 

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -30,8 +30,9 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import TessieConfigEntry
+from .const import TessieChargeStates
 from .entity import TessieEnergyEntity, TessieEntity
-from .helpers import handle_command, is_charging_or_starting
+from .helpers import charge_state_to_option, handle_command
 from .models import TessieEnergyData, TessieVehicleData
 
 
@@ -71,7 +72,10 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         unique_id="charge_state_charge_enable_request",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
-        value_func=is_charging_or_starting,
+        value_func=lambda state: (
+            charge_state_to_option(state)
+            in {TessieChargeStates["Starting"], TessieChargeStates["Charging"]}
+        ),
     ),
 )
 

--- a/tests/components/tessie/snapshots/test_switch.ambr
+++ b/tests/components/tessie/snapshots/test_switch.ambr
@@ -379,6 +379,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---

--- a/tests/components/tessie/test_binary_sensor.py
+++ b/tests/components/tessie/test_binary_sensor.py
@@ -3,11 +3,33 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.tessie.binary_sensor import VEHICLE_DESCRIPTIONS
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import StateType
 
 from .common import assert_entities, setup_platform
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Charging", True),
+        ("Stopped", False),
+        (True, True),
+        (False, False),
+        ("Unexpected", False),
+    ],
+)
+def test_charging_binary_sensor_state(value: StateType, expected: bool) -> None:
+    """Test charging binary sensor state conversion."""
+    description = next(
+        description
+        for description in VEHICLE_DESCRIPTIONS
+        if description.key == "charge_state_charging_state"
+    )
+    assert description.is_on(value) is expected
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -17,6 +17,7 @@ from .common import assert_entities, setup_platform
     ("value", "expected"),
     [
         ("Charging", "charging"),
+        ("charging", "charging"),
         (True, "charging"),
         (False, "stopped"),
         ("Unexpected", None),

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -4,11 +4,27 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.tessie.sensor import charge_state_to_option
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import StateType
 
 from .common import assert_entities, setup_platform
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Charging", "charging"),
+        (True, "charging"),
+        (False, "stopped"),
+        ("Unexpected", None),
+    ],
+)
+def test_charge_state_to_option(value: StateType, expected: str | None) -> None:
+    """Test charge state conversion for enum sensor values."""
+    assert charge_state_to_option(value) == expected
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -4,7 +4,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.tessie.sensor import charge_state_to_option
+from homeassistant.components.tessie.helpers import charge_state_to_option
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er

--- a/tests/components/tessie/test_switch.py
+++ b/tests/components/tessie/test_switch.py
@@ -10,11 +10,35 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.components.tessie.switch import DESCRIPTIONS
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.typing import StateType
 
 from .common import RESPONSE_OK, assert_entities, setup_platform
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Starting", True),
+        ("Charging", True),
+        ("Stopped", False),
+        (True, True),
+        (False, False),
+        ("Unexpected", False),
+        (None, False),
+    ],
+)
+def test_charge_switch_state(value: StateType, expected: bool) -> None:
+    """Test charging switch state conversion."""
+    description = next(
+        description
+        for description in DESCRIPTIONS
+        if description.key == "charge_state_charging_state"
+    )
+    assert description.value_func(value) is expected
 
 
 async def test_switches(


### PR DESCRIPTION
## Proposed change
- add a safe converter for `charge_state_charging_state` in the Tessie sensor platform
- map boolean values to Tessie enum options (`true -> charging`, `false -> stopped`)
- keep string mappings and gracefully ignore unexpected values
- add regression tests for string, boolean, and unknown values

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #165169
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
