### PR TITLE
Support new Z-Wave JS "Opening state" notification variable

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -418,12 +418,6 @@ def is_valid_notification_binary_sensor(
     # of fanning out one binary sensor per state.
     if is_opening_state_notification_value(info.primary_value):
         return False
-    # Access Control legacy door/window states are handled by dedicated discovery
-    # schemas when Opening state is present.
-    if get_opening_state_notification_value(
-        info.node
-    ) is not None and is_legacy_access_control_window_door_value(info.primary_value):
-        return False
     return len(info.primary_value.metadata.states) > 1
 
 
@@ -471,6 +465,14 @@ async def async_setup_entry(
         elif info.platform_hint == "notification":
             # ensure the notification CC Value is valid as binary sensor
             if not is_valid_notification_binary_sensor(info):
+                return
+            # When Opening state is present, legacy door/window values are
+            # represented by ZWaveLegacyDoorStateBinarySensor via new-style discovery.
+            if get_opening_state_notification_value(
+                info.node
+            ) is not None and is_legacy_access_control_window_door_value(
+                info.primary_value
+            ):
                 return
             if (
                 notification_type := info.primary_value.metadata.cc_specific[
@@ -859,6 +861,29 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
             key="legacy_access_control_door_state_open_tilt",
             name="Window/door is open in tilt position",
             state_key=str(ACCESS_CONTROL_DOOR_STATE_OPEN_TILT),
+            parse_opening_state=_legacy_is_tilted,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door tilt state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={OpeningState.OPEN},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_tilt_state_tilted",
+            name="Window/door is tilted",
+            state_key=str(OpeningState.OPEN),
             parse_opening_state=_legacy_is_tilted,
             entity_registry_enabled_default=False,
         ),

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -34,7 +34,6 @@ from .const import DOMAIN
 from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity
 from .helpers import (
     get_opening_state_notification_value,
-    is_legacy_access_control_window_door_value,
     is_opening_state_notification_value,
 )
 from .models import (
@@ -467,14 +466,6 @@ async def async_setup_entry(
         elif info.platform_hint == "notification":
             # ensure the notification CC Value is valid as binary sensor
             if not is_valid_notification_binary_sensor(info):
-                return
-            # When Opening state is present, legacy door/window values are
-            # represented by ZWaveLegacyDoorStateBinarySensor via new-style discovery.
-            if get_opening_state_notification_value(
-                info.node
-            ) is not None and is_legacy_access_control_window_door_value(
-                info.primary_value
-            ):
                 return
             if (
                 notification_type := info.primary_value.metadata.cc_specific[

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -616,7 +616,10 @@ class ZWaveLegacyDoorStateBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return if the sensor is on or off."""
-        opening_state = self.info.node.values[self._opening_state_value_id].value
+        value = self.info.node.values.get(self._opening_state_value_id)
+        if value is None:
+            return None
+        opening_state = value.value
         if opening_state is None:
             return None
         try:
@@ -1017,6 +1020,42 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=NotificationZWaveJSEntityDescription(
             key=NOTIFICATION_ACCESS_CONTROL,
             states={OpeningState.OPEN},
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            type={ValueType.NUMBER},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        allow_multi=True,
+        entity_description=NotificationZWaveJSEntityDescription(
+            # NotificationType 6: Access Control - All other notification values.
+            # not_states excludes states already handled by more specific schemas above,
+            # so this catch-all only fires for genuinely unhandled property keys
+            # (e.g. barrier, keypad, credential events).
+            key=NOTIFICATION_ACCESS_CONTROL,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            not_states={
+                0,
+                # Lock state values (Lock state schemas consume the value when state 11 is
+                # available, but may not when state 11 is absent)
+                1,
+                2,
+                3,
+                4,
+                11,
+                # Door state (simple) / Door state values
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN,
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED,
+                ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR,
+                ACCESS_CONTROL_DOOR_STATE_OPEN_TILT,
+            },
         ),
         entity_class=ZWaveNotificationBinarySensor,
     ),

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING, cast
@@ -10,6 +11,7 @@ from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.lock import DOOR_STATUS_PROPERTY
 from zwave_js_server.const.command_class.notification import (
     CC_SPECIFIC_NOTIFICATION_TYPE,
+    AccessControlNotificationEvent,
     NotificationEvent,
     NotificationType,
     SmokeAlarmNotificationEvent,
@@ -65,6 +67,11 @@ NOTIFICATION_WEATHER = "16"
 NOTIFICATION_IRRIGATION = "17"
 NOTIFICATION_GAS = "18"
 
+# Deprecated/legacy synthetic Access Control door state notification
+# event IDs that don't exist in zwave-js-server
+ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR = 5632
+ACCESS_CONTROL_DOOR_STATE_OPEN_TILT = 5633
+
 
 class OpeningState(IntEnum):
     """Opening state values exposed by Access Control notifications."""
@@ -74,21 +81,25 @@ class OpeningState(IntEnum):
     TILTED = 2
 
 
-LEGACY_SIMPLE_DOOR_STATE_MAP: dict[str, set[OpeningState]] = {
-    "22": {OpeningState.OPEN, OpeningState.TILTED},
-    "23": {OpeningState.CLOSED},
-}
+# parse_opening_state helpers for the DEPRECATED legacy Access Control binary sensors.
+def _legacy_is_closed(opening_state: OpeningState) -> bool:
+    """Return if Opening state represents closed."""
+    return opening_state is OpeningState.CLOSED
 
-LEGACY_DOOR_STATE_MAP: dict[str, OpeningState] = {
-    "22": OpeningState.OPEN,
-    "23": OpeningState.CLOSED,
-    "5632": OpeningState.OPEN,
-    "5633": OpeningState.TILTED,
-}
 
-LEGACY_TILT_STATE_MAP: dict[str, OpeningState] = {
-    "1": OpeningState.TILTED,
-}
+def _legacy_is_open(opening_state: OpeningState) -> bool:
+    """Return if Opening state represents open."""
+    return opening_state is OpeningState.OPEN
+
+
+def _legacy_is_open_or_tilted(opening_state: OpeningState) -> bool:
+    """Return if Opening state represents open or tilted."""
+    return opening_state in (OpeningState.OPEN, OpeningState.TILTED)
+
+
+def _legacy_is_tilted(opening_state: OpeningState) -> bool:
+    """Return if Opening state represents tilted."""
+    return opening_state is OpeningState.TILTED
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -111,6 +122,14 @@ class NewNotificationZWaveJSEntityDescription(BinarySensorEntityDescription):
     """Represent a Z-Wave JS binary sensor entity description."""
 
     state_key: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class OpeningStateZWaveJSEntityDescription(BinarySensorEntityDescription):
+    """Describe a legacy Access Control binary sensor that derives state from Opening state."""
+
+    state_key: str
+    parse_opening_state: Callable[[OpeningState], bool]
 
 
 # Mappings for Notification sensors
@@ -399,6 +418,12 @@ def is_valid_notification_binary_sensor(
     # of fanning out one binary sensor per state.
     if is_opening_state_notification_value(info.primary_value):
         return False
+    # Access Control legacy door/window states are handled by dedicated discovery
+    # schemas when Opening state is present.
+    if get_opening_state_notification_value(
+        info.node
+    ) is not None and is_legacy_access_control_window_door_value(info.primary_value):
+        return False
     return len(info.primary_value.metadata.states) > 1
 
 
@@ -442,7 +467,7 @@ async def async_setup_entry(
         ):
             entities.append(ZWaveBooleanBinarySensor(config_entry, driver, info))
         elif isinstance(info, NewZwaveDiscoveryInfo):
-            pass  # other entity classes are not migrated yet
+            entities.append(info.entity_class(config_entry, driver, info))
         elif info.platform_hint == "notification":
             # ensure the notification CC Value is valid as binary sensor
             if not is_valid_notification_binary_sensor(info):
@@ -560,27 +585,8 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         """Initialize a ZWaveNotificationBinarySensor entity."""
         super().__init__(config_entry, driver, info)
         self.state_key = state_key
-        self._opening_state_notification_value = get_opening_state_notification_value(
-            self.info.node
-        )
         if description:
             self.entity_description = description
-
-        self._is_legacy_access_control_entity = False
-        if (
-            self._opening_state_notification_value is not None
-            and is_legacy_access_control_window_door_value(self.info.primary_value)
-        ):
-            self._is_legacy_access_control_entity = True
-            # Keep the old Access Control door/window entities for backwards
-            # compatibility, but discover them disabled by default when the new
-            # Opening state value is available. If a user re-enables one of
-            # those legacy entities, derive its state from Opening state so it
-            # stays consistent with the new enum sensor. Once those legacy
-            # entities are removed in a future deprecation cycle, this
-            # compatibility path can go away as well.
-            self._attr_entity_registry_enabled_default = False
-            self.watched_value_ids.add(self._opening_state_notification_value.value_id)
 
         # Entity class attributes
         self._attr_name = self.generate_name(
@@ -588,48 +594,54 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         )
         self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
 
-    def _derive_legacy_state_from_opening_state(self) -> bool | None:
-        """Derive a legacy Access Control binary sensor state from Opening state."""
-        if self._opening_state_notification_value is None:
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the sensor is on or off."""
+        if self.info.primary_value.value is None:
             return None
+        return int(self.info.primary_value.value) == int(self.state_key)
 
-        opening_state = self.info.node.values[
-            self._opening_state_notification_value.value_id
-        ].value
-        if opening_state is None:
-            return None
 
-        property_key = self.info.primary_value.property_key
+class ZWaveLegacyDoorStateBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
+    """DEPRECATED: Legacy door state binary sensors.
 
-        try:
-            opening_state = OpeningState(int(opening_state))
-        except TypeError, ValueError:
-            return None
+    These entities exist purely for backwards compatibility with users who had
+    door state binary sensors before the Opening state value was introduced.
+    They are disabled by default when the Opening state value is present and
+    should not be extended. State is derived from the Opening state notification
+    value using the parse_opening_state function defined on the entity description.
+    """
 
-        # Derive the deprecated legacy Access Control entities from the unified
-        # Opening state for users who explicitly re-enable them.
-        if property_key == "Door state (simple)":
-            expected_states = LEGACY_SIMPLE_DOOR_STATE_MAP.get(self.state_key)
-            return expected_states is not None and opening_state in expected_states
+    entity_description: OpeningStateZWaveJSEntityDescription
 
-        if property_key == "Door state":
-            expected_state = LEGACY_DOOR_STATE_MAP.get(self.state_key)
-            return expected_state is not None and opening_state == expected_state
-
-        if property_key == "Door tilt state":
-            expected_state = LEGACY_TILT_STATE_MAP.get(self.state_key)
-            return expected_state is not None and opening_state == expected_state
-
-        return None
+    def __init__(
+        self,
+        config_entry: ZwaveJSConfigEntry,
+        driver: Driver,
+        info: NewZwaveDiscoveryInfo,
+    ) -> None:
+        """Initialize a legacy Door state binary sensor entity."""
+        super().__init__(config_entry, driver, info)
+        opening_state_value = get_opening_state_notification_value(self.info.node)
+        assert opening_state_value is not None  # guaranteed by required_values schema
+        self._opening_state_value_id = opening_state_value.value_id
+        self.watched_value_ids.add(opening_state_value.value_id)
+        self._attr_unique_id = (
+            f"{self._attr_unique_id}.{self.entity_description.state_key}"
+        )
 
     @property
     def is_on(self) -> bool | None:
         """Return if the sensor is on or off."""
-        if self._is_legacy_access_control_entity:
-            return self._derive_legacy_state_from_opening_state()
-        if self.info.primary_value.value is None:
+        opening_state = self.info.node.values[self._opening_state_value_id].value
+        if opening_state is None:
             return None
-        return int(self.info.primary_value.value) == int(self.state_key)
+        try:
+            return self.entity_description.parse_opening_state(
+                OpeningState(int(opening_state))
+            )
+        except TypeError, ValueError:
+            return None
 
 
 class ZWavePropertyBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
@@ -676,7 +688,183 @@ class ZWaveConfigParameterBinarySensor(ZWaveBooleanBinarySensor):
         )
 
 
+OPENING_STATE_NOTIFICATION_SCHEMA = ZWaveValueDiscoverySchema(
+    command_class={CommandClass.NOTIFICATION},
+    property={"Access Control"},
+    property_key={"Opening state"},
+    type={ValueType.NUMBER},
+    any_available_cc_specific={
+        (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+    },
+)
+
+
 DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    # -------------------------------------------------------------------
+    # DEPRECATED legacy Access Control door/window binary sensors.
+    # These schemas exist only for backwards compatibility with users who
+    # already have these entities registered. New integrations should use
+    # the Opening state enum sensor instead. Do not add new schemas here.
+    # All schemas below use ZWaveLegacyDoorStateBinarySensor and are
+    # disabled by default (entity_registry_enabled_default=False).
+    # -------------------------------------------------------------------
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state (simple)"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_simple_open",
+            name="Window/door is open",
+            state_key=str(
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            ),
+            parse_opening_state=_legacy_is_open_or_tilted,
+            device_class=BinarySensorDeviceClass.DOOR,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state (simple)"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_simple_closed",
+            name="Window/door is closed",
+            state_key=str(
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
+            ),
+            parse_opening_state=_legacy_is_closed,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_open",
+            name="Window/door is open",
+            state_key=str(
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            ),
+            parse_opening_state=_legacy_is_open,
+            device_class=BinarySensorDeviceClass.DOOR,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_closed",
+            name="Window/door is closed",
+            state_key=str(
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
+            ),
+            parse_opening_state=_legacy_is_closed,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_open_regular",
+            name="Window/door is open in regular position",
+            state_key=str(ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR),
+            parse_opening_state=_legacy_is_open,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={ACCESS_CONTROL_DOOR_STATE_OPEN_TILT},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        required_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=OpeningStateZWaveJSEntityDescription(
+            key="legacy_access_control_door_state_open_tilt",
+            name="Window/door is open in tilt position",
+            state_key=str(ACCESS_CONTROL_DOOR_STATE_OPEN_TILT),
+            parse_opening_state=_legacy_is_tilted,
+            entity_registry_enabled_default=False,
+        ),
+        entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    # -------------------------------------------------------------------
     NewZWaveDiscoverySchema(
         # Hoppe eHandle ConnectSense (0x0313:0x0701:0x0002) - window tilt sensor.
         # The window tilt state is exposed as a binary sensor that is disabled by default

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -178,6 +178,7 @@ class OpeningStateZWaveJSEntityDescription(BinarySensorEntityDescription):
 # to use the new discovery schema and we've removed the old discovery code.
 MIGRATED_NOTIFICATION_TYPES = {
     NotificationType.SMOKE_ALARM,
+    NotificationType.ACCESS_CONTROL,
 }
 
 NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] = (
@@ -251,19 +252,6 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
     NotificationZWaveJSEntityDescription(
         # NotificationType 5: Water - All other State Id's
         key=NOTIFICATION_WATER,
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    NotificationZWaveJSEntityDescription(
-        # NotificationType 6: Access Control - State Id's 1, 2, 3, 4 (Lock)
-        key=NOTIFICATION_ACCESS_CONTROL,
-        states={1, 2, 3, 4},
-        device_class=BinarySensorDeviceClass.LOCK,
-    ),
-    NotificationZWaveJSEntityDescription(
-        # NotificationType 6: Access Control - State Id's 11 (Lock jammed)
-        key=NOTIFICATION_ACCESS_CONTROL,
-        states={11},
-        device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     NotificationZWaveJSEntityDescription(
@@ -695,6 +683,48 @@ OPENING_STATE_NOTIFICATION_SCHEMA = ZWaveValueDiscoverySchema(
 
 
 DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Lock state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={1, 2, 3, 4},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        allow_multi=True,
+        entity_description=NotificationZWaveJSEntityDescription(
+            # NotificationType 6: Access Control - State Id's 1, 2, 3, 4 (Lock)
+            key=NOTIFICATION_ACCESS_CONTROL,
+            states={1, 2, 3, 4},
+            device_class=BinarySensorDeviceClass.LOCK,
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Lock state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={11},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        entity_description=NotificationZWaveJSEntityDescription(
+            # NotificationType 6: Access Control - State Id's 11 (Lock jammed)
+            key=NOTIFICATION_ACCESS_CONTROL,
+            states={11},
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
     # -------------------------------------------------------------------
     # DEPRECATED legacy Access Control door/window binary sensors.
     # These schemas exist only for backwards compatibility with users who

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -73,6 +73,8 @@ ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR = 5632
 ACCESS_CONTROL_DOOR_STATE_OPEN_TILT = 5633
 
 
+# Numeric State values used by the "Opening state" notification variable.
+# This is only needed temporarily until the legacy Access Control door state binary sensors are removed.
 class OpeningState(IntEnum):
     """Opening state values exposed by Access Control notifications."""
 

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -130,7 +130,7 @@ class NewNotificationZWaveJSEntityDescription(BinarySensorEntityDescription):
 class OpeningStateZWaveJSEntityDescription(BinarySensorEntityDescription):
     """Describe a legacy Access Control binary sensor that derives state from Opening state."""
 
-    state_key: str
+    state_key: int
     parse_opening_state: Callable[[OpeningState], bool]
 
 
@@ -266,13 +266,6 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         states={11},
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    NotificationZWaveJSEntityDescription(
-        # NotificationType 6: Access Control - State Id 22 (door/window open)
-        key=NOTIFICATION_ACCESS_CONTROL,
-        not_states={23},
-        states={22},
-        device_class=BinarySensorDeviceClass.DOOR,
     ),
     NotificationZWaveJSEntityDescription(
         # NotificationType 7: Home Security - State Id's 1, 2 (intrusion)
@@ -462,8 +455,15 @@ async def async_setup_entry(
             and info.entity_class is ZWaveBooleanBinarySensor
         ):
             entities.append(ZWaveBooleanBinarySensor(config_entry, driver, info))
+        elif (
+            isinstance(info, NewZwaveDiscoveryInfo)
+            and info.entity_class is ZWaveLegacyDoorStateBinarySensor
+        ):
+            entities.append(
+                ZWaveLegacyDoorStateBinarySensor(config_entry, driver, info)
+            )
         elif isinstance(info, NewZwaveDiscoveryInfo):
-            entities.append(info.entity_class(config_entry, driver, info))
+            pass  # other entity classes are not migrated yet
         elif info.platform_hint == "notification":
             # ensure the notification CC Value is valid as binary sensor
             if not is_valid_notification_binary_sensor(info):
@@ -731,9 +731,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_simple_open",
             name="Window/door is open",
-            state_key=str(
-                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
-            ),
+            state_key=AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN,
             parse_opening_state=_legacy_is_open_or_tilted,
             device_class=BinarySensorDeviceClass.DOOR,
             entity_registry_enabled_default=False,
@@ -759,9 +757,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_simple_closed",
             name="Window/door is closed",
-            state_key=str(
-                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
-            ),
+            state_key=AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED,
             parse_opening_state=_legacy_is_closed,
             entity_registry_enabled_default=False,
         ),
@@ -786,9 +782,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_open",
             name="Window/door is open",
-            state_key=str(
-                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
-            ),
+            state_key=AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN,
             parse_opening_state=_legacy_is_open,
             device_class=BinarySensorDeviceClass.DOOR,
             entity_registry_enabled_default=False,
@@ -814,9 +808,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_closed",
             name="Window/door is closed",
-            state_key=str(
-                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED
-            ),
+            state_key=AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_CLOSED,
             parse_opening_state=_legacy_is_closed,
             entity_registry_enabled_default=False,
         ),
@@ -839,7 +831,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_open_regular",
             name="Window/door is open in regular position",
-            state_key=str(ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR),
+            state_key=ACCESS_CONTROL_DOOR_STATE_OPEN_REGULAR,
             parse_opening_state=_legacy_is_open,
             entity_registry_enabled_default=False,
         ),
@@ -862,7 +854,7 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_state_open_tilt",
             name="Window/door is open in tilt position",
-            state_key=str(ACCESS_CONTROL_DOOR_STATE_OPEN_TILT),
+            state_key=ACCESS_CONTROL_DOOR_STATE_OPEN_TILT,
             parse_opening_state=_legacy_is_tilted,
             entity_registry_enabled_default=False,
         ),
@@ -885,11 +877,127 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         entity_description=OpeningStateZWaveJSEntityDescription(
             key="legacy_access_control_door_tilt_state_tilted",
             name="Window/door is tilted",
-            state_key=str(OpeningState.OPEN),
+            state_key=OpeningState.OPEN,
             parse_opening_state=_legacy_is_tilted,
             entity_registry_enabled_default=False,
         ),
         entity_class=ZWaveLegacyDoorStateBinarySensor,
+    ),
+    # -------------------------------------------------------------------
+    # Access Control door/window binary sensors for devices that do NOT have the
+    # new "Opening state" notification value. These replace the old-style discovery
+    # that used NOTIFICATION_SENSOR_MAPPINGS.
+    #
+    # Each property_key uses two schemas so that only the "open" state entity gets
+    # device_class=DOOR, while the other state entities (e.g. "closed") do not.
+    # The first schema uses allow_multi=True so it does not consume the value, allowing
+    # the second schema to also match and create entities for the remaining states.
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state (simple)"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        absent_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=NotificationZWaveJSEntityDescription(
+            key=NOTIFICATION_ACCESS_CONTROL,
+            states={AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN},
+            device_class=BinarySensorDeviceClass.DOOR,
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state (simple)"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        absent_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        entity_description=NotificationZWaveJSEntityDescription(
+            key=NOTIFICATION_ACCESS_CONTROL,
+            not_states={AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN},
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        absent_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        allow_multi=True,
+        entity_description=NotificationZWaveJSEntityDescription(
+            key=NOTIFICATION_ACCESS_CONTROL,
+            states={AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN},
+            device_class=BinarySensorDeviceClass.DOOR,
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={
+                AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN
+            },
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        absent_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        entity_description=NotificationZWaveJSEntityDescription(
+            key=NOTIFICATION_ACCESS_CONTROL,
+            not_states={AccessControlNotificationEvent.DOOR_STATE_WINDOW_DOOR_IS_OPEN},
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Access Control"},
+            property_key={"Door tilt state"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={OpeningState.OPEN},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.ACCESS_CONTROL)
+            },
+        ),
+        absent_values=[OPENING_STATE_NOTIFICATION_SCHEMA],
+        entity_description=NotificationZWaveJSEntityDescription(
+            key=NOTIFICATION_ACCESS_CONTROL,
+            states={OpeningState.OPEN},
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
     ),
     # -------------------------------------------------------------------
     NewZWaveDiscoverySchema(

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import IntEnum
 from typing import TYPE_CHECKING, cast
 
 from zwave_js_server.const import CommandClass
@@ -29,6 +30,11 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity
+from .helpers import (
+    get_opening_state_notification_value,
+    is_legacy_access_control_window_door_value,
+    is_opening_state_notification_value,
+)
 from .models import (
     NewZWaveDiscoverySchema,
     ValueType,
@@ -58,6 +64,31 @@ NOTIFICATION_WATER_VALVE = "15"
 NOTIFICATION_WEATHER = "16"
 NOTIFICATION_IRRIGATION = "17"
 NOTIFICATION_GAS = "18"
+
+
+class OpeningState(IntEnum):
+    """Opening state values exposed by Access Control notifications."""
+
+    CLOSED = 0
+    OPEN = 1
+    TILTED = 2
+
+
+LEGACY_SIMPLE_DOOR_STATE_MAP: dict[str, set[OpeningState]] = {
+    "22": {OpeningState.OPEN, OpeningState.TILTED},
+    "23": {OpeningState.CLOSED},
+}
+
+LEGACY_DOOR_STATE_MAP: dict[str, OpeningState] = {
+    "22": OpeningState.OPEN,
+    "23": OpeningState.CLOSED,
+    "5632": OpeningState.OPEN,
+    "5633": OpeningState.TILTED,
+}
+
+LEGACY_TILT_STATE_MAP: dict[str, OpeningState] = {
+    "1": OpeningState.TILTED,
+}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -364,6 +395,10 @@ def is_valid_notification_binary_sensor(
     """Return if the notification CC Value is valid as binary sensor."""
     if not info.primary_value.metadata.states:
         return False
+    # Access Control - Opening state is exposed as a single enum sensor instead
+    # of fanning out one binary sensor per state.
+    if is_opening_state_notification_value(info.primary_value):
+        return False
     return len(info.primary_value.metadata.states) > 1
 
 
@@ -525,8 +560,27 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         """Initialize a ZWaveNotificationBinarySensor entity."""
         super().__init__(config_entry, driver, info)
         self.state_key = state_key
+        self._opening_state_notification_value = get_opening_state_notification_value(
+            self.info.node
+        )
         if description:
             self.entity_description = description
+
+        self._is_legacy_access_control_entity = False
+        if (
+            self._opening_state_notification_value is not None
+            and is_legacy_access_control_window_door_value(self.info.primary_value)
+        ):
+            self._is_legacy_access_control_entity = True
+            # Keep the old Access Control door/window entities for backwards
+            # compatibility, but discover them disabled by default when the new
+            # Opening state value is available. If a user re-enables one of
+            # those legacy entities, derive its state from Opening state so it
+            # stays consistent with the new enum sensor. Once those legacy
+            # entities are removed in a future deprecation cycle, this
+            # compatibility path can go away as well.
+            self._attr_entity_registry_enabled_default = False
+            self.watched_value_ids.add(self._opening_state_notification_value.value_id)
 
         # Entity class attributes
         self._attr_name = self.generate_name(
@@ -534,9 +588,45 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         )
         self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
 
+    def _derive_legacy_state_from_opening_state(self) -> bool | None:
+        """Derive a legacy Access Control binary sensor state from Opening state."""
+        if self._opening_state_notification_value is None:
+            return None
+
+        opening_state = self.info.node.values[
+            self._opening_state_notification_value.value_id
+        ].value
+        if opening_state is None:
+            return None
+
+        property_key = self.info.primary_value.property_key
+
+        try:
+            opening_state = OpeningState(int(opening_state))
+        except TypeError, ValueError:
+            return None
+
+        # Derive the deprecated legacy Access Control entities from the unified
+        # Opening state for users who explicitly re-enable them.
+        if property_key == "Door state (simple)":
+            expected_states = LEGACY_SIMPLE_DOOR_STATE_MAP.get(self.state_key)
+            return expected_states is not None and opening_state in expected_states
+
+        if property_key == "Door state":
+            expected_state = LEGACY_DOOR_STATE_MAP.get(self.state_key)
+            return expected_state is not None and opening_state == expected_state
+
+        if property_key == "Door tilt state":
+            expected_state = LEGACY_TILT_STATE_MAP.get(self.state_key)
+            return expected_state is not None and opening_state == expected_state
+
+        return None
+
     @property
     def is_on(self) -> bool | None:
         """Return if the sensor is on or off."""
+        if self._is_legacy_access_control_entity:
+            return self._derive_legacy_state_from_opening_state()
         if self.info.primary_value.value is None:
             return None
         return int(self.info.primary_value.value) == int(self.state_key)

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -207,3 +207,12 @@ COVER_TILT_PROPERTY_KEYS: set[str | int | None] = {
     WindowCoveringPropertyKey.VERTICAL_SLATS_ANGLE,
     WindowCoveringPropertyKey.VERTICAL_SLATS_ANGLE_NO_POSITION,
 }
+
+# notification
+NOTIFICATION_ACCESS_CONTROL_PROPERTY = "Access Control"
+OPENING_STATE_PROPERTY_KEY = "Opening state"
+LEGACY_DOOR_STATE_PROPERTY_KEYS: set[str] = {
+    "Door state",
+    "Door state (simple)",
+    "Door tilt state",
+}

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -211,8 +211,3 @@ COVER_TILT_PROPERTY_KEYS: set[str | int | None] = {
 # notification
 NOTIFICATION_ACCESS_CONTROL_PROPERTY = "Access Control"
 OPENING_STATE_PROPERTY_KEY = "Opening state"
-LEGACY_DOOR_STATE_PROPERTY_KEYS: set[str] = {
-    "Door state",
-    "Door state (simple)",
-    "Door tilt state",
-}

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -16,6 +16,10 @@ from zwave_js_server.const import (
     ConfigurationValueType,
     LogLevel,
 )
+from zwave_js_server.const.command_class.notification import (
+    CC_SPECIFIC_NOTIFICATION_TYPE,
+    NotificationType,
+)
 from zwave_js_server.model.controller import Controller, ProvisioningEntry
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.log_config import LogConfig
@@ -51,8 +55,11 @@ from .const import (
     ATTR_PROPERTY,
     ATTR_PROPERTY_KEY,
     DOMAIN,
+    LEGACY_DOOR_STATE_PROPERTY_KEYS,
     LIB_LOGGER,
     LOGGER,
+    NOTIFICATION_ACCESS_CONTROL_PROPERTY,
+    OPENING_STATE_PROPERTY_KEY,
 )
 from .models import ZwaveJSConfigEntry
 
@@ -124,6 +131,48 @@ def get_state_key_from_unique_id(unique_id: str) -> int | None:
 def get_value_of_zwave_value(value: ZwaveValue | None) -> Any | None:
     """Return the value of a ZwaveValue."""
     return value.value if value else None
+
+
+def _get_notification_type(value: ZwaveValue) -> int | None:
+    """Return the notification type for a value, if available."""
+    return value.metadata.cc_specific.get(CC_SPECIFIC_NOTIFICATION_TYPE)
+
+
+def is_opening_state_notification_value(value: ZwaveValue) -> bool:
+    """Return if the value is the Access Control Opening state notification."""
+    if (
+        value.command_class != CommandClass.NOTIFICATION
+        or _get_notification_type(value) != NotificationType.ACCESS_CONTROL
+    ):
+        return False
+
+    return (
+        value.property_ == NOTIFICATION_ACCESS_CONTROL_PROPERTY
+        and value.property_key == OPENING_STATE_PROPERTY_KEY
+    )
+
+
+def get_opening_state_notification_value(node: ZwaveNode) -> ZwaveValue | None:
+    """Return the Access Control Opening state value for a node."""
+    value_id = get_value_id_str(
+        node,
+        CommandClass.NOTIFICATION,
+        NOTIFICATION_ACCESS_CONTROL_PROPERTY,
+        None,
+        OPENING_STATE_PROPERTY_KEY,
+    )
+    return node.values.get(value_id)
+
+
+def is_legacy_access_control_window_door_value(value: ZwaveValue) -> bool:
+    """Return if the value is a legacy Access Control door/window notification."""
+    if (
+        value.command_class != CommandClass.NOTIFICATION
+        or _get_notification_type(value) != NotificationType.ACCESS_CONTROL
+    ):
+        return False
+
+    return value.property_key in LEGACY_DOOR_STATE_PROPERTY_KEYS
 
 
 async def async_enable_statistics(driver: Driver) -> None:

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -55,7 +55,6 @@ from .const import (
     ATTR_PROPERTY,
     ATTR_PROPERTY_KEY,
     DOMAIN,
-    LEGACY_DOOR_STATE_PROPERTY_KEYS,
     LIB_LOGGER,
     LOGGER,
     NOTIFICATION_ACCESS_CONTROL_PROPERTY,
@@ -162,17 +161,6 @@ def get_opening_state_notification_value(node: ZwaveNode) -> ZwaveValue | None:
         OPENING_STATE_PROPERTY_KEY,
     )
     return node.values.get(value_id)
-
-
-def is_legacy_access_control_window_door_value(value: ZwaveValue) -> bool:
-    """Return if the value is a legacy Access Control door/window notification."""
-    if (
-        value.command_class != CommandClass.NOTIFICATION
-        or _get_notification_type(value) != NotificationType.ACCESS_CONTROL
-    ):
-        return False
-
-    return value.property_key in LEGACY_DOOR_STATE_PROPERTY_KEYS
 
 
 async def async_enable_statistics(driver: Driver) -> None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -862,10 +862,19 @@ class ZWaveListSensor(ZwaveSensor):
         # Notification sensors have the following name mapping (variables are property
         # keys, name is property)
         # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/notifications.json
-        self._attr_name = self.generate_name(
-            alternate_value_name=self.info.primary_value.property_name,
-            additional_info=[self.info.primary_value.property_key_name],
-        )
+        if info.platform_hint == "notification":
+            self._attr_name = self.generate_name(
+                alternate_value_name=(
+                    info.primary_value.property_key_name
+                    or info.primary_value.metadata.label
+                    or info.primary_value.property_name
+                )
+            )
+        else:
+            self._attr_name = self.generate_name(
+                alternate_value_name=info.primary_value.property_name,
+                additional_info=[info.primary_value.property_key_name],
+            )
         if self.info.primary_value.metadata.states:
             self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_options = list(info.primary_value.metadata.states.values())

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -859,8 +859,8 @@ class ZWaveListSensor(ZwaveSensor):
         )
 
         # Entity class attributes
-        # Notification sensors have the following name mapping (variables are property
-        # keys, name is property)
+        # Notification sensors use the notification event label as the name
+        # (property_key_name/metadata.label, falling back to property_name)
         # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/notifications.json
         if info.platform_hint == "notification":
             self._attr_name = self.generate_name(

--- a/tests/components/zwave_js/fixtures/hoppe_ehandle_connectsense_state.json
+++ b/tests/components/zwave_js/fixtures/hoppe_ehandle_connectsense_state.json
@@ -109,6 +109,33 @@
       "commandClass": 113,
       "commandClassName": "Notification",
       "property": "Access Control",
+      "propertyKey": "Opening state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Opening state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Opening state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Closed",
+          "1": "Open"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
       "propertyKey": "Door state",
       "propertyName": "Access Control",
       "propertyKeyName": "Door state",

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -419,6 +419,73 @@ async def test_opening_state_disables_legacy_window_door_notification_sensors(
     assert all(hass.states.get(entry.entity_id) is None for entry in legacy_entries)
 
 
+async def test_reenabled_legacy_door_state_entity_follows_opening_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test a re-enabled legacy Door state entity derives state from Opening state."""
+    node = Node(
+        client,
+        _add_opening_state_value(
+            hoppe_ehandle_connectsense_state,
+            value=1,
+            include_tilt_metadata=True,
+        ),
+    )
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    legacy_entry = next(
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.platform == "zwave_js"
+        and entry.original_name == "Window/door is open in tilt position"
+    )
+
+    entity_registry.async_update_entity(legacy_entry.entity_id, disabled_by=None)
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(legacy_entry.entity_id)
+    assert state
+    assert state.state == STATE_OFF
+
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Notification",
+                    "commandClass": 113,
+                    "endpoint": 0,
+                    "property": "Access Control",
+                    "propertyKey": "Opening state",
+                    "newValue": 2,
+                    "prevValue": 1,
+                    "propertyName": "Access Control",
+                    "propertyKeyName": "Opening state",
+                },
+            },
+        )
+    )
+
+    state = hass.states.get(legacy_entry.entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+
 async def test_config_parameter_binary_sensor(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -102,6 +102,27 @@ def _add_door_tilt_state_value(node_state: dict[str, Any]) -> dict[str, Any]:
     return updated_state
 
 
+def _add_lock_state_notification_states(node_state: dict[str, Any]) -> dict[str, Any]:
+    """Return a node state with Access Control lock state notification states 1-4."""
+    updated_state = copy.deepcopy(node_state)
+    for value_data in updated_state["values"]:
+        if (
+            value_data.get("commandClass") == 113
+            and value_data.get("property") == "Access Control"
+            and value_data.get("propertyKey") == "Lock state"
+        ):
+            value_data["metadata"].setdefault("states", {}).update(
+                {
+                    "1": "Manual lock operation",
+                    "2": "Manual unlock operation",
+                    "3": "RF lock operation",
+                    "4": "RF unlock operation",
+                }
+            )
+            break
+    return updated_state
+
+
 @pytest.fixture
 def platforms() -> list[str]:
     """Fixture to specify platforms to test."""
@@ -616,6 +637,44 @@ async def test_legacy_door_state_entities_follow_opening_state(
         assert state.state == STATE_OFF, (
             f"{e.entity_id} ({e.original_name}) should be OFF when Opening state=Open"
         )
+
+
+async def test_access_control_lock_state_notification_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    lock_august_asl03_state,
+) -> None:
+    """Test Access Control lock state notification sensors from new discovery schemas."""
+    node = Node(client, _add_lock_state_notification_states(lock_august_asl03_state))
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    lock_state_entities = [
+        state
+        for state in hass.states.async_all("binary_sensor")
+        if state.attributes.get(ATTR_DEVICE_CLASS) == BinarySensorDeviceClass.LOCK
+    ]
+    assert len(lock_state_entities) == 4
+    assert all(state.state == STATE_OFF for state in lock_state_entities)
+
+    jammed_entry = next(
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "binary_sensor"
+        and entry.platform == "zwave_js"
+        and entry.original_name == "Lock jammed"
+    )
+    assert jammed_entry.original_device_class == BinarySensorDeviceClass.PROBLEM
+    assert jammed_entry.entity_category == EntityCategory.DIAGNOSTIC
+
+    jammed_state = hass.states.get(jammed_entry.entity_id)
+    assert jammed_state
+    assert jammed_state.state == STATE_OFF
 
 
 async def test_config_parameter_binary_sensor(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -411,13 +411,7 @@ async def test_opening_state_disables_legacy_window_door_notification_sensors(
     """Test Opening state disables legacy Access Control window/door sensors."""
     node = Node(
         client,
-        _add_door_tilt_state_value(
-            _add_opening_state_value(
-                hoppe_ehandle_connectsense_state,
-                value=1,
-                include_tilt_metadata=True,
-            )
-        ),
+        _add_door_tilt_state_value(hoppe_ehandle_connectsense_state),
     )
     client.driver.controller.nodes[node.node_id] = node
 
@@ -461,14 +455,7 @@ async def test_reenabled_legacy_door_state_entity_follows_opening_state(
     hoppe_ehandle_connectsense_state,
 ) -> None:
     """Test a re-enabled legacy Door state entity derives state from Opening state."""
-    node = Node(
-        client,
-        _add_opening_state_value(
-            hoppe_ehandle_connectsense_state,
-            value=1,
-            include_tilt_metadata=True,
-        ),
-    )
+    node = Node(client, hoppe_ehandle_connectsense_state)
     client.driver.controller.nodes[node.node_id] = node
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
@@ -508,7 +495,7 @@ async def test_reenabled_legacy_door_state_entity_follows_opening_state(
                     "property": "Access Control",
                     "propertyKey": "Opening state",
                     "newValue": 2,
-                    "prevValue": 1,
+                    "prevValue": 0,
                     "propertyName": "Access Control",
                     "propertyKeyName": "Opening state",
                 },
@@ -519,6 +506,116 @@ async def test_reenabled_legacy_door_state_entity_follows_opening_state(
     state = hass.states.get(legacy_entry.entity_id)
     assert state
     assert state.state == STATE_ON
+
+
+async def test_legacy_door_state_entities_follow_opening_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test all legacy door state entities correctly derive state from Opening state."""
+    node = Node(client, hoppe_ehandle_connectsense_state)
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Re-enable all 6 legacy door state entities.
+    legacy_names = {
+        "Window/door is open",
+        "Window/door is closed",
+        "Window/door is open in regular position",
+        "Window/door is open in tilt position",
+    }
+    legacy_entries = [
+        e
+        for e in entity_registry.entities.values()
+        if e.domain == "binary_sensor"
+        and e.platform == "zwave_js"
+        and e.original_name in legacy_names
+    ]
+    assert len(legacy_entries) == 6
+    for legacy_entry in legacy_entries:
+        entity_registry.async_update_entity(legacy_entry.entity_id, disabled_by=None)
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # With Opening state = 0 (Closed), all "open" entities should be OFF and
+    # all "closed" entities should be ON.
+    open_entries = [
+        e for e in legacy_entries if e.original_name == "Window/door is open"
+    ]
+    closed_entries = [
+        e for e in legacy_entries if e.original_name == "Window/door is closed"
+    ]
+    open_regular_entries = [
+        e
+        for e in legacy_entries
+        if e.original_name == "Window/door is open in regular position"
+    ]
+    open_tilt_entries = [
+        e
+        for e in legacy_entries
+        if e.original_name == "Window/door is open in tilt position"
+    ]
+
+    for e in open_entries + open_regular_entries + open_tilt_entries:
+        state = hass.states.get(e.entity_id)
+        assert state, f"{e.entity_id} should have a state"
+        assert state.state == STATE_OFF, (
+            f"{e.entity_id} ({e.original_name}) should be OFF when Opening state=Closed"
+        )
+    for e in closed_entries:
+        state = hass.states.get(e.entity_id)
+        assert state, f"{e.entity_id} should have a state"
+        assert state.state == STATE_ON, (
+            f"{e.entity_id} ({e.original_name}) should be ON when Opening state=Closed"
+        )
+
+    # Update Opening state to 1 (Open).
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Notification",
+                    "commandClass": 113,
+                    "endpoint": 0,
+                    "property": "Access Control",
+                    "propertyKey": "Opening state",
+                    "newValue": 1,
+                    "prevValue": 0,
+                    "propertyName": "Access Control",
+                    "propertyKeyName": "Opening state",
+                },
+            },
+        )
+    )
+    await hass.async_block_till_done()
+
+    # All "open" entities should now be ON, "closed" OFF, "tilt" OFF.
+    for e in open_entries + open_regular_entries:
+        state = hass.states.get(e.entity_id)
+        assert state, f"{e.entity_id} should have a state"
+        assert state.state == STATE_ON, (
+            f"{e.entity_id} ({e.original_name}) should be ON when Opening state=Open"
+        )
+    for e in closed_entries + open_tilt_entries:
+        state = hass.states.get(e.entity_id)
+        assert state, f"{e.entity_id} should have a state"
+        assert state.state == STATE_OFF, (
+            f"{e.entity_id} ({e.original_name}) should be OFF when Opening state=Open"
+        )
 
 
 async def test_config_parameter_binary_sensor(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -33,42 +33,6 @@ from .common import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-def _add_opening_state_value(
-    node_state: dict[str, Any], *, value: int, include_tilt_metadata: bool
-) -> dict[str, Any]:
-    """Return a node state with an Opening state notification value added."""
-    updated_state = copy.deepcopy(node_state)
-    states = {"0": "Closed", "1": "Open"}
-    if include_tilt_metadata:
-        states["2"] = "Tilted"
-
-    updated_state["values"].append(
-        {
-            "commandClass": 113,
-            "commandClassName": "Notification",
-            "property": "Access Control",
-            "propertyKey": "Opening state",
-            "propertyName": "Access Control",
-            "propertyKeyName": "Opening state",
-            "ccVersion": 8,
-            "metadata": {
-                "type": "number",
-                "readable": True,
-                "writeable": False,
-                "label": "Opening state",
-                "ccSpecific": {"notificationType": 6},
-                "min": 0,
-                "max": 255,
-                "states": states,
-                "stateful": True,
-                "secret": False,
-            },
-            "value": value,
-        }
-    )
-    return updated_state
-
-
 def _add_door_tilt_state_value(node_state: dict[str, Any]) -> dict[str, Any]:
     """Return a node state with a Door tilt state notification value added."""
     updated_state = copy.deepcopy(node_state)
@@ -403,16 +367,15 @@ async def test_opening_state_notification_does_not_create_binary_sensors(
     hoppe_ehandle_connectsense_state,
 ) -> None:
     """Test Opening state does not fan out into per-state binary sensors."""
-    node_state = copy.deepcopy(hoppe_ehandle_connectsense_state)
-    node_state["values"] = []
-    node = Node(
-        client,
-        _add_opening_state_value(
-            node_state,
-            value=1,
-            include_tilt_metadata=True,
-        ),
-    )
+    # The eHandle fixture has a Binary Sensor CC value for tilt, which we
+    # want to ignore in the assertion below
+    state = copy.deepcopy(hoppe_ehandle_connectsense_state)
+    state["values"] = [
+        v
+        for v in state["values"]
+        if v.get("commandClass") != 48  # Binary Sensor CC
+    ]
+    node = Node(client, state)
     client.driver.controller.nodes[node.node_id] = node
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -66,6 +66,40 @@ def _add_door_tilt_state_value(node_state: dict[str, Any]) -> dict[str, Any]:
     return updated_state
 
 
+def _add_barrier_status_value(node_state: dict[str, Any]) -> dict[str, Any]:
+    """Return a node state with a Barrier status Access Control notification value added."""
+    updated_state = copy.deepcopy(node_state)
+    updated_state["values"].append(
+        {
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Access Control",
+            "propertyKey": "Barrier status",
+            "propertyName": "Access Control",
+            "propertyKeyName": "Barrier status",
+            "ccVersion": 8,
+            "metadata": {
+                "type": "number",
+                "readable": True,
+                "writeable": False,
+                "label": "Barrier status",
+                "ccSpecific": {"notificationType": 6},
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "idle",
+                    "64": "Barrier performing initialization process",
+                    "72": "Barrier safety beam obstacle",
+                },
+                "stateful": True,
+                "secret": False,
+            },
+            "value": 0,
+        }
+    )
+    return updated_state
+
+
 def _add_lock_state_notification_states(node_state: dict[str, Any]) -> dict[str, Any]:
     """Return a node state with Access Control lock state notification states 1-4."""
     updated_state = copy.deepcopy(node_state)
@@ -638,6 +672,43 @@ async def test_access_control_lock_state_notification_sensors(
     jammed_state = hass.states.get(jammed_entry.entity_id)
     assert jammed_state
     assert jammed_state.state == STATE_OFF
+
+
+async def test_access_control_catch_all_with_opening_state_present(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test that unrelated Access Control values are discovered even when Opening state is present."""
+    node = Node(
+        client,
+        _add_barrier_status_value(hoppe_ehandle_connectsense_state),
+    )
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The two non-idle barrier states should each become a diagnostic binary sensor
+    barrier_entries = [
+        reg_entry
+        for reg_entry in entity_registry.entities.values()
+        if reg_entry.domain == "binary_sensor"
+        and reg_entry.platform == "zwave_js"
+        and reg_entry.entity_category == EntityCategory.DIAGNOSTIC
+        and reg_entry.original_name
+        and "barrier" in reg_entry.original_name.lower()
+    ]
+    assert len(barrier_entries) == 2, (
+        f"Expected 2 barrier status sensors, got {[e.original_name for e in barrier_entries]}"
+    )
+    for reg_entry in barrier_entries:
+        state = hass.states.get(reg_entry.entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
 
 
 async def test_config_parameter_binary_sensor(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -69,6 +69,39 @@ def _add_opening_state_value(
     return updated_state
 
 
+def _add_door_tilt_state_value(node_state: dict[str, Any]) -> dict[str, Any]:
+    """Return a node state with a Door tilt state notification value added."""
+    updated_state = copy.deepcopy(node_state)
+    updated_state["values"].append(
+        {
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Access Control",
+            "propertyKey": "Door tilt state",
+            "propertyName": "Access Control",
+            "propertyKeyName": "Door tilt state",
+            "ccVersion": 8,
+            "metadata": {
+                "type": "number",
+                "readable": True,
+                "writeable": False,
+                "label": "Door tilt state",
+                "ccSpecific": {"notificationType": 6},
+                "min": 0,
+                "max": 255,
+                "states": {
+                    "0": "Window/door is not tilted",
+                    "1": "Window/door is tilted",
+                },
+                "stateful": True,
+                "secret": False,
+            },
+            "value": 0,
+        }
+    )
+    return updated_state
+
+
 @pytest.fixture
 def platforms() -> list[str]:
     """Fixture to specify platforms to test."""
@@ -378,10 +411,12 @@ async def test_opening_state_disables_legacy_window_door_notification_sensors(
     """Test Opening state disables legacy Access Control window/door sensors."""
     node = Node(
         client,
-        _add_opening_state_value(
-            hoppe_ehandle_connectsense_state,
-            value=1,
-            include_tilt_metadata=True,
+        _add_door_tilt_state_value(
+            _add_opening_state_value(
+                hoppe_ehandle_connectsense_state,
+                value=1,
+                include_tilt_metadata=True,
+            )
         ),
     )
     client.driver.controller.nodes[node.node_id] = node
@@ -411,7 +446,7 @@ async def test_opening_state_disables_legacy_window_door_notification_sensors(
         )
     ]
 
-    assert len(legacy_entries) == 6
+    assert len(legacy_entries) == 7
     assert all(
         entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
         for entry in legacy_entries

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Test the Z-Wave JS binary sensor platform."""
 
+import copy
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from zwave_js_server.event import Event
@@ -29,6 +31,42 @@ from .common import (
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def _add_opening_state_value(
+    node_state: dict[str, Any], *, value: int, include_tilt_metadata: bool
+) -> dict[str, Any]:
+    """Return a node state with an Opening state notification value added."""
+    updated_state = copy.deepcopy(node_state)
+    states = {"0": "Closed", "1": "Open"}
+    if include_tilt_metadata:
+        states["2"] = "Tilted"
+
+    updated_state["values"].append(
+        {
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Access Control",
+            "propertyKey": "Opening state",
+            "propertyName": "Access Control",
+            "propertyKeyName": "Opening state",
+            "ccVersion": 8,
+            "metadata": {
+                "type": "number",
+                "readable": True,
+                "writeable": False,
+                "label": "Opening state",
+                "ccSpecific": {"notificationType": 6},
+                "min": 0,
+                "max": 255,
+                "states": states,
+                "stateful": True,
+                "secret": False,
+            },
+            "value": value,
+        }
+    )
+    return updated_state
 
 
 @pytest.fixture
@@ -303,6 +341,82 @@ async def test_property_sensor_door_status(
     state = hass.states.get(PROPERTY_DOOR_STATUS_BINARY_SENSOR)
     assert state
     assert state.state == STATE_UNKNOWN
+
+
+async def test_opening_state_notification_does_not_create_binary_sensors(
+    hass: HomeAssistant,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test Opening state does not fan out into per-state binary sensors."""
+    node_state = copy.deepcopy(hoppe_ehandle_connectsense_state)
+    node_state["values"] = []
+    node = Node(
+        client,
+        _add_opening_state_value(
+            node_state,
+            value=1,
+            include_tilt_metadata=True,
+        ),
+    )
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.states.async_all("binary_sensor")
+
+
+async def test_opening_state_disables_legacy_window_door_notification_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test Opening state disables legacy Access Control window/door sensors."""
+    node = Node(
+        client,
+        _add_opening_state_value(
+            hoppe_ehandle_connectsense_state,
+            value=1,
+            include_tilt_metadata=True,
+        ),
+    )
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    legacy_entries = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "binary_sensor"
+        and entry.platform == "zwave_js"
+        and (
+            entry.original_name
+            in {
+                "Window/door is open",
+                "Window/door is closed",
+                "Window/door is open in regular position",
+                "Window/door is open in tilt position",
+            }
+            or (
+                entry.original_name == "Window/door is tilted"
+                and entry.original_device_class != BinarySensorDeviceClass.WINDOW
+            )
+        )
+    ]
+
+    assert len(legacy_entries) == 6
+    assert all(
+        entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        for entry in legacy_entries
+    )
+    assert all(hass.states.get(entry.entity_id) is None for entry in legacy_entries)
 
 
 async def test_config_parameter_binary_sensor(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -2,6 +2,7 @@
 
 import copy
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from zwave_js_server.const.command_class.meter import MeterType
@@ -10,6 +11,7 @@ from zwave_js_server.exceptions import FailedZWaveCommand
 from zwave_js_server.model.node import Node
 
 from homeassistant.components.sensor import (
+    ATTR_OPTIONS,
     ATTR_STATE_CLASS,
     SensorDeviceClass,
     SensorStateClass,
@@ -62,6 +64,42 @@ from .common import (
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def _add_opening_state_value(
+    node_state: dict[str, Any], *, value: int, include_tilt_metadata: bool
+) -> dict[str, Any]:
+    """Return a node state with an Opening state notification value added."""
+    updated_state = copy.deepcopy(node_state)
+    states = {"0": "Closed", "1": "Open"}
+    if include_tilt_metadata:
+        states["2"] = "Tilted"
+
+    updated_state["values"].append(
+        {
+            "commandClass": 113,
+            "commandClassName": "Notification",
+            "property": "Access Control",
+            "propertyKey": "Opening state",
+            "propertyName": "Access Control",
+            "propertyKeyName": "Opening state",
+            "ccVersion": 11,
+            "metadata": {
+                "type": "number",
+                "readable": True,
+                "writeable": False,
+                "label": "Opening state",
+                "ccSpecific": {"notificationType": 6},
+                "min": 0,
+                "max": 255,
+                "states": states,
+                "stateful": True,
+                "secret": False,
+            },
+            "value": value,
+        }
+    )
+    return updated_state
 
 
 @pytest.fixture
@@ -775,6 +813,35 @@ async def test_unit_change(hass: HomeAssistant, zp3111, client, integration) -> 
     assert state.state == "100.0"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
+
+
+async def test_opening_state_sensor(
+    hass: HomeAssistant,
+    client,
+    hoppe_ehandle_connectsense_state,
+) -> None:
+    """Test Opening state is exposed as an enum sensor."""
+    node = Node(
+        client,
+        _add_opening_state_value(
+            hoppe_ehandle_connectsense_state,
+            value=2,
+            include_tilt_metadata=True,
+        ),
+    )
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.ehandle_connectsense_opening_state")
+    assert state
+    assert state.state == "Tilted"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
+    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open", "Tilted"]
+    assert state.attributes[ATTR_VALUE] == 2
 
 
 CONTROLLER_STATISTICS_ENTITY_PREFIX = "sensor.z_stick_gen5_usb_controller_"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -2,7 +2,6 @@
 
 import copy
 from datetime import timedelta
-from typing import Any
 
 import pytest
 from zwave_js_server.const.command_class.meter import MeterType
@@ -64,42 +63,6 @@ from .common import (
 )
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-
-
-def _add_opening_state_value(
-    node_state: dict[str, Any], *, value: int, include_tilt_metadata: bool
-) -> dict[str, Any]:
-    """Return a node state with an Opening state notification value added."""
-    updated_state = copy.deepcopy(node_state)
-    states = {"0": "Closed", "1": "Open"}
-    if include_tilt_metadata:
-        states["2"] = "Tilted"
-
-    updated_state["values"].append(
-        {
-            "commandClass": 113,
-            "commandClassName": "Notification",
-            "property": "Access Control",
-            "propertyKey": "Opening state",
-            "propertyName": "Access Control",
-            "propertyKeyName": "Opening state",
-            "ccVersion": 11,
-            "metadata": {
-                "type": "number",
-                "readable": True,
-                "writeable": False,
-                "label": "Opening state",
-                "ccSpecific": {"notificationType": 6},
-                "min": 0,
-                "max": 255,
-                "states": states,
-                "stateful": True,
-                "secret": False,
-            },
-            "value": value,
-        }
-    )
-    return updated_state
 
 
 @pytest.fixture
@@ -821,14 +784,7 @@ async def test_opening_state_sensor(
     hoppe_ehandle_connectsense_state,
 ) -> None:
     """Test Opening state is exposed as an enum sensor."""
-    node = Node(
-        client,
-        _add_opening_state_value(
-            hoppe_ehandle_connectsense_state,
-            value=2,
-            include_tilt_metadata=True,
-        ),
-    )
+    node = Node(client, hoppe_ehandle_connectsense_state)
     client.driver.controller.nodes[node.node_id] = node
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
@@ -838,10 +794,10 @@ async def test_opening_state_sensor(
 
     state = hass.states.get("sensor.ehandle_connectsense_opening_state")
     assert state
-    assert state.state == "Tilted"
+    assert state.state == "Closed"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
-    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open", "Tilted"]
-    assert state.attributes[ATTR_VALUE] == 2
+    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open"]
+    assert state.attributes[ATTR_VALUE] == 0
 
     # Make sure we're not accidentally creating enum sensors for legacy
     # Door/Window notification variables.

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -843,6 +843,15 @@ async def test_opening_state_sensor(
     assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open", "Tilted"]
     assert state.attributes[ATTR_VALUE] == 2
 
+    # Make sure we're not accidentally creating enum sensors for legacy
+    # Door/Window notification variables.
+    legacy_sensor_ids = [
+        "sensor.ehandle_connectsense_door_state",
+        "sensor.ehandle_connectsense_door_state_simple",
+    ]
+    for entity_id in legacy_sensor_ids:
+        assert hass.states.get(entity_id) is None
+
 
 CONTROLLER_STATISTICS_ENTITY_PREFIX = "sensor.z_stick_gen5_usb_controller_"
 # controller statistics with initial state of 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Window/door sensors are currently a mess. For a simple tilt-capable sensor, 7 entities are exposed, half of which don't work for some devices and which cannot really be distinguished.

To solve this, Z-Wave JS will add a new synthetic "Opening state" notification variable that replaces "Door state", "Door state (simple)" and "Door tilt state". This notification variable has 3 states: Closed, Open, Tilted.

This PR adds support for that variable. It changes the discovery of all other door state sensors to be disabled by default, and it discovers a new enum sensor for "Opening state", just like the Homee and HomaticIP integrations also do.
It also syncs the state of those legacy sensors with the Opening state, so they at least work a bit better.

<img width="334" height="669" alt="grafik" src="https://github.com/user-attachments/assets/6897ca4c-e920-4b46-8e47-1953b6e1d435" />

In the long run we should remove those legacy sensors entirely. How can we mark them as deprecated?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/zwave-js/backlog/issues/23
- This PR is related to issue: depends on https://github.com/home-assistant/core/pull/165234 and a Z-Wave JS release
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
