### PR TITLE
Buffer backup upload progress events

### DIFF
--- a/homeassistant/components/backup/coordinator.py
+++ b/homeassistant/components/backup/coordinator.py
@@ -16,6 +16,7 @@ from .manager import (
     BackupManagerState,
     BackupPlatformEvent,
     ManagerStateEvent,
+    UploadBackupEvent,
 )
 
 type BackupConfigEntry = ConfigEntry[BackupDataUpdateCoordinator]
@@ -64,6 +65,8 @@ class BackupDataUpdateCoordinator(DataUpdateCoordinator[BackupCoordinatorData]):
         """Handle new event."""
         LOGGER.debug("Received backup event: %s", event)
         self._last_event = event
+        if isinstance(event, UploadBackupEvent):
+            return
         self.config_entry.async_create_task(self.hass, self.async_refresh())
 
     async def _async_update_data(self) -> BackupCoordinatorData:

--- a/homeassistant/components/backup/coordinator.py
+++ b/homeassistant/components/backup/coordinator.py
@@ -16,7 +16,6 @@ from .manager import (
     BackupManagerState,
     BackupPlatformEvent,
     ManagerStateEvent,
-    UploadBackupEvent,
 )
 
 type BackupConfigEntry = ConfigEntry[BackupDataUpdateCoordinator]
@@ -65,8 +64,6 @@ class BackupDataUpdateCoordinator(DataUpdateCoordinator[BackupCoordinatorData]):
         """Handle new event."""
         LOGGER.debug("Received backup event: %s", event)
         self._last_event = event
-        if isinstance(event, UploadBackupEvent):
-            return
         self.config_entry.async_create_task(self.hass, self.async_refresh())
 
     async def _async_update_data(self) -> BackupCoordinatorData:

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -620,6 +620,14 @@ class BackupManager:
                 on_progress=on_upload_progress,
             )
             upload_progress_debouncer.async_cancel()
+            self.async_on_backup_event(
+                UploadBackupEvent(
+                    manager_state=self.state,
+                    agent_id=agent_id,
+                    uploaded_bytes=_backup.size,
+                    total_bytes=_backup.size,
+                )
+            )
             if streamer:
                 await streamer.wait()
 

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -24,7 +24,7 @@ from securetar import SecureTarArchive, atomic_contents_add
 
 from homeassistant.backup_restore import RESTORE_BACKUP_FILE, RESTORE_BACKUP_RESULT_FILE
 from homeassistant.const import __version__ as HAVERSION
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import (
     frame,
     instance_id,
@@ -32,6 +32,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
     start,
 )
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.json import json_bytes
 from homeassistant.util import dt as dt_util, json as json_util
 from homeassistant.util.async_iterator import AsyncIteratorReader
@@ -381,6 +382,10 @@ class BackupManager:
         self._backup_platform_event_subscriptions: list[
             Callable[[BackupPlatformEvent], None]
         ] = []
+
+        # Upload progress throttling
+        self._pending_upload_events: dict[str, UploadBackupEvent] = {}
+        self._upload_progress_unsub: CALLBACK_TYPE | None = None
 
     async def async_setup(self) -> None:
         """Set up the backup manager."""
@@ -1398,12 +1403,51 @@ class BackupManager:
         """Forward event to subscribers."""
         if (current_state := self.state) != (new_state := event.manager_state):
             LOGGER.debug("Backup state: %s -> %s", current_state, new_state)
-        if not isinstance(event, UploadBackupEvent):
-            self.last_event = event
-            if not isinstance(event, (BlockedEvent, IdleEvent)):
-                self.last_action_event = event
+        if isinstance(event, UploadBackupEvent):
+            self._pending_upload_events[event.agent_id] = event
+            if self._upload_progress_unsub is None:
+                # Send the first event immediately, then throttle
+                self._flush_upload_events()
+                self._schedule_upload_flush()
+            return
+        # Flush any pending upload events before sending a non-upload event
+        self._cancel_upload_flush()
+        self._flush_upload_events()
+        self.last_event = event
+        if not isinstance(event, (BlockedEvent, IdleEvent)):
+            self.last_action_event = event
         for subscription in self._backup_event_subscriptions:
             subscription(event)
+
+    @callback
+    def _schedule_upload_flush(self) -> None:
+        """Schedule a flush of pending upload events."""
+        self._upload_progress_unsub = async_call_later(
+            self.hass, 1, self._on_upload_flush_timer
+        )
+
+    @callback
+    def _on_upload_flush_timer(self, _now: Any) -> None:
+        """Flush pending upload events on timer."""
+        self._upload_progress_unsub = None
+        self._flush_upload_events()
+        if self._pending_upload_events:
+            self._schedule_upload_flush()
+
+    @callback
+    def _cancel_upload_flush(self) -> None:
+        """Cancel a scheduled upload flush."""
+        if self._upload_progress_unsub is not None:
+            self._upload_progress_unsub()
+            self._upload_progress_unsub = None
+
+    @callback
+    def _flush_upload_events(self) -> None:
+        """Send all pending upload events to subscribers."""
+        for event in self._pending_upload_events.values():
+            for subscription in self._backup_event_subscriptions:
+                subscription(event)
+        self._pending_upload_events.clear()
 
     @callback
     def async_subscribe_events(

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -24,7 +24,7 @@ from securetar import SecureTarArchive, atomic_contents_add
 
 from homeassistant.backup_restore import RESTORE_BACKUP_FILE, RESTORE_BACKUP_RESULT_FILE
 from homeassistant.const import __version__ as HAVERSION
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     frame,
     instance_id,
@@ -32,7 +32,7 @@ from homeassistant.helpers import (
     issue_registry as ir,
     start,
 )
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.json import json_bytes
 from homeassistant.util import dt as dt_util, json as json_util
 from homeassistant.util.async_iterator import AsyncIteratorReader
@@ -78,6 +78,8 @@ from .util import (
     validate_password,
     validate_password_stream,
 )
+
+UPLOAD_PROGRESS_DEBOUNCE_SECONDS = 1
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -383,10 +385,6 @@ class BackupManager:
             Callable[[BackupPlatformEvent], None]
         ] = []
 
-        # Upload progress throttling
-        self._pending_upload_events: dict[str, UploadBackupEvent] = {}
-        self._upload_progress_unsub: CALLBACK_TYPE | None = None
-
     async def async_setup(self) -> None:
         """Set up the backup manager."""
         stored = await self.store.load()
@@ -595,17 +593,26 @@ class BackupManager:
                 )
             agent = self.backup_agents[agent_id]
 
+            upload_progress_debouncer: Debouncer[None] = Debouncer(
+                self.hass,
+                LOGGER,
+                cooldown=UPLOAD_PROGRESS_DEBOUNCE_SECONDS,
+                immediate=True,
+            )
+
             @callback
             def on_upload_progress(*, bytes_uploaded: int, **kwargs: Any) -> None:
                 """Handle upload progress."""
-                self.async_on_backup_event(
-                    UploadBackupEvent(
-                        manager_state=self.state,
-                        agent_id=agent_id,
-                        uploaded_bytes=bytes_uploaded,
-                        total_bytes=_backup.size,
-                    )
+                event = UploadBackupEvent(
+                    manager_state=self.state,
+                    agent_id=agent_id,
+                    uploaded_bytes=bytes_uploaded,
+                    total_bytes=_backup.size,
                 )
+                upload_progress_debouncer.function = callback(
+                    lambda: self.async_on_backup_event(event)
+                )
+                upload_progress_debouncer.async_schedule_call()
 
             await agent.async_upload_backup(
                 open_stream=open_stream_func,
@@ -1403,51 +1410,12 @@ class BackupManager:
         """Forward event to subscribers."""
         if (current_state := self.state) != (new_state := event.manager_state):
             LOGGER.debug("Backup state: %s -> %s", current_state, new_state)
-        if isinstance(event, UploadBackupEvent):
-            self._pending_upload_events[event.agent_id] = event
-            if self._upload_progress_unsub is None:
-                # Send the first event immediately, then throttle
-                self._flush_upload_events()
-                self._schedule_upload_flush()
-            return
-        # Flush any pending upload events before sending a non-upload event
-        self._cancel_upload_flush()
-        self._flush_upload_events()
-        self.last_event = event
-        if not isinstance(event, (BlockedEvent, IdleEvent)):
-            self.last_action_event = event
+        if not isinstance(event, UploadBackupEvent):
+            self.last_event = event
+            if not isinstance(event, (BlockedEvent, IdleEvent)):
+                self.last_action_event = event
         for subscription in self._backup_event_subscriptions:
             subscription(event)
-
-    @callback
-    def _schedule_upload_flush(self) -> None:
-        """Schedule a flush of pending upload events."""
-        self._upload_progress_unsub = async_call_later(
-            self.hass, 1, self._on_upload_flush_timer
-        )
-
-    @callback
-    def _on_upload_flush_timer(self, _now: Any) -> None:
-        """Flush pending upload events on timer."""
-        self._upload_progress_unsub = None
-        self._flush_upload_events()
-        if self._pending_upload_events:
-            self._schedule_upload_flush()
-
-    @callback
-    def _cancel_upload_flush(self) -> None:
-        """Cancel a scheduled upload flush."""
-        if self._upload_progress_unsub is not None:
-            self._upload_progress_unsub()
-            self._upload_progress_unsub = None
-
-    @callback
-    def _flush_upload_events(self) -> None:
-        """Send all pending upload events to subscribers."""
-        for event in self._pending_upload_events.values():
-            for subscription in self._backup_event_subscriptions:
-                subscription(event)
-        self._pending_upload_events.clear()
 
     @callback
     def async_subscribe_events(

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -619,6 +619,7 @@ class BackupManager:
                 backup=_backup,
                 on_progress=on_upload_progress,
             )
+            upload_progress_debouncer.async_cancel()
             if streamer:
                 await streamer.wait()
 

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -593,25 +593,33 @@ class BackupManager:
                 )
             agent = self.backup_agents[agent_id]
 
+            latest_uploaded_bytes = 0
+
+            @callback
+            def _emit_upload_progress() -> None:
+                """Emit the latest upload progress event."""
+                self.async_on_backup_event(
+                    UploadBackupEvent(
+                        manager_state=self.state,
+                        agent_id=agent_id,
+                        uploaded_bytes=latest_uploaded_bytes,
+                        total_bytes=_backup.size,
+                    )
+                )
+
             upload_progress_debouncer: Debouncer[None] = Debouncer(
                 self.hass,
                 LOGGER,
                 cooldown=UPLOAD_PROGRESS_DEBOUNCE_SECONDS,
                 immediate=True,
+                function=_emit_upload_progress,
             )
 
             @callback
             def on_upload_progress(*, bytes_uploaded: int, **kwargs: Any) -> None:
                 """Handle upload progress."""
-                event = UploadBackupEvent(
-                    manager_state=self.state,
-                    agent_id=agent_id,
-                    uploaded_bytes=bytes_uploaded,
-                    total_bytes=_backup.size,
-                )
-                upload_progress_debouncer.function = callback(
-                    lambda: self.async_on_backup_event(event)
-                )
+                nonlocal latest_uploaded_bytes
+                latest_uploaded_bytes = bytes_uploaded
                 upload_progress_debouncer.async_schedule_call()
 
             await agent.async_upload_backup(

--- a/tests/components/backup/snapshots/test_websocket.ambr
+++ b/tests/components/backup/snapshots/test_websocket.ambr
@@ -5619,10 +5619,10 @@
 # name: test_generate[None].6
   dict({
     'event': dict({
+      'agent_id': 'backup.local',
       'manager_state': 'create_backup',
-      'reason': None,
-      'stage': None,
-      'state': 'completed',
+      'total_bytes': 10240,
+      'uploaded_bytes': 10240,
     }),
     'id': 1,
     'type': 'event',
@@ -5694,10 +5694,10 @@
 # name: test_generate[data1].6
   dict({
     'event': dict({
+      'agent_id': 'backup.local',
       'manager_state': 'create_backup',
-      'reason': None,
-      'stage': None,
-      'state': 'completed',
+      'total_bytes': 10240,
+      'uploaded_bytes': 10240,
     }),
     'id': 1,
     'type': 'event',
@@ -5769,10 +5769,10 @@
 # name: test_generate[data2].6
   dict({
     'event': dict({
+      'agent_id': 'backup.local',
       'manager_state': 'create_backup',
-      'reason': None,
-      'stage': None,
-      'state': 'completed',
+      'total_bytes': 10240,
+      'uploaded_bytes': 10240,
     }),
     'id': 1,
     'type': 'event',

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Generator
 from dataclasses import replace
-from datetime import timedelta
 from io import StringIO
 import json
 from pathlib import Path
@@ -44,19 +43,16 @@ from homeassistant.components.backup.manager import (
     BackupManagerState,
     CreateBackupStage,
     CreateBackupState,
-    IdleEvent,
     NewBackup,
     ReceiveBackupStage,
     ReceiveBackupState,
     RestoreBackupState,
-    UploadBackupEvent,
     WrittenBackup,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.util import dt as dt_util
 
 from .common import (
     LOCAL_AGENT_ID,
@@ -69,7 +65,6 @@ from .common import (
     setup_backup_platform,
 )
 
-from tests.common import async_fire_time_changed
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 _EXPECTED_FILES = [
@@ -3766,7 +3761,7 @@ async def test_upload_progress_event(
     result = await ws_client.receive_json()
     assert result["event"]["stage"] == CreateBackupStage.UPLOAD_TO_AGENTS
 
-    # Upload progress events for the remote agent
+    # Upload progress event for the remote agent (first fires immediately)
     result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
@@ -3775,14 +3770,7 @@ async def test_upload_progress_event(
         "total_bytes": ANY,
     }
 
-    result = await ws_client.receive_json()
-    assert result["event"] == {
-        "manager_state": BackupManagerState.CREATE_BACKUP,
-        "agent_id": "test.remote",
-        "uploaded_bytes": 1000,
-        "total_bytes": ANY,
-    }
-
+    # Second progress event is debounced; backup completes before it fires
     result = await ws_client.receive_json()
     assert result["event"]["state"] == CreateBackupState.COMPLETED
 
@@ -3790,111 +3778,69 @@ async def test_upload_progress_event(
     assert result["event"] == {"manager_state": BackupManagerState.IDLE}
 
 
-async def test_upload_progress_throttled(
+async def test_upload_progress_debounced(
     hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    generate_backup_id: MagicMock,
 ) -> None:
-    """Test that rapid upload progress events are throttled."""
-    await setup_backup_integration(hass)
-    manager = hass.data[DATA_MANAGER]
+    """Test that rapid upload progress events are debounced."""
+    agent_ids = [LOCAL_AGENT_ID, "test.remote"]
+    mock_agents = await setup_backup_integration(hass, remote_agents=["test.remote"])
 
-    events: list[UploadBackupEvent] = []
-    manager.async_subscribe_events(events.append)
+    remote_agent = mock_agents["test.remote"]
+    original_side_effect = remote_agent.async_upload_backup.side_effect
 
-    upload_event_1 = UploadBackupEvent(
-        manager_state=BackupManagerState.CREATE_BACKUP,
-        agent_id="test.remote",
-        uploaded_bytes=100,
-        total_bytes=1000,
-    )
-    upload_event_2 = UploadBackupEvent(
-        manager_state=BackupManagerState.CREATE_BACKUP,
-        agent_id="test.remote",
-        uploaded_bytes=500,
-        total_bytes=1000,
-    )
-    upload_event_3 = UploadBackupEvent(
-        manager_state=BackupManagerState.CREATE_BACKUP,
-        agent_id="test.remote",
-        uploaded_bytes=1000,
-        total_bytes=1000,
-    )
+    async def upload_with_progress(**kwargs: Any) -> None:
+        """Upload and report progress."""
+        on_progress = kwargs["on_progress"]
+        on_progress(bytes_uploaded=100)
+        on_progress(bytes_uploaded=500)
+        on_progress(bytes_uploaded=1000)
+        await original_side_effect(**kwargs)
 
-    # First event fires immediately
-    manager.async_on_backup_event(upload_event_1)
-    assert len(events) == 1
-    assert events[-1] == upload_event_1
+    remote_agent.async_upload_backup.side_effect = upload_with_progress
 
-    # Subsequent events within the throttle window are buffered
-    manager.async_on_backup_event(upload_event_2)
-    manager.async_on_backup_event(upload_event_3)
-    assert len(events) == 1
+    ws_client = await hass_ws_client(hass)
 
-    # After the throttle timer fires, only the latest event per agent is sent
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
-    await hass.async_block_till_done()
-    assert len(events) == 2
-    assert events[-1] == upload_event_3
+    await ws_client.send_json_auto_id({"type": "backup/subscribe_events"})
 
+    result = await ws_client.receive_json()
+    assert result["event"] == {"manager_state": BackupManagerState.IDLE}
 
-async def test_upload_progress_flushed_on_state_change(
-    hass: HomeAssistant,
-) -> None:
-    """Test that pending upload progress events are flushed on state change."""
-    await setup_backup_integration(hass)
-    manager = hass.data[DATA_MANAGER]
+    result = await ws_client.receive_json()
+    assert result["success"] is True
 
-    events = []
-    manager.async_subscribe_events(events.append)
-
-    upload_event = UploadBackupEvent(
-        manager_state=BackupManagerState.CREATE_BACKUP,
-        agent_id="test.remote",
-        uploaded_bytes=100,
-        total_bytes=1000,
-    )
-
-    # First event fires immediately
-    manager.async_on_backup_event(upload_event)
-    assert len(events) == 1
-
-    # Buffer another event
-    upload_event_2 = UploadBackupEvent(
-        manager_state=BackupManagerState.CREATE_BACKUP,
-        agent_id="test.remote",
-        uploaded_bytes=500,
-        total_bytes=1000,
-    )
-    manager.async_on_backup_event(upload_event_2)
-    assert len(events) == 1
-
-    # A non-upload event flushes pending upload events first
-    manager.async_on_backup_event(IdleEvent())
-    assert len(events) == 3
-    assert events[1] == upload_event_2
-    assert events[2].manager_state == BackupManagerState.IDLE
-
-
-async def test_coordinator_skips_refresh_on_upload_progress(
-    hass: HomeAssistant,
-) -> None:
-    """Test that the coordinator does not refresh on upload progress events."""
-    await setup_backup_integration(hass)
-
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    coordinator = config_entry.runtime_data
-
-    with patch.object(coordinator, "async_refresh") as mock_refresh:
-        coordinator._on_event(
-            UploadBackupEvent(
-                manager_state=BackupManagerState.CREATE_BACKUP,
-                agent_id="test.remote",
-                uploaded_bytes=500,
-                total_bytes=1000,
-            )
+    with patch("pathlib.Path.open", mock_open(read_data=b"test")):
+        await ws_client.send_json_auto_id(
+            {"type": "backup/generate", "agent_ids": agent_ids}
         )
-        await hass.async_block_till_done()
-        mock_refresh.assert_not_called()
+        result = await ws_client.receive_json()
+        assert result["event"]["manager_state"] == BackupManagerState.CREATE_BACKUP
 
-        coordinator._on_event(IdleEvent())
+        result = await ws_client.receive_json()
+        assert result["success"] is True
+
         await hass.async_block_till_done()
-        mock_refresh.assert_called_once()
+
+    # Consume intermediate stage events (home_assistant, upload_to_agents)
+    result = await ws_client.receive_json()
+    assert result["event"]["stage"] == CreateBackupStage.HOME_ASSISTANT
+
+    result = await ws_client.receive_json()
+    assert result["event"]["stage"] == CreateBackupStage.UPLOAD_TO_AGENTS
+
+    # Only the first upload progress event fires immediately (debounced)
+    result = await ws_client.receive_json()
+    assert result["event"] == {
+        "manager_state": BackupManagerState.CREATE_BACKUP,
+        "agent_id": "test.remote",
+        "uploaded_bytes": 100,
+        "total_bytes": ANY,
+    }
+
+    # The remaining events are debounced; backup completes before they fire
+    result = await ws_client.receive_json()
+    assert result["event"]["state"] == CreateBackupState.COMPLETED
+
+    result = await ws_client.receive_json()
+    assert result["event"] == {"manager_state": BackupManagerState.IDLE}

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3824,6 +3824,9 @@ async def test_upload_progress_debounced(
     remote_agent = mock_agents["test.remote"]
     original_side_effect = remote_agent.async_upload_backup.side_effect
 
+    progress_done = asyncio.Event()
+    upload_done = asyncio.Event()
+
     async def upload_with_progress(**kwargs: Any) -> None:
         """Upload and report progress."""
         on_progress = kwargs["on_progress"]
@@ -3832,6 +3835,8 @@ async def test_upload_progress_debounced(
         # These two are buffered during cooldown; 1000 should replace 500
         on_progress(bytes_uploaded=500)
         on_progress(bytes_uploaded=1000)
+        progress_done.set()
+        await upload_done.wait()
         await original_side_effect(**kwargs)
 
     remote_agent.async_upload_backup.side_effect = upload_with_progress

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3872,3 +3872,29 @@ async def test_upload_progress_flushed_on_state_change(
     assert len(events) == 3
     assert events[1] == upload_event_2
     assert events[2].manager_state == BackupManagerState.IDLE
+
+
+async def test_coordinator_skips_refresh_on_upload_progress(
+    hass: HomeAssistant,
+) -> None:
+    """Test that the coordinator does not refresh on upload progress events."""
+    await setup_backup_integration(hass)
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    coordinator = config_entry.runtime_data
+
+    with patch.object(coordinator, "async_refresh") as mock_refresh:
+        coordinator._on_event(
+            UploadBackupEvent(
+                manager_state=BackupManagerState.CREATE_BACKUP,
+                agent_id="test.remote",
+                uploaded_bytes=500,
+                total_bytes=1000,
+            )
+        )
+        await hass.async_block_till_done()
+        mock_refresh.assert_not_called()
+
+        coordinator._on_event(IdleEvent())
+        await hass.async_block_till_done()
+        mock_refresh.assert_called_once()

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Generator
 from dataclasses import replace
+from datetime import timedelta
 from io import StringIO
 import json
 from pathlib import Path
@@ -47,12 +48,14 @@ from homeassistant.components.backup.manager import (
     ReceiveBackupStage,
     ReceiveBackupState,
     RestoreBackupState,
+    UploadBackupEvent,
     WrittenBackup,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 
 from .common import (
     LOCAL_AGENT_ID,
@@ -65,6 +68,7 @@ from .common import (
     setup_backup_platform,
 )
 
+from tests.common import async_fire_time_changed
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 _EXPECTED_FILES = [
@@ -596,7 +600,10 @@ async def test_initiate_backup(
         "state": CreateBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
         "reason": None,
@@ -843,7 +850,10 @@ async def test_initiate_backup_with_agent_error(
         "state": CreateBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
         "reason": "upload_failed",
@@ -1401,7 +1411,10 @@ async def test_initiate_backup_non_agent_upload_error(
         "state": CreateBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
         "reason": "upload_failed",
@@ -1594,7 +1607,10 @@ async def test_initiate_backup_file_error_upload_to_agents(
         "state": CreateBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
         "reason": "upload_failed",
@@ -2709,7 +2725,10 @@ async def test_receive_backup_file_read_error(
         "state": ReceiveBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.RECEIVE_BACKUP,
         "reason": final_state_reason,
@@ -3526,7 +3545,10 @@ async def test_initiate_backup_per_agent_encryption(
         "state": CreateBackupState.IN_PROGRESS,
     }
 
+    # Consume any upload progress events before the final state event
     result = await ws_client.receive_json()
+    while "uploaded_bytes" in result["event"]:
+        result = await ws_client.receive_json()
     assert result["event"] == {
         "manager_state": BackupManagerState.CREATE_BACKUP,
         "reason": None,
@@ -3761,17 +3783,24 @@ async def test_upload_progress_event(
     result = await ws_client.receive_json()
     assert result["event"]["stage"] == CreateBackupStage.UPLOAD_TO_AGENTS
 
-    # Upload progress event for the remote agent (first fires immediately)
+    # Collect all upload progress events until the final state event
+    progress_events = []
     result = await ws_client.receive_json()
-    assert result["event"] == {
-        "manager_state": BackupManagerState.CREATE_BACKUP,
-        "agent_id": "test.remote",
-        "uploaded_bytes": 500,
-        "total_bytes": ANY,
-    }
+    while "uploaded_bytes" in result["event"]:
+        progress_events.append(result["event"])
+        result = await ws_client.receive_json()
 
-    # Second progress event is debounced; backup completes before it fires
-    result = await ws_client.receive_json()
+    # Verify progress events from the remote agent (500 from agent + final from manager)
+    remote_progress = [e for e in progress_events if e["agent_id"] == "test.remote"]
+    assert len(remote_progress) == 2
+    assert remote_progress[0]["uploaded_bytes"] == 500
+    assert remote_progress[1]["uploaded_bytes"] == remote_progress[1]["total_bytes"]
+
+    # Verify progress event from the local agent (final from manager)
+    local_progress = [e for e in progress_events if e["agent_id"] == LOCAL_AGENT_ID]
+    assert len(local_progress) == 1
+    assert local_progress[0]["uploaded_bytes"] == local_progress[0]["total_bytes"]
+
     assert result["event"]["state"] == CreateBackupState.COMPLETED
 
     result = await ws_client.receive_json()
@@ -3783,9 +3812,14 @@ async def test_upload_progress_debounced(
     hass_ws_client: WebSocketGenerator,
     generate_backup_id: MagicMock,
 ) -> None:
-    """Test that rapid upload progress events are debounced."""
+    """Test that rapid upload progress events are debounced.
+
+    Verify that when the on_progress callback is called multiple times during
+    the debounce cooldown period, only the latest event is fired.
+    """
     agent_ids = [LOCAL_AGENT_ID, "test.remote"]
     mock_agents = await setup_backup_integration(hass, remote_agents=["test.remote"])
+    manager = hass.data[DATA_MANAGER]
 
     remote_agent = mock_agents["test.remote"]
     original_side_effect = remote_agent.async_upload_backup.side_effect
@@ -3793,54 +3827,46 @@ async def test_upload_progress_debounced(
     async def upload_with_progress(**kwargs: Any) -> None:
         """Upload and report progress."""
         on_progress = kwargs["on_progress"]
+        # First call fires immediately
         on_progress(bytes_uploaded=100)
+        # These two are buffered during cooldown; 1000 should replace 500
         on_progress(bytes_uploaded=500)
         on_progress(bytes_uploaded=1000)
         await original_side_effect(**kwargs)
 
     remote_agent.async_upload_backup.side_effect = upload_with_progress
 
+    # Subscribe directly to collect all events
+    events: list[Any] = []
+    manager.async_subscribe_events(events.append)
+
     ws_client = await hass_ws_client(hass)
-
-    await ws_client.send_json_auto_id({"type": "backup/subscribe_events"})
-
-    result = await ws_client.receive_json()
-    assert result["event"] == {"manager_state": BackupManagerState.IDLE}
-
-    result = await ws_client.receive_json()
-    assert result["success"] is True
 
     with patch("pathlib.Path.open", mock_open(read_data=b"test")):
         await ws_client.send_json_auto_id(
             {"type": "backup/generate", "agent_ids": agent_ids}
         )
         result = await ws_client.receive_json()
-        assert result["event"]["manager_state"] == BackupManagerState.CREATE_BACKUP
-
-        result = await ws_client.receive_json()
         assert result["success"] is True
 
         await hass.async_block_till_done()
 
-    # Consume intermediate stage events (home_assistant, upload_to_agents)
-    result = await ws_client.receive_json()
-    assert result["event"]["stage"] == CreateBackupStage.HOME_ASSISTANT
+    # Advance time past the cooldown to trigger any pending debouncer timer
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+    await hass.async_block_till_done()
 
-    result = await ws_client.receive_json()
-    assert result["event"]["stage"] == CreateBackupStage.UPLOAD_TO_AGENTS
+    # Filter to only upload progress events
+    upload_events = [e for e in events if isinstance(e, UploadBackupEvent)]
 
-    # Only the first upload progress event fires immediately (debounced)
-    result = await ws_client.receive_json()
-    assert result["event"] == {
-        "manager_state": BackupManagerState.CREATE_BACKUP,
-        "agent_id": "test.remote",
-        "uploaded_bytes": 100,
-        "total_bytes": ANY,
-    }
+    # The first event (100 bytes) fires immediately.
+    # The 500 and ∂1000 byte events are buffered during cooldown but the debouncer
+    # is cancelled when the upload completes.
+    # A final 100% progress event is sent for each agent.
+    remote_events = [e for e in upload_events if e.agent_id == "test.remote"]
+    assert len(remote_events) == 2
+    assert remote_events[0].uploaded_bytes == 100
+    assert remote_events[1].uploaded_bytes == remote_events[1].total_bytes
 
-    # The remaining events are debounced; backup completes before they fire
-    result = await ws_client.receive_json()
-    assert result["event"]["state"] == CreateBackupState.COMPLETED
-
-    result = await ws_client.receive_json()
-    assert result["event"] == {"manager_state": BackupManagerState.IDLE}
+    local_events = [e for e in upload_events if e.agent_id == LOCAL_AGENT_ID]
+    assert len(local_events) == 1
+    assert local_events[0].uploaded_bytes == local_events[0].total_bytes

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3885,3 +3885,12 @@ async def test_upload_progress_debounced(
             hass, dt_util.utcnow() + timedelta(seconds=10), fire_all=True
         )
         await hass.async_block_till_done()
+
+    # Check the final 100% progress event is sent, that is sent for every agent
+    remote_events = [
+        e
+        for e in events
+        if isinstance(e, UploadBackupEvent) and e.agent_id == "test.remote"
+    ]
+    assert len(remote_events) == 3
+    assert remote_events[2].uploaded_bytes == remote_events[2].total_bytes

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3817,12 +3817,11 @@ async def test_upload_progress_debounced(
     Verify that when the on_progress callback is called multiple times during
     the debounce cooldown period, only the latest event is fired.
     """
-    agent_ids = [LOCAL_AGENT_ID, "test.remote"]
+    agent_ids = ["test.remote"]
     mock_agents = await setup_backup_integration(hass, remote_agents=["test.remote"])
     manager = hass.data[DATA_MANAGER]
 
     remote_agent = mock_agents["test.remote"]
-    original_side_effect = remote_agent.async_upload_backup.side_effect
 
     progress_done = asyncio.Event()
     upload_done = asyncio.Event()
@@ -3837,7 +3836,6 @@ async def test_upload_progress_debounced(
         on_progress(bytes_uploaded=1000)
         progress_done.set()
         await upload_done.wait()
-        await original_side_effect(**kwargs)
 
     remote_agent.async_upload_backup.side_effect = upload_with_progress
 
@@ -3854,24 +3852,36 @@ async def test_upload_progress_debounced(
         result = await ws_client.receive_json()
         assert result["success"] is True
 
+        # Wait for upload to reach the sync point (progress reported, upload paused)
+        await progress_done.wait()
+
+        # At this point the debouncer's cooldown timer is pending.
+        # The first event (100 bytes) fired immediately, 500 and 1000 are buffered.
+        remote_events = [
+            e
+            for e in events
+            if isinstance(e, UploadBackupEvent) and e.agent_id == "test.remote"
+        ]
+        assert len(remote_events) == 1
+        assert remote_events[0].uploaded_bytes == 100
+
+        # Advance time past the cooldown to trigger the debouncer timer.
+        # This fires the coalesced event: 500 was replaced by 1000.
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+
+        remote_events = [
+            e
+            for e in events
+            if isinstance(e, UploadBackupEvent) and e.agent_id == "test.remote"
+        ]
+        assert len(remote_events) == 2
+        assert remote_events[0].uploaded_bytes == 100
+        assert remote_events[1].uploaded_bytes == 1000
+
+        # Let the upload finish
+        upload_done.set()
+        # Fire pending timers so the backup task can complete
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=10), fire_all=True
+        )
         await hass.async_block_till_done()
-
-    # Advance time past the cooldown to trigger any pending debouncer timer
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-    await hass.async_block_till_done()
-
-    # Filter to only upload progress events
-    upload_events = [e for e in events if isinstance(e, UploadBackupEvent)]
-
-    # The first event (100 bytes) fires immediately.
-    # The 500 and 1000 byte events are buffered during cooldown but the debouncer
-    # is cancelled when the upload completes.
-    # A final 100% progress event is sent for each agent.
-    remote_events = [e for e in upload_events if e.agent_id == "test.remote"]
-    assert len(remote_events) == 2
-    assert remote_events[0].uploaded_bytes == 100
-    assert remote_events[1].uploaded_bytes == remote_events[1].total_bytes
-
-    local_events = [e for e in upload_events if e.agent_id == LOCAL_AGENT_ID]
-    assert len(local_events) == 1
-    assert local_events[0].uploaded_bytes == local_events[0].total_bytes

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Generator
 from dataclasses import replace
+from datetime import timedelta
 from io import StringIO
 import json
 from pathlib import Path
@@ -43,16 +44,19 @@ from homeassistant.components.backup.manager import (
     BackupManagerState,
     CreateBackupStage,
     CreateBackupState,
+    IdleEvent,
     NewBackup,
     ReceiveBackupStage,
     ReceiveBackupState,
     RestoreBackupState,
+    UploadBackupEvent,
     WrittenBackup,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 
 from .common import (
     LOCAL_AGENT_ID,
@@ -65,6 +69,7 @@ from .common import (
     setup_backup_platform,
 )
 
+from tests.common import async_fire_time_changed
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 _EXPECTED_FILES = [
@@ -3783,3 +3788,87 @@ async def test_upload_progress_event(
 
     result = await ws_client.receive_json()
     assert result["event"] == {"manager_state": BackupManagerState.IDLE}
+
+
+async def test_upload_progress_throttled(
+    hass: HomeAssistant,
+) -> None:
+    """Test that rapid upload progress events are throttled."""
+    await setup_backup_integration(hass)
+    manager = hass.data[DATA_MANAGER]
+
+    events: list[UploadBackupEvent] = []
+    manager.async_subscribe_events(events.append)
+
+    upload_event_1 = UploadBackupEvent(
+        manager_state=BackupManagerState.CREATE_BACKUP,
+        agent_id="test.remote",
+        uploaded_bytes=100,
+        total_bytes=1000,
+    )
+    upload_event_2 = UploadBackupEvent(
+        manager_state=BackupManagerState.CREATE_BACKUP,
+        agent_id="test.remote",
+        uploaded_bytes=500,
+        total_bytes=1000,
+    )
+    upload_event_3 = UploadBackupEvent(
+        manager_state=BackupManagerState.CREATE_BACKUP,
+        agent_id="test.remote",
+        uploaded_bytes=1000,
+        total_bytes=1000,
+    )
+
+    # First event fires immediately
+    manager.async_on_backup_event(upload_event_1)
+    assert len(events) == 1
+    assert events[-1] == upload_event_1
+
+    # Subsequent events within the throttle window are buffered
+    manager.async_on_backup_event(upload_event_2)
+    manager.async_on_backup_event(upload_event_3)
+    assert len(events) == 1
+
+    # After the throttle timer fires, only the latest event per agent is sent
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(events) == 2
+    assert events[-1] == upload_event_3
+
+
+async def test_upload_progress_flushed_on_state_change(
+    hass: HomeAssistant,
+) -> None:
+    """Test that pending upload progress events are flushed on state change."""
+    await setup_backup_integration(hass)
+    manager = hass.data[DATA_MANAGER]
+
+    events = []
+    manager.async_subscribe_events(events.append)
+
+    upload_event = UploadBackupEvent(
+        manager_state=BackupManagerState.CREATE_BACKUP,
+        agent_id="test.remote",
+        uploaded_bytes=100,
+        total_bytes=1000,
+    )
+
+    # First event fires immediately
+    manager.async_on_backup_event(upload_event)
+    assert len(events) == 1
+
+    # Buffer another event
+    upload_event_2 = UploadBackupEvent(
+        manager_state=BackupManagerState.CREATE_BACKUP,
+        agent_id="test.remote",
+        uploaded_bytes=500,
+        total_bytes=1000,
+    )
+    manager.async_on_backup_event(upload_event_2)
+    assert len(events) == 1
+
+    # A non-upload event flushes pending upload events first
+    manager.async_on_backup_event(IdleEvent())
+    assert len(events) == 3
+    assert events[1] == upload_event_2
+    assert events[2].manager_state == BackupManagerState.IDLE

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -3859,7 +3859,7 @@ async def test_upload_progress_debounced(
     upload_events = [e for e in events if isinstance(e, UploadBackupEvent)]
 
     # The first event (100 bytes) fires immediately.
-    # The 500 and ∂1000 byte events are buffered during cooldown but the debouncer
+    # The 500 and 1000 byte events are buffered during cooldown but the debouncer
     # is cancelled when the upload completes.
     # A final 100% progress event is sent for each agent.
     remote_events = [e for e in upload_events if e.agent_id == "test.remote"]

--- a/tests/components/hassio/test_backup.py
+++ b/tests/components/hassio/test_backup.py
@@ -980,7 +980,10 @@ async def test_reader_writer_create(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,
@@ -1094,7 +1097,10 @@ async def test_reader_writer_create_addon_folder_error(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,
@@ -1211,7 +1217,10 @@ async def test_reader_writer_create_report_progress(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,
@@ -1273,7 +1282,10 @@ async def test_reader_writer_create_job_done(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,
@@ -1536,7 +1548,10 @@ async def test_reader_writer_create_per_agent_encryption(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,
@@ -1788,7 +1803,10 @@ async def test_reader_writer_create_download_remove_error(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": "upload_failed",
@@ -1952,7 +1970,10 @@ async def test_reader_writer_create_remote_backup(
         "state": "in_progress",
     }
 
+    # Consume any upload progress events before the final state event
     response = await client.receive_json()
+    while "uploaded_bytes" in response["event"]:
+        response = await client.receive_json()
     assert response["event"] == {
         "manager_state": "create_backup",
         "reason": None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For the upload progress validation during backup buffer the progress events so we don't flood the websocket with messages for large backups with multiple different backup targets.
Additionally, don't let the coordinator refresh for progress events, it does not need to know about those state changes, only when the upload starts and completes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
