### PR TITLE
Add binary sensor platform to Arcam FMJ

### DIFF
--- a/homeassistant/components/arcam_fmj/__init__.py
+++ b/homeassistant/components/arcam_fmj/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import ArcamFmjConfigEntry, ArcamFmjCoordinator, ArcamFmjRunti
 _LOGGER = logging.getLogger(__name__)
 
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.MEDIA_PLAYER, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ArcamFmjConfigEntry) -> bool:

--- a/homeassistant/components/arcam_fmj/binary_sensor.py
+++ b/homeassistant/components/arcam_fmj/binary_sensor.py
@@ -1,0 +1,68 @@
+"""Arcam binary sensors for incoming stream info."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from arcam.fmj.state import State
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ArcamFmjConfigEntry
+from .entity import ArcamFmjEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class ArcamFmjBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes an Arcam FMJ binary sensor entity."""
+
+    value_fn: Callable[[State], bool | None]
+
+
+BINARY_SENSORS: tuple[ArcamFmjBinarySensorEntityDescription, ...] = (
+    ArcamFmjBinarySensorEntityDescription(
+        key="incoming_video_interlaced",
+        translation_key="incoming_video_interlaced",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda state: (
+            vp.interlaced
+            if (vp := state.get_incoming_video_parameters()) is not None
+            else None
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ArcamFmjConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Arcam FMJ binary sensors from a config entry."""
+    coordinators = config_entry.runtime_data.coordinators
+
+    entities: list[ArcamFmjBinarySensorEntity] = []
+    for coordinator in coordinators.values():
+        entities.extend(
+            ArcamFmjBinarySensorEntity(coordinator, description)
+            for description in BINARY_SENSORS
+        )
+    async_add_entities(entities)
+
+
+class ArcamFmjBinarySensorEntity(ArcamFmjEntity, BinarySensorEntity):
+    """Representation of an Arcam FMJ binary sensor."""
+
+    entity_description: ArcamFmjBinarySensorEntityDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the binary sensor value."""
+        return self.entity_description.value_fn(self.coordinator.state)

--- a/homeassistant/components/arcam_fmj/strings.json
+++ b/homeassistant/components/arcam_fmj/strings.json
@@ -25,6 +25,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "incoming_video_interlaced": {
+        "name": "Incoming video interlaced"
+      }
+    },
     "sensor": {
       "incoming_audio_config": {
         "name": "Incoming audio configuration",

--- a/tests/components/arcam_fmj/snapshots/test_binary_sensor.ambr
+++ b/tests/components/arcam_fmj/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,99 @@
+# serializer version: 1
+# name: test_setup[binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Incoming video interlaced',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Incoming video interlaced',
+    'platform': 'arcam_fmj',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'incoming_video_interlaced',
+    'unique_id': '456789abcdef-1-incoming_video_interlaced',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Arcam FMJ (127.0.0.1) Incoming video interlaced',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_setup[binary_sensor.arcam_fmj_127_0_0_1_zone_2_incoming_video_interlaced-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.arcam_fmj_127_0_0_1_zone_2_incoming_video_interlaced',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Incoming video interlaced',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Incoming video interlaced',
+    'platform': 'arcam_fmj',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'incoming_video_interlaced',
+    'unique_id': '456789abcdef-2-incoming_video_interlaced',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[binary_sensor.arcam_fmj_127_0_0_1_zone_2_incoming_video_interlaced-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Arcam FMJ (127.0.0.1) Zone 2 Incoming video interlaced',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.arcam_fmj_127_0_0_1_zone_2_incoming_video_interlaced',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/arcam_fmj/test_binary_sensor.py
+++ b/tests/components/arcam_fmj/test_binary_sensor.py
@@ -1,0 +1,88 @@
+"""Tests for Arcam FMJ binary sensor entities."""
+
+from collections.abc import Generator
+from unittest.mock import Mock, patch
+
+from arcam.fmj.state import State
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_only() -> Generator[None]:
+    """Limit platform setup to binary_sensor only."""
+    with patch(
+        "homeassistant.components.arcam_fmj.PLATFORMS", [Platform.BINARY_SENSOR]
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "player_setup")
+async def test_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test snapshot of the binary sensor platform."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("player_setup")
+async def test_binary_sensor_none(
+    hass: HomeAssistant,
+) -> None:
+    """Test binary sensor when video parameters are None."""
+    state = hass.states.get(
+        "binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced"
+    )
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("player_setup")
+async def test_binary_sensor_interlaced(
+    hass: HomeAssistant,
+    state_1: State,
+    client: Mock,
+) -> None:
+    """Test binary sensor reports on when video is interlaced."""
+    video_params = Mock()
+    video_params.interlaced = True
+    state_1.get_incoming_video_parameters.return_value = video_params
+
+    client.notify_data_updated()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(
+        "binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced"
+    )
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+@pytest.mark.usefixtures("player_setup")
+async def test_binary_sensor_not_interlaced(
+    hass: HomeAssistant,
+    state_1: State,
+    client: Mock,
+) -> None:
+    """Test binary sensor reports off when video is not interlaced."""
+    video_params = Mock()
+    video_params.interlaced = False
+    state_1.get_incoming_video_parameters.return_value = video_params
+
+    client.notify_data_updated()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(
+        "binary_sensor.arcam_fmj_127_0_0_1_incoming_video_interlaced"
+    )
+    assert state is not None
+    assert state.state == STATE_OFF


### PR DESCRIPTION
Add incoming video interlaced binary sensor for each zone, using the coordinator pattern.

This is a breakdown of https://github.com/home-assistant/core/pull/165098 per request, a follow-up to https://github.com/home-assistant/core/pull/165232, and sibling to https://github.com/home-assistant/core/pull/165271

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a binary sensor that indicated whether the incoming video is interlaced

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository] https://github.com/home-assistant/home-assistant.io/pull/44019

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
