### PR TITLE
Reset MQTT valve opening/closing state at intermediate positions

### DIFF
--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -279,8 +279,11 @@ class MqttValve(MqttEntity, ValveEntity):
             else:
                 percentage_payload = min(max(percentage_payload, 0), 100)
                 self._attr_current_valve_position = percentage_payload
-                # Reset closing and opening if the valve is fully opened or fully closed
-                if state is None and percentage_payload in (0, 100):
+                # Reset closing and opening when a position-only update is
+                # received without an explicit opening/closing state.
+                # This handles valves that stop at intermediate positions
+                # (not just 0% or 100%).
+                if state is None:
                     state = RESET_CLOSING_OPENING
                 position_set = True
         if state_payload and state is None and not position_set:

--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -271,7 +271,7 @@ class MqttValve(MqttEntity, ValveEntity):
                     self._range, float(position_payload)
                 )
             except ValueError:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Ignoring non numeric payload '%s' received on topic '%s'",
                     position_payload,
                     msg.topic,

--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -279,13 +279,9 @@ class MqttValve(MqttEntity, ValveEntity):
             else:
                 percentage_payload = min(max(percentage_payload, 0), 100)
                 self._attr_current_valve_position = percentage_payload
-                # Reset closing and opening when a position update is
-                # received without an explicit opening/closing transitional
-                # state (including when other states such as "open" or
-                # "closed" are used). This handles valves that stop at
-                # intermediate positions, not just 0% or 100%.
-                if state is None:
-                    state = RESET_CLOSING_OPENING
+                # Reset opening/closing when a position update is received
+                # without an explicit opening/closing transitional state.
+                state = state or RESET_CLOSING_OPENING
                 position_set = True
         if state_payload and state is None and not position_set:
             _LOGGER.warning(
@@ -294,8 +290,6 @@ class MqttValve(MqttEntity, ValveEntity):
                 msg.topic,
                 state_payload,
             )
-            return
-        if state is None:
             return
         self._update_state(state)
 

--- a/homeassistant/components/mqtt/valve.py
+++ b/homeassistant/components/mqtt/valve.py
@@ -279,10 +279,11 @@ class MqttValve(MqttEntity, ValveEntity):
             else:
                 percentage_payload = min(max(percentage_payload, 0), 100)
                 self._attr_current_valve_position = percentage_payload
-                # Reset closing and opening when a position-only update is
-                # received without an explicit opening/closing state.
-                # This handles valves that stop at intermediate positions
-                # (not just 0% or 100%).
+                # Reset closing and opening when a position update is
+                # received without an explicit opening/closing transitional
+                # state (including when other states such as "open" or
+                # "closed" are used). This handles valves that stop at
+                # intermediate positions, not just 0% or 100%.
                 if state is None:
                     state = RESET_CLOSING_OPENING
                 position_set = True

--- a/tests/components/mqtt/test_valve.py
+++ b/tests/components/mqtt/test_valve.py
@@ -320,11 +320,13 @@ async def test_opening_closing_state_is_reset(
     messages = [
         ('{"position": 0, "state": "opening"}', ValveState.OPENING, 0),
         ('{"position": 50, "state": "opening"}', ValveState.OPENING, 50),
-        ('{"position": 60}', ValveState.OPENING, 60),
+        # Position-only update at intermediate position resets opening state
+        ('{"position": 60}', ValveState.OPEN, 60),
         ('{"position": 100, "state": "opening"}', ValveState.OPENING, 100),
         ('{"position": 100, "state": null}', ValveState.OPEN, 100),
         ('{"position": 90, "state": "closing"}', ValveState.CLOSING, 90),
-        ('{"position": 40}', ValveState.CLOSING, 40),
+        # Position-only update at intermediate position resets closing state
+        ('{"position": 40}', ValveState.OPEN, 40),
         ('{"position": 0}', ValveState.CLOSED, 0),
         ('{"position": 10}', ValveState.OPEN, 10),
         ('{"position": 0, "state": "opening"}', ValveState.OPENING, 0),

--- a/tests/components/mqtt/test_valve.py
+++ b/tests/components/mqtt/test_valve.py
@@ -270,7 +270,7 @@ async def test_state_via_state_topic_through_position(
 ) -> None:
     """Test the controlling state via topic through position.
 
-    Test is still possible to process a `opening` or `closing`
+    Test it is still possible to process a `opening` or `closing`
     state update. Additional we test json messages can be
     processed containing both position and state. Incoming
     rendered positions are clamped between 0..100.
@@ -308,7 +308,7 @@ async def test_opening_closing_state_is_reset(
 ) -> None:
     """Test the controlling state via topic through position.
 
-    Test a `opening` or `closing` state update is reset
+    Test an `opening` or `closing` state update is reset
     correctly after sequential updates.
     """
     await mqtt_mock_entry()
@@ -440,7 +440,7 @@ async def test_state_via_state_trough_position_with_alt_range(
     asserted_state: str,
     valve_position: int | None,
 ) -> None:
-    """Test controlling state via position with alternative range.
+    """Test controlling state via position with an alternative range.
 
     Test is still possible to process a `opening` or `closing`
     state update. Additional we test json messages can be


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

No breaking changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix MQTT valve to properly reset the `opening`/`closing` transitional state when a position-only update is received at an intermediate position.

Previously, the `opening`/`closing` state was only reset when the valve reached a fully open (100) or fully closed (0) position. This meant that if a valve stopped at an intermediate position (e.g., 60%) and sent a position-only MQTT update (without an explicit state), the valve entity would incorrectly remain in the `opening` or `closing` state instead of transitioning to `open`.

The fix changes the logic so that any position-only update (without an explicit transitional state) will reset the `opening`/`closing` state. This correctly reflects the physical state of the valve — if the device reports a position without stating it is still transitioning, the valve should be considered at rest.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you will most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you are unsure about any of them, do not hesitate to ask.
  We are here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that has not yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr