### PR TITLE
Remove use of media player internals in arcam

### DIFF
--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -44,12 +44,14 @@ def state_1_fixture(client: Mock) -> State:
     state.zn = 1
     state.get_power.return_value = True
     state.get_volume.return_value = 0.0
+    state.get_source.return_value = None
     state.get_source_list.return_value = []
     state.get_incoming_audio_format.return_value = (None, None)
     state.get_incoming_video_parameters.return_value = None
     state.get_incoming_audio_sample_rate.return_value = 0
     state.get_mute.return_value = None
     state.get_decode_modes.return_value = []
+    state.get_decode_mode.return_value = None
     return state
 
 
@@ -61,12 +63,14 @@ def state_2_fixture(client: Mock) -> State:
     state.zn = 2
     state.get_power.return_value = True
     state.get_volume.return_value = 0.0
+    state.get_source.return_value = None
     state.get_source_list.return_value = []
     state.get_incoming_audio_format.return_value = (None, None)
     state.get_incoming_video_parameters.return_value = None
     state.get_incoming_audio_sample_rate.return_value = 0
     state.get_mute.return_value = None
     state.get_decode_modes.return_value = []
+    state.get_decode_mode.return_value = None
     return state
 
 
@@ -90,7 +94,8 @@ async def player_setup_fixture(
     state_1: State,
     state_2: State,
     client: Mock,
-) -> AsyncGenerator[str]:
+    entity_registry_enabled_by_default: None,
+) -> AsyncGenerator[None]:
     """Get standard player."""
 
     def state_mock(cli, zone):
@@ -119,4 +124,4 @@ async def player_setup_fixture(
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        yield MOCK_ENTITY_ID
+        yield

--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -94,7 +94,6 @@ async def player_setup_fixture(
     state_1: State,
     state_2: State,
     client: Mock,
-    entity_registry_enabled_by_default: None,
 ) -> AsyncGenerator[None]:
     """Get standard player."""
 
@@ -106,7 +105,15 @@ async def player_setup_fixture(
         raise ValueError(f"Unknown player zone: {zone}")
 
     async def _mock_run_client(hass: HomeAssistant, runtime_data, interval):
-        for coordinator in runtime_data.coordinators.values():
+        coordinators = runtime_data.coordinators
+
+        def _notify_data_updated() -> None:
+            for coordinator in coordinators.values():
+                coordinator.async_notify_data_updated()
+
+        client.notify_data_updated = _notify_data_updated
+
+        for coordinator in coordinators.values():
             coordinator.async_notify_connected()
 
     await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/arcam_fmj/snapshots/test_media_player.ambr
+++ b/tests/components/arcam_fmj/snapshots/test_media_player.ambr
@@ -1,0 +1,105 @@
+# serializer version: 1
+# name: test_setup[media_player.arcam_fmj_127_0_0_1_zone_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.arcam_fmj_127_0_0_1_zone_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 1',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 1',
+    'platform': 'arcam_fmj',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 200588>,
+    'translation_key': None,
+    'unique_id': '456789abcdef-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[media_player.arcam_fmj_127_0_0_1_zone_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Arcam FMJ (127.0.0.1) Zone 1',
+      'supported_features': <MediaPlayerEntityFeature: 200588>,
+      'volume_level': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.arcam_fmj_127_0_0_1_zone_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_setup[media_player.arcam_fmj_127_0_0_1_zone_2_zone_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.arcam_fmj_127_0_0_1_zone_2_zone_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Zone 2',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Zone 2',
+    'platform': 'arcam_fmj',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 135052>,
+    'translation_key': None,
+    'unique_id': '456789abcdef-2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[media_player.arcam_fmj_127_0_0_1_zone_2_zone_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Arcam FMJ (127.0.0.1) Zone 2 Zone 2',
+      'supported_features': <MediaPlayerEntityFeature: 135052>,
+      'volume_level': 0.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.arcam_fmj_127_0_0_1_zone_2_zone_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/arcam_fmj/test_device_trigger.py
+++ b/tests/components/arcam_fmj/test_device_trigger.py
@@ -9,6 +9,8 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from .conftest import MOCK_ENTITY_ID
+
 from tests.common import MockConfigEntry, async_get_device_automations
 
 
@@ -59,7 +61,7 @@ async def test_if_fires_on_turn_on_request(
     state_1: State,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    entry = entity_registry.async_get(player_setup)
+    entry = entity_registry.async_get(MOCK_ENTITY_ID)
 
     state_1.get_power.return_value = None
 
@@ -91,13 +93,13 @@ async def test_if_fires_on_turn_on_request(
     await hass.services.async_call(
         "media_player",
         "turn_on",
-        {"entity_id": player_setup},
+        {"entity_id": MOCK_ENTITY_ID},
         blocking=True,
     )
 
     await hass.async_block_till_done()
     assert len(service_calls) == 2
-    assert service_calls[1].data["some"] == player_setup
+    assert service_calls[1].data["some"] == MOCK_ENTITY_ID
     assert service_calls[1].data["id"] == 0
 
 
@@ -109,7 +111,7 @@ async def test_if_fires_on_turn_on_request_legacy(
     state_1: State,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
-    entry = entity_registry.async_get(player_setup)
+    entry = entity_registry.async_get(MOCK_ENTITY_ID)
 
     state_1.get_power.return_value = None
 
@@ -141,11 +143,11 @@ async def test_if_fires_on_turn_on_request_legacy(
     await hass.services.async_call(
         "media_player",
         "turn_on",
-        {"entity_id": player_setup},
+        {"entity_id": MOCK_ENTITY_ID},
         blocking=True,
     )
 
     await hass.async_block_till_done()
     assert len(service_calls) == 2
-    assert service_calls[1].data["some"] == player_setup
+    assert service_calls[1].data["some"] == MOCK_ENTITY_ID
     assert service_calls[1].data["id"] == 0

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -64,12 +64,7 @@ async def test_setup(
 
 async def update(hass: HomeAssistant, client: Mock, entity_id: str) -> CoreState:
     """Force a update of player and return current state data."""
-    await hass.services.async_call(
-        HA_DOMAIN,
-        SERVICE_UPDATE_ENTITY,
-        service_data={ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
+    client.notify_data_updated()
     await hass.async_block_till_done()
     data = hass.states.get(entity_id)
     assert data

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -1,11 +1,12 @@
 """Tests for arcam fmj receivers."""
 
 from math import isclose
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
 from arcam.fmj import ConnectionFailed, DecodeMode2CH, DecodeModeMCH, SourceCodes
 from arcam.fmj.state import State
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.arcam_fmj.media_player import ArcamFmj
 from homeassistant.components.homeassistant import (
@@ -14,137 +15,144 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
+    ATTR_MEDIA_ARTIST,
+    ATTR_MEDIA_CHANNEL,
+    ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
     ATTR_SOUND_MODE,
     ATTR_SOUND_MODE_LIST,
-    DATA_COMPONENT,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOUND_MODE,
     SERVICE_SELECT_SOURCE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
+    SERVICE_VOLUME_UP,
     MediaType,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_NAME,
-)
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant, State as CoreState
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 
-from .conftest import MOCK_ENTITY_ID, MOCK_HOST, MOCK_UUID
+from .conftest import MOCK_ENTITY_ID
 
-from tests.common import MockConfigEntry
-
-MOCK_TURN_ON = {
-    "service": "switch.turn_on",
-    "data": {"entity_id": "switch.test"},
-}
+from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.fixture(name="player")
-def player_fixture(
+@pytest.fixture(autouse=True)
+def platform_fixture():
+    """Only test single platform."""
+    with patch("homeassistant.components.arcam_fmj.PLATFORMS", [Platform.MEDIA_PLAYER]):
+        yield
+
+
+async def test_setup(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
-    client: Mock,
-    state_1: State,
+    entity_registry: er.EntityRegistry,
     player_setup: str,
-) -> ArcamFmj:
-    """Get standard player.
-
-    This fixture tests internals and should not be used going forward.
-    """
-    player: ArcamFmj = hass.data[DATA_COMPONENT].get_entity(MOCK_ENTITY_ID)
-    player.async_write_ha_state = Mock(wraps=player.async_write_ha_state)
-    return player
+) -> None:
+    """Test setup creates expected entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-async def update(player: ArcamFmj, force_refresh=False):
+async def update(hass: HomeAssistant, entity_id: str) -> CoreState:
     """Force a update of player and return current state data."""
-    await player.async_update_ha_state(force_refresh=force_refresh)
-    return player.hass.states.get(player.entity_id)
-
-
-async def test_properties(player: ArcamFmj) -> None:
-    """Test standard properties."""
-    assert player.unique_id == f"{MOCK_UUID}-1"
-    assert player.device_info == {
-        ATTR_NAME: f"Arcam FMJ ({MOCK_HOST})",
-        ATTR_IDENTIFIERS: {
-            ("arcam_fmj", MOCK_UUID),
-        },
-        ATTR_MODEL: "Arcam FMJ AVR",
-        ATTR_MANUFACTURER: "Arcam",
-    }
-    assert not player.should_poll
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        service_data={ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    data = hass.states.get(entity_id)
+    assert data
+    return data
 
 
 async def test_powered_off(
-    hass: HomeAssistant, player: ArcamFmj, state_1: State
+    hass: HomeAssistant, player_setup: None, state_1: State
 ) -> None:
     """Test properties in powered off state."""
     state_1.get_source.return_value = None
     state_1.get_power.return_value = None
 
-    data = await update(player)
+    data = await update(hass, MOCK_ENTITY_ID)
     assert "source" not in data.attributes
     assert data.state == "off"
 
 
-async def test_powered_on(player: ArcamFmj, state_1: State) -> None:
+async def test_powered_on(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test properties in powered on state."""
     state_1.get_source.return_value = SourceCodes.PVR
     state_1.get_power.return_value = True
 
-    data = await update(player)
+    data = await update(hass, MOCK_ENTITY_ID)
     assert data.attributes["source"] == "PVR"
     assert data.state == "on"
 
 
-async def test_supported_features(player: ArcamFmj) -> None:
-    """Test supported features."""
-    data = await update(player)
-    assert data.attributes["supported_features"] == 200588
-
-
-async def test_turn_on(player: ArcamFmj, state_1: State) -> None:
+async def test_turn_on(hass: HomeAssistant, player_setup: None, state_1: State) -> None:
     """Test turn on service."""
     state_1.get_power.return_value = None
-    await player.async_turn_on()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_ON,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
+        blocking=True,
+    )
     state_1.set_power.assert_not_called()
 
     state_1.get_power.return_value = False
-    await player.async_turn_on()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_ON,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
+        blocking=True,
+    )
     state_1.set_power.assert_called_with(True)
 
 
-async def test_turn_off(player: ArcamFmj, state_1: State) -> None:
+async def test_turn_off(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test command to turn off."""
-    await player.async_turn_off()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_TURN_OFF,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
+        blocking=True,
+    )
     state_1.set_power.assert_called_with(False)
 
 
 @pytest.mark.parametrize("mute", [True, False])
-async def test_mute_volume(player: ArcamFmj, state_1: State, mute: bool) -> None:
+async def test_mute_volume(
+    hass: HomeAssistant, player_setup: None, state_1: State, mute: bool
+) -> None:
     """Test mute functionality."""
-    player.async_write_ha_state.reset_mock()
-    await player.async_mute_volume(mute)
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_MUTE,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID, ATTR_MEDIA_VOLUME_MUTED: mute},
+        blocking=True,
+    )
     state_1.set_mute.assert_called_with(mute)
-    player.async_write_ha_state.assert_called_with()
 
 
-async def test_name(player: ArcamFmj) -> None:
-    """Test name."""
-    data = await update(player)
-    assert data.attributes["friendly_name"] == "Arcam FMJ (127.0.0.1) Zone 1"
-
-
-async def test_update(hass: HomeAssistant, player_setup: str, state_1: State) -> None:
+async def test_update(hass: HomeAssistant, player_setup: None, state_1: State) -> None:
     """Test update."""
     await hass.services.async_call(
         HA_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        service_data={ATTR_ENTITY_ID: player_setup},
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
         blocking=True,
     )
     state_1.update.assert_called_with()
@@ -152,7 +160,7 @@ async def test_update(hass: HomeAssistant, player_setup: str, state_1: State) ->
 
 async def test_update_lost(
     hass: HomeAssistant,
-    player_setup: str,
+    player_setup: None,
     state_1: State,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -162,7 +170,7 @@ async def test_update_lost(
     await hass.services.async_call(
         HA_DOMAIN,
         SERVICE_UPDATE_ENTITY,
-        service_data={ATTR_ENTITY_ID: player_setup},
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
         blocking=True,
     )
     state_1.update.assert_called_with()
@@ -174,7 +182,7 @@ async def test_update_lost(
 )
 async def test_select_source(
     hass: HomeAssistant,
-    player_setup,
+    player_setup: None,
     state_1: State,
     source: str,
     value: SourceCodes | None,
@@ -183,7 +191,7 @@ async def test_select_source(
     await hass.services.async_call(
         "media_player",
         SERVICE_SELECT_SOURCE,
-        service_data={ATTR_ENTITY_ID: player_setup, ATTR_INPUT_SOURCE: source},
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID, ATTR_INPUT_SOURCE: source},
         blocking=True,
     )
 
@@ -193,10 +201,12 @@ async def test_select_source(
         state_1.set_source.assert_not_called()
 
 
-async def test_source_list(player: ArcamFmj, state_1: State) -> None:
+async def test_source_list(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test source list."""
     state_1.get_source_list.return_value = [SourceCodes.BD]
-    data = await update(player)
+    data = await update(hass, MOCK_ENTITY_ID)
     assert data.attributes["source_list"] == ["BD"]
 
 
@@ -207,26 +217,43 @@ async def test_source_list(player: ArcamFmj, state_1: State) -> None:
         "DOLBY_PL",
     ],
 )
-async def test_select_sound_mode(player: ArcamFmj, state_1: State, mode: str) -> None:
+async def test_select_sound_mode(
+    hass: HomeAssistant, player_setup: None, state_1: State, mode: str
+) -> None:
     """Test selection sound mode."""
-    await player.async_select_sound_mode(mode)
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOUND_MODE,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID, ATTR_SOUND_MODE: mode},
+        blocking=True,
+    )
     state_1.set_decode_mode.assert_called_with(mode)
 
 
-async def test_volume_up(player: ArcamFmj, state_1: State) -> None:
+async def test_volume_up(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test mute functionality."""
-    player.async_write_ha_state.reset_mock()
-    await player.async_volume_up()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_UP,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
+        blocking=True,
+    )
     state_1.inc_volume.assert_called_with()
-    player.async_write_ha_state.assert_called_with()
 
 
-async def test_volume_down(player: ArcamFmj, state_1: State) -> None:
+async def test_volume_down(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test mute functionality."""
-    player.async_write_ha_state.reset_mock()
-    await player.async_volume_down()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_VOLUME_DOWN,
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID},
+        blocking=True,
+    )
     state_1.dec_volume.assert_called_with()
-    player.async_write_ha_state.assert_called_with()
 
 
 @pytest.mark.parametrize(
@@ -237,10 +264,12 @@ async def test_volume_down(player: ArcamFmj, state_1: State) -> None:
         (None, None),
     ],
 )
-async def test_sound_mode(player: ArcamFmj, state_1: State, mode, mode_enum) -> None:
+async def test_sound_mode(
+    hass: HomeAssistant, player_setup: None, state_1: State, mode, mode_enum
+) -> None:
     """Test selection sound mode."""
     state_1.get_decode_mode.return_value = mode_enum
-    data = await update(player)
+    data = await update(hass, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_SOUND_MODE) == mode
 
 
@@ -253,46 +282,62 @@ async def test_sound_mode(player: ArcamFmj, state_1: State, mode, mode_enum) -> 
     ],
 )
 async def test_sound_mode_list(
-    player: ArcamFmj, state_1: State, modes, modes_enum
+    hass: HomeAssistant, player_setup: None, state_1: State, modes, modes_enum
 ) -> None:
     """Test sound mode list."""
     state_1.get_decode_modes.return_value = modes_enum
-    data = await update(player)
+    data = await update(hass, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_SOUND_MODE_LIST) == modes
 
 
-async def test_is_volume_muted(player: ArcamFmj, state_1: State) -> None:
+async def test_is_volume_muted(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test muted."""
     state_1.get_mute.return_value = True
-    assert player.is_volume_muted is True
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is True
+
     state_1.get_mute.return_value = False
-    assert player.is_volume_muted is False
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
+
     state_1.get_mute.return_value = None
-    assert player.is_volume_muted is None
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is None
 
 
-async def test_volume_level(player: ArcamFmj, state_1: State) -> None:
+async def test_volume_level(
+    hass: HomeAssistant, player_setup: None, state_1: State
+) -> None:
     """Test volume."""
     state_1.get_volume.return_value = 0
-    assert isclose(player.volume_level, 0.0)
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 0.0)
+
     state_1.get_volume.return_value = 50
-    assert isclose(player.volume_level, 50.0 / 99)
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 50.0 / 99)
+
     state_1.get_volume.return_value = 99
-    assert isclose(player.volume_level, 1.0)
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 1.0)
+
     state_1.get_volume.return_value = None
-    assert player.volume_level is None
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert ATTR_MEDIA_VOLUME_LEVEL not in data.attributes
 
 
 @pytest.mark.parametrize(("volume", "call"), [(0.0, 0), (0.5, 50), (1.0, 99)])
 async def test_set_volume_level(
-    hass: HomeAssistant, player_setup: str, state_1: State, volume, call
+    hass: HomeAssistant, player_setup: None, state_1: State, volume, call
 ) -> None:
     """Test setting volume."""
 
     await hass.services.async_call(
         "media_player",
         SERVICE_VOLUME_SET,
-        service_data={ATTR_ENTITY_ID: player_setup, ATTR_MEDIA_VOLUME_LEVEL: volume},
+        service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: volume},
         blocking=True,
     )
 
@@ -300,7 +345,7 @@ async def test_set_volume_level(
 
 
 async def test_set_volume_level_lost(
-    hass: HomeAssistant, player_setup: str, state_1: State
+    hass: HomeAssistant, player_setup: None, state_1: State
 ) -> None:
     """Test setting volume, with a lost connection."""
 
@@ -310,7 +355,7 @@ async def test_set_volume_level_lost(
         await hass.services.async_call(
             "media_player",
             SERVICE_VOLUME_SET,
-            service_data={ATTR_ENTITY_ID: player_setup, ATTR_MEDIA_VOLUME_LEVEL: 0.0},
+            service_data={ATTR_ENTITY_ID: MOCK_ENTITY_ID, ATTR_MEDIA_VOLUME_LEVEL: 0.0},
             blocking=True,
         )
 
@@ -325,11 +370,12 @@ async def test_set_volume_level_lost(
     ],
 )
 async def test_media_content_type(
-    player: ArcamFmj, state_1: State, source, media_content_type
+    hass: HomeAssistant, player_setup: None, state_1: State, source, media_content_type
 ) -> None:
     """Test content type deduction."""
     state_1.get_source.return_value = source
-    assert player.media_content_type == media_content_type
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == media_content_type
 
 
 @pytest.mark.parametrize(
@@ -343,13 +389,14 @@ async def test_media_content_type(
     ],
 )
 async def test_media_channel(
-    player: ArcamFmj, state_1: State, source, dab, rds, channel
+    hass: HomeAssistant, player_setup: None, state_1: State, source, dab, rds, channel
 ) -> None:
     """Test media channel."""
     state_1.get_dab_station.return_value = dab
     state_1.get_rds_information.return_value = rds
     state_1.get_source.return_value = source
-    assert player.media_channel == channel
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_CHANNEL) == channel
 
 
 @pytest.mark.parametrize(
@@ -361,12 +408,13 @@ async def test_media_channel(
     ],
 )
 async def test_media_artist(
-    player: ArcamFmj, state_1: State, source, dls, artist
+    hass: HomeAssistant, player_setup: None, state_1: State, source, dls, artist
 ) -> None:
     """Test media artist."""
     state_1.get_dls_pdt.return_value = dls
     state_1.get_source.return_value = source
-    assert player.media_artist == artist
+    data = await update(hass, MOCK_ENTITY_ID)
+    assert data.attributes.get(ATTR_MEDIA_ARTIST) == artist
 
 
 @pytest.mark.parametrize(
@@ -378,7 +426,7 @@ async def test_media_artist(
     ],
 )
 async def test_media_title(
-    player: ArcamFmj, state_1: State, source, channel, title
+    hass: HomeAssistant, player_setup: None, state_1: State, source, channel, title
 ) -> None:
     """Test media title."""
 
@@ -387,7 +435,7 @@ async def test_media_title(
         ArcamFmj, "media_channel", new_callable=PropertyMock
     ) as media_channel:
         media_channel.return_value = channel
-        data = await update(player)
+        data = await update(hass, MOCK_ENTITY_ID)
         if title is None:
             assert "media_title" not in data.attributes
         else:

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for arcam fmj receivers."""
 
 from math import isclose
-from unittest.mock import PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 from arcam.fmj import ConnectionFailed, DecodeMode2CH, DecodeModeMCH, SourceCodes
 from arcam.fmj.state import State
@@ -50,18 +50,19 @@ def platform_fixture():
         yield
 
 
+@pytest.mark.usefixtures("player_setup")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_setup(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    player_setup: str,
 ) -> None:
     """Test setup creates expected entities."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-async def update(hass: HomeAssistant, entity_id: str) -> CoreState:
+async def update(hass: HomeAssistant, client: Mock, entity_id: str) -> CoreState:
     """Force a update of player and return current state data."""
     await hass.services.async_call(
         HA_DOMAIN,
@@ -75,31 +76,30 @@ async def update(hass: HomeAssistant, entity_id: str) -> CoreState:
     return data
 
 
-async def test_powered_off(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_powered_off(hass: HomeAssistant, client: Mock, state_1: State) -> None:
     """Test properties in powered off state."""
     state_1.get_source.return_value = None
     state_1.get_power.return_value = None
 
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert "source" not in data.attributes
     assert data.state == "off"
 
 
-async def test_powered_on(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_powered_on(hass: HomeAssistant, client: Mock, state_1: State) -> None:
     """Test properties in powered on state."""
     state_1.get_source.return_value = SourceCodes.PVR
     state_1.get_power.return_value = True
 
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes["source"] == "PVR"
     assert data.state == "on"
 
 
-async def test_turn_on(hass: HomeAssistant, player_setup: None, state_1: State) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_turn_on(hass: HomeAssistant, state_1: State) -> None:
     """Test turn on service."""
     state_1.get_power.return_value = None
     await hass.services.async_call(
@@ -120,9 +120,8 @@ async def test_turn_on(hass: HomeAssistant, player_setup: None, state_1: State) 
     state_1.set_power.assert_called_with(True)
 
 
-async def test_turn_off(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_turn_off(hass: HomeAssistant, state_1: State) -> None:
     """Test command to turn off."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -134,9 +133,8 @@ async def test_turn_off(
 
 
 @pytest.mark.parametrize("mute", [True, False])
-async def test_mute_volume(
-    hass: HomeAssistant, player_setup: None, state_1: State, mute: bool
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_mute_volume(hass: HomeAssistant, state_1: State, mute: bool) -> None:
     """Test mute functionality."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -147,7 +145,8 @@ async def test_mute_volume(
     state_1.set_mute.assert_called_with(mute)
 
 
-async def test_update(hass: HomeAssistant, player_setup: None, state_1: State) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_update(hass: HomeAssistant, state_1: State) -> None:
     """Test update."""
     await hass.services.async_call(
         HA_DOMAIN,
@@ -158,9 +157,9 @@ async def test_update(hass: HomeAssistant, player_setup: None, state_1: State) -
     state_1.update.assert_called_with()
 
 
+@pytest.mark.usefixtures("player_setup")
 async def test_update_lost(
     hass: HomeAssistant,
-    player_setup: None,
     state_1: State,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -180,9 +179,9 @@ async def test_update_lost(
     ("source", "value"),
     [("PVR", SourceCodes.PVR), ("BD", SourceCodes.BD), ("INVALID", None)],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_select_source(
     hass: HomeAssistant,
-    player_setup: None,
     state_1: State,
     source: str,
     value: SourceCodes | None,
@@ -201,12 +200,11 @@ async def test_select_source(
         state_1.set_source.assert_not_called()
 
 
-async def test_source_list(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_source_list(hass: HomeAssistant, client: Mock, state_1: State) -> None:
     """Test source list."""
     state_1.get_source_list.return_value = [SourceCodes.BD]
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes["source_list"] == ["BD"]
 
 
@@ -217,8 +215,9 @@ async def test_source_list(
         "DOLBY_PL",
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_select_sound_mode(
-    hass: HomeAssistant, player_setup: None, state_1: State, mode: str
+    hass: HomeAssistant, state_1: State, mode: str
 ) -> None:
     """Test selection sound mode."""
     await hass.services.async_call(
@@ -230,9 +229,8 @@ async def test_select_sound_mode(
     state_1.set_decode_mode.assert_called_with(mode)
 
 
-async def test_volume_up(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_volume_up(hass: HomeAssistant, state_1: State) -> None:
     """Test mute functionality."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -243,9 +241,8 @@ async def test_volume_up(
     state_1.inc_volume.assert_called_with()
 
 
-async def test_volume_down(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_volume_down(hass: HomeAssistant, state_1: State) -> None:
     """Test mute functionality."""
     await hass.services.async_call(
         MEDIA_PLAYER_DOMAIN,
@@ -264,12 +261,13 @@ async def test_volume_down(
         (None, None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_sound_mode(
-    hass: HomeAssistant, player_setup: None, state_1: State, mode, mode_enum
+    hass: HomeAssistant, client: Mock, state_1: State, mode, mode_enum
 ) -> None:
     """Test selection sound mode."""
     state_1.get_decode_mode.return_value = mode_enum
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_SOUND_MODE) == mode
 
 
@@ -281,56 +279,58 @@ async def test_sound_mode(
         (None, None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_sound_mode_list(
-    hass: HomeAssistant, player_setup: None, state_1: State, modes, modes_enum
+    hass: HomeAssistant, client: Mock, state_1: State, modes, modes_enum
 ) -> None:
     """Test sound mode list."""
     state_1.get_decode_modes.return_value = modes_enum
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_SOUND_MODE_LIST) == modes
 
 
+@pytest.mark.usefixtures("player_setup")
 async def test_is_volume_muted(
-    hass: HomeAssistant, player_setup: None, state_1: State
+    hass: HomeAssistant, client: Mock, state_1: State
 ) -> None:
     """Test muted."""
     state_1.get_mute.return_value = True
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is True
 
     state_1.get_mute.return_value = False
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is False
 
     state_1.get_mute.return_value = None
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_VOLUME_MUTED) is None
 
 
-async def test_volume_level(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_volume_level(hass: HomeAssistant, client: Mock, state_1: State) -> None:
     """Test volume."""
     state_1.get_volume.return_value = 0
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 0.0)
 
     state_1.get_volume.return_value = 50
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 50.0 / 99)
 
     state_1.get_volume.return_value = 99
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert isclose(data.attributes[ATTR_MEDIA_VOLUME_LEVEL], 1.0)
 
     state_1.get_volume.return_value = None
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert ATTR_MEDIA_VOLUME_LEVEL not in data.attributes
 
 
 @pytest.mark.parametrize(("volume", "call"), [(0.0, 0), (0.5, 50), (1.0, 99)])
+@pytest.mark.usefixtures("player_setup")
 async def test_set_volume_level(
-    hass: HomeAssistant, player_setup: None, state_1: State, volume, call
+    hass: HomeAssistant, state_1: State, volume, call
 ) -> None:
     """Test setting volume."""
 
@@ -344,9 +344,8 @@ async def test_set_volume_level(
     state_1.set_volume.assert_called_with(call)
 
 
-async def test_set_volume_level_lost(
-    hass: HomeAssistant, player_setup: None, state_1: State
-) -> None:
+@pytest.mark.usefixtures("player_setup")
+async def test_set_volume_level_lost(hass: HomeAssistant, state_1: State) -> None:
     """Test setting volume, with a lost connection."""
 
     state_1.set_volume.side_effect = ConnectionFailed()
@@ -369,12 +368,13 @@ async def test_set_volume_level_lost(
         (None, None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_media_content_type(
-    hass: HomeAssistant, player_setup: None, state_1: State, source, media_content_type
+    hass: HomeAssistant, client: Mock, state_1: State, source, media_content_type
 ) -> None:
     """Test content type deduction."""
     state_1.get_source.return_value = source
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_CONTENT_TYPE) == media_content_type
 
 
@@ -388,14 +388,15 @@ async def test_media_content_type(
         (SourceCodes.PVR, "dab", "rds", None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_media_channel(
-    hass: HomeAssistant, player_setup: None, state_1: State, source, dab, rds, channel
+    hass: HomeAssistant, client: Mock, state_1: State, source, dab, rds, channel
 ) -> None:
     """Test media channel."""
     state_1.get_dab_station.return_value = dab
     state_1.get_rds_information.return_value = rds
     state_1.get_source.return_value = source
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_CHANNEL) == channel
 
 
@@ -407,13 +408,14 @@ async def test_media_channel(
         (SourceCodes.DAB, None, None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_media_artist(
-    hass: HomeAssistant, player_setup: None, state_1: State, source, dls, artist
+    hass: HomeAssistant, client: Mock, state_1: State, source, dls, artist
 ) -> None:
     """Test media artist."""
     state_1.get_dls_pdt.return_value = dls
     state_1.get_source.return_value = source
-    data = await update(hass, MOCK_ENTITY_ID)
+    data = await update(hass, client, MOCK_ENTITY_ID)
     assert data.attributes.get(ATTR_MEDIA_ARTIST) == artist
 
 
@@ -425,8 +427,9 @@ async def test_media_artist(
         (None, None, None),
     ],
 )
+@pytest.mark.usefixtures("player_setup")
 async def test_media_title(
-    hass: HomeAssistant, player_setup: None, state_1: State, source, channel, title
+    hass: HomeAssistant, client: Mock, state_1: State, source, channel, title
 ) -> None:
     """Test media title."""
 
@@ -435,7 +438,7 @@ async def test_media_title(
         ArcamFmj, "media_channel", new_callable=PropertyMock
     ) as media_channel:
         media_channel.return_value = channel
-        data = await update(hass, MOCK_ENTITY_ID)
+        data = await update(hass, client, MOCK_ENTITY_ID)
         if title is None:
             assert "media_title" not in data.attributes
         else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the use of home assistant internal media player components in tests 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
