### PR TITLE
Update migration message for Telegram bot

### DIFF
--- a/homeassistant/components/telegram/notify.py
+++ b/homeassistant/components/telegram/notify.py
@@ -16,6 +16,7 @@ from homeassistant.components.notify import (
     BaseNotificationService,
 )
 from homeassistant.components.telegram_bot import (
+    ATTR_CHAT_ID,
     ATTR_DISABLE_NOTIF,
     ATTR_DISABLE_WEB_PREV,
     ATTR_MESSAGE_TAG,
@@ -58,7 +59,7 @@ async def async_get_service(
         hass,
         DOMAIN,
         "migrate_notify",
-        breaks_in_ha_version="2026.5.0",
+        breaks_in_ha_version="2026.8.0",
         is_fixable=False,
         translation_key="migrate_notify",
         severity=ir.IssueSeverity.WARNING,
@@ -80,7 +81,7 @@ class TelegramNotificationService(BaseNotificationService):
 
     def send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to a user."""
-        service_data = {ATTR_TARGET: kwargs.get(ATTR_TARGET, self._chat_id)}
+        service_data = {ATTR_CHAT_ID: kwargs.get(ATTR_TARGET, self._chat_id)}
         data = kwargs.get(ATTR_DATA)
 
         # Set message tag

--- a/tests/components/telegram/test_notify.py
+++ b/tests/components/telegram/test_notify.py
@@ -112,7 +112,7 @@ async def test_notify(hass: HomeAssistant) -> None:
             call(
                 "telegram_bot",
                 "send_message",
-                {"target": 1, "title": "mock title", "message": "mock message"},
+                {"chat_id": 1, "title": "mock title", "message": "mock message"},
                 False,
                 None,
                 None,
@@ -151,7 +151,7 @@ async def test_notify(hass: HomeAssistant) -> None:
                 "telegram_bot",
                 "send_photo",
                 {
-                    "target": 1,
+                    "chat_id": 1,
                     "url": "https://mock/photo.jpg",
                     "caption": "mock caption",
                 },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Note: Telegram and Telegram bot are 2 different integrations. Telegram simply invokes Telegram bot's `send_*` action (e.g. `telegram_bot.send_message`).

1. In version 2026.3, the `target` parameter for Telegram bot actions was deprecated. Because the legacy Telegram service still relied on this parameter, it triggered two redundant repair issues: a migration warning from the Telegram integration and a deprecation warning from the Telegram bot integration. This PR switches the parameter from `target` to `chat_id` to eliminate the unnecessary second warning and reduce user confusion.

2. To postpone the planned removal of the legacy Telegram integration (originally 2026.5). Some integrations/modules such as the `auth_mfa_module` still depend on the legacy notifier service. The postponement is for sufficient time for the dependencies to be updated to support modern notify entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
