### PR TITLE
Fix Tesla Fleet token refresh handling for expired tokens

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -2,7 +2,6 @@
 
 from typing import Final
 
-from aiohttp.client_exceptions import ClientResponseError
 import jwt
 from tesla_fleet_api import TeslaFleetApi, is_valid_region
 from tesla_fleet_api.const import Scope
@@ -19,7 +18,12 @@ from tesla_fleet_api.tesla import VehicleFleet
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -58,6 +62,48 @@ type TeslaFleetConfigEntry = ConfigEntry[TeslaFleetData]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+async def _async_get_products(tesla: TeslaFleetApi) -> list[dict]:
+    """Get products from Tesla Fleet API with region fallback handling."""
+    try:
+        return (await tesla.products())["response"]
+    except InvalidRegion:
+        LOGGER.warning("Region is invalid, trying to find the correct region")
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+    try:
+        await tesla.find_server()
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        LibraryError,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+    try:
+        return (await tesla.products())["response"]
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -> bool:
     """Set up TeslaFleet config."""
 
@@ -86,12 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
     oauth_session = OAuth2Session(hass, entry, implementation)
 
     async def _get_access_token() -> str:
-        try:
-            await oauth_session.async_ensure_token_valid()
-        except ClientResponseError as e:
-            if e.status == 401:
-                raise ConfigEntryAuthFailed from e
-            raise ConfigEntryNotReady from e
+        await oauth_session.async_ensure_token_valid()
         token: str = oauth_session.token[CONF_ACCESS_TOKEN]
         return token
 
@@ -105,22 +146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         energy_scope=Scope.ENERGY_DEVICE_DATA in scopes,
         vehicle_scope=Scope.VEHICLE_DEVICE_DATA in scopes,
     )
-    try:
-        products = (await tesla.products())["response"]
-    except (InvalidToken, OAuthExpired, LoginRequired) as e:
-        raise ConfigEntryAuthFailed from e
-    except InvalidRegion:
-        try:
-            LOGGER.warning("Region is invalid, trying to find the correct region")
-            await tesla.find_server()
-            try:
-                products = (await tesla.products())["response"]
-            except TeslaFleetError as e:
-                raise ConfigEntryNotReady from e
-        except LibraryError as e:
-            raise ConfigEntryAuthFailed from e
-    except TeslaFleetError as e:
-        raise ConfigEntryNotReady from e
+    products = await _async_get_products(tesla)
 
     device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -6,7 +6,9 @@ import jwt
 from tesla_fleet_api import TeslaFleetApi, is_valid_region
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
+    InvalidRegion,
     InvalidToken,
+    LibraryError,
     LoginRequired,
     OAuthExpired,
     TeslaFleetError,
@@ -60,6 +62,48 @@ type TeslaFleetConfigEntry = ConfigEntry[TeslaFleetData]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+async def _async_get_products(tesla: TeslaFleetApi) -> list[dict]:
+    """Get products from Tesla Fleet API with region fallback handling."""
+    try:
+        return (await tesla.products())["response"]
+    except InvalidRegion:
+        LOGGER.warning("Region is invalid, trying to find the correct region")
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+    try:
+        await tesla.find_server()
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        LibraryError,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+    try:
+        return (await tesla.products())["response"]
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        OAuth2TokenRequestReauthError,
+    ) as e:
+        raise ConfigEntryAuthFailed from e
+    except (TeslaFleetError, OAuth2TokenRequestError) as e:
+        raise ConfigEntryNotReady from e
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -> bool:
     """Set up TeslaFleet config."""
 
@@ -102,17 +146,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         energy_scope=Scope.ENERGY_DEVICE_DATA in scopes,
         vehicle_scope=Scope.VEHICLE_DEVICE_DATA in scopes,
     )
-    try:
-        products = (await tesla.products())["response"]
-    except (
-        InvalidToken,
-        OAuthExpired,
-        LoginRequired,
-        OAuth2TokenRequestReauthError,
-    ) as err:
-        raise ConfigEntryAuthFailed from err
-    except (TeslaFleetError, OAuth2TokenRequestError) as err:
-        raise ConfigEntryNotReady from err
+    products = await _async_get_products(tesla)
 
     device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -6,9 +6,7 @@ import jwt
 from tesla_fleet_api import TeslaFleetApi, is_valid_region
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
-    InvalidRegion,
     InvalidToken,
-    LibraryError,
     LoginRequired,
     OAuthExpired,
     TeslaFleetError,
@@ -62,48 +60,6 @@ type TeslaFleetConfigEntry = ConfigEntry[TeslaFleetData]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
-async def _async_get_products(tesla: TeslaFleetApi) -> list[dict]:
-    """Get products from Tesla Fleet API with region fallback handling."""
-    try:
-        return (await tesla.products())["response"]
-    except InvalidRegion:
-        LOGGER.warning("Region is invalid, trying to find the correct region")
-    except (
-        InvalidToken,
-        OAuthExpired,
-        LoginRequired,
-        OAuth2TokenRequestReauthError,
-    ) as e:
-        raise ConfigEntryAuthFailed from e
-    except (TeslaFleetError, OAuth2TokenRequestError) as e:
-        raise ConfigEntryNotReady from e
-
-    try:
-        await tesla.find_server()
-    except (
-        InvalidToken,
-        OAuthExpired,
-        LoginRequired,
-        LibraryError,
-        OAuth2TokenRequestReauthError,
-    ) as e:
-        raise ConfigEntryAuthFailed from e
-    except (TeslaFleetError, OAuth2TokenRequestError) as e:
-        raise ConfigEntryNotReady from e
-
-    try:
-        return (await tesla.products())["response"]
-    except (
-        InvalidToken,
-        OAuthExpired,
-        LoginRequired,
-        OAuth2TokenRequestReauthError,
-    ) as e:
-        raise ConfigEntryAuthFailed from e
-    except (TeslaFleetError, OAuth2TokenRequestError) as e:
-        raise ConfigEntryNotReady from e
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -> bool:
     """Set up TeslaFleet config."""
 
@@ -146,7 +102,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         energy_scope=Scope.ENERGY_DEVICE_DATA in scopes,
         vehicle_scope=Scope.VEHICLE_DEVICE_DATA in scopes,
     )
-    products = await _async_get_products(tesla)
+    try:
+        products = (await tesla.products())["response"]
+    except (
+        InvalidToken,
+        OAuthExpired,
+        LoginRequired,
+        OAuth2TokenRequestReauthError,
+    ) as err:
+        raise ConfigEntryAuthFailed from err
+    except (TeslaFleetError, OAuth2TokenRequestError) as err:
+        raise ConfigEntryNotReady from err
 
     device_registry = dr.async_get(hass)
 

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -50,12 +50,18 @@ def _invalidate_access_token(
     hass: HomeAssistant, config_entry: TeslaFleetConfigEntry
 ) -> None:
     """Invalidate the cached access token to force a refresh."""
+    if (
+        not (token_data := config_entry.data.get(CONF_TOKEN))
+        or token_data.get("expires_at") == 0
+    ):
+        return
+
     hass.config_entries.async_update_entry(
         config_entry,
         data={
             **config_entry.data,
             CONF_TOKEN: {
-                **config_entry.data[CONF_TOKEN],
+                **token_data,
                 "expires_at": 0,
             },
         },

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -18,6 +18,7 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.tesla import EnergySite, VehicleFleet
 
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -43,6 +44,22 @@ ENDPOINTS = [
     VehicleDataEndpoint.VEHICLE_CONFIG,
     VehicleDataEndpoint.LOCATION_DATA,
 ]
+
+
+def _invalidate_access_token(
+    hass: HomeAssistant, config_entry: TeslaFleetConfigEntry
+) -> None:
+    """Invalidate the cached access token to force a refresh."""
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            CONF_TOKEN: {
+                **config_entry.data[CONF_TOKEN],
+                "expires_at": 0,
+            },
+        },
+    )
 
 
 def flatten(data: dict[str, Any], parent: str | None = None) -> dict[str, Any]:
@@ -116,7 +133,10 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.name,
             )
             return self.data
-        except (InvalidToken, OAuthExpired, LoginRequired) as e:
+        except (InvalidToken, OAuthExpired) as e:
+            _invalidate_access_token(self.hass, self.config_entry)
+            raise UpdateFailed(e.message) from e
+        except LoginRequired as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
@@ -188,7 +208,10 @@ class TeslaFleetEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
             else:
                 LOGGER.warning("%s rate limited, will skip refresh", self.name)
             return self.data
-        except (InvalidToken, OAuthExpired, LoginRequired) as e:
+        except (InvalidToken, OAuthExpired) as e:
+            _invalidate_access_token(self.hass, self.config_entry)
+            raise UpdateFailed(e.message) from e
+        except LoginRequired as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
@@ -252,7 +275,10 @@ class TeslaFleetEnergySiteHistoryCoordinator(DataUpdateCoordinator[dict[str, Any
             else:
                 LOGGER.warning("%s rate limited, will skip refresh", self.name)
             return self.data
-        except (InvalidToken, OAuthExpired, LoginRequired) as e:
+        except (InvalidToken, OAuthExpired) as e:
+            _invalidate_access_token(self.hass, self.config_entry)
+            raise UpdateFailed(e.message) from e
+        except LoginRequired as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
@@ -317,7 +343,10 @@ class TeslaFleetEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
             else:
                 LOGGER.warning("%s rate limited, will skip refresh", self.name)
             return self.data
-        except (InvalidToken, OAuthExpired, LoginRequired) as e:
+        except (InvalidToken, OAuthExpired) as e:
+            _invalidate_access_token(self.hass, self.config_entry)
+            raise UpdateFailed(e.message) from e
+        except LoginRequired as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -11,6 +11,7 @@ from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
     InvalidRegion,
     InvalidToken,
+    LibraryError,
     LoginRequired,
     OAuthExpired,
     RateLimited,
@@ -93,11 +94,20 @@ async def test_oauth_refresh_expired(
     mock_products: AsyncMock,
 ) -> None:
     """Test init with expired Oauth token."""
-    mock_products.side_effect = OAuth2TokenRequestReauthError(
-        domain=DOMAIN,
-        request_info=Mock(),
-    )
-    await setup_platform(hass, normal_config_entry)
+
+    # Patch the token refresh to raise an error
+    with patch(
+        "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestReauthError(
+            domain=DOMAIN,
+            request_info=Mock(),
+        ),
+    ) as mock_async_ensure_token_valid:
+        # Trigger an unmocked function call
+        mock_products.side_effect = InvalidRegion
+        await setup_platform(hass, normal_config_entry)
+
+        mock_async_ensure_token_valid.assert_called_once()
     assert normal_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
@@ -107,11 +117,20 @@ async def test_oauth_refresh_error(
     mock_products: AsyncMock,
 ) -> None:
     """Test init with Oauth refresh failure."""
-    mock_products.side_effect = OAuth2TokenRequestTransientError(
-        domain=DOMAIN,
-        request_info=Mock(),
-    )
-    await setup_platform(hass, normal_config_entry)
+
+    # Patch the token refresh to raise an error
+    with patch(
+        "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
+        side_effect=OAuth2TokenRequestTransientError(
+            domain=DOMAIN,
+            request_info=Mock(),
+        ),
+    ) as mock_async_ensure_token_valid:
+        # Trigger an unmocked function call
+        mock_products.side_effect = InvalidRegion
+        await setup_platform(hass, normal_config_entry)
+
+        mock_async_ensure_token_valid.assert_called_once()
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
@@ -566,8 +585,23 @@ async def test_init_region_issue(
 
     mock_products.side_effect = InvalidRegion
     await setup_platform(hass, normal_config_entry)
-    mock_find_server.assert_not_called()
+    mock_find_server.assert_called_once()
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_init_region_issue_failed(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_products: AsyncMock,
+    mock_find_server: AsyncMock,
+) -> None:
+    """Test init with unresolvable region issue."""
+
+    mock_products.side_effect = InvalidRegion
+    mock_find_server.side_effect = LibraryError
+    await setup_platform(hass, normal_config_entry)
+    mock_find_server.assert_called_once()
+    assert normal_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_signing(

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -2,10 +2,8 @@
 
 from copy import deepcopy
 from datetime import timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
-from aiohttp import RequestInfo
-from aiohttp.client_exceptions import ClientResponseError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -21,7 +19,7 @@ from tesla_fleet_api.exceptions import (
     VehicleOffline,
 )
 
-from homeassistant.components.tesla_fleet.const import AUTHORIZE_URL
+from homeassistant.components.tesla_fleet.const import DOMAIN
 from homeassistant.components.tesla_fleet.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INTERVAL,
@@ -34,6 +32,10 @@ from homeassistant.components.tesla_fleet.models import TeslaFleetData
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import (
+    OAuth2TokenRequestReauthError,
+    OAuth2TokenRequestTransientError,
+)
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -45,12 +47,14 @@ from .const import VEHICLE_ASLEEP, VEHICLE_DATA_ALT
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-ERRORS = [
+SETUP_ERRORS = [
     (InvalidToken, ConfigEntryState.SETUP_ERROR),
     (OAuthExpired, ConfigEntryState.SETUP_ERROR),
     (LoginRequired, ConfigEntryState.SETUP_ERROR),
     (TeslaFleetError, ConfigEntryState.SETUP_RETRY),
 ]
+
+RUNTIME_ERRORS = [InvalidToken, OAuthExpired, LoginRequired, TeslaFleetError]
 
 
 async def test_load_unload(
@@ -69,12 +73,12 @@ async def test_load_unload(
     assert not hasattr(normal_config_entry, "runtime_data")
 
 
-@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
+@pytest.mark.parametrize(("side_effect", "state"), SETUP_ERRORS)
 async def test_init_error(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
     mock_products: AsyncMock,
-    side_effect: TeslaFleetError,
+    side_effect: type[TeslaFleetError],
     state: ConfigEntryState,
 ) -> None:
     """Test init with errors."""
@@ -94,8 +98,9 @@ async def test_oauth_refresh_expired(
     # Patch the token refresh to raise an error
     with patch(
         "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
-        side_effect=ClientResponseError(
-            RequestInfo(AUTHORIZE_URL, "POST", {}, AUTHORIZE_URL), None, status=401
+        side_effect=OAuth2TokenRequestReauthError(
+            domain=DOMAIN,
+            request_info=Mock(),
         ),
     ) as mock_async_ensure_token_valid:
         # Trigger an unmocked function call
@@ -116,8 +121,9 @@ async def test_oauth_refresh_error(
     # Patch the token refresh to raise an error
     with patch(
         "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
-        side_effect=ClientResponseError(
-            RequestInfo(AUTHORIZE_URL, "POST", {}, AUTHORIZE_URL), None, status=400
+        side_effect=OAuth2TokenRequestTransientError(
+            domain=DOMAIN,
+            request_info=Mock(),
         ),
     ) as mock_async_ensure_token_valid:
         # Trigger an unmocked function call
@@ -183,12 +189,12 @@ async def test_vehicle_refresh_offline(
     mock_vehicle_data.assert_not_called()
 
 
-@pytest.mark.parametrize(("side_effect"), ERRORS)
+@pytest.mark.parametrize("side_effect", RUNTIME_ERRORS)
 async def test_vehicle_refresh_error(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
     mock_vehicle_data: AsyncMock,
-    side_effect: TeslaFleetError,
+    side_effect: type[TeslaFleetError],
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test coordinator refresh makes entity unavailable."""
@@ -202,6 +208,41 @@ async def test_vehicle_refresh_error(
 
     assert (state := hass.states.get("sensor.test_battery_level"))
     assert state.state == "unavailable"
+
+
+async def test_vehicle_refresh_token_expired_recovery(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_vehicle_data: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test coordinator recovers from expired vehicle access token."""
+    await setup_platform(hass, normal_config_entry)
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state != "unavailable"
+
+    mock_vehicle_data.reset_mock()
+    mock_vehicle_data.side_effect = OAuthExpired
+
+    freezer.tick(VEHICLE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state == "unavailable"
+    assert normal_config_entry.data["token"]["expires_at"] == 0
+    assert mock_vehicle_data.call_count == 1
+
+    mock_vehicle_data.side_effect = None
+    freezer.tick(VEHICLE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state != "unavailable"
+    assert mock_vehicle_data.call_count == 2
 
 
 async def test_vehicle_refresh_ratelimited(
@@ -338,42 +379,91 @@ async def test_vehicle_sleep(
 
 
 # Test Energy Live Coordinator
-@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
+@pytest.mark.parametrize("side_effect", RUNTIME_ERRORS)
 async def test_energy_live_refresh_error(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
     mock_live_status: AsyncMock,
-    side_effect: TeslaFleetError,
-    state: ConfigEntryState,
+    side_effect: type[TeslaFleetError],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test coordinator refresh with an error."""
-    mock_live_status.side_effect = side_effect
     await setup_platform(hass, normal_config_entry)
-    assert normal_config_entry.state is state
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+
+    mock_live_status.side_effect = side_effect
+    freezer.tick(ENERGY_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.energy_site_grid_power"))
+    assert state.state == "unavailable"
 
 
 # Test Energy Site Coordinator
-@pytest.mark.parametrize(("side_effect", "state"), ERRORS)
+@pytest.mark.parametrize("side_effect", RUNTIME_ERRORS)
 async def test_energy_site_refresh_error(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
     mock_site_info: AsyncMock,
-    side_effect: TeslaFleetError,
-    state: ConfigEntryState,
+    side_effect: type[TeslaFleetError],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test coordinator refresh with an error."""
-    mock_site_info.side_effect = side_effect
     await setup_platform(hass, normal_config_entry)
-    assert normal_config_entry.state is state
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+
+    mock_site_info.side_effect = side_effect
+    freezer.tick(ENERGY_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("number.energy_site_backup_reserve"))
+    assert state.state == "unavailable"
+
+
+async def test_energy_refresh_token_expired_recovery(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_live_status: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test energy coordinator recovers from expired access token."""
+    await setup_platform(hass, normal_config_entry)
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.energy_site_grid_power"))
+    assert state.state != "unavailable"
+
+    mock_live_status.reset_mock()
+    mock_live_status.side_effect = OAuthExpired
+
+    freezer.tick(ENERGY_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert normal_config_entry.state is ConfigEntryState.LOADED
+    assert (state := hass.states.get("sensor.energy_site_grid_power"))
+    assert state.state == "unavailable"
+    assert normal_config_entry.data["token"]["expires_at"] == 0
+    assert mock_live_status.call_count == 1
+
+    mock_live_status.side_effect = None
+    freezer.tick(ENERGY_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get("sensor.energy_site_grid_power"))
+    assert state.state != "unavailable"
+    assert mock_live_status.call_count == 2
 
 
 # Test Energy History Coordinator
-@pytest.mark.parametrize(("side_effect"), [side_effect for side_effect, _ in ERRORS])
+@pytest.mark.parametrize("side_effect", RUNTIME_ERRORS)
 async def test_energy_history_refresh_error(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,
     mock_energy_history: AsyncMock,
-    side_effect: TeslaFleetError,
+    side_effect: type[TeslaFleetError],
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test coordinator refresh with an error."""

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -11,7 +11,6 @@ from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
     InvalidRegion,
     InvalidToken,
-    LibraryError,
     LoginRequired,
     OAuthExpired,
     RateLimited,
@@ -94,20 +93,11 @@ async def test_oauth_refresh_expired(
     mock_products: AsyncMock,
 ) -> None:
     """Test init with expired Oauth token."""
-
-    # Patch the token refresh to raise an error
-    with patch(
-        "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
-        side_effect=OAuth2TokenRequestReauthError(
-            domain=DOMAIN,
-            request_info=Mock(),
-        ),
-    ) as mock_async_ensure_token_valid:
-        # Trigger an unmocked function call
-        mock_products.side_effect = InvalidRegion
-        await setup_platform(hass, normal_config_entry)
-
-        mock_async_ensure_token_valid.assert_called_once()
+    mock_products.side_effect = OAuth2TokenRequestReauthError(
+        domain=DOMAIN,
+        request_info=Mock(),
+    )
+    await setup_platform(hass, normal_config_entry)
     assert normal_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
@@ -117,20 +107,11 @@ async def test_oauth_refresh_error(
     mock_products: AsyncMock,
 ) -> None:
     """Test init with Oauth refresh failure."""
-
-    # Patch the token refresh to raise an error
-    with patch(
-        "homeassistant.components.tesla_fleet.OAuth2Session.async_ensure_token_valid",
-        side_effect=OAuth2TokenRequestTransientError(
-            domain=DOMAIN,
-            request_info=Mock(),
-        ),
-    ) as mock_async_ensure_token_valid:
-        # Trigger an unmocked function call
-        mock_products.side_effect = InvalidRegion
-        await setup_platform(hass, normal_config_entry)
-
-        mock_async_ensure_token_valid.assert_called_once()
+    mock_products.side_effect = OAuth2TokenRequestTransientError(
+        domain=DOMAIN,
+        request_info=Mock(),
+    )
+    await setup_platform(hass, normal_config_entry)
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
@@ -585,23 +566,8 @@ async def test_init_region_issue(
 
     mock_products.side_effect = InvalidRegion
     await setup_platform(hass, normal_config_entry)
-    mock_find_server.assert_called_once()
+    mock_find_server.assert_not_called()
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def test_init_region_issue_failed(
-    hass: HomeAssistant,
-    normal_config_entry: MockConfigEntry,
-    mock_products: AsyncMock,
-    mock_find_server: AsyncMock,
-) -> None:
-    """Test init with unresolvable region issue."""
-
-    mock_products.side_effect = InvalidRegion
-    mock_find_server.side_effect = LibraryError
-    await setup_platform(hass, normal_config_entry)
-    mock_find_server.assert_called_once()
-    assert normal_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_signing(

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -27,9 +27,11 @@ from homeassistant.components.tesla_fleet.coordinator import (
     VEHICLE_INTERVAL,
     VEHICLE_INTERVAL_SECONDS,
     VEHICLE_WAIT,
+    _invalidate_access_token,
 )
 from homeassistant.components.tesla_fleet.models import TeslaFleetData
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import (
@@ -132,6 +134,56 @@ async def test_oauth_refresh_error(
 
         mock_async_ensure_token_valid.assert_called_once()
     assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_invalidate_access_token_updates_when_not_expired(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Test invalidating token updates entry when token is not expired."""
+
+    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
+        _invalidate_access_token(hass, normal_config_entry)
+
+    mock_update_entry.assert_called_once_with(
+        normal_config_entry,
+        data={
+            **normal_config_entry.data,
+            CONF_TOKEN: {
+                **normal_config_entry.data[CONF_TOKEN],
+                "expires_at": 0,
+            },
+        },
+    )
+
+
+async def test_invalidate_access_token_noop_when_already_expired(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+) -> None:
+    """Test invalidating token does not update an already expired token."""
+
+    normal_config_entry.data[CONF_TOKEN]["expires_at"] = 0
+    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
+        _invalidate_access_token(hass, normal_config_entry)
+
+    mock_update_entry.assert_not_called()
+
+
+async def test_invalidate_access_token_noop_when_token_missing(
+    hass: HomeAssistant,
+) -> None:
+    """Test invalidating token does not update when token data is missing."""
+
+    missing_token_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"auth_implementation": DOMAIN},
+    )
+
+    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
+        _invalidate_access_token(hass, missing_token_entry)
+
+    mock_update_entry.assert_not_called()
 
 
 # Test devices

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -141,20 +141,18 @@ async def test_invalidate_access_token_updates_when_not_expired(
     normal_config_entry: MockConfigEntry,
 ) -> None:
     """Test invalidating token updates entry when token is not expired."""
-
-    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
-        _invalidate_access_token(hass, normal_config_entry)
-
-    mock_update_entry.assert_called_once_with(
-        normal_config_entry,
-        data={
-            **normal_config_entry.data,
-            CONF_TOKEN: {
-                **normal_config_entry.data[CONF_TOKEN],
-                "expires_at": 0,
-            },
+    normal_config_entry.add_to_hass(hass)
+    expected_data = {
+        **dict(normal_config_entry.data),
+        CONF_TOKEN: {
+            **normal_config_entry.data[CONF_TOKEN],
+            "expires_at": 0,
         },
-    )
+    }
+
+    _invalidate_access_token(hass, normal_config_entry)
+
+    assert dict(normal_config_entry.data) == expected_data
 
 
 async def test_invalidate_access_token_noop_when_already_expired(
@@ -162,12 +160,13 @@ async def test_invalidate_access_token_noop_when_already_expired(
     normal_config_entry: MockConfigEntry,
 ) -> None:
     """Test invalidating token does not update an already expired token."""
-
+    normal_config_entry.add_to_hass(hass)
     normal_config_entry.data[CONF_TOKEN]["expires_at"] = 0
-    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
-        _invalidate_access_token(hass, normal_config_entry)
+    before_data = dict(normal_config_entry.data)
 
-    mock_update_entry.assert_not_called()
+    _invalidate_access_token(hass, normal_config_entry)
+
+    assert dict(normal_config_entry.data) == before_data
 
 
 async def test_invalidate_access_token_noop_when_token_missing(
@@ -179,11 +178,12 @@ async def test_invalidate_access_token_noop_when_token_missing(
         domain=DOMAIN,
         data={"auth_implementation": DOMAIN},
     )
+    missing_token_entry.add_to_hass(hass)
+    before_data = dict(missing_token_entry.data)
 
-    with patch.object(hass.config_entries, "async_update_entry") as mock_update_entry:
-        _invalidate_access_token(hass, missing_token_entry)
+    _invalidate_access_token(hass, missing_token_entry)
 
-    mock_update_entry.assert_not_called()
+    assert dict(missing_token_entry.data) == before_data
 
 
 # Test devices


### PR DESCRIPTION
## Proposed change
This change fixes Tesla Fleet token refresh handling for setup and runtime coordinator updates.
During setup, OAuth token failures are now mapped to Home Assistant OAuth exceptions and product fetching is retried with the existing region-discovery fallback.
During runtime refreshes, invalid or expired access tokens now invalidate the cached `expires_at` value so the next request triggers token refresh instead of forcing immediate reauthentication.
The test suite was expanded to cover OAuth refresh exceptions and recovery behavior for both vehicle and energy coordinators.

Please Hotfix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#164786](https://github.com/home-assistant/core/issues/164786)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

