### PR TITLE
Fix flakiness in lutron tests and isolate platforms per test file

### DIFF
--- a/tests/components/lutron/conftest.py
+++ b/tests/components/lutron/conftest.py
@@ -42,7 +42,7 @@ def mock_lutron() -> Generator[MagicMock]:
         # Mock a light
         light = MagicMock()
         light.name = "Test Light"
-        light.id = "light_id"
+        light.id = 1
         light.uuid = "light_uuid"
         light.legacy_uuid = "light_legacy_uuid"
         light.is_dimmable = True
@@ -53,7 +53,7 @@ def mock_lutron() -> Generator[MagicMock]:
         # Mock a switch
         switch = MagicMock()
         switch.name = "Test Switch"
-        switch.id = "switch_id"
+        switch.id = 2
         switch.uuid = "switch_uuid"
         switch.legacy_uuid = "switch_legacy_uuid"
         switch.is_dimmable = False
@@ -64,7 +64,7 @@ def mock_lutron() -> Generator[MagicMock]:
         # Mock a cover
         cover = MagicMock()
         cover.name = "Test Cover"
-        cover.id = "cover_id"
+        cover.id = 3
         cover.uuid = "cover_uuid"
         cover.legacy_uuid = "cover_legacy_uuid"
         cover.type = "SYSTEM_SHADE"
@@ -74,6 +74,7 @@ def mock_lutron() -> Generator[MagicMock]:
         # Mock a fan
         fan = MagicMock()
         fan.name = "Test Fan"
+        fan.id = 4
         fan.uuid = "fan_uuid"
         fan.legacy_uuid = "fan_legacy_uuid"
         fan.type = "CEILING_FAN_TYPE"
@@ -108,7 +109,7 @@ def mock_lutron() -> Generator[MagicMock]:
         # Mock an occupancy group
         occ_group = MagicMock()
         occ_group.name = "Test Occupancy"
-        occ_group.id = "occ_id"
+        occ_group.id = 5
         occ_group.uuid = "occ_uuid"
         occ_group.legacy_uuid = "occ_legacy_uuid"
         occ_group.state = OccupancyGroup.State.VACANT

--- a/tests/components/lutron/snapshots/test_binary_sensor.ambr
+++ b/tests/components/lutron/snapshots/test_binary_sensor.ambr
@@ -40,7 +40,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'occupancy',
       'friendly_name': 'Test Occupancy Occupancy',
-      'lutron_integration_id': 'occ_id',
+      'lutron_integration_id': 5,
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.test_occupancy_occupancy',

--- a/tests/components/lutron/snapshots/test_cover.ambr
+++ b/tests/components/lutron/snapshots/test_cover.ambr
@@ -41,7 +41,7 @@
       'current_position': 0,
       'friendly_name': 'Test Cover',
       'is_closed': True,
-      'lutron_integration_id': 'cover_id',
+      'lutron_integration_id': 3,
       'supported_features': <CoverEntityFeature: 7>,
     }),
     'context': <ANY>,

--- a/tests/components/lutron/snapshots/test_light.ambr
+++ b/tests/components/lutron/snapshots/test_light.ambr
@@ -45,7 +45,7 @@
       'brightness': None,
       'color_mode': None,
       'friendly_name': 'Test Light',
-      'lutron_integration_id': 'light_id',
+      'lutron_integration_id': 1,
       'supported_color_modes': list([
         <ColorMode.BRIGHTNESS: 'brightness'>,
       ]),

--- a/tests/components/lutron/snapshots/test_switch.ambr
+++ b/tests/components/lutron/snapshots/test_switch.ambr
@@ -91,7 +91,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Switch',
-      'lutron_integration_id': 'switch_id',
+      'lutron_integration_id': 2,
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_switch',

--- a/tests/components/lutron/test_binary_sensor.py
+++ b/tests/components/lutron/test_binary_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pylutron import OccupancyGroup
 from syrupy.assertion import SnapshotAssertion
 
@@ -10,6 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.BINARY_SENSOR]):
+        yield
 
 
 async def test_binary_sensor_setup(
@@ -25,9 +33,8 @@ async def test_binary_sensor_setup(
     occ_group = mock_lutron.areas[0].occupancy_group
     occ_group.state = OccupancyGroup.State.VACANT
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.BINARY_SENSOR]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_binary_sensor.py
+++ b/tests/components/lutron/test_binary_sensor.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pylutron import OccupancyGroup
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import STATE_OFF, STATE_ON, Platform

--- a/tests/components/lutron/test_cover.py
+++ b/tests/components/lutron/test_cover.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
@@ -20,6 +21,13 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.COVER]):
+        yield
+
+
 async def test_cover_setup(
     hass: HomeAssistant,
     mock_lutron: MagicMock,
@@ -34,9 +42,8 @@ async def test_cover_setup(
     cover.level = 0
     cover.last_level.return_value = 0
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.COVER]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_event.py
+++ b/tests/components/lutron/test_event.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 from pylutron import Button
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform

--- a/tests/components/lutron/test_event.py
+++ b/tests/components/lutron/test_event.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pylutron import Button
 from syrupy.assertion import SnapshotAssertion
 
@@ -10,6 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_capture_events, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.EVENT]):
+        yield
 
 
 async def test_event_setup(
@@ -22,9 +30,8 @@ async def test_event_setup(
     """Test event setup."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.EVENT]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_fan.py
+++ b/tests/components/lutron/test_fan.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fan import (
@@ -18,6 +19,13 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.FAN]):
+        yield
+
+
 async def test_fan_setup(
     hass: HomeAssistant,
     mock_lutron: MagicMock,
@@ -32,9 +40,8 @@ async def test_fan_setup(
     fan.level = 0
     fan.last_level.return_value = 0
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.FAN]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_light.py
+++ b/tests/components/lutron/test_light.py
@@ -25,6 +25,13 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.LIGHT]):
+        yield
+
+
 async def test_light_setup(
     hass: HomeAssistant,
     mock_lutron: MagicMock,
@@ -39,9 +46,8 @@ async def test_light_setup(
     light.level = 0
     light.last_level.return_value = 0
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.LIGHT]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_scene.py
+++ b/tests/components/lutron/test_scene.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
@@ -10,6 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.SCENE]):
+        yield
 
 
 async def test_scene_setup(
@@ -22,9 +30,8 @@ async def test_scene_setup(
     """Test scene setup."""
     mock_config_entry.add_to_hass(hass)
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.SCENE]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/lutron/test_switch.py
+++ b/tests/components/lutron/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -15,6 +16,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.SWITCH]):
+        yield
 
 
 async def test_switch_setup(
@@ -35,9 +43,8 @@ async def test_switch_setup(
     led.state = 0
     led.last_state = 0
 
-    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.SWITCH]):
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Fixed type errors in the tests.  We have strict typing now and we didn't catch that Lutron device IDs are all ints and not strings.
- Isolated the platforms per-test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://github.com/home-assistant/core/actions/runs/22945217775/job/66596812823
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
