### PR TITLE
Add diagnostics to OpenDisplay integration

### DIFF
--- a/homeassistant/components/opendisplay/diagnostics.py
+++ b/homeassistant/components/opendisplay/diagnostics.py
@@ -1,0 +1,42 @@
+"""Diagnostics support for OpenDisplay."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from . import OpenDisplayConfigEntry
+
+TO_REDACT = {"ssid", "password", "server_url"}
+
+
+def _asdict(obj: Any) -> Any:
+    """Recursively convert a dataclass to a dict, encoding bytes as hex strings."""
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {f.name: _asdict(getattr(obj, f.name)) for f in dataclasses.fields(obj)}
+    if isinstance(obj, bytes):
+        return obj.hex()
+    if isinstance(obj, list):
+        return [_asdict(item) for item in obj]
+    return obj
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: OpenDisplayConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    runtime = entry.runtime_data
+    fw = runtime.firmware
+
+    return {
+        "firmware": {
+            "major": fw["major"],
+            "minor": fw["minor"],
+            "sha": fw["sha"],
+        },
+        "is_flex": runtime.is_flex,
+        "device_config": async_redact_data(_asdict(runtime.device_config), TO_REDACT),
+    }

--- a/homeassistant/components/opendisplay/quality_scale.yaml
+++ b/homeassistant/components/opendisplay/quality_scale.yaml
@@ -54,7 +54,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: The device's BLE MAC address is both its unique identifier and does not change.

--- a/tests/components/opendisplay/snapshots/test_diagnostics.ambr
+++ b/tests/components/opendisplay/snapshots/test_diagnostics.ambr
@@ -1,0 +1,78 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'device_config': dict({
+      'binary_inputs': list([
+      ]),
+      'data_buses': list([
+      ]),
+      'displays': list([
+        dict({
+          'active_height_mm': 29,
+          'active_width_mm': 67,
+          'busy_pin': 255,
+          'clk_pin': 0,
+          'color_scheme': 1,
+          'cs_pin': 255,
+          'data_pin': 0,
+          'dc_pin': 255,
+          'display_technology': 0,
+          'full_update_mC': 0,
+          'instance_number': 0,
+          'panel_ic_type': 0,
+          'partial_update_support': 0,
+          'pixel_height': 128,
+          'pixel_width': 296,
+          'reserved': '000000000000000000000000000000000000000000000000000000000000000000',
+          'reserved_pins': '00000000000000',
+          'reset_pin': 255,
+          'rotation': 0,
+          'tag_type': 0,
+          'transmission_modes': 1,
+        }),
+      ]),
+      'leds': list([
+      ]),
+      'loaded': False,
+      'manufacturer': dict({
+        'board_revision': 0,
+        'board_type': 1,
+        'manufacturer_id': 1,
+        'reserved': '000000000000000000000000000000000000',
+      }),
+      'minor_version': 0,
+      'power': dict({
+        'battery_capacity_mah': '000000',
+        'battery_sense_enable_pin': 255,
+        'battery_sense_flags': 0,
+        'battery_sense_pin': 255,
+        'capacity_estimator': 0,
+        'deep_sleep_current_ua': 0,
+        'deep_sleep_time_seconds': 0,
+        'power_mode': 0,
+        'reserved': '000000000000000000000000',
+        'sleep_flags': 0,
+        'sleep_timeout_ms': 0,
+        'tx_power': 0,
+        'voltage_scaling_factor': 0,
+      }),
+      'sensors': list([
+      ]),
+      'system': dict({
+        'communication_modes': 0,
+        'device_flags': 0,
+        'ic_type': 0,
+        'pwr_pin': 255,
+        'reserved': '0000000000000000000000000000000000',
+      }),
+      'version': 0,
+      'wifi_config': None,
+    }),
+    'firmware': dict({
+      'major': 1,
+      'minor': 2,
+      'sha': 'abc123',
+    }),
+    'is_flex': True,
+  })
+# ---

--- a/tests/components/opendisplay/test_diagnostics.py
+++ b/tests/components/opendisplay/test_diagnostics.py
@@ -1,0 +1,29 @@
+"""Test the OpenDisplay diagnostics."""
+
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_opendisplay_device: MagicMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics output matches snapshot."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+    assert result == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds diagnostics support for the OpenDisplay integration. The diagnostics output includes the firmware version, whether the device is a Flex device, and the full device configuration (system, manufacturer, power, display, and peripheral settings). Sensitive Wi-Fi fields (`ssid`, `password`, `server_url`) are redacted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
