### PR TITLE
Feat/radio browser server side search

### DIFF
--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import mimetypes
+from urllib.parse import unquote
 
 import pycountry
 from radios import FilterBy, Order, RadioBrowser, Station
@@ -364,8 +365,11 @@ class RadioMediaSource(MediaSource):
         """Handle searching radio stations by name and optional codec filter.
 
         Identifier format:
-          search/<query>          - search by name only
-          search/<query>/<codec>  - search by name, then filter by codec (e.g. AAC)
+          search/<encoded_query>          - search by name only
+          search/<encoded_query>/<codec>  - search by name, then filter by codec (e.g. AAC)
+
+        The query portion must be URL-encoded by the caller (e.g. "AC%2FDC", "Radio%20Bob%21")
+        so that slashes and other special characters do not conflict with the path separator.
         """
         identifier = item.identifier or ""
         if not identifier.startswith(SEARCH_PREFIX):
@@ -375,12 +379,14 @@ class RadioMediaSource(MediaSource):
         if not remainder:
             return []
 
-        # Split optional codec suffix: "rock/AAC" → query="rock", codec="AAC"
-        query, _, codec = remainder.partition("/")
+        # Split optional codec suffix: "rock%20pop/AAC" → query="rock pop", codec="AAC"
+        encoded_query, _, codec = remainder.partition("/")
         codec = codec.upper() if codec else ""
+        query = unquote(encoded_query)
 
         if not query:
             return []
+
 
         stations = await radios.stations(
             filter_by=FilterBy.NAME,

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -380,18 +380,20 @@ class RadioMediaSource(MediaSource):
             return []
 
         # Split optional codec suffix: "rock%20pop/AAC" → query="rock pop", codec="AAC"
-        encoded_query, _, codec = remainder.partition("/")
-        codec = codec.upper() if codec else ""
+        encoded_query, _, raw_codec = remainder.partition("/")
+        codec = unquote(raw_codec).upper() if raw_codec else ""
         query = unquote(encoded_query)
 
         if not query:
             return []
 
+        # When a codec filter is active, fetch more stations so post-filter
+        # results aren't truncated (the Radio Browser API has no codec filter).
         stations = await radios.stations(
             filter_by=FilterBy.NAME,
             filter_term=query,
             hide_broken=True,
-            limit=100,
+            limit=100 if not codec else 500,
             order=Order.CLICK_COUNT,
             reverse=True,
         )

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -21,6 +21,8 @@ from homeassistant.util.location import vincenty
 from . import RadioBrowserConfigEntry
 from .const import DOMAIN
 
+SEARCH_PREFIX = "search/"
+
 CODEC_TO_MIMETYPE = {
     "MP3": "audio/mpeg",
     "AAC": "audio/aac",
@@ -91,6 +93,7 @@ class RadioMediaSource(MediaSource):
                 *await self._async_build_by_language(radios, item),
                 *await self._async_build_local(radios, item),
                 *await self._async_build_by_country(radios, item),
+                *await self._async_build_search(radios, item),
             ],
         )
 
@@ -354,3 +357,41 @@ class RadioMediaSource(MediaSource):
             ]
 
         return []
+
+    async def _async_build_search(
+        self, radios: RadioBrowser, item: MediaSourceItem
+    ) -> list[BrowseMediaSource]:
+        """Handle searching radio stations by name and optional codec filter.
+
+        Identifier format:
+          search/<query>          - search by name only
+          search/<query>/<codec>  - search by name, then filter by codec (e.g. AAC)
+        """
+        identifier = item.identifier or ""
+        if not identifier.startswith(SEARCH_PREFIX):
+            return []
+
+        remainder = identifier[len(SEARCH_PREFIX) :]
+        if not remainder:
+            return []
+
+        # Split optional codec suffix: "rock/AAC" → query="rock", codec="AAC"
+        query, _, codec = remainder.partition("/")
+        codec = codec.upper() if codec else ""
+
+        if not query:
+            return []
+
+        stations = await radios.stations(
+            filter_by=FilterBy.NAME,
+            filter_term=query,
+            hide_broken=True,
+            limit=100,
+            order=Order.CLICK_COUNT,
+            reverse=True,
+        )
+
+        if codec:
+            stations = [s for s in stations if s.codec.upper() == codec]
+
+        return self._async_build_stations(radios, stations)

--- a/homeassistant/components/radio_browser/media_source.py
+++ b/homeassistant/components/radio_browser/media_source.py
@@ -387,7 +387,6 @@ class RadioMediaSource(MediaSource):
         if not query:
             return []
 
-
         stations = await radios.stations(
             filter_by=FilterBy.NAME,
             filter_term=query,

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -139,7 +139,7 @@ async def test_search_stations_with_codec_filter(
         filter_by=FilterBy.NAME,
         filter_term="rock",
         hide_broken=True,
-        limit=100,
+        limit=500,
         order=Order.CLICK_COUNT,
         reverse=True,
     )
@@ -164,6 +164,46 @@ async def test_search_stations_with_codec_filter_case_insensitive(
     assert item is not None
     assert item.children is not None
     assert len(item.children) > 0
+
+
+async def test_search_stations_with_url_encoded_codec(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test that a URL-encoded codec segment is decoded correctly (e.g. AAC%2B → AAC+)."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    class AacPlusStation:
+        """Mock station with AAC+ codec."""
+
+        country_code = "US"
+        latitude = None
+        longitude = None
+        uuid = "aac-plus-1"
+        name = "AAC+ Station"
+        codec = "AAC+"
+        favicon = "fake.png"
+
+    source.radios.stations = AsyncMock(return_value=[AacPlusStation()])
+
+    # "AAC%2B" must be URL-decoded to "AAC+" before the codec filter is applied
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/station/AAC%2B"
+    )
+
+    source.radios.stations.assert_awaited_with(
+        filter_by=FilterBy.NAME,
+        filter_term="station",
+        hide_broken=True,
+        limit=500,
+        order=Order.CLICK_COUNT,
+        reverse=True,
+    )
+
+    assert item is not None
+    assert item.children is not None
+    assert len(item.children) == 1
+    assert item.children[0].title == "AAC+ Station"
 
 
 async def test_search_stations_empty_query(

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -71,3 +71,88 @@ async def test_browsing_local(
     assert other_browse is not None
     assert other_browse.title == "My Radios"
     assert len(other_browse.children) == 0
+
+
+async def test_search_stations(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test server-side search for radio stations by name."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/rock"
+    )
+
+    source.radios.stations.assert_awaited_with(
+        filter_by=FilterBy.NAME,
+        filter_term="rock",
+        hide_broken=True,
+        limit=100,
+        order=Order.CLICK_COUNT,
+        reverse=True,
+    )
+
+    assert item is not None
+    assert item.children is not None
+    assert len(item.children) > 0
+
+
+async def test_search_stations_with_codec_filter(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test server-side search filtered by codec (e.g. AAC for Apple TV)."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    # The mock stations all have codec "MP3", so filtering for AAC returns nothing
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/rock/AAC"
+    )
+
+    source.radios.stations.assert_awaited_with(
+        filter_by=FilterBy.NAME,
+        filter_term="rock",
+        hide_broken=True,
+        limit=100,
+        order=Order.CLICK_COUNT,
+        reverse=True,
+    )
+
+    # Mock stations are all MP3, so AAC filter yields empty result
+    assert item is not None
+    assert item.children == []
+
+
+async def test_search_stations_with_codec_filter_case_insensitive(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test that codec filter is case-insensitive."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    # Mock stations are all MP3 — search with lowercase "mp3" should still match
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/rock/mp3"
+    )
+
+    assert item is not None
+    assert item.children is not None
+    assert len(item.children) > 0
+
+
+async def test_search_stations_empty_query(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test that an empty search query returns no results without calling the API."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/"
+    )
+
+    source.radios.stations.assert_not_awaited()
+
+    assert item is not None
+    assert item.children == []

--- a/tests/components/radio_browser/test_media_source.py
+++ b/tests/components/radio_browser/test_media_source.py
@@ -98,6 +98,31 @@ async def test_search_stations(
     assert len(item.children) > 0
 
 
+async def test_search_stations_url_encoded_query(
+    hass: HomeAssistant, init_integration: AsyncMock, patch_radios
+) -> None:
+    """Test that URL-encoded queries are decoded correctly (e.g. AC%2FDC, Radio%20Bob%21)."""
+    source = await async_get_media_source(hass)
+    patch_radios(source)
+
+    # "AC%2FDC" must be decoded to "AC/DC" before being sent to the API,
+    # so the "/" does not get misinterpreted as the codec path separator.
+    item = await media_source.async_browse_media(
+        hass, f"{media_source.URI_SCHEME}{DOMAIN}/search/AC%2FDC"
+    )
+
+    source.radios.stations.assert_awaited_with(
+        filter_by=FilterBy.NAME,
+        filter_term="AC/DC",
+        hide_broken=True,
+        limit=100,
+        order=Order.CLICK_COUNT,
+        reverse=True,
+    )
+
+    assert item is not None
+
+
 async def test_search_stations_with_codec_filter(
     hass: HomeAssistant, init_integration: AsyncMock, patch_radios
 ) -> None:


### PR DESCRIPTION
## Proposed change

The Radio Browser media source currently only supports browsing stations by category
(country, tag, language). This PR adds server-side search support so clients can search
for stations by name directly via the Radio Browser API.

**New identifier format:**
- `media-source://radio_browser/search/<encoded_query>` – search by name
- `media-source://radio_browser/search/<encoded_query>/<CODEC>` – search by name, filtered by codec (e.g. `AAC`)

The query must be URL-encoded so that special characters like `/` in names (e.g. `AC/DC`
→ `AC%2FDC`) don't conflict with the path separator.

**Note on `media_player.search_media` (added in #140321):**
That feature adds a `ServiceCall`-based search to `MediaPlayerEntity` integrations
(Sonos, Cast, Plex, etc.) which manage their own content libraries.
Radio Browser is a `MediaSource`, not a `MediaPlayer`. It exposes its content via
`async_browse_media()`, so the correct and idiomatic extension point is the
`search/` identifier prefix within the browse hierarchy — which is exactly what this PR uses.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request:

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added