### PR TITLE
Prevent the intellifire client from polling independently of its coordinator

### DIFF
--- a/homeassistant/components/intellifire/__init__.py
+++ b/homeassistant/components/intellifire/__init__.py
@@ -143,7 +143,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntellifireConfigEntry) 
     try:
         fireplace: UnifiedFireplace = (
             await UnifiedFireplace.build_fireplace_from_common(
-                _construct_common_data(entry)
+                _construct_common_data(entry),
+                polling_enabled=False,
             )
         )
         LOGGER.debug("Waiting for Fireplace to Initialize")

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -52,6 +52,7 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntelliFirePollData
         return self.fireplace.control_api
 
     async def _async_update_data(self) -> IntelliFirePollData:
+        await self.fireplace.perform_poll()
         return self.fireplace.data
 
     @property

--- a/homeassistant/components/intellifire/coordinator.py
+++ b/homeassistant/components/intellifire/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+import aiohttp
 from intellifire4py import UnifiedFireplace
 from intellifire4py.control import IntelliFireController
 from intellifire4py.model import IntelliFirePollData
@@ -11,8 +12,9 @@ from intellifire4py.read import IntelliFireDataProvider
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER
 
@@ -52,7 +54,14 @@ class IntellifireDataUpdateCoordinator(DataUpdateCoordinator[IntelliFirePollData
         return self.fireplace.control_api
 
     async def _async_update_data(self) -> IntelliFirePollData:
-        await self.fireplace.perform_poll()
+        try:
+            await self.fireplace.perform_poll()
+        except aiohttp.ClientResponseError as err:
+            if err.status == 403:
+                raise ConfigEntryAuthFailed("Authentication failed") from err
+            raise UpdateFailed(f"Error communicating with fireplace: {err}") from err
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise UpdateFailed(f"Error communicating with fireplace: {err}") from err
         return self.fireplace.data
 
     @property

--- a/tests/components/intellifire/conftest.py
+++ b/tests/components/intellifire/conftest.py
@@ -257,6 +257,8 @@ def mock_fp(mock_common_data_local) -> Generator[AsyncMock]:
         mock_instance.set_read_mode = AsyncMock()
         mock_instance.set_control_mode = AsyncMock()
 
+        mock_instance.perform_poll = AsyncMock()
+
         mock_instance.async_validate_connectivity = AsyncMock(
             return_value=(True, False)
         )

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -371,8 +371,8 @@ async def test_fireplace_built_with_polling_disabled(
 ) -> None:
     """Test that the fireplace is built with polling_enabled=False.
 
-    This is the other half of the double-polling fix: we tell the library
-    not to auto-poll, so Home Assistant can control polling via perform_poll().
+    The library auto-polls by default; ensure it is constructed with polling
+    disabled so the coordinator controls all polling via perform_poll().
     """
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -349,12 +349,10 @@ async def test_coordinator_performs_poll(
     mock_config_entry_current: MockConfigEntry,
     mock_apis_single_fp,
 ) -> None:
-    """Test that the coordinator uses perform_poll() for data refresh.
+    """Test that the library only polls when instructed by the coordinator.
 
-    This verifies the double-polling fix: instead of the library polling
-    automatically AND Home Assistant polling on its schedule, we disable
-    the library's auto-polling and have HA explicitly call perform_poll()
-    when it wants fresh data.
+    The library auto-polls by default; ensure the coordinator disables that
+    and drives polling explicitly via perform_poll().
     """
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
@@ -363,7 +361,7 @@ async def test_coordinator_performs_poll(
     await hass.async_block_till_done()
 
     # Verify perform_poll was called during initial setup/refresh
-    mock_fp.perform_poll.assert_called()
+    mock_fp.perform_poll.assert_called_once()
 
 
 async def test_fireplace_built_with_polling_disabled(

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -390,3 +390,6 @@ async def test_fireplace_built_with_polling_disabled(
         mock_build.assert_called_once()
         call_kwargs = mock_build.call_args.kwargs
         assert call_kwargs.get("polling_enabled") is False
+        # Coordinator drives exactly one poll; if the library were also auto-polling
+        # this would be > 1, catching the double-poll regression.
+        mock_fp.perform_poll.assert_called_once()

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -1,7 +1,9 @@
 """Test the IntelliFire config flow."""
 
+import inspect
 from unittest.mock import AsyncMock, patch
 
+from intellifire4py import UnifiedFireplace
 from intellifire4py.const import IntelliFireApiMode
 
 from homeassistant.components.intellifire import CONF_USER_ID
@@ -393,3 +395,12 @@ async def test_fireplace_built_with_polling_disabled(
         # Coordinator drives exactly one poll; if the library were also auto-polling
         # this would be > 1, catching the double-poll regression.
         mock_fp.perform_poll.assert_awaited_once()
+
+
+async def test_build_fireplace_from_common_accepts_polling_enabled() -> None:
+    """Verify the backing lib's build_fireplace_from_common accepts polling_enabled.
+
+    Guards against the library renaming the kwarg without us noticing.
+    """
+    sig = inspect.signature(UnifiedFireplace.build_fireplace_from_common)
+    assert "polling_enabled" in sig.parameters

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -342,3 +342,53 @@ async def test_update_options_no_change(
     mock_fp.set_control_mode.assert_not_called()
     # But async_request_refresh should still be called
     coordinator.async_request_refresh.assert_called_once()
+
+
+async def test_coordinator_performs_poll(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test that the coordinator uses perform_poll() for data refresh.
+
+    This verifies the double-polling fix: instead of the library polling
+    automatically AND Home Assistant polling on its schedule, we disable
+    the library's auto-polling and have HA explicitly call perform_poll()
+    when it wants fresh data.
+    """
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    mock_config_entry_current.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify perform_poll was called during initial setup/refresh
+    mock_fp.perform_poll.assert_called()
+
+
+async def test_fireplace_built_with_polling_disabled(
+    hass: HomeAssistant,
+    mock_config_entry_current: MockConfigEntry,
+    mock_apis_single_fp,
+) -> None:
+    """Test that the fireplace is built with polling_enabled=False.
+
+    This is the other half of the double-polling fix: we tell the library
+    not to auto-poll, so Home Assistant can control polling via perform_poll().
+    """
+    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
+
+    # We need to capture the call to build_fireplace_from_common
+    with patch(
+        "homeassistant.components.intellifire.UnifiedFireplace.build_fireplace_from_common",
+        new_callable=AsyncMock,
+        return_value=mock_fp,
+    ) as mock_build:
+        mock_config_entry_current.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+        await hass.async_block_till_done()
+
+        # Verify build_fireplace_from_common was called with polling_enabled=False
+        mock_build.assert_called_once()
+        call_kwargs = mock_build.call_args.kwargs
+        assert call_kwargs.get("polling_enabled") is False

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -360,8 +360,8 @@ async def test_coordinator_performs_poll(
     await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
     await hass.async_block_till_done()
 
-    # Verify perform_poll was called during initial setup/refresh
-    mock_fp.perform_poll.assert_called_once()
+    # Verify perform_poll was awaited during initial setup/refresh
+    mock_fp.perform_poll.assert_awaited_once()
 
 
 async def test_fireplace_built_with_polling_disabled(
@@ -387,9 +387,9 @@ async def test_fireplace_built_with_polling_disabled(
         await hass.async_block_till_done()
 
         # Verify build_fireplace_from_common was called with polling_enabled=False
-        mock_build.assert_called_once()
+        mock_build.assert_awaited_once()
         call_kwargs = mock_build.call_args.kwargs
         assert call_kwargs.get("polling_enabled") is False
         # Coordinator drives exactly one poll; if the library were also auto-polling
         # this would be > 1, catching the double-poll regression.
-        mock_fp.perform_poll.assert_called_once()
+        mock_fp.perform_poll.assert_awaited_once()

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -1,11 +1,6 @@
 """Test the IntelliFire config flow."""
 
-import inspect
 from unittest.mock import AsyncMock, patch
-
-from intellifire4py import UnifiedFireplace
-from intellifire4py.const import IntelliFireApiMode
-
 from homeassistant.components.intellifire import CONF_USER_ID
 from homeassistant.components.intellifire.const import (
     API_MODE_CLOUD,

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -356,9 +356,18 @@ async def test_coordinator_performs_poll(
     """
     _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
 
-    mock_config_entry_current.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.intellifire.UnifiedFireplace.build_fireplace_from_common",
+        new_callable=AsyncMock,
+        return_value=mock_fp,
+    ) as mock_build:
+        mock_config_entry_current.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
+        await hass.async_block_till_done()
 
-    # Verify perform_poll was awaited during initial setup/refresh
-    mock_fp.perform_poll.assert_awaited_once()
+        # Verify the fireplace was constructed with library background polling disabled
+        mock_build.assert_awaited_once()
+        assert mock_build.call_args.kwargs.get("polling_enabled") is False
+
+        # Verify the coordinator drove exactly one poll during initial refresh
+        mock_fp.perform_poll.assert_awaited_once()

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -395,12 +395,3 @@ async def test_fireplace_built_with_polling_disabled(
         # Coordinator drives exactly one poll; if the library were also auto-polling
         # this would be > 1, catching the double-poll regression.
         mock_fp.perform_poll.assert_awaited_once()
-
-
-async def test_build_fireplace_from_common_accepts_polling_enabled() -> None:
-    """Verify the backing lib's build_fireplace_from_common accepts polling_enabled.
-
-    Guards against the library renaming the kwarg without us noticing.
-    """
-    sig = inspect.signature(UnifiedFireplace.build_fireplace_from_common)
-    assert "polling_enabled" in sig.parameters

--- a/tests/components/intellifire/test_init.py
+++ b/tests/components/intellifire/test_init.py
@@ -1,6 +1,9 @@
 """Test the IntelliFire config flow."""
 
 from unittest.mock import AsyncMock, patch
+
+from intellifire4py.const import IntelliFireApiMode
+
 from homeassistant.components.intellifire import CONF_USER_ID
 from homeassistant.components.intellifire.const import (
     API_MODE_CLOUD,
@@ -359,34 +362,3 @@ async def test_coordinator_performs_poll(
 
     # Verify perform_poll was awaited during initial setup/refresh
     mock_fp.perform_poll.assert_awaited_once()
-
-
-async def test_fireplace_built_with_polling_disabled(
-    hass: HomeAssistant,
-    mock_config_entry_current: MockConfigEntry,
-    mock_apis_single_fp,
-) -> None:
-    """Test that the fireplace is built with polling_enabled=False.
-
-    The library auto-polls by default; ensure it is constructed with polling
-    disabled so the coordinator controls all polling via perform_poll().
-    """
-    _mock_local, _mock_cloud, mock_fp = mock_apis_single_fp
-
-    # We need to capture the call to build_fireplace_from_common
-    with patch(
-        "homeassistant.components.intellifire.UnifiedFireplace.build_fireplace_from_common",
-        new_callable=AsyncMock,
-        return_value=mock_fp,
-    ) as mock_build:
-        mock_config_entry_current.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry_current.entry_id)
-        await hass.async_block_till_done()
-
-        # Verify build_fireplace_from_common was called with polling_enabled=False
-        mock_build.assert_awaited_once()
-        call_kwargs = mock_build.call_args.kwargs
-        assert call_kwargs.get("polling_enabled") is False
-        # Coordinator drives exactly one poll; if the library were also auto-polling
-        # this would be > 1, catching the double-poll regression.
-        mock_fp.perform_poll.assert_awaited_once()


### PR DESCRIPTION
## Proposed change

In the current mode of operation Home Assistant issues a change request to the fireplace via the backing library, then waits until the next coordinator poll to pick up the new state. Meanwhile the backing library is also running its own internal polling loop, resulting in duplicate polls and slower responsiveness.

This PR fixes that by:
- Passing `polling_enabled=False` when constructing the `UnifiedFireplace`, disabling the library's internal polling loop
- Calling `perform_poll()` directly from the coordinator's `_async_update_data()`, so HA controls all polling

The required library changes (`perform_poll()` and `polling_enabled` flag) landed in `intellifire4py==4.4.0`, which was bumped in the preliminary PR #165356.

- see: https://github.com/jeeftor/intellifire4py/issues/238

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr