### PR TITLE
Fix Meter Pro CO2 not discoverable via BT proxies

### DIFF
--- a/homeassistant/components/switchbot/__init__.py
+++ b/homeassistant/components/switchbot/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     DOMAIN,
     ENCRYPTED_MODELS,
     HASS_SENSOR_TYPE_TO_SWITCHBOT_MODEL,
+    NON_CONNECTABLE_SUPPORTED_MODEL_TYPES,
     SupportedModels,
 )
 from .coordinator import SwitchbotConfigEntry, SwitchbotDataUpdateCoordinator
@@ -198,7 +199,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchbotConfigEntry) ->
     sensor_type: str = entry.data[CONF_SENSOR_TYPE]
     switchbot_model = HASS_SENSOR_TYPE_TO_SWITCHBOT_MODEL[sensor_type]
     # connectable means we can make connections to the device
-    connectable = switchbot_model in CONNECTABLE_SUPPORTED_MODEL_TYPES
+    connectable = (
+        switchbot_model in CONNECTABLE_SUPPORTED_MODEL_TYPES
+        and switchbot_model not in NON_CONNECTABLE_SUPPORTED_MODEL_TYPES
+    )
     address: str = entry.data[CONF_ADDRESS]
 
     await switchbot.close_stale_connections_by_address(address)

--- a/homeassistant/components/switchbot/config_flow.py
+++ b/homeassistant/components/switchbot/config_flow.py
@@ -113,8 +113,9 @@ class SwitchbotConfigFlow(ConfigFlow, domain=DOMAIN):
         if (
             not discovery_info.connectable
             and model_name in CONNECTABLE_SUPPORTED_MODEL_TYPES
+            and model_name not in NON_CONNECTABLE_SUPPORTED_MODEL_TYPES
         ):
-            # Source is not connectable but the model is connectable
+            # Source is not connectable but the model is connectable only
             return self.async_abort(reason="not_supported")
         self._discovered_adv = parsed
         data = parsed.data

--- a/homeassistant/components/switchbot/const.py
+++ b/homeassistant/components/switchbot/const.py
@@ -113,6 +113,7 @@ NON_CONNECTABLE_SUPPORTED_MODEL_TYPES = {
     SwitchbotModel.METER: SupportedModels.HYGROMETER,
     SwitchbotModel.IO_METER: SupportedModels.HYGROMETER,
     SwitchbotModel.METER_PRO: SupportedModels.HYGROMETER,
+    SwitchbotModel.METER_PRO_C: SupportedModels.HYGROMETER_CO2,
     SwitchbotModel.CONTACT_SENSOR: SupportedModels.CONTACT,
     SwitchbotModel.MOTION_SENSOR: SupportedModels.MOTION,
     SwitchbotModel.PRESENCE_SENSOR: SupportedModels.PRESENCE_SENSOR,

--- a/tests/components/switchbot/__init__.py
+++ b/tests/components/switchbot/__init__.py
@@ -239,6 +239,30 @@ WOMETERTHPC_SERVICE_INFO = BluetoothServiceInfoBleak(
     tx_power=-127,
 )
 
+WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE = BluetoothServiceInfoBleak(
+    name="WoTHPc",
+    manufacturer_data={
+        2409: b"\xb0\xe9\xfeT2\x15\xb7\xe4\x07\x9b\xa4\x007\x02\xd5\x00"
+    },
+    service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"5\x00d"},
+    service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    address="AA:BB:CC:DD:EE:FF",
+    rssi=-60,
+    source="local",
+    advertisement=generate_advertisement_data(
+        local_name="WoTHPc",
+        manufacturer_data={
+            2409: b"\xb0\xe9\xfeT2\x15\xb7\xe4\x07\x9b\xa4\x007\x02\xd5\x00"
+        },
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"5\x00d"},
+        service_uuids=["cba20d00-224d-11e6-9fb8-0002a5d5c51b"],
+    ),
+    device=generate_ble_device("AA:BB:CC:DD:EE:FF", "WoTHPc"),
+    time=0,
+    connectable=False,
+    tx_power=-127,
+)
+
 WORELAY_SWITCH_1PM_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="W1080000",
     manufacturer_data={2409: b"$X|\x0866G\x81\x00\x00\x001\x00\x00\x00\x00"},

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -34,6 +34,7 @@ from . import (
     WOHAND_SERVICE_INFO,
     WOHAND_SERVICE_INFO_NOT_CONNECTABLE,
     WOLOCK_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
     WORELAY_SWITCH_1PM_SERVICE_INFO,
     WOSENSORTH_SERVICE_INFO,
     init_integration,
@@ -262,6 +263,35 @@ async def test_async_step_bluetooth_not_connectable(hass: HomeAssistant) -> None
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_supported"
+
+
+async def test_async_step_bluetooth_meter_pro_co2_not_connectable(
+    hass: HomeAssistant,
+) -> None:
+    """Test discovery via bluetooth for Meter Pro CO2 from a non-connectable source."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=WOMETERTHPC_SERVICE_INFO_NOT_CONNECTABLE,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    with patch_async_setup_entry() as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Meter Pro CO2 EEFF"
+    assert result["data"] == {
+        CONF_ADDRESS: "AA:BB:CC:DD:EE:FF",
+        CONF_SENSOR_TYPE: "hygrometer_co2",
+    }
+
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 @pytest.mark.usefixtures("mock_scanners_all_passive")

--- a/tests/components/switchbot/test_init.py
+++ b/tests/components/switchbot/test_init.py
@@ -19,6 +19,7 @@ from . import (
     HUBMINI_MATTER_SERVICE_INFO,
     LOCK_SERVICE_INFO,
     WOCURTAIN_SERVICE_INFO,
+    WOMETERTHPC_SERVICE_INFO,
     WOSENSORTH_SERVICE_INFO,
     patch_async_ble_device_from_address,
 )
@@ -76,6 +77,32 @@ async def test_setup_entry_without_ble_device(
         "Could not find Switchbot hygrometer_co2 with address aa:bb:cc:dd:ee:ff"
         in caplog.text
     )
+
+
+async def test_setup_entry_meter_pro_co2_uses_non_connectable(
+    hass: HomeAssistant,
+    mock_entry_factory: Callable[[str], MockConfigEntry],
+) -> None:
+    """Test that Meter Pro CO2 setup uses connectable=False for BLE lookup.
+
+    Meter Pro CO2 is in both CONNECTABLE and NON_CONNECTABLE model types,
+    so async_ble_device_from_address should be called with connectable=False
+    to support passive BT proxies.
+    """
+    inject_bluetooth_service_info(hass, WOMETERTHPC_SERVICE_INFO)
+
+    entry = mock_entry_factory("hygrometer_co2")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.bluetooth.async_ble_device_from_address",
+    ) as mock_ble:
+        mock_ble.return_value = WOMETERTHPC_SERVICE_INFO.device
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # connectable should be False since METER_PRO_C is in both lists
+        assert mock_ble.call_args_list[0][0][2] is False
 
 
 async def test_coordinator_wait_ready_timeout(


### PR DESCRIPTION
Add METER_PRO_C back to NON_CONNECTABLE_SUPPORTED_MODEL_TYPES while keeping it in CONNECTABLE_SUPPORTED_MODEL_TYPES. PR #163008 moved it to connectable-only, which broke discovery via passive BT proxies (Shelly/ESPHome) since async_ble_device_from_address with connectable=True requires an active BLE connection.

Fixes #164817

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #164817
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
