### PR TITLE
OwnTracks: expose message tst as update_timestamp in device_tracker attribute

### DIFF
--- a/homeassistant/components/owntracks/const.py
+++ b/homeassistant/components/owntracks/const.py
@@ -1,3 +1,4 @@
 """Constants for OwnTracks."""
 
 DOMAIN = "owntracks"
+ATTR_UPDATE_TIMESTAMP = "update_timestamp"

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from . import DOMAIN
+from .const import ATTR_UPDATE_TIMESTAMP, DOMAIN
 
 
 async def async_setup_entry(
@@ -147,6 +147,9 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
             "gps_accuracy": attr.get(ATTR_GPS_ACCURACY),
             "battery": attr.get(ATTR_BATTERY_LEVEL),
             "source_type": attr.get(ATTR_SOURCE_TYPE),
+            "attributes": {ATTR_UPDATE_TIMESTAMP: attr[ATTR_UPDATE_TIMESTAMP]}
+            if ATTR_UPDATE_TIMESTAMP in attr
+            else {},
         }
 
     @callback

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -144,10 +144,7 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
         attr = state.attributes
         attributes: dict[str, Any] = {}
         if (update_timestamp := attr.get(ATTR_UPDATE_TIMESTAMP)) is not None:
-            if isinstance(update_timestamp, str):
-                update_timestamp = dt_util.parse_datetime(update_timestamp)
-            if update_timestamp is not None:
-                attributes[ATTR_UPDATE_TIMESTAMP] = update_timestamp
+            attributes[ATTR_UPDATE_TIMESTAMP] = dt_util.parse_datetime(update_timestamp)
 
         self._data = {
             "host_name": state.name,

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -21,9 +21,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.util import dt as dt_util
 
-from .const import ATTR_UPDATE_TIMESTAMP, DOMAIN
+from .const import DOMAIN
 
 
 async def async_setup_entry(
@@ -142,17 +141,12 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
             return
 
         attr = state.attributes
-        attributes: dict[str, Any] = {}
-        if (update_timestamp := attr.get(ATTR_UPDATE_TIMESTAMP)) is not None:
-            attributes[ATTR_UPDATE_TIMESTAMP] = dt_util.parse_datetime(update_timestamp)
-
         self._data = {
             "host_name": state.name,
             "gps": (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE)),
             "gps_accuracy": attr.get(ATTR_GPS_ACCURACY),
             "battery": attr.get(ATTR_BATTERY_LEVEL),
             "source_type": attr.get(ATTR_SOURCE_TYPE),
-            "attributes": attributes,
         }
 
     @callback

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
 
 from .const import ATTR_UPDATE_TIMESTAMP, DOMAIN
 
@@ -141,15 +142,20 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
             return
 
         attr = state.attributes
+        attributes: dict[str, Any] = {}
+        if (update_timestamp := attr.get(ATTR_UPDATE_TIMESTAMP)) is not None:
+            if isinstance(update_timestamp, str):
+                update_timestamp = dt_util.parse_datetime(update_timestamp)
+            if update_timestamp is not None:
+                attributes[ATTR_UPDATE_TIMESTAMP] = update_timestamp
+
         self._data = {
             "host_name": state.name,
             "gps": (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE)),
             "gps_accuracy": attr.get(ATTR_GPS_ACCURACY),
             "battery": attr.get(ATTR_BATTERY_LEVEL),
             "source_type": attr.get(ATTR_SOURCE_TYPE),
-            "attributes": {ATTR_UPDATE_TIMESTAMP: attr[ATTR_UPDATE_TIMESTAMP]}
-            if ATTR_UPDATE_TIMESTAMP in attr
-            else {},
+            "attributes": attributes,
         }
 
     @callback

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -85,6 +85,8 @@ def _parse_see_args(message, subscribe_topic):
             kwargs["source_type"] = SourceType.GPS
         if message["t"] == "b":
             kwargs["source_type"] = SourceType.BLUETOOTH_LE
+    if "tst" in message:
+        kwargs["attributes"]["update_timestamp"] = message["tst"]
 
     return dev_id, kwargs
 

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -9,8 +9,9 @@ from nacl.secret import SecretBox
 from homeassistant.components import zone as zone_comp
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_HOME
-from homeassistant.util import decorator, slugify
+from homeassistant.util import decorator, dt as dt_util, slugify
 
+from .const import ATTR_UPDATE_TIMESTAMP
 from .helper import supports_encryption
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,6 +86,10 @@ def _parse_see_args(message, subscribe_topic):
             kwargs["source_type"] = SourceType.GPS
         if message["t"] == "b":
             kwargs["source_type"] = SourceType.BLUETOOTH_LE
+    if "tst" in message:
+        kwargs["attributes"][ATTR_UPDATE_TIMESTAMP] = dt_util.utc_from_timestamp(
+            message["tst"]
+        )
 
     return dev_id, kwargs
 

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -1624,11 +1624,6 @@ async def test_restore_state(
     assert state_1.attributes["longitude"] == state_2.attributes["longitude"]
     assert state_1.attributes["battery_level"] == state_2.attributes["battery_level"]
     assert state_1.attributes["source_type"] == state_2.attributes["source_type"]
-    assert (
-        state_1.attributes[ATTR_UPDATE_TIMESTAMP]
-        == state_2.attributes[ATTR_UPDATE_TIMESTAMP]
-        == dt_util.utc_from_timestamp(LOCATION_MESSAGE["tst"])
-    )
 
 
 async def test_returns_empty_friends(

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -12,10 +12,12 @@ from nacl.secret import SecretBox
 import pytest
 
 from homeassistant.components import owntracks
+from homeassistant.components.owntracks.const import ATTR_UPDATE_TIMESTAMP
 from homeassistant.components.device_tracker.legacy import Device
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
 from tests.typing import ClientSessionGenerator, MqttMockHAClient
@@ -392,6 +394,14 @@ def assert_location_source_type(hass: HomeAssistant, source_type: str) -> None:
     assert state.attributes.get("source_type") == source_type
 
 
+def assert_location_update_timestamp(hass: HomeAssistant, timestamp: int) -> None:
+    """Test the assertion of update_timestamp."""
+    state = hass.states.get(DEVICE_TRACKER_STATE)
+    assert state.attributes.get(ATTR_UPDATE_TIMESTAMP) == dt_util.utc_from_timestamp(
+        timestamp
+    )
+
+
 def assert_mobile_tracker_state(
     hass: HomeAssistant, location: str, beacon: str = IBEACON_DEVICE
 ) -> None:
@@ -435,6 +445,7 @@ async def test_location_update(hass: HomeAssistant) -> None:
     assert_location_source_type(hass, "gps")
     assert_location_latitude(hass, LOCATION_MESSAGE["lat"])
     assert_location_accuracy(hass, LOCATION_MESSAGE["acc"])
+    assert_location_update_timestamp(hass, LOCATION_MESSAGE["tst"])
     assert_location_state(hass, "outer")
 
 
@@ -1613,6 +1624,11 @@ async def test_restore_state(
     assert state_1.attributes["longitude"] == state_2.attributes["longitude"]
     assert state_1.attributes["battery_level"] == state_2.attributes["battery_level"]
     assert state_1.attributes["source_type"] == state_2.attributes["source_type"]
+    assert (
+        state_1.attributes[ATTR_UPDATE_TIMESTAMP]
+        == state_2.attributes[ATTR_UPDATE_TIMESTAMP]
+        == dt_util.utc_from_timestamp(LOCATION_MESSAGE["tst"])
+    )
 
 
 async def test_returns_empty_friends(

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -12,8 +12,8 @@ from nacl.secret import SecretBox
 import pytest
 
 from homeassistant.components import owntracks
-from homeassistant.components.owntracks.const import ATTR_UPDATE_TIMESTAMP
 from homeassistant.components.device_tracker.legacy import Device
+from homeassistant.components.owntracks.const import ATTR_UPDATE_TIMESTAMP
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `update_timestamp` attribute to the OwnTracks `device_tracker`, populated from the `tst` value in the OwnTracks location message.

The OwnTracks message already contains a `tst` field, which is the original Unix timestamp sent by the device. This PR exposes it as `update_timestamp` in the device tracker attributes, converted to a datetime object.

This helps detect delayed messages, for example due to poor network connectivity, and allows automations to account for message latency. In automations such as opening a gate when arriving home, users can verify when the location update was actually created by the device instead of relying only on when Home Assistant received it.

Example OwnTracks payload:

```json
{
  "_type": "location",
  "lat": 12.345678,
  "lon": 12.345678,
  "tst": 1773049120
}
```

This corresponds to the original device update time rather than the receive time.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/45052
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
       Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
       Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr