### PR TITLE
Influxdb: Add reconfigure flow

### DIFF
--- a/homeassistant/components/influxdb/config_flow.py
+++ b/homeassistant/components/influxdb/config_flow.py
@@ -241,6 +241,104 @@ class InfluxDBConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration."""
+        entry = self._get_reconfigure_entry()
+        if entry.data[CONF_API_VERSION] == API_VERSION_2:
+            return await self.async_step_reconfigure_v2(user_input)
+        return await self.async_step_reconfigure_v1(user_input)
+
+    async def async_step_reconfigure_v1(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of InfluxDB v1."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            url = URL(user_input[CONF_URL])
+            data = {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: url.host,
+                CONF_PORT: url.port,
+                CONF_USERNAME: user_input.get(CONF_USERNAME),
+                CONF_PASSWORD: user_input.get(CONF_PASSWORD),
+                CONF_DB_NAME: user_input[CONF_DB_NAME],
+                CONF_SSL: url.scheme == "https",
+                CONF_PATH: url.path,
+                CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+            }
+            if (cert := user_input.get(CONF_SSL_CA_CERT)) is not None:
+                path = await _save_uploaded_cert_file(self.hass, cert)
+                data[CONF_SSL_CA_CERT] = str(path)
+            elif CONF_SSL_CA_CERT in entry.data:
+                data[CONF_SSL_CA_CERT] = entry.data[CONF_SSL_CA_CERT]
+            errors = await _validate_influxdb_connection(self.hass, data)
+
+            if not errors:
+                title = f"{data[CONF_DB_NAME]} ({data[CONF_HOST]})"
+                return self.async_update_reload_and_abort(
+                    entry, title=title, data_updates=data
+                )
+
+        suggested_values = dict(entry.data) | (user_input or {})
+        if user_input is None:
+            suggested_values[CONF_URL] = str(
+                URL.build(
+                    scheme="https" if entry.data.get(CONF_SSL) else "http",
+                    host=entry.data.get(CONF_HOST, ""),
+                    port=entry.data.get(CONF_PORT),
+                    path=entry.data.get(CONF_PATH, ""),
+                )
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_v1",
+            data_schema=self.add_suggested_values_to_schema(
+                INFLUXDB_V1_SCHEMA, suggested_values
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_v2(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of InfluxDB v2."""
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            data = {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: user_input[CONF_URL],
+                CONF_TOKEN: user_input[CONF_TOKEN],
+                CONF_ORG: user_input[CONF_ORG],
+                CONF_BUCKET: user_input[CONF_BUCKET],
+                CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
+            }
+            if (cert := user_input.get(CONF_SSL_CA_CERT)) is not None:
+                path = await _save_uploaded_cert_file(self.hass, cert)
+                data[CONF_SSL_CA_CERT] = str(path)
+            elif CONF_SSL_CA_CERT in entry.data:
+                data[CONF_SSL_CA_CERT] = entry.data[CONF_SSL_CA_CERT]
+            errors = await _validate_influxdb_connection(self.hass, data)
+
+            if not errors:
+                title = f"{data[CONF_BUCKET]} ({data[CONF_URL]})"
+                return self.async_update_reload_and_abort(
+                    entry, title=title, data_updates=data
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure_v2",
+            data_schema=self.add_suggested_values_to_schema(
+                INFLUXDB_V2_SCHEMA, entry.data | (user_input or {})
+            ),
+            errors=errors,
+        )
+
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle the initial step."""
         import_data = {**import_data}

--- a/homeassistant/components/influxdb/strings.json
+++ b/homeassistant/components/influxdb/strings.json
@@ -3,6 +3,9 @@
     "ssl_ca_cert": "SSL CA certificate (Optional)"
   },
   "config": {
+    "abort": {
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
@@ -45,6 +48,39 @@
       },
       "import": {
         "title": "Import configuration"
+      },
+      "reconfigure_v1": {
+        "data": {
+          "database": "[%key:component::influxdb::config::step::configure_v1::data::database%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "ssl_ca_cert": "[%key:component::influxdb::common::ssl_ca_cert%]",
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "database": "[%key:component::influxdb::config::step::configure_v1::data_description::database%]",
+          "ssl_ca_cert": "[%key:component::influxdb::config::step::configure_v1::data_description::ssl_ca_cert%]"
+        },
+        "description": "Update the connection settings for your InfluxDB v1.x server.",
+        "title": "[%key:component::influxdb::config::step::configure_v1::title%]"
+      },
+      "reconfigure_v2": {
+        "data": {
+          "bucket": "[%key:component::influxdb::config::step::configure_v2::data::bucket%]",
+          "organization": "[%key:component::influxdb::config::step::configure_v2::data::organization%]",
+          "ssl_ca_cert": "[%key:component::influxdb::common::ssl_ca_cert%]",
+          "token": "[%key:common::config_flow::data::api_token%]",
+          "url": "[%key:common::config_flow::data::url%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "bucket": "[%key:component::influxdb::config::step::configure_v2::data_description::bucket%]",
+          "organization": "[%key:component::influxdb::config::step::configure_v2::data_description::organization%]",
+          "ssl_ca_cert": "[%key:component::influxdb::config::step::configure_v2::data_description::ssl_ca_cert%]"
+        },
+        "description": "Update the connection settings for your InfluxDB v2.x / v3 server.",
+        "title": "[%key:component::influxdb::config::step::configure_v2::title%]"
       },
       "user": {
         "menu_options": {

--- a/tests/components/influxdb/test_config_flow.py
+++ b/tests/components/influxdb/test_config_flow.py
@@ -745,3 +745,446 @@ async def test_single_instance_import(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "single_instance_allowed"
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "entry_data", "user_input", "expected_data", "expected_title"),
+    [
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: False,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "https://newhost:9999",
+                CONF_VERIFY_SSL: True,
+                CONF_DB_NAME: "new_db",
+                CONF_USERNAME: "new_user",
+                CONF_PASSWORD: "new_pass",
+            },
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "newhost",
+                CONF_PORT: 9999,
+                CONF_USERNAME: "new_user",
+                CONF_PASSWORD: "new_pass",
+                CONF_DB_NAME: "new_db",
+                CONF_SSL: True,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: True,
+            },
+            "new_db (newhost)",
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_v1(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+    expected_data: dict[str, Any],
+    expected_title: str,
+) -> None:
+    """Test reconfiguration of InfluxDB v1."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_v1"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data == expected_data
+    assert mock_entry.title == expected_title
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "entry_data", "user_input", "expected_data", "expected_title"),
+    [
+        (
+            API_VERSION_2,
+            {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: "http://localhost:8086",
+                CONF_TOKEN: "old_token",
+                CONF_ORG: "old_org",
+                CONF_BUCKET: "old_bucket",
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "https://newhost:9999",
+                CONF_VERIFY_SSL: True,
+                CONF_ORG: "new_org",
+                CONF_BUCKET: "new_bucket",
+                CONF_TOKEN: "new_token",
+            },
+            {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: "https://newhost:9999",
+                CONF_TOKEN: "new_token",
+                CONF_ORG: "new_org",
+                CONF_BUCKET: "new_bucket",
+                CONF_VERIFY_SSL: True,
+            },
+            "new_bucket (https://newhost:9999)",
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_v2(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+    expected_data: dict[str, Any],
+    expected_title: str,
+) -> None:
+    """Test reconfiguration of InfluxDB v2."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_v2"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data == expected_data
+    assert mock_entry.title == expected_title
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "entry_data", "user_input"),
+    [
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: True,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: True,
+                CONF_SSL_CA_CERT: "/old/cert.pem",
+            },
+            {
+                CONF_URL: "https://localhost:8086",
+                CONF_VERIFY_SSL: True,
+                CONF_DB_NAME: "home_assistant",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_SSL_CA_CERT: FIXTURE_UPLOAD_UUID,
+            },
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_v1_ssl_cert(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+) -> None:
+    """Test reconfiguration of InfluxDB v1 with SSL certificate upload."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_v1"
+
+    with patch_file_upload():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data[CONF_SSL_CA_CERT] == "/.storage/influxdb.crt"
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "entry_data", "user_input"),
+    [
+        (
+            API_VERSION_2,
+            {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: "https://localhost:8086",
+                CONF_TOKEN: "token",
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_VERIFY_SSL: True,
+                CONF_SSL_CA_CERT: "/old/cert.pem",
+            },
+            {
+                CONF_URL: "https://localhost:8086",
+                CONF_VERIFY_SSL: True,
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_TOKEN: "token",
+                CONF_SSL_CA_CERT: FIXTURE_UPLOAD_UUID,
+            },
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_v2_ssl_cert(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+) -> None:
+    """Test reconfiguration of InfluxDB v2 with SSL certificate upload."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_v2"
+
+    with patch_file_upload():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data[CONF_SSL_CA_CERT] == "/.storage/influxdb.crt"
+
+
+@pytest.mark.parametrize(
+    ("mock_client", "entry_data", "user_input"),
+    [
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: False,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: False,
+                CONF_SSL_CA_CERT: "/old/cert.pem",
+            },
+            {
+                CONF_URL: "http://localhost:8086",
+                CONF_VERIFY_SSL: False,
+                CONF_DB_NAME: "home_assistant",
+                CONF_USERNAME: "user",
+                CONF_PASSWORD: "pass",
+            },
+        ),
+        (
+            API_VERSION_2,
+            {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: "https://localhost:8086",
+                CONF_TOKEN: "token",
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_VERIFY_SSL: True,
+                CONF_SSL_CA_CERT: "/old/cert.pem",
+            },
+            {
+                CONF_URL: "https://localhost:8086",
+                CONF_VERIFY_SSL: True,
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_TOKEN: "token",
+            },
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_preserves_existing_cert(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+) -> None:
+    """Test reconfiguration preserves existing cert when none uploaded."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data[CONF_SSL_CA_CERT] == "/old/cert.pem"
+
+
+@pytest.mark.parametrize(
+    (
+        "mock_client",
+        "entry_data",
+        "user_input",
+        "get_write_api",
+        "test_exception",
+        "reason",
+    ),
+    [
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: False,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "http://localhost:8086",
+                CONF_VERIFY_SSL: False,
+                CONF_DB_NAME: "home_assistant",
+            },
+            _get_write_api_mock_v1,
+            InfluxDBClientError("SSLError"),
+            "ssl_error",
+        ),
+        (
+            DEFAULT_API_VERSION,
+            {
+                CONF_API_VERSION: DEFAULT_API_VERSION,
+                CONF_HOST: "localhost",
+                CONF_PORT: 8086,
+                CONF_DB_NAME: "home_assistant",
+                CONF_SSL: False,
+                CONF_PATH: "/",
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "http://localhost:8086",
+                CONF_VERIFY_SSL: False,
+                CONF_DB_NAME: "home_assistant",
+            },
+            _get_write_api_mock_v1,
+            InfluxDBClientError("authorization failed"),
+            "invalid_auth",
+        ),
+        (
+            API_VERSION_2,
+            {
+                CONF_API_VERSION: API_VERSION_2,
+                CONF_URL: "http://localhost:8086",
+                CONF_TOKEN: "token",
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_VERIFY_SSL: False,
+            },
+            {
+                CONF_URL: "http://localhost:8086",
+                CONF_VERIFY_SSL: False,
+                CONF_ORG: "org",
+                CONF_BUCKET: "bucket",
+                CONF_TOKEN: "token",
+            },
+            _get_write_api_mock_v2,
+            ApiException("SSLError"),
+            "ssl_error",
+        ),
+    ],
+    indirect=["mock_client"],
+)
+async def test_reconfigure_connection_error(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_client: MagicMock,
+    entry_data: dict[str, Any],
+    user_input: dict[str, Any],
+    get_write_api: Any,
+    test_exception: Exception,
+    reason: str,
+) -> None:
+    """Test reconfiguration handles connection errors."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=entry_data,
+    )
+    mock_entry.add_to_hass(hass)
+
+    write_api = get_write_api(mock_client)
+    write_api.side_effect = test_exception
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": reason}
+
+    write_api.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SSIA

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: [community forum](https://community.home-assistant.io/t/warning-the-influxdb-yaml-configuration-is-being-removed/992831)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
