### PR TITLE
Improve error handling when addon unavailable for install/update

### DIFF
--- a/homeassistant/components/hassio/addon_manager.py
+++ b/homeassistant/components/hassio/addon_manager.py
@@ -10,7 +10,11 @@ from functools import partial, wraps
 import logging
 from typing import Any, Concatenate
 
-from aiohasupervisor import SupervisorError
+from aiohasupervisor import (
+    AddonNotSupportedError,
+    SupervisorError,
+    SupervisorNotFoundError,
+)
 from aiohasupervisor.models import (
     AddonsOptions,
     AddonState as SupervisorAddonState,
@@ -165,15 +169,7 @@ class AddonManager:
             )
 
         addon_info = await self._supervisor_client.addons.addon_info(self.addon_slug)
-        addon_state = self.async_get_addon_state(addon_info)
-        return AddonInfo(
-            available=addon_info.available,
-            hostname=addon_info.hostname,
-            options=addon_info.options,
-            state=addon_state,
-            update_available=addon_info.update_available,
-            version=addon_info.version,
-        )
+        return self.async_convert_installed_app_info(addon_info)
 
     @callback
     def async_get_addon_state(self, addon_info: InstalledAddonComplete) -> AddonState:
@@ -188,6 +184,20 @@ class AddonManager:
             addon_state = AddonState.UPDATING
 
         return addon_state
+
+    @callback
+    def async_convert_installed_app_info(
+        self, app_info: InstalledAddonComplete
+    ) -> AddonInfo:
+        """Convert InstalledAddonComplete model to AddonInfo model."""
+        return AddonInfo(
+            available=app_info.available,
+            hostname=app_info.hostname,
+            options=app_info.options,
+            state=self.async_get_addon_state(app_info),
+            update_available=app_info.update_available,
+            version=app_info.version,
+        )
 
     @api_error(
         "Failed to set the {addon_name} app options",
@@ -209,11 +219,12 @@ class AddonManager:
     )
     async def async_install_addon(self) -> None:
         """Install the managed add-on."""
-        addon_info = await self.async_get_addon_info()
-
-        self._check_addon_available(addon_info)
-
-        await self._supervisor_client.store.install_addon(self.addon_slug)
+        try:
+            await self._supervisor_client.store.install_addon(self.addon_slug)
+        except AddonNotSupportedError as err:
+            raise AddonError(
+                f"{self.addon_name} app is not available: {err!s}"
+            ) from None
 
     @api_error(
         "Failed to uninstall the {addon_name} app",
@@ -226,17 +237,24 @@ class AddonManager:
     @api_error("Failed to update the {addon_name} app")
     async def async_update_addon(self) -> None:
         """Update the managed add-on if needed."""
-        addon_info = await self.async_get_addon_info()
+        try:
+            app_info = await self._supervisor_client.addons.addon_info(self.addon_slug)
+        except SupervisorNotFoundError:
+            raise AddonError(f"{self.addon_name} app is not installed") from None
 
-        self._check_addon_available(addon_info)
-
-        if addon_info.state is AddonState.NOT_INSTALLED:
-            raise AddonError(f"{self.addon_name} app is not installed")
-
-        if not addon_info.update_available:
+        if not app_info.update_available:
             return
 
-        await self.async_create_backup()
+        try:
+            await self._supervisor_client.store.addon_availability(self.addon_slug)
+        except AddonNotSupportedError as err:
+            raise AddonError(
+                f"{self.addon_name} app is not available: {err!s}"
+            ) from None
+
+        await self.async_create_backup(
+            app_info=self.async_convert_installed_app_info(app_info)
+        )
         await self._supervisor_client.store.update_addon(
             self.addon_slug, StoreAddonUpdate(backup=False)
         )
@@ -266,10 +284,14 @@ class AddonManager:
         "Failed to create a backup of the {addon_name} app",
         expected_error_type=SupervisorError,
     )
-    async def async_create_backup(self) -> None:
+    async def async_create_backup(self, *, app_info: AddonInfo | None = None) -> None:
         """Create a partial backup of the managed add-on."""
-        addon_info = await self.async_get_addon_info()
-        name = f"addon_{self.addon_slug}_{addon_info.version}"
+        if app_info:
+            app_version = app_info.version
+        else:
+            app_version = (await self.async_get_addon_info()).version
+
+        name = f"addon_{self.addon_slug}_{app_version}"
 
         self._logger.debug("Creating backup: %s", name)
         await self._supervisor_client.backups.partial_backup(

--- a/homeassistant/components/hassio/addon_manager.py
+++ b/homeassistant/components/hassio/addon_manager.py
@@ -169,7 +169,7 @@ class AddonManager:
             )
 
         addon_info = await self._supervisor_client.addons.addon_info(self.addon_slug)
-        return self.async_convert_installed_app_info(addon_info)
+        return self._async_convert_installed_addon_info(addon_info)
 
     @callback
     def async_get_addon_state(self, addon_info: InstalledAddonComplete) -> AddonState:
@@ -186,17 +186,17 @@ class AddonManager:
         return addon_state
 
     @callback
-    def async_convert_installed_app_info(
-        self, app_info: InstalledAddonComplete
+    def _async_convert_installed_addon_info(
+        self, addon_info: InstalledAddonComplete
     ) -> AddonInfo:
         """Convert InstalledAddonComplete model to AddonInfo model."""
         return AddonInfo(
-            available=app_info.available,
-            hostname=app_info.hostname,
-            options=app_info.options,
-            state=self.async_get_addon_state(app_info),
-            update_available=app_info.update_available,
-            version=app_info.version,
+            available=addon_info.available,
+            hostname=addon_info.hostname,
+            options=addon_info.options,
+            state=self.async_get_addon_state(addon_info),
+            update_available=addon_info.update_available,
+            version=addon_info.version,
         )
 
     @api_error(
@@ -233,11 +233,16 @@ class AddonManager:
     async def async_update_addon(self) -> None:
         """Update the managed add-on if needed."""
         try:
-            app_info = await self._supervisor_client.addons.addon_info(self.addon_slug)
+            # Not using async_get_addon_info here because it would make an unnecessary
+            # call to /store/addon/{slug}/info. This will raise if the addon is not
+            # installed so one call to /addon/{slug}/info is all that is needed
+            addon_info = await self._supervisor_client.addons.addon_info(
+                self.addon_slug
+            )
         except SupervisorNotFoundError:
             raise AddonError(f"{self.addon_name} app is not installed") from None
 
-        if not app_info.update_available:
+        if not addon_info.update_available:
             return
 
         try:
@@ -248,7 +253,7 @@ class AddonManager:
             ) from None
 
         await self.async_create_backup(
-            app_info=self.async_convert_installed_app_info(app_info)
+            addon_info=self._async_convert_installed_addon_info(addon_info)
         )
         await self._supervisor_client.store.update_addon(
             self.addon_slug, StoreAddonUpdate(backup=False)
@@ -279,14 +284,14 @@ class AddonManager:
         "Failed to create a backup of the {addon_name} app",
         expected_error_type=SupervisorError,
     )
-    async def async_create_backup(self, *, app_info: AddonInfo | None = None) -> None:
+    async def async_create_backup(self, *, addon_info: AddonInfo | None = None) -> None:
         """Create a partial backup of the managed add-on."""
-        if app_info:
-            app_version = app_info.version
+        if addon_info:
+            addon_version = addon_info.version
         else:
-            app_version = (await self.async_get_addon_info()).version
+            addon_version = (await self.async_get_addon_info()).version
 
-        name = f"addon_{self.addon_slug}_{app_version}"
+        name = f"addon_{self.addon_slug}_{addon_version}"
 
         self._logger.debug("Creating backup: %s", name)
         await self._supervisor_client.backups.partial_backup(

--- a/homeassistant/components/hassio/addon_manager.py
+++ b/homeassistant/components/hassio/addon_manager.py
@@ -209,11 +209,6 @@ class AddonManager:
             self.addon_slug, AddonsOptions(config=config)
         )
 
-    def _check_addon_available(self, addon_info: AddonInfo) -> None:
-        """Check if the managed add-on is available."""
-        if not addon_info.available:
-            raise AddonError(f"{self.addon_name} app is not available")
-
     @api_error(
         "Failed to install the {addon_name} app", expected_error_type=SupervisorError
     )

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -13,6 +13,7 @@ import string
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiohasupervisor import SupervisorNotFoundError
 from aiohasupervisor.models import (
     Discovery,
     GreenInfo,
@@ -313,6 +314,7 @@ def addon_not_installed_fixture(
     """Mock add-on not installed."""
     from .hassio.common import mock_addon_not_installed  # noqa: PLC0415
 
+    addon_info.side_effect = SupervisorNotFoundError
     return mock_addon_not_installed(addon_store_info, addon_info)
 
 

--- a/tests/components/hassio/test_addon_manager.py
+++ b/tests/components/hassio/test_addon_manager.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 from unittest.mock import AsyncMock, call
 from uuid import uuid4
 
-from aiohasupervisor import SupervisorError
+from aiohasupervisor import (
+    AddonNotSupportedArchitectureError,
+    AddonNotSupportedHomeAssistantVersionError,
+    AddonNotSupportedMachineTypeError,
+    SupervisorError,
+)
 from aiohasupervisor.models import AddonsOptions, Discovery, PartialBackupOptions
 import pytest
 
@@ -20,10 +24,8 @@ from homeassistant.components.hassio.addon_manager import (
 from homeassistant.core import HomeAssistant
 
 
-async def test_not_installed_raises_exception(
-    addon_manager: AddonManager,
-    addon_not_installed: dict[str, Any],
-) -> None:
+@pytest.mark.usefixtures("addon_not_installed")
+async def test_not_installed_raises_exception(addon_manager: AddonManager) -> None:
     """Test addon not installed raises exception."""
     addon_config = {"test_key": "test"}
 
@@ -38,24 +40,40 @@ async def test_not_installed_raises_exception(
     assert str(err.value) == "Test app is not installed"
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        AddonNotSupportedArchitectureError(
+            "Add-on test not supported on this platform, supported architectures: test"
+        ),
+        AddonNotSupportedHomeAssistantVersionError(
+            "Add-on test not supported on this system, requires Home Assistant version 2026.1.0 or greater"
+        ),
+        AddonNotSupportedMachineTypeError(
+            "Add-on test not supported on this machine, supported machine types: test"
+        ),
+    ],
+)
 async def test_not_available_raises_exception(
     addon_manager: AddonManager,
-    addon_store_info: AsyncMock,
+    supervisor_client: AsyncMock,
     addon_info: AsyncMock,
+    exception: SupervisorError,
 ) -> None:
     """Test addon not available raises exception."""
-    addon_store_info.return_value.available = False
-    addon_info.return_value.available = False
+    supervisor_client.store.addon_availability.side_effect = exception
+    supervisor_client.store.install_addon.side_effect = exception
+    addon_info.return_value.update_available = True
 
     with pytest.raises(AddonError) as err:
         await addon_manager.async_install_addon()
 
-    assert str(err.value) == "Test app is not available"
+    assert str(err.value) == f"Test app is not available: {exception!s}"
 
     with pytest.raises(AddonError) as err:
         await addon_manager.async_update_addon()
 
-    assert str(err.value) == "Test app is not available"
+    assert str(err.value) == f"Test app is not available: {exception!s}"
 
 
 async def test_get_addon_discovery_info(
@@ -496,11 +514,10 @@ async def test_stop_addon_error(
     assert stop_addon.call_count == 1
 
 
+@pytest.mark.usefixtures("hass", "addon_installed")
 async def test_update_addon(
-    hass: HomeAssistant,
     addon_manager: AddonManager,
     addon_info: AsyncMock,
-    addon_installed: AsyncMock,
     create_backup: AsyncMock,
     update_addon: AsyncMock,
 ) -> None:
@@ -509,7 +526,7 @@ async def test_update_addon(
 
     await addon_manager.async_update_addon()
 
-    assert addon_info.call_count == 2
+    assert addon_info.call_count == 1
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         PartialBackupOptions(name="addon_test_addon_1.0.0", addons={"test_addon"})
@@ -517,10 +534,10 @@ async def test_update_addon(
     assert update_addon.call_count == 1
 
 
+@pytest.mark.usefixtures("addon_installed")
 async def test_update_addon_no_update(
     addon_manager: AddonManager,
     addon_info: AsyncMock,
-    addon_installed: AsyncMock,
     create_backup: AsyncMock,
     update_addon: AsyncMock,
 ) -> None:
@@ -534,11 +551,10 @@ async def test_update_addon_no_update(
     assert update_addon.call_count == 0
 
 
+@pytest.mark.usefixtures("hass", "addon_installed")
 async def test_update_addon_error(
-    hass: HomeAssistant,
     addon_manager: AddonManager,
     addon_info: AsyncMock,
-    addon_installed: AsyncMock,
     create_backup: AsyncMock,
     update_addon: AsyncMock,
 ) -> None:
@@ -551,7 +567,7 @@ async def test_update_addon_error(
 
     assert str(err.value) == "Failed to update the Test app: Boom"
 
-    assert addon_info.call_count == 2
+    assert addon_info.call_count == 1
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         PartialBackupOptions(name="addon_test_addon_1.0.0", addons={"test_addon"})
@@ -559,11 +575,10 @@ async def test_update_addon_error(
     assert update_addon.call_count == 1
 
 
+@pytest.mark.usefixtures("hass", "addon_installed")
 async def test_schedule_update_addon(
-    hass: HomeAssistant,
     addon_manager: AddonManager,
     addon_info: AsyncMock,
-    addon_installed: AsyncMock,
     create_backup: AsyncMock,
     update_addon: AsyncMock,
 ) -> None:
@@ -589,7 +604,7 @@ async def test_schedule_update_addon(
     await asyncio.gather(update_task, update_task_two)
 
     assert addon_manager.task_in_progress() is False
-    assert addon_info.call_count == 3
+    assert addon_info.call_count == 2
     assert create_backup.call_count == 1
     assert create_backup.call_args == call(
         PartialBackupOptions(name="addon_test_addon_1.0.0", addons={"test_addon"})

--- a/tests/components/homeassistant_hardware/test_config_flow.py
+++ b/tests/components/homeassistant_hardware/test_config_flow.py
@@ -906,7 +906,6 @@ async def test_config_flow_thread_addon_already_installed(
     }
 
 
-@pytest.mark.usefixtures("addon_not_installed")
 async def test_options_flow_zigbee_to_thread(
     hass: HomeAssistant,
     install_addon: AsyncMock,

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -445,17 +445,15 @@ async def test_zeroconf_not_onboarded_installed(
         ]
     ],
 )
+@pytest.mark.usefixtures("supervisor", "addon_not_installed", "not_onboarded")
 async def test_zeroconf_not_onboarded_not_installed(
     hass: HomeAssistant,
-    supervisor: MagicMock,
     addon_info: AsyncMock,
     addon_store_info: AsyncMock,
-    addon_not_installed: AsyncMock,
     install_addon: AsyncMock,
     start_addon: AsyncMock,
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
-    not_onboarded: MagicMock,
     zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow Zeroconf discovery when not onboarded and add-on not installed."""
@@ -467,7 +465,7 @@ async def test_zeroconf_not_onboarded_not_installed(
     await hass.async_block_till_done()
 
     assert addon_info.call_count == 0
-    assert addon_store_info.call_count == 2
+    assert addon_store_info.call_count == 1
     assert install_addon.call_args == call("core_matter_server")
     assert start_addon.call_args == call("core_matter_server")
     assert client_connect.call_count == 1

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -258,10 +258,7 @@ async def test_listen_failure_config_entry_loaded(
 
 
 async def test_raise_addon_task_in_progress(
-    hass: HomeAssistant,
-    addon_not_installed: AsyncMock,
-    install_addon: AsyncMock,
-    start_addon: AsyncMock,
+    hass: HomeAssistant, install_addon: AsyncMock, start_addon: AsyncMock
 ) -> None:
     """Test raise ConfigEntryNotReady if an add-on task is in progress."""
     install_event = asyncio.Event()
@@ -337,7 +334,6 @@ async def test_start_addon(
 
 async def test_install_addon(
     hass: HomeAssistant,
-    addon_not_installed: AsyncMock,
     addon_store_info: AsyncMock,
     install_addon: AsyncMock,
     start_addon: AsyncMock,
@@ -357,7 +353,7 @@ async def test_install_addon(
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
-    assert addon_store_info.call_count == 3
+    assert addon_store_info.call_count == 2
     assert install_addon.call_count == 1
     assert install_addon.call_args == call("core_matter_server")
     assert start_addon.call_count == 1

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -651,7 +651,7 @@ async def test_abort_hassio_discovery_for_other_addon(hass: HomeAssistant) -> No
     assert result2["reason"] == "not_zwave_js_addon"
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 @pytest.mark.parametrize(
     ("usb_discovery_info", "device", "discovery_name"),
     [
@@ -1176,7 +1176,7 @@ async def test_usb_discovery_migration_restore_driver_ready_timeout(
 @pytest.mark.parametrize(
     "service_info", [ESPHOME_DISCOVERY_INFO, ESPHOME_DISCOVERY_INFO_CLEAN]
 )
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_esphome_discovery_intent_custom(
     hass: HomeAssistant,
     install_addon: AsyncMock,
@@ -1460,7 +1460,7 @@ async def test_esphome_discovery_already_configured_unmanaged_addon(
     }
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_esphome_discovery_usb_same_home_id(
     hass: HomeAssistant,
     install_addon: AsyncMock,
@@ -1699,7 +1699,7 @@ async def test_discovery_addon_not_running(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_discovery_addon_not_installed(
     hass: HomeAssistant,
     install_addon: AsyncMock,
@@ -2768,7 +2768,7 @@ async def test_addon_installed_already_configured(
     assert entry.data["lr_s2_authenticated_key"] == "new321"
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_addon_not_installed(
     hass: HomeAssistant,
     install_addon: AsyncMock,
@@ -3873,7 +3873,7 @@ async def test_reconfigure_addon_running_server_info_failure(
     assert client.disconnect.call_count == 1
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed")
+@pytest.mark.usefixtures("supervisor")
 @pytest.mark.parametrize(
     (
         "entry_data",
@@ -5036,7 +5036,7 @@ async def test_get_usb_ports_ignored_devices() -> None:
         ]
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 async def test_intent_recommended_user(
     hass: HomeAssistant,
     install_addon: AsyncMock,
@@ -5132,7 +5132,7 @@ async def test_intent_recommended_user(
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.usefixtures("supervisor", "addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("supervisor", "addon_info")
 @pytest.mark.parametrize(
     ("usb_discovery_info", "device", "discovery_name"),
     [

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -933,7 +933,7 @@ async def test_start_addon(
     assert start_addon.call_args == call("core_zwave_js")
 
 
-@pytest.mark.usefixtures("addon_not_installed", "addon_info")
+@pytest.mark.usefixtures("addon_info")
 async def test_install_addon(
     hass: HomeAssistant,
     install_addon: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Use availability API from Supervisor to provide more intuitive errors when install/update of an addon fails since the version is unavailable on the current system.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #148954
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
