### PR TITLE
Harden recorder statistics against bad integration data

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -777,9 +777,15 @@ def _compile_statistics(
             )
         ):
             continue
-        compiled: PlatformCompiledStatistics = platform_compile_statistics(
-            instance.hass, session, start, end, custom_equivalent_units_per_entity
-        )
+        try:
+            compiled: PlatformCompiledStatistics = platform_compile_statistics(
+                instance.hass, session, start, end, custom_equivalent_units_per_entity
+            )
+        except Exception:
+            _LOGGER.exception(
+                "Error compiling statistics for platform %s; skipping", domain
+            )
+            continue
         _LOGGER.debug(
             "Statistics for %s during %s-%s: %s",
             domain,
@@ -795,16 +801,33 @@ def _compile_statistics(
     now_timestamp = time_time()
     # Insert collected statistics in the database
     for stats in platform_stats:
-        modified_statistic_id, metadata_id = statistics_meta_manager.update_or_add(
-            session, stats["meta"], current_metadata
-        )
-        if modified_statistic_id is not None:
-            modified_statistic_ids.add(modified_statistic_id)
-        updated_metadata_ids.add(metadata_id)
-        if new_stat := _insert_statistics(
-            session, StatisticsShortTerm, metadata_id, stats["stat"], now_timestamp
-        ):
-            new_short_term_stats.append(new_stat)
+        try:
+            with session.begin_nested():
+                modified_statistic_id, metadata_id = (
+                    statistics_meta_manager.update_or_add(
+                        session, stats["meta"], current_metadata
+                    )
+                )
+                if modified_statistic_id is not None:
+                    modified_statistic_ids.add(modified_statistic_id)
+                updated_metadata_ids.add(metadata_id)
+                if new_stat := _insert_statistics(
+                    session,
+                    StatisticsShortTerm,
+                    metadata_id,
+                    stats["stat"],
+                    now_timestamp,
+                ):
+                    new_short_term_stats.append(new_stat)
+        except Exception:
+            try:
+                statistic_id = stats["meta"]["statistic_id"]
+            except KeyError, TypeError:
+                statistic_id = "unknown"
+            _LOGGER.exception(
+                "Error while processing statistics for %s; skipping",
+                statistic_id,
+            )
 
     if start.minute == 50:
         # Once every hour, update issues

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -831,16 +831,24 @@ def _compile_statistics(
 
     if start.minute == 50:
         # Once every hour, update issues
-        for platform in instance.hass.data[DATA_RECORDER].recorder_platforms.values():
+        for domain, platform in instance.hass.data[
+            DATA_RECORDER
+        ].recorder_platforms.items():
             if not (
                 platform_update_issues := getattr(
                     platform, INTEGRATION_PLATFORM_UPDATE_STATISTICS_ISSUES, None
                 )
             ):
                 continue
-            platform_update_issues(
-                instance.hass, session, custom_equivalent_units_per_entity
-            )
+            try:
+                platform_update_issues(
+                    instance.hass, session, custom_equivalent_units_per_entity
+                )
+            except Exception:
+                _LOGGER.exception(
+                    "Error updating statistics issues for platform %s; skipping",
+                    domain,
+                )
 
     if start.minute == 55:
         # A full hour is ready, summarize it
@@ -2758,13 +2766,19 @@ def update_statistics_issues(hass: HomeAssistant) -> None:
     custom_equivalent_units_per_entity = _get_custom_equivalent_units(hass)
 
     with session_scope(hass=hass, read_only=True) as session:
-        for platform in hass.data[DATA_RECORDER].recorder_platforms.values():
+        for domain, platform in hass.data[DATA_RECORDER].recorder_platforms.items():
             if platform_update_statistics_issues := getattr(
                 platform, INTEGRATION_PLATFORM_UPDATE_STATISTICS_ISSUES, None
             ):
-                platform_update_statistics_issues(
-                    hass, session, custom_equivalent_units_per_entity
-                )
+                try:
+                    platform_update_statistics_issues(
+                        hass, session, custom_equivalent_units_per_entity
+                    )
+                except Exception:
+                    _LOGGER.exception(
+                        "Error updating statistics issues for platform %s; skipping",
+                        domain,
+                    )
 
 
 def _statistics_exists(

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -92,6 +92,8 @@ WARN_NEGATIVE: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_total_increasing_nega
 # Keep track of entities for which a warning about unsupported unit has been logged
 WARN_UNSUPPORTED_UNIT: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_unsupported_unit")
 WARN_UNSTABLE_UNIT: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_unstable_unit")
+# Keep track of entities for which a warning about non-string unit has been logged
+WARN_NON_STRING_UNIT: HassKey[set[str]] = HassKey(f"{DOMAIN}_warn_non_string_unit")
 # Keep track of entities for which a warning about
 # statistics mean algorithm change has been logged
 WARN_STATISTICS_MEAN_CHANGED: HassKey[set[str]] = HassKey(
@@ -291,6 +293,20 @@ def _normalize_states(
     state_unit: str | None = None
     statistics_unit: str | None
     state_unit = fstates[0][1].attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+    if state_unit is not None and not isinstance(state_unit, str):
+        if WARN_NON_STRING_UNIT not in hass.data:
+            hass.data[WARN_NON_STRING_UNIT] = set()
+        if entity_id not in hass.data[WARN_NON_STRING_UNIT]:
+            hass.data[WARN_NON_STRING_UNIT].add(entity_id)
+            _LOGGER.error(
+                "Entity %s has a non-string unit_of_measurement: %s (type %s); "
+                "this is a bug in the integration providing this entity. "
+                "Statistics will not be tracked for this entity",
+                entity_id,
+                state_unit,
+                type(state_unit).__name__,
+            )
+        return None, None, []
     device_class = fstates[0][1].attributes.get(ATTR_DEVICE_CLASS)
     old_metadata = old_metadatas[entity_id][1] if entity_id in old_metadatas else None
     equivalent_units_for_entity = _collect_equivalent_units_for_entity(

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -3845,6 +3845,163 @@ async def test_recorder_platform_with_statistics(
     recorder_platform.validate_statistics.assert_called_once_with(hass, {})
 
 
+async def test_bad_platform_does_not_block_other_platforms(
+    hass: HomeAssistant,
+    setup_recorder: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a crashing platform callback doesn't block other platforms.
+
+    Without per-platform error isolation the exception from bad_domain would
+    propagate up and prevent good_domain from recording any statistics.
+    """
+    good_meta = {
+        "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
+        "name": None,
+        "statistic_id": "good_domain:good_entity",
+        "unit_class": None,
+        "unit_of_measurement": "dogs",
+    }
+
+    zero = get_start_time(dt_util.utcnow())
+
+    def _good_compile_statistics(
+        _hass: Any,
+        session: Any,
+        start: Any,
+        _end: Any,
+        _custom_equivalent_units: Any,
+    ) -> PlatformCompiledStatistics:
+        return PlatformCompiledStatistics(
+            [{"meta": good_meta, "stat": {"start": start}}],
+            get_metadata_with_session(
+                recorder.get_instance(_hass),
+                session,
+                statistic_ids={"good_domain:good_entity"},
+            ),
+        )
+
+    def _bad_compile_statistics(*args: Any) -> PlatformCompiledStatistics:
+        raise RuntimeError("Simulated integration crash")
+
+    good_platform = Mock(
+        compile_statistics=Mock(wraps=_good_compile_statistics),
+    )
+    bad_platform = Mock(
+        compile_statistics=Mock(wraps=_bad_compile_statistics),
+    )
+
+    mock_platform(hass, "bad_domain.recorder", bad_platform)
+    assert await async_setup_component(hass, "bad_domain", {})
+    mock_platform(hass, "good_domain.recorder", good_platform)
+    assert await async_setup_component(hass, "good_domain", {})
+    await async_recorder_block_till_done(hass)
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    # The good platform should still have recorded statistics
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "good_domain:good_entity" in stats
+
+    # The bad platform should have been caught and logged
+    assert "Error compiling statistics for platform bad_domain; skipping" in caplog.text
+    assert "Error while processing event StatisticsTask" not in caplog.text
+
+
+async def test_bad_entity_does_not_block_other_entities(
+    hass: HomeAssistant,
+    setup_recorder: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a bad entity in the stats loop doesn't block other entities.
+
+    Without per-entity error isolation, a single bad entity would crash
+    the entire statistics insertion loop, losing data for every entity.
+    We simulate this by making _insert_statistics raise for one entity.
+    """
+    zero = get_start_time(dt_util.utcnow())
+
+    good_meta = {
+        "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
+        "name": None,
+        "statistic_id": "some_domain:good_entity",
+        "unit_class": None,
+        "unit_of_measurement": "dogs",
+    }
+    bad_meta = {
+        "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
+        "name": None,
+        "statistic_id": "some_domain:bad_entity",
+        "unit_class": None,
+        "unit_of_measurement": "cats",
+    }
+
+    def _mock_compile_statistics(
+        _hass: Any,
+        session: Any,
+        start: Any,
+        _end: Any,
+        _custom_equivalent_units: Any,
+    ) -> PlatformCompiledStatistics:
+        return PlatformCompiledStatistics(
+            [
+                {"meta": bad_meta, "stat": {"start": start}},
+                {"meta": good_meta, "stat": {"start": start}},
+            ],
+            get_metadata_with_session(
+                recorder.get_instance(_hass),
+                session,
+                statistic_ids={
+                    "some_domain:good_entity",
+                    "some_domain:bad_entity",
+                },
+            ),
+        )
+
+    mock_compile_platform = Mock(
+        compile_statistics=Mock(wraps=_mock_compile_statistics),
+    )
+
+    mock_platform(hass, "some_domain.recorder", mock_compile_platform)
+    assert await async_setup_component(hass, "some_domain", {})
+    await async_recorder_block_till_done(hass)
+
+    real_insert = statistics._insert_statistics
+    call_count = 0
+
+    def _insert_statistics_that_fails_for_first(
+        session, table, metadata_id, stat, now_timestamp
+    ):
+        nonlocal call_count
+        call_count += 1
+        # The bad entity is first in the platform_stats list, so fail on first call
+        if call_count == 1:
+            raise ValueError("Simulated bad entity data")
+        return real_insert(session, table, metadata_id, stat, now_timestamp)
+
+    with patch(
+        "homeassistant.components.recorder.statistics._insert_statistics",
+        side_effect=_insert_statistics_that_fails_for_first,
+    ):
+        do_adhoc_statistics(hass, start=zero)
+        await async_wait_recording_done(hass)
+
+    # The good entity should still have statistics recorded
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "some_domain:good_entity" in stats
+
+    # The bad entity should have been caught per-entity
+    assert (
+        "Error while processing statistics for some_domain:bad_entity; skipping"
+        in caplog.text
+    )
+    assert "Error while processing event StatisticsTask" not in caplog.text
+
+
 async def test_recorder_platform_without_statistics(
     hass: HomeAssistant,
     setup_recorder: None,

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4002,6 +4002,70 @@ async def test_bad_entity_does_not_block_other_entities(
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 
+async def test_bad_update_issues_does_not_crash_statistics(
+    hass: HomeAssistant,
+    setup_recorder: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a crashing update_statistics_issues callback doesn't crash the pipeline.
+
+    Without error isolation, a platform whose update_statistics_issues raises
+    would crash the entire _compile_statistics call at minute=50.
+    """
+    good_meta = {
+        "has_sum": False,
+        "mean_type": StatisticMeanType.ARITHMETIC,
+        "name": None,
+        "statistic_id": "good_domain:good_entity",
+        "unit_class": None,
+        "unit_of_measurement": "dogs",
+    }
+
+    zero = get_start_time(dt_util.utcnow()).replace(minute=50)
+
+    def _good_compile_statistics(
+        _hass: Any,
+        session: Any,
+        start: Any,
+        _end: Any,
+        _custom_equivalent_units: Any,
+    ) -> PlatformCompiledStatistics:
+        return PlatformCompiledStatistics(
+            [{"meta": good_meta, "stat": {"start": start}}],
+            get_metadata_with_session(
+                recorder.get_instance(_hass),
+                session,
+                statistic_ids={"good_domain:good_entity"},
+            ),
+        )
+
+    def _bad_update_issues(*args: Any) -> None:
+        raise RuntimeError("Simulated update_issues crash")
+
+    good_platform = Mock(
+        compile_statistics=Mock(wraps=_good_compile_statistics),
+        update_statistics_issues=Mock(wraps=_bad_update_issues),
+    )
+
+    mock_platform(hass, "good_domain.recorder", good_platform)
+    assert await async_setup_component(hass, "good_domain", {})
+    await async_recorder_block_till_done(hass)
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    # Statistics should still have been recorded despite update_issues crash
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "good_domain:good_entity" in stats
+
+    # The crash should have been caught and logged
+    assert (
+        "Error updating statistics issues for platform good_domain; skipping"
+        in caplog.text
+    )
+    assert "Error while processing event StatisticsTask" not in caplog.text
+
+
 async def test_recorder_platform_without_statistics(
     hass: HomeAssistant,
     setup_recorder: None,

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -2926,7 +2926,62 @@ async def test_compile_hourly_statistics_fails(
     ):
         do_adhoc_statistics(hass, start=zero)
         await async_wait_recording_done(hass)
-    assert "Error while processing event StatisticsTask" in caplog.text
+    assert "Error compiling statistics for platform sensor; skipping" in caplog.text
+
+
+async def test_non_string_unit_of_measurement_skipped(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a non-string unit_of_measurement is caught and the entity skipped.
+
+    Simulates an integration bug where a Python object (instead of a string) is
+    passed as unit_of_measurement.  Without hardening, this would crash the
+    entire statistics pipeline.  With hardening, the bad entity is skipped and
+    well-behaved entities continue to be recorded.
+    """
+    zero = get_start_time(dt_util.utcnow())
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    # Record states for a good sensor
+    good_attributes = {
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": "°C",
+    }
+    with freeze_time(zero) as freezer:
+        _four, _states = await async_record_states(
+            hass, freezer, zero, "sensor.good", good_attributes
+        )
+
+    # Record states for a bad sensor whose unit_of_measurement is a non-string object
+    bad_unit = object()
+    bad_attributes = {
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": bad_unit,
+    }
+    with freeze_time(zero) as freezer:
+        await async_record_states(hass, freezer, zero, "sensor.bad", bad_attributes)
+
+    await async_wait_recording_done(hass)
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    # The good entity should have statistics
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "sensor.good" in stats
+    assert len(stats["sensor.good"]) == 1
+
+    # The bad entity should have been skipped
+    assert "sensor.bad" not in stats
+
+    # A clear error log should identify the offending entity
+    assert "Entity sensor.bad has a non-string unit_of_measurement" in caplog.text
+    assert "this is a bug in the integration providing this entity" in caplog.text
+    # The global crash message should NOT appear
+    assert "Error while processing event StatisticsTask" not in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -2984,6 +2984,46 @@ async def test_non_string_unit_of_measurement_skipped(
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 
+async def test_list_state_class_caught_by_platform_error_isolation(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a list-typed state_class is caught by per-platform try/except.
+
+    Related to https://github.com/home-assistant/core/issues/158494
+    where an integration set state_class to ['signal_strength'] (a list),
+    causing TypeError: unhashable type: 'list' in _get_sensor_states which
+    killed the entire statistics pipeline for all integrations.
+
+    The per-platform try/except around compile_statistics catches this error.
+    Note: the update_statistics_issues path (run at minute=50) has the same
+    bug and needs a separate fix; this test uses a non-50 minute to isolate
+    the compile_statistics path only.
+    """
+    # Use a start time where minute != 50 to avoid the update_issues path
+    zero = get_start_time(dt_util.utcnow()).replace(minute=0)
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    # Set up a bad sensor with state_class as a list (the bug from #158494)
+    hass.states.async_set(
+        "sensor.bad_state_class",
+        "42",
+        {
+            "device_class": "signal_strength",
+            "state_class": ["signal_strength"],
+            "unit_of_measurement": "dBm",
+        },
+    )
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    # The per-platform try/except should have caught the TypeError
+    assert "Error compiling statistics for platform sensor; skipping" in caplog.text
+    # The crash should NOT have propagated to the task handler
+    assert "Error while processing event StatisticsTask" not in caplog.text
+
+
 @pytest.mark.parametrize(
     (
         "state_class",

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -2995,12 +2995,9 @@ async def test_list_state_class_caught_by_platform_error_isolation(
     killed the entire statistics pipeline for all integrations.
 
     The per-platform try/except around compile_statistics catches this error.
-    Note: the update_statistics_issues path (run at minute=50) has the same
-    bug and needs a separate fix; this test uses a non-50 minute to isolate
-    the compile_statistics path only.
     """
-    # Use a start time where minute != 50 to avoid the update_issues path
-    zero = get_start_time(dt_util.utcnow()).replace(minute=0)
+    # Use a future hour to avoid "Statistics already compiled" guard
+    zero = get_start_time(dt_util.utcnow()).replace(minute=0) + timedelta(hours=1)
     await async_setup_component(hass, "sensor", {})
     await async_recorder_block_till_done(hass)
 
@@ -3021,6 +3018,40 @@ async def test_list_state_class_caught_by_platform_error_isolation(
     # The per-platform try/except should have caught the TypeError
     assert "Error compiling statistics for platform sensor; skipping" in caplog.text
     # The crash should NOT have propagated to the task handler
+    assert "Error while processing event StatisticsTask" not in caplog.text
+
+
+async def test_list_state_class_caught_by_update_issues_error_isolation(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a list-typed state_class at minute=50 is caught by error isolation.
+
+    Related to https://github.com/home-assistant/core/issues/158494
+    The update_statistics_issues path (run at minute=50) also calls into
+    the sensor platform and can crash on unhashable state_class values.
+    """
+    fifty = get_start_time(dt_util.utcnow()).replace(minute=50) + timedelta(hours=1)
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    hass.states.async_set(
+        "sensor.bad_state_class",
+        "42",
+        {
+            "device_class": "signal_strength",
+            "state_class": ["signal_strength"],
+            "unit_of_measurement": "dBm",
+        },
+    )
+
+    do_adhoc_statistics(hass, start=fifty)
+    await async_wait_recording_done(hass)
+
+    # Both error isolation layers should have caught errors
+    assert "Error compiling statistics for platform sensor; skipping" in caplog.text
+    assert (
+        "Error updating statistics issues for platform sensor; skipping" in caplog.text
+    )
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 


### PR DESCRIPTION
## Proposed change

A misbehaving integration (e.g. Victron passing a Python object as `unit_of_measurement` instead of a string, see https://github.com/sfstar/hass-victron/pull/424) can crash the entire statistics pipeline, killing statistics collection for **all** integrations — not just the offending one. The user sees a blank statistics dashboard with no indication of which integration caused it.

This PR adds three layers of error isolation:

1. **Per-platform try/except** around `compile_statistics` callbacks — a crashing platform no longer blocks other platforms.
2. **Per-entity try/except** in the statistics insertion loop — a bad entity no longer prevents other entities from being recorded.
3. **Type validation for `unit_of_measurement`** in the sensor recorder — a non-string value is caught early with a clear error log naming the offending entity and integration, instead of propagating into SQLite and crashing there.

All error paths produce clear log messages identifying the offending entity or platform domain.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr