### PR TITLE
Replace unused flow_objects_urls placeholder with examples_url in Yee…

### DIFF
--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -171,7 +171,7 @@
       "name": "Set music mode"
     },
     "start_flow": {
-      "description": "Starts a custom flow, using transitions. Examples {examples_url}.",
+      "description": "Starts a custom flow using transitions; see {examples_url} for examples.",
       "fields": {
         "action": {
           "description": "[%key:component::yeelight::services::set_color_flow_scene::fields::action::description%]",

--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -171,7 +171,7 @@
       "name": "Set music mode"
     },
     "start_flow": {
-      "description": "Starts a custom flow, using transitions from {flow_objects_urls}.",
+      "description": "Starts a custom flow, using transitions. Examples {examples_url}.",
       "fields": {
         "action": {
           "description": "[%key:component::yeelight::services::set_color_flow_scene::fields::action::description%]",


### PR DESCRIPTION
## Summary

- Fix frontend translation error for `component.yeelight.services.start_flow.description` in Russian (and other locales).
- Replace the unused `{flow_objects_urls}` placeholder with the supported `{examples_url}` placeholder in the Yeelight `start_flow` service description.

## Details

The Yeelight `start_flow` service description previously used `{flow_objects_urls}`, but the frontend never provides this variable when formatting the string, which caused `formatjs Error: MISSING_VALUE`. Other Yeelight service descriptions already rely on `{examples_url}`, which is correctly provided, so this change aligns `start_flow` with the existing pattern.

## Testing

- Restarted Home Assistant and opened the Yeelight `start_flow` service in the UI.
- Confirmed that no `MISSING_VALUE` errors are logged for `component.yeelight.services.start_flow.description`.