### PR TITLE
Envisalink: wake DSC panel from keypad blanking before arm/disarm

### DIFF
--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -215,7 +215,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 hass,
                 Platform.ALARM_CONTROL_PANEL,
                 "envisalink",
-                {CONF_PARTITIONS: partitions, CONF_CODE: code, CONF_PANIC: panic_type},
+                {
+                    CONF_PARTITIONS: partitions,
+                    CONF_CODE: code,
+                    CONF_PANIC: panic_type,
+                    CONF_PANEL_TYPE: panel_type,
+                },
                 config,
             )
         )

--- a/homeassistant/components/envisalink/alarm_control_panel.py
+++ b/homeassistant/components/envisalink/alarm_control_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -20,10 +21,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import (
+    CONF_PANEL_TYPE,
     CONF_PANIC,
     CONF_PARTITIONNAME,
     DATA_EVL,
     DOMAIN,
+    PANEL_TYPE_DSC,
     PARTITION_SCHEMA,
     SIGNAL_KEYPAD_UPDATE,
     SIGNAL_PARTITION_UPDATE,
@@ -54,6 +57,7 @@ async def async_setup_platform(
     configured_partitions = discovery_info["partitions"]
     code = discovery_info[CONF_CODE]
     panic_type = discovery_info[CONF_PANIC]
+    panel_type = discovery_info[CONF_PANEL_TYPE]
 
     entities = []
     for part_num in configured_partitions:
@@ -64,6 +68,7 @@ async def async_setup_platform(
             entity_config_data[CONF_PARTITIONNAME],
             code,
             panic_type,
+            panel_type,
             hass.data[DATA_EVL].alarm_state["partition"][part_num],
             hass.data[DATA_EVL],
         )
@@ -103,11 +108,20 @@ class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
     )
 
     def __init__(
-        self, hass, partition_number, alarm_name, code, panic_type, info, controller
+        self,
+        hass,
+        partition_number,
+        alarm_name,
+        code,
+        panic_type,
+        panel_type,
+        info,
+        controller,
     ):
         """Initialize the alarm panel."""
         self._partition_number = partition_number
         self._panic_type = panic_type
+        self._panel_type = panel_type
         self._alarm_control_panel_option_default_code = code
         self._attr_code_format = CodeFormat.NUMBER if not code else None
 
@@ -154,16 +168,33 @@ class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
             state = AlarmControlPanelState.DISARMED
         return state
 
+    async def _async_wake_panel(self) -> None:
+        """Wake DSC panel from keypad blanking state before sending commands.
+
+        DSC panels enter a low-power display-off (blanking) mode after
+        inactivity. TPI arm/disarm commands sent while blanked are silently
+        rejected. Sending '#' wakes the panel, equivalent to pressing # on
+        the physical keypad.
+        """
+        if self._panel_type != PANEL_TYPE_DSC:
+            return
+        _LOGGER.debug("Sending '#' keypress to wake panel from possible blanking state")
+        self.hass.data[DATA_EVL].keypresses_to_partition(self._partition_number, "#")
+        await asyncio.sleep(1)
+
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
+        await self._async_wake_panel()
         self.hass.data[DATA_EVL].disarm_partition(code, self._partition_number)
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
+        await self._async_wake_panel()
         self.hass.data[DATA_EVL].arm_stay_partition(code, self._partition_number)
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
+        await self._async_wake_panel()
         self.hass.data[DATA_EVL].arm_away_partition(code, self._partition_number)
 
     async def async_alarm_trigger(self, code: str | None = None) -> None:
@@ -172,6 +203,7 @@ class EnvisalinkAlarm(EnvisalinkEntity, AlarmControlPanelEntity):
 
     async def async_alarm_arm_night(self, code: str | None = None) -> None:
         """Send arm night command."""
+        await self._async_wake_panel()
         self.hass.data[DATA_EVL].arm_night_partition(code, self._partition_number)
 
     @callback


### PR DESCRIPTION
## Proposed change

DSC alarm panels can enter a low-power display-off ("keypad blanking") mode after a period of inactivity. When the panel is in this state, TPI arm/disarm commands (030/031/032/040) sent via the Envisalink are silently rejected because the EVL pre-validates the panel state and sees it as "not ready."

This PR sends a `#` keypress to the partition before each arm/disarm command on DSC panels, which wakes the panel from blanking — equivalent to pressing `#` on the physical keypad. A 1-second delay follows the keypress to allow the panel to become ready before the actual command is sent.

The wakeup is only applied to DSC panels; Honeywell panels are unaffected. The panic alarm command is intentionally excluded since TPI command 060 bypasses normal partition validation.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
