### PR TITLE
motion_blinds: add UI option to override blind type

### DIFF
--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from motionblinds import MotionDiscovery, MotionGateway
+from motionblinds import BlindType, MotionDiscovery, MotionGateway
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -18,9 +18,17 @@ from homeassistant.const import CONF_API_KEY, CONF_HOST
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from homeassistant.helpers import (
+    device_registry,
+    entity_registry,
+    selector,
+)
 
 from .const import (
+    CONF_BLIND_TYPE,
+    CONF_COVER_DETAILS,
     CONF_INTERFACE,
+    DEFAULT_BLIND_TYPE,
     CONF_WAIT_FOR_PUSH,
     DEFAULT_GATEWAY_NAME,
     DEFAULT_INTERFACE,
@@ -45,15 +53,33 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
+
+        if not hasattr(self, "_staged_options"):
+            self._staged_options = self.config_entry.options.copy()
+
         errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            if CONF_COVER_DETAILS not in user_input:
+                self._staged_options.update(user_input)
+                return self.async_create_entry(title="", data=self._staged_options)
+
+            selected_cover = user_input.pop(CONF_COVER_DETAILS)
+            self._staged_options.update(user_input)
+            return await self.async_show_details(selected_cover)
 
         settings_schema = vol.Schema(
             {
+                vol.Optional(CONF_COVER_DETAILS): selector.DeviceSelector(
+                    selector.DeviceSelectorConfig(
+                        entity=selector.EntityFilterSelectorConfig(
+                            domain="cover",
+                            integration=DOMAIN,
+                        )
+                    )
+                ),
                 vol.Optional(
                     CONF_WAIT_FOR_PUSH,
-                    default=self.config_entry.options.get(
+                    default=self._staged_options.get(
                         CONF_WAIT_FOR_PUSH, DEFAULT_WAIT_FOR_PUSH
                     ),
                 ): bool,
@@ -64,6 +90,78 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             step_id="init", data_schema=settings_schema, errors=errors
         )
 
+    async def async_show_details(self, selected_cover: str) -> ConfigFlowResult:
+        dev_reg = device_registry.async_get(self.hass)
+        device = dev_reg.async_get(selected_cover)
+        if device is None:
+            return await self.async_step_init()
+
+        self._selected_cover_mac = next(
+            (
+                identifier
+                for domain, identifier in device.identifiers
+                if domain == DOMAIN
+            ),
+            None,
+        )
+        device_name = device.name_by_user or device.name_by_user or self._selected_cover_mac
+
+        blind_type_key = f"{self._selected_cover_mac}_{CONF_BLIND_TYPE}"
+
+        try:
+            blind_type = BlindType(int(self._staged_options[blind_type_key]))
+        except (KeyError, ValueError):
+            blind_type = DEFAULT_BLIND_TYPE
+
+        schema = {
+            vol.Required(
+                CONF_BLIND_TYPE, default=f"blind_type_{blind_type.name.lower()}"
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=[
+                        {
+                            "value": f"blind_type_{v.name.lower()}",
+                            "label": v.name,
+                        }
+                        for v in BlindType
+                    ],
+                    translation_key=CONF_BLIND_TYPE,
+                    mode=selector.SelectSelectorMode.DROPDOWN
+                )
+            )
+        }
+
+        return self.async_show_form(
+            step_id="details",
+            data_schema=vol.Schema(schema),
+            errors={},
+            description_placeholders={"device_name": device_name},
+        )
+
+    async def async_step_details(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        blind_type = DEFAULT_BLIND_TYPE
+
+        if user_input:
+            raw = user_input.get(CONF_BLIND_TYPE)
+            if raw:
+                prefix = "blind_type_"
+                if raw.startswith(prefix):
+                    name = raw[len(prefix):]
+                    for v in BlindType:
+                        if v.name.lower() == name:
+                            blind_type = v
+                            break
+
+        blind_type_key = f"{self._selected_cover_mac}_{CONF_BLIND_TYPE}"
+
+        if blind_type == DEFAULT_BLIND_TYPE:
+            self._staged_options.pop(blind_type_key, None)
+        else:
+            self._staged_options[blind_type_key] = blind_type.value
+
+        return await self.async_step_init()
 
 class MotionBlindsFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Motionblinds config flow."""

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -1,5 +1,7 @@
 """Constants for the Motionblinds component."""
 
+from motionblinds import BlindType
+
 from homeassistant.const import Platform
 
 DOMAIN = "motion_blinds"
@@ -9,9 +11,12 @@ DEFAULT_GATEWAY_NAME = "Motionblinds Gateway"
 PLATFORMS = [Platform.BUTTON, Platform.COVER, Platform.SENSOR]
 
 CONF_BLIND_TYPE_LIST = "blind_type_list"
+CONF_BLIND_TYPE = "blind_type"
+CONF_COVER_DETAILS = "cover_details"
 CONF_WAIT_FOR_PUSH = "wait_for_push"
 CONF_INTERFACE = "interface"
 DEFAULT_WAIT_FOR_PUSH = False
+DEFAULT_BLIND_TYPE = BlindType.Unknown
 DEFAULT_INTERFACE = "any"
 
 KEY_GATEWAY = "gateway"

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -25,6 +25,7 @@ from .const import (
     ATTR_ABSOLUTE_POSITION,
     ATTR_AVAILABLE,
     ATTR_WIDTH,
+    CONF_BLIND_TYPE,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_GATEWAY,
@@ -93,39 +94,54 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
 
     for blind in motion_gateway.device_list.values():
-        if blind.type in POSITION_DEVICE_MAP:
+        option_key = f"{blind.mac}_{CONF_BLIND_TYPE}"
+        if option_key in config_entry.options:
+            try:
+                blind_type = BlindType(int(config_entry.options[option_key]))
+            except ValueError:
+                blind_type = blind.type
+            else:
+                _LOGGER.debug(
+                    "Blind %s: using overridden blind type %s",
+                    blind.mac,
+                    blind_type.name,
+                )
+        else:
+            blind_type = blind.type
+
+        if blind_type in POSITION_DEVICE_MAP:
             entities.append(
                 MotionPositionDevice(
                     coordinator,
                     blind,
-                    POSITION_DEVICE_MAP[blind.type],
+                    POSITION_DEVICE_MAP[blind_type],
                 )
             )
 
-        elif blind.type in TILT_DEVICE_MAP:
+        elif blind_type in TILT_DEVICE_MAP:
             entities.append(
                 MotionTiltDevice(
                     coordinator,
                     blind,
-                    TILT_DEVICE_MAP[blind.type],
+                    TILT_DEVICE_MAP[blind_type],
                 )
             )
 
-        elif blind.type in TILT_ONLY_DEVICE_MAP:
+        elif blind_type in TILT_ONLY_DEVICE_MAP:
             entities.append(
                 MotionTiltOnlyDevice(
                     coordinator,
                     blind,
-                    TILT_ONLY_DEVICE_MAP[blind.type],
+                    TILT_ONLY_DEVICE_MAP[blind_type],
                 )
             )
 
-        elif blind.type in TDBU_DEVICE_MAP:
+        elif blind_type in TDBU_DEVICE_MAP:
             entities.append(
                 MotionTDBUDevice(
                     coordinator,
                     blind,
-                    TDBU_DEVICE_MAP[blind.type],
+                    TDBU_DEVICE_MAP[blind_type],
                     "Top",
                 )
             )
@@ -133,7 +149,7 @@ async def async_setup_entry(
                 MotionTDBUDevice(
                     coordinator,
                     blind,
-                    TDBU_DEVICE_MAP[blind.type],
+                    TDBU_DEVICE_MAP[blind_type],
                     "Bottom",
                 )
             )
@@ -141,7 +157,7 @@ async def async_setup_entry(
                 MotionTDBUDevice(
                     coordinator,
                     blind,
-                    TDBU_DEVICE_MAP[blind.type],
+                    TDBU_DEVICE_MAP[blind_type],
                     "Combined",
                 )
             )
@@ -149,7 +165,7 @@ async def async_setup_entry(
         else:
             _LOGGER.warning(
                 "Blind type '%s' not yet supported, assuming RollerBlind",
-                blind.blind_type,
+                blind_type.name,
             )
             entities.append(
                 MotionPositionDevice(

--- a/homeassistant/components/motion_blinds/strings.json
+++ b/homeassistant/components/motion_blinds/strings.json
@@ -63,10 +63,52 @@
   },
   "options": {
     "step": {
+      "details": {
+        "data": {
+          "blind_type": "Blind type"
+        },
+        "description": "Advanced options for {device_name}"
+      },
       "init": {
         "data": {
+          "cover_details": "Select a cover for advanced options",
           "wait_for_push": "Wait for multicast push on update"
-        }
+        },
+        "description": "Select a cover for advanced options"
+      }
+    }
+  },
+  "selector": {
+    "blind_type": {
+      "options": {
+        "blind_type_awning": "Awning",
+        "blind_type_curtain": "Curtain",
+        "blind_type_curtainleft": "Curtain Left",
+        "blind_type_curtainright": "Curtain Right",
+        "blind_type_daynightblind": "Day Night Blind",
+        "blind_type_dimmingblind": "Dimming Blind",
+        "blind_type_doubleroller": "Double Roller",
+        "blind_type_dualshade": "Dual Shade",
+        "blind_type_honeycombblind": "Honeycomb Blind",
+        "blind_type_insectscreen": "Insect Screen",
+        "blind_type_radioreceiver": "Radio Receiver",
+        "blind_type_rollerblind": "Roller Blind",
+        "blind_type_rollergate": "Roller Gate",
+        "blind_type_rollershutter": "Roller Shutter",
+        "blind_type_rollertiltmotor": "Roller Tilt Motor",
+        "blind_type_romanblind": "Roman Blind",
+        "blind_type_shangrilablind": "Shangri-La Blind",
+        "blind_type_skylightblind": "Skylight Blind",
+        "blind_type_switch": "Switch",
+        "blind_type_topdownbottomup": "Top Down Bottom Up",
+        "blind_type_triangleblind": "Triangle Blind",
+        "blind_type_unknown": "(auto detect)",
+        "blind_type_venetianblind": "Venetian Blind",
+        "blind_type_verticalblind": "Vertical Blind",
+        "blind_type_verticalblindleft": "Vertical Blind Left",
+        "blind_type_verticalblindright": "Vertical Blind Right",
+        "blind_type_woodshutter": "Wood Shutter",
+        "blind_type_wovenwoodshades": "Woven Wood Shades"
       }
     }
   },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes the blind type is not detected correctly. I have several battery RF modules for venetian blinds, but most report roller blind although I add them in the same way to the gateway. This patch adds an advanced options dialog for overriding the blind type. Unfortunately there is no possibility in home assistant to add a device config/options flow, therefore this this is an extension of the integration options flow. If a device is selected then the submit button leads to a details flow, where the blind type can be set manually or reset to "auto detect".

I tested this code successfully with my Kaiser Nienhaus solar powered controllers for venetian blinds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
