### PR TITLE
Add STT options and X-Speech-Options header

### DIFF
--- a/homeassistant/components/stt/__init__.py
+++ b/homeassistant/components/stt/__init__.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_suggest_report_issue
 from homeassistant.util import dt as dt_util, language as language_util
+from homeassistant.util.json import json_loads_object
 
 from .const import (
     DATA_COMPONENT,
@@ -269,6 +270,7 @@ class SpeechToTextView(HomeAssistantView):
         # Get metadata
         try:
             metadata = _metadata_from_header(request)
+            metadata.options = _options_from_header(request)
         except ValueError as err:
             raise HTTPBadRequest(text=str(err)) from err
 
@@ -403,6 +405,22 @@ def _metadata_from_header(request: web.Request) -> SpeechMetadata:
             sample_rate=args["sample_rate"],
             channel=args["channel"],
         )
+    except ValueError as err:
+        raise ValueError(f"Wrong format of X-Speech-Content: {err}") from err
+
+
+def _options_from_header(request: web.Request) -> dict[str, Any] | None:
+    """Extract options from STT options header.
+
+    X-Speech-Options:
+        {"key":"value", ...}
+    """
+    data = request.headers.get(istr("X-Speech-Options"))
+    if not data:
+        return None
+
+    try:
+        return json_loads_object(data)
     except ValueError as err:
         raise ValueError(f"Wrong format of X-Speech-Content: {err}") from err
 

--- a/homeassistant/components/stt/models.py
+++ b/homeassistant/components/stt/models.py
@@ -1,6 +1,7 @@
 """Speech-to-text data models."""
 
 from dataclasses import dataclass
+from typing import Any
 
 from .const import (
     AudioBitRates,
@@ -22,6 +23,7 @@ class SpeechMetadata:
     bit_rate: AudioBitRates
     sample_rate: AudioSampleRates
     channel: AudioChannels
+    options: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         """Finish initializing the metadata."""

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator, Iterable
 from contextlib import ExitStack
 from http import HTTPStatus
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -554,3 +555,59 @@ async def test_get_engine_entity(
     await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
 
     assert async_get_speech_to_text_engine(hass, "stt.test") is mock_provider_entity
+
+
+@pytest.mark.parametrize(
+    "setup", ["mock_setup", "mock_config_entry_setup"], indirect=True
+)
+async def test_speech_options_header(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup: MockSTTProvider | MockSTTProviderEntity,
+) -> None:
+    """Test that X-Speech-Options header is passed to SpeechMetadata."""
+    client = await hass_client()
+    options = {"key1": "value1", "key2": 123, "nested": {"a": "b"}}
+    response = await client.post(
+        f"/api/stt/{setup.url_path}",
+        headers={
+            "X-Speech-Content": (
+                "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=1;"
+                " language=en"
+            ),
+            "X-Speech-Options": json.dumps(
+                options,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ),
+        },
+    )
+    assert response.status == HTTPStatus.OK
+    assert len(setup.calls) == 1
+    metadata, _ = setup.calls[0]
+    assert metadata.options == options
+
+
+@pytest.mark.parametrize(
+    "setup", ["mock_setup", "mock_config_entry_setup"], indirect=True
+)
+async def test_speech_options_header_not_present(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    setup: MockSTTProvider | MockSTTProviderEntity,
+) -> None:
+    """Test that options are None when X-Speech-Options header is not present."""
+    client = await hass_client()
+    response = await client.post(
+        f"/api/stt/{setup.url_path}",
+        headers={
+            "X-Speech-Content": (
+                "format=wav; codec=pcm; sample_rate=16000; bit_rate=16; channel=1;"
+                " language=en"
+            ),
+        },
+    )
+    assert response.status == HTTPStatus.OK
+    assert len(setup.calls) == 1
+    metadata, _ = setup.calls[0]
+    assert metadata.options is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extends the `stt` integration's `SpeechMetadata` dataclass with an options `dict` that the speech-to-text integration can use in `async_process_audio_stream`. This is intended for STT services that support extra context, such as the domain of the speech and any custom terms.

In order to use these options externally from an app or add-on, a new `X-Speech-Options` header is added alongside the existing `X-Speech-Content` header in the REST API. A new header was used to avoid breaking existing clients, and to allow JSON to be used instead of the existing `key=value` format.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
