### PR TITLE
Reduce internal testing in arcam_fmj tests

### DIFF
--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -8,14 +8,11 @@ from arcam.fmj.state import State
 import pytest
 
 from homeassistant.components.arcam_fmj.const import DEFAULT_NAME
-from homeassistant.components.arcam_fmj.coordinator import ArcamFmjCoordinator
-from homeassistant.components.arcam_fmj.media_player import ArcamFmj
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityPlatformState
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, MockEntityPlatform
+from tests.common import MockConfigEntry
 
 MOCK_HOST = "127.0.0.1"
 MOCK_PORT = 50000
@@ -84,29 +81,6 @@ def mock_config_entry_fixture(hass: HomeAssistant) -> MockConfigEntry:
     )
     config_entry.add_to_hass(hass)
     return config_entry
-
-
-@pytest.fixture(name="player")
-def player_fixture(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    client: Mock,
-    state_1: Mock,
-) -> ArcamFmj:
-    """Get standard player.
-
-    This fixture tests internals and should not be used going forward.
-    """
-    coordinator = ArcamFmjCoordinator(hass, mock_config_entry, client, 1)
-    coordinator.state = state_1
-    coordinator.last_update_success = True
-    player = ArcamFmj(MOCK_NAME, coordinator, MOCK_UUID)
-    player.entity_id = MOCK_ENTITY_ID
-    player.hass = hass
-    player.platform = MockEntityPlatform(hass)
-    player._platform_state = EntityPlatformState.ADDED
-    player.async_write_ha_state = Mock()
-    return player
 
 
 @pytest.fixture(name="player_setup")

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for arcam fmj receivers."""
 
 from math import isclose
-from unittest.mock import PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 from arcam.fmj import ConnectionFailed, DecodeMode2CH, DecodeModeMCH, SourceCodes
 from arcam.fmj.state import State
@@ -17,6 +17,7 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
+    DATA_COMPONENT,
     SERVICE_SELECT_SOURCE,
     SERVICE_VOLUME_SET,
     MediaType,
@@ -31,12 +32,31 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .conftest import MOCK_HOST, MOCK_UUID
+from .conftest import MOCK_ENTITY_ID, MOCK_HOST, MOCK_UUID
+
+from tests.common import MockConfigEntry
 
 MOCK_TURN_ON = {
     "service": "switch.turn_on",
     "data": {"entity_id": "switch.test"},
 }
+
+
+@pytest.fixture(name="player")
+def player_fixture(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    client: Mock,
+    state_1: State,
+    player_setup: str,
+) -> ArcamFmj:
+    """Get standard player.
+
+    This fixture tests internals and should not be used going forward.
+    """
+    player: ArcamFmj = hass.data[DATA_COMPONENT].get_entity(MOCK_ENTITY_ID)
+    player.async_write_ha_state = Mock(wraps=player.async_write_ha_state)
+    return player
 
 
 async def update(player: ArcamFmj, force_refresh=False):
@@ -107,6 +127,7 @@ async def test_turn_off(player: ArcamFmj, state_1: State) -> None:
 @pytest.mark.parametrize("mute", [True, False])
 async def test_mute_volume(player: ArcamFmj, state_1: State, mute: bool) -> None:
     """Test mute functionality."""
+    player.async_write_ha_state.reset_mock()
     await player.async_mute_volume(mute)
     state_1.set_mute.assert_called_with(mute)
     player.async_write_ha_state.assert_called_with()
@@ -115,7 +136,7 @@ async def test_mute_volume(player: ArcamFmj, state_1: State, mute: bool) -> None
 async def test_name(player: ArcamFmj) -> None:
     """Test name."""
     data = await update(player)
-    assert data.attributes["friendly_name"] == "Zone 1"
+    assert data.attributes["friendly_name"] == "Arcam FMJ (127.0.0.1) Zone 1"
 
 
 async def test_update(hass: HomeAssistant, player_setup: str, state_1: State) -> None:
@@ -194,6 +215,7 @@ async def test_select_sound_mode(player: ArcamFmj, state_1: State, mode: str) ->
 
 async def test_volume_up(player: ArcamFmj, state_1: State) -> None:
     """Test mute functionality."""
+    player.async_write_ha_state.reset_mock()
     await player.async_volume_up()
     state_1.inc_volume.assert_called_with()
     player.async_write_ha_state.assert_called_with()
@@ -201,6 +223,7 @@ async def test_volume_up(player: ArcamFmj, state_1: State) -> None:
 
 async def test_volume_down(player: ArcamFmj, state_1: State) -> None:
     """Test mute functionality."""
+    player.async_write_ha_state.reset_mock()
     await player.async_volume_down()
     state_1.dec_volume.assert_called_with()
     player.async_write_ha_state.assert_called_with()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The current "player" fixture creates a coordinator and an entity explicitly, rather than going through the standard config entry setup.

Even if we are still accessing the entity directly, this at least makes sure that we do not create it explicitly.
It is also moved from conftest to test_media_player to reduce the exposure

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
