### PR TITLE
Add start selected program action to Home Connect

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -63,6 +63,7 @@ BSH_DOOR_STATE_OPEN = "BSH.Common.EnumType.DoorState.Open"
 
 SERVICE_SET_PROGRAM_AND_OPTIONS = "set_program_and_options"
 SERVICE_SETTING = "change_setting"
+SERVICE_START_SELECTED_PROGRAM = "start_selected_program"
 
 ATTR_AFFECTS_TO = "affects_to"
 ATTR_KEY = "key"

--- a/homeassistant/components/home_connect/icons.json
+++ b/homeassistant/components/home_connect/icons.json
@@ -245,25 +245,10 @@
     "change_setting": {
       "service": "mdi:cog"
     },
-    "pause_program": {
-      "service": "mdi:pause"
-    },
-    "resume_program": {
-      "service": "mdi:play-pause"
-    },
-    "select_program": {
-      "service": "mdi:form-select"
-    },
-    "set_option_active": {
-      "service": "mdi:gesture-tap"
-    },
-    "set_option_selected": {
-      "service": "mdi:gesture-tap"
-    },
     "set_program_and_options": {
       "service": "mdi:form-select"
     },
-    "start_program": {
+    "start_selected_program": {
       "service": "mdi:play"
     }
   }

--- a/homeassistant/components/home_connect/services.py
+++ b/homeassistant/components/home_connect/services.py
@@ -13,7 +13,7 @@ from aiohomeconnect.model import (
     ProgramKey,
     SettingKey,
 )
-from aiohomeconnect.model.error import HomeConnectError
+from aiohomeconnect.model.error import HomeConnectError, NoProgramActiveError
 import voluptuous as vol
 
 from homeassistant.const import ATTR_DEVICE_ID
@@ -32,6 +32,7 @@ from .const import (
     PROGRAM_ENUM_OPTIONS,
     SERVICE_SET_PROGRAM_AND_OPTIONS,
     SERVICE_SETTING,
+    SERVICE_START_SELECTED_PROGRAM,
     TRANSLATION_KEYS_PROGRAMS_MAP,
 )
 from .coordinator import HomeConnectConfigEntry
@@ -119,7 +120,23 @@ SERVICE_PROGRAM_AND_OPTIONS_SCHEMA = vol.All(
     _require_program_or_at_least_one_option,
 )
 
-SERVICE_COMMAND_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_ID): str})
+SERVICE_START_SELECTED_PROGRAM_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required(ATTR_DEVICE_ID): str,
+        }
+    ).extend(
+        {
+            vol.Optional(translation_key): schema
+            for translation_key, (key, schema) in PROGRAM_OPTIONS.items()
+            if key
+            in (
+                OptionKey.BSH_COMMON_START_IN_RELATIVE,
+                OptionKey.BSH_COMMON_FINISH_IN_RELATIVE,
+            )
+        }
+    )
+)
 
 
 async def _get_client_and_ha_id(
@@ -257,6 +274,50 @@ async def async_service_set_program_and_options(call: ServiceCall) -> None:
         ) from err
 
 
+async def async_service_start_selected_program(call: ServiceCall) -> None:
+    """Service to start a program that is already selected."""
+    data = dict(call.data)
+    client, ha_id = await _get_client_and_ha_id(call.hass, data.pop(ATTR_DEVICE_ID))
+    try:
+        try:
+            program_obj = await client.get_active_program(ha_id)
+        except NoProgramActiveError:
+            program_obj = await client.get_selected_program(ha_id)
+    except HomeConnectError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="fetch_program_error",
+            translation_placeholders=get_dict_from_home_connect_error(err),
+        ) from err
+    if not program_obj.key:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_program_to_start",
+        )
+
+    program = program_obj.key
+    options_dict = {option.key: option for option in program_obj.options or []}
+    for option, value in data.items():
+        option_key = PROGRAM_OPTIONS[option][0]
+        options_dict[option_key] = Option(option_key, value)
+
+    try:
+        await client.start_program(
+            ha_id,
+            program_key=program,
+            options=list(options_dict.values()) if options_dict else None,
+        )
+    except HomeConnectError as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="start_program",
+            translation_placeholders={
+                "program": program,
+                **get_dict_from_home_connect_error(err),
+            },
+        ) from err
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register custom actions."""
@@ -269,4 +330,10 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SET_PROGRAM_AND_OPTIONS,
         async_service_set_program_and_options,
         schema=SERVICE_PROGRAM_AND_OPTIONS_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_SELECTED_PROGRAM,
+        async_service_start_selected_program,
+        schema=SERVICE_START_SELECTED_PROGRAM_SCHEMA,
     )

--- a/homeassistant/components/home_connect/services.yaml
+++ b/homeassistant/components/home_connect/services.yaml
@@ -678,3 +678,29 @@ change_setting:
       required: true
       selector:
         object:
+
+start_selected_program:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: home_connect
+    b_s_h_common_option_finish_in_relative:
+      example: 3600
+      required: false
+      selector:
+        number:
+          min: 0
+          step: 1
+          mode: box
+          unit_of_measurement: s
+    b_s_h_common_option_start_in_relative:
+      example: 3600
+      required: false
+      selector:
+        number:
+          min: 0
+          step: 1
+          mode: box
+          unit_of_measurement: s

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1324,7 +1324,7 @@
       "message": "Error obtaining data from the API: {error}"
     },
     "fetch_program_error": {
-      "message": "Error obtaining the selected or the active program: {error}"
+      "message": "Error obtaining the selected or active program: {error}"
     },
     "no_program_to_start": {
       "message": "No program to start"
@@ -2063,7 +2063,7 @@
       }
     },
     "start_selected_program": {
-      "description": "Starts the program that is already selected. You can add options that can be used when starting the program uniquely.",
+      "description": "Starts the program that is already selected. You can optionally provide additional options that are only supported when starting a program.",
       "fields": {
         "b_s_h_common_option_finish_in_relative": {
           "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::description%]",

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -2063,7 +2063,7 @@
       }
     },
     "start_selected_program": {
-      "description": "Starts the program that is already selected. You can optionally provide additional options that are only supported when starting a program.",
+      "description": "Starts the already selected program. You can also update start-only options to start the program with them or modify them on a program that is already delayed.",
       "fields": {
         "b_s_h_common_option_finish_in_relative": {
           "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::description%]",

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -2063,7 +2063,7 @@
       }
     },
     "start_selected_program": {
-      "description": "Starts the already selected program. You can also update start-only options to start the program with them or modify them on a program that is already delayed.",
+      "description": "Starts the already selected program. You can update start-only options to start the program with them or modify them on a program that is already delayed.",
       "fields": {
         "b_s_h_common_option_finish_in_relative": {
           "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::description%]",

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -2063,7 +2063,7 @@
       }
     },
     "start_selected_program": {
-      "description": "Starts the already selected program. You can update start-only options to start the program with them or modify them on a program that is already delayed.",
+      "description": "Starts the already selected program. You can update start-only options to start the program with them or modify them on a program that is already active with a delayed start.",
       "fields": {
         "b_s_h_common_option_finish_in_relative": {
           "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::description%]",

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1323,6 +1323,12 @@
     "fetch_api_error": {
       "message": "Error obtaining data from the API: {error}"
     },
+    "fetch_program_error": {
+      "message": "Error obtaining the selected or the active program: {error}"
+    },
+    "no_program_to_start": {
+      "message": "No program to start"
+    },
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
     },
@@ -2055,6 +2061,24 @@
           "name": "Washer options"
         }
       }
+    },
+    "start_selected_program": {
+      "description": "Starts the program that is already selected. You can add options that can be used when starting the program uniquely.",
+      "fields": {
+        "b_s_h_common_option_finish_in_relative": {
+          "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::description%]",
+          "name": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_finish_in_relative::name%]"
+        },
+        "b_s_h_common_option_start_in_relative": {
+          "description": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_start_in_relative::description%]",
+          "name": "[%key:component::home_connect::services::set_program_and_options::fields::b_s_h_common_option_start_in_relative::name%]"
+        },
+        "device_id": {
+          "description": "[%key:component::home_connect::services::set_program_and_options::fields::device_id::description%]",
+          "name": "[%key:component::home_connect::services::set_program_and_options::fields::device_id::name%]"
+        }
+      },
+      "name": "Start selected program"
     }
   }
 }

--- a/tests/components/home_connect/conftest.py
+++ b/tests/components/home_connect/conftest.py
@@ -195,7 +195,7 @@ def _get_set_program_side_effect(
                                     value=str(option.key),
                                 )
                                 for option in cast(
-                                    list[Option], kwargs.get("options", [])
+                                    list[Option], kwargs.get("options") or []
                                 )
                             ],
                         ]

--- a/tests/components/home_connect/snapshots/test_services.ambr
+++ b/tests/components/home_connect/snapshots/test_services.ambr
@@ -77,3 +77,361 @@
     }),
   )
 # ---
+# name: test_start_selected_program[False-None-additional_service_data0-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': None,
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-None-additional_service_data1-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-None-additional_service_data2-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-None-additional_service_data3-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-options_already_set1-additional_service_data0-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-options_already_set1-additional_service_data1-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-options_already_set1-additional_service_data2-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[False-options_already_set1-additional_service_data3-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-None-additional_service_data0-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': None,
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-None-additional_service_data1-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-None-additional_service_data2-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-None-additional_service_data3-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-options_already_set1-additional_service_data0-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-options_already_set1-additional_service_data1-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-options_already_set1-additional_service_data2-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[True-options_already_set1-additional_service_data3-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---

--- a/tests/components/home_connect/snapshots/test_services.ambr
+++ b/tests/components/home_connect/snapshots/test_services.ambr
@@ -77,7 +77,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-None-additional_service_data0-Dishwasher]
+# name: test_start_selected_program[None-0-None-additional_service_data0-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -88,7 +88,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-None-additional_service_data1-Dishwasher]
+# name: test_start_selected_program[None-0-None-additional_service_data1-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -114,7 +114,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-None-additional_service_data2-Dishwasher]
+# name: test_start_selected_program[None-0-None-additional_service_data2-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -133,7 +133,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-None-additional_service_data3-Dishwasher]
+# name: test_start_selected_program[None-0-None-additional_service_data3-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -152,7 +152,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-options_already_set1-additional_service_data0-Dishwasher]
+# name: test_start_selected_program[None-0-options_already_set1-additional_service_data0-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -171,40 +171,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[False-options_already_set1-additional_service_data1-Dishwasher]
-  _Call(
-    tuple(
-      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
-    ),
-    dict({
-      'options': list([
-        dict({
-          'display_value': None,
-          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
-          'name': None,
-          'unit': None,
-          'value': True,
-        }),
-        dict({
-          'display_value': None,
-          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
-          'name': None,
-          'unit': None,
-          'value': 1200,
-        }),
-        dict({
-          'display_value': None,
-          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
-          'name': None,
-          'unit': None,
-          'value': 1200,
-        }),
-      ]),
-      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
-    }),
-  )
-# ---
-# name: test_start_selected_program[False-options_already_set1-additional_service_data2-Dishwasher]
+# name: test_start_selected_program[None-0-options_already_set1-additional_service_data1-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -225,12 +192,45 @@
           'unit': None,
           'value': 1200,
         }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_FINISH_IN_RELATIVE: 'BSH.Common.Option.FinishInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
       ]),
       'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
     }),
   )
 # ---
-# name: test_start_selected_program[False-options_already_set1-additional_service_data3-Dishwasher]
+# name: test_start_selected_program[None-0-options_already_set1-additional_service_data2-Dishwasher]
+  _Call(
+    tuple(
+      'SIEMENS-HCS02DWH1-6BE58C26DCC1',
+    ),
+    dict({
+      'options': list([
+        dict({
+          'display_value': None,
+          'key': <OptionKey.DISHCARE_DISHWASHER_HALF_LOAD: 'Dishcare.Dishwasher.Option.HalfLoad'>,
+          'name': None,
+          'unit': None,
+          'value': True,
+        }),
+        dict({
+          'display_value': None,
+          'key': <OptionKey.BSH_COMMON_START_IN_RELATIVE: 'BSH.Common.Option.StartInRelative'>,
+          'name': None,
+          'unit': None,
+          'value': 1200,
+        }),
+      ]),
+      'program_key': <ProgramKey.DISHCARE_DISHWASHER_ECO_50: 'Dishcare.Dishwasher.Program.Eco50'>,
+    }),
+  )
+# ---
+# name: test_start_selected_program[None-0-options_already_set1-additional_service_data3-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -256,7 +256,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-None-additional_service_data0-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-None-additional_service_data0-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -267,7 +267,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-None-additional_service_data1-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-None-additional_service_data1-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -293,7 +293,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-None-additional_service_data2-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-None-additional_service_data2-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -312,7 +312,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-None-additional_service_data3-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-None-additional_service_data3-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -331,7 +331,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-options_already_set1-additional_service_data0-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-options_already_set1-additional_service_data0-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -350,7 +350,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-options_already_set1-additional_service_data1-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-options_already_set1-additional_service_data1-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -383,7 +383,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-options_already_set1-additional_service_data2-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-options_already_set1-additional_service_data2-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',
@@ -409,7 +409,7 @@
     }),
   )
 # ---
-# name: test_start_selected_program[True-options_already_set1-additional_service_data3-Dishwasher]
+# name: test_start_selected_program[get_active_program_side_effect1-1-options_already_set1-additional_service_data3-Dishwasher]
   _Call(
     tuple(
       'SIEMENS-HCS02DWH1-6BE58C26DCC1',

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -421,8 +421,8 @@ async def test_services_appliance_not_found(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    service_call = service_call.copy()
-    service_call["service_data"] = dict(service_call.get("service_data", {}))
+    service_call = service_call.copy()  # To avoid mutating the original test data
+    service_call.setdefault("service_data", {})
 
     service_call["service_data"]["device_id"] = "DOES_NOT_EXISTS"
 

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -353,18 +353,75 @@ async def test_start_selected_program_and_options_exceptions(
         )
 
 
+@pytest.mark.parametrize(
+    "get_active_program_side_effect",
+    [None, NoProgramActiveError("error.key")],
+)
+async def test_no_program_error(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    get_active_program_side_effect: NoProgramActiveError | None,
+) -> None:
+    """Test handling of no program active error."""
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "HA_ID")},
+    )
+
+    client.get_active_program = AsyncMock(
+        return_value=Program(
+            key=None,
+        ),
+        side_effect=get_active_program_side_effect,
+    )
+    client.get_selected_program = AsyncMock(
+        return_value=Program(
+            key=None,
+        )
+    )
+
+    with pytest.raises(HomeAssistantError, match="No program to start"):
+        await hass.services.async_call(
+            domain=DOMAIN,
+            service="start_selected_program",
+            service_data={
+                "device_id": device_entry.id,
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "service_call",
+    [
+        SERVICE_KV_CALL_PARAMS[0],
+        {
+            "domain": DOMAIN,
+            "service": "start_selected_program",
+            "service_data": {},
+            "blocking": True,
+        },
+    ],
+)
 async def test_services_appliance_not_found(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    service_call: dict[str, Any],
 ) -> None:
     """Raise a ServiceValidationError when device id does not match."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    service_call = SERVICE_KV_CALL_PARAMS[0]
+    service_call = service_call.copy()
 
     service_call["service_data"]["device_id"] = "DOES_NOT_EXISTS"
 

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -2,15 +2,21 @@
 
 from collections.abc import Awaitable, Callable
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-from aiohomeconnect.model import HomeAppliance, ProgramKey, SettingKey
+from aiohomeconnect.model import (
+    HomeAppliance,
+    Option,
+    OptionKey,
+    Program,
+    ProgramKey,
+    SettingKey,
+)
+from aiohomeconnect.model.error import HomeConnectError, NoProgramActiveError
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.home_connect.const import DOMAIN
-from homeassistant.components.home_connect.utils import bsh_key_to_translation_key
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -196,6 +202,154 @@ async def test_set_program_and_options_exceptions(
         await hass.services.async_call(**service_call)
 
 
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(
+    "additional_service_data",
+    [
+        {},
+        {
+            "b_s_h_common_option_start_in_relative": 1200,
+            "b_s_h_common_option_finish_in_relative": 1200,
+        },
+        {
+            "b_s_h_common_option_start_in_relative": 1200,
+        },
+        {
+            "b_s_h_common_option_finish_in_relative": 1200,
+        },
+    ],
+)
+@pytest.mark.parametrize(
+    "options_already_set",
+    [
+        None,
+        [
+            Option(
+                key=OptionKey.DISHCARE_DISHWASHER_HALF_LOAD,
+                value=True,
+            )
+        ],
+    ],
+)
+@pytest.mark.parametrize("obtain_from_active_program", [True, False])
+async def test_start_selected_program(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    additional_service_data: dict[str, Any],
+    options_already_set: list[Option] | None,
+    obtain_from_active_program: bool,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test starting the selected program with optional parameter overrides."""
+    client.get_active_program = AsyncMock(
+        return_value=Program(
+            key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
+            options=options_already_set,
+        ),
+        side_effect=NoProgramActiveError("error.key")
+        if not obtain_from_active_program
+        else None,
+    )
+    client.get_selected_program = AsyncMock(
+        return_value=Program(
+            key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
+            options=options_already_set,
+        )
+    )
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, appliance.ha_id)},
+    )
+
+    await hass.services.async_call(
+        domain=DOMAIN,
+        service="start_selected_program",
+        service_data={
+            "device_id": device_entry.id,
+            **additional_service_data,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    client.get_active_program.assert_awaited_once_with(appliance.ha_id)
+    if not obtain_from_active_program:
+        client.get_selected_program.assert_awaited_once_with(appliance.ha_id)
+    assert client.start_program.call_count == 1
+    assert client.start_program.call_args == snapshot
+
+
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(
+    ("mock_attr", "error_regex", "obtain_from_active_program"),
+    [
+        (
+            "get_active_program",
+            r"Error.*obtaining.*program.*",
+            True,
+        ),
+        (
+            "get_selected_program",
+            r"Error.*obtaining.*program.*",
+            False,
+        ),
+        ("start_program", r"Error.*starting.*program.*", True),
+    ],
+)
+async def test_start_selected_program_and_options_exceptions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    mock_attr: str,
+    error_regex: str,
+    obtain_from_active_program: bool,
+) -> None:
+    """Test error handling when starting the selected program."""
+    client.get_active_program = AsyncMock(
+        return_value=Program(
+            key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
+        ),
+        side_effect=NoProgramActiveError("error.key")
+        if not obtain_from_active_program
+        else None,
+    )
+    client.get_selected_program = AsyncMock(
+        return_value=Program(
+            key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
+        )
+    )
+    getattr(client, mock_attr).side_effect = HomeConnectError("error.key")
+
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, appliance.ha_id)},
+    )
+
+    with pytest.raises(HomeAssistantError, match=error_regex):
+        await hass.services.async_call(
+            domain=DOMAIN,
+            service="start_selected_program",
+            service_data={
+                "device_id": device_entry.id,
+            },
+            blocking=True,
+        )
+
+
 async def test_services_appliance_not_found(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -268,34 +422,3 @@ async def test_services_exception(
         match=SERVICE_VALIDATION_ERROR_MAPPING[service_name],
     ):
         await hass.services.async_call(**service_call)
-
-
-async def test_not_possible_to_use_favorite_program(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    client: MagicMock,
-    config_entry: MockConfigEntry,
-    integration_setup: Callable[[MagicMock], Awaitable[bool]],
-) -> None:
-    """Raise a MultipleInvalid when trying to use a favorite program."""
-    assert await integration_setup(client)
-    assert config_entry.state is ConfigEntryState.LOADED
-
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        identifiers={(DOMAIN, "HA_ID")},
-    )
-
-    with pytest.raises(MultipleInvalid):
-        await hass.services.async_call(
-            DOMAIN,
-            "set_program_and_options",
-            {
-                "device_id": device_entry.id,
-                "affects_to": "selected_program",
-                "program": bsh_key_to_translation_key(
-                    ProgramKey.BSH_COMMON_FAVORITE_001.value
-                ),
-            },
-            blocking=True,
-        )

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -15,8 +15,10 @@ from aiohomeconnect.model import (
 from aiohomeconnect.model.error import HomeConnectError, NoProgramActiveError
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.home_connect.const import DOMAIN
+from homeassistant.components.home_connect.utils import bsh_key_to_translation_key
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -231,7 +233,10 @@ async def test_set_program_and_options_exceptions(
         ],
     ],
 )
-@pytest.mark.parametrize("obtain_from_active_program", [True, False])
+@pytest.mark.parametrize(
+    ("get_active_program_side_effect", "get_selected_program_call_count"),
+    [(None, 0), (NoProgramActiveError("error.key"), 1)],
+)
 async def test_start_selected_program(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -241,7 +246,8 @@ async def test_start_selected_program(
     appliance: HomeAppliance,
     additional_service_data: dict[str, Any],
     options_already_set: list[Option] | None,
-    obtain_from_active_program: bool,
+    get_active_program_side_effect: NoProgramActiveError | None,
+    get_selected_program_call_count: int,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test starting the selected program with optional parameter overrides."""
@@ -250,9 +256,7 @@ async def test_start_selected_program(
             key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
             options=options_already_set,
         ),
-        side_effect=NoProgramActiveError("error.key")
-        if not obtain_from_active_program
-        else None,
+        side_effect=get_active_program_side_effect,
     )
     client.get_selected_program = AsyncMock(
         return_value=Program(
@@ -281,27 +285,28 @@ async def test_start_selected_program(
     await hass.async_block_till_done()
 
     client.get_active_program.assert_awaited_once_with(appliance.ha_id)
-    if not obtain_from_active_program:
-        client.get_selected_program.assert_awaited_once_with(appliance.ha_id)
+    assert client.get_selected_program.call_count == get_selected_program_call_count
+    for call_args in client.start_program.call_args_list:
+        assert call_args[0][0] == appliance.ha_id
     assert client.start_program.call_count == 1
     assert client.start_program.call_args == snapshot
 
 
 @pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
 @pytest.mark.parametrize(
-    ("mock_attr", "error_regex", "obtain_from_active_program"),
+    ("mock_attr", "error_regex", "get_active_program_side_effect"),
     [
         (
             "get_active_program",
             r"Error.*obtaining.*program.*",
-            True,
+            None,
         ),
         (
             "get_selected_program",
             r"Error.*obtaining.*program.*",
-            False,
+            NoProgramActiveError("error.key"),
         ),
-        ("start_program", r"Error.*starting.*program.*", True),
+        ("start_program", r"Error.*starting.*program.*", None),
     ],
 )
 async def test_start_selected_program_and_options_exceptions(
@@ -313,16 +318,14 @@ async def test_start_selected_program_and_options_exceptions(
     appliance: HomeAppliance,
     mock_attr: str,
     error_regex: str,
-    obtain_from_active_program: bool,
+    get_active_program_side_effect: NoProgramActiveError | None,
 ) -> None:
     """Test error handling when starting the selected program."""
     client.get_active_program = AsyncMock(
         return_value=Program(
             key=ProgramKey.DISHCARE_DISHWASHER_ECO_50,
         ),
-        side_effect=NoProgramActiveError("error.key")
-        if not obtain_from_active_program
-        else None,
+        side_effect=get_active_program_side_effect,
     )
     client.get_selected_program = AsyncMock(
         return_value=Program(
@@ -422,3 +425,34 @@ async def test_services_exception(
         match=SERVICE_VALIDATION_ERROR_MAPPING[service_name],
     ):
         await hass.services.async_call(**service_call)
+
+
+async def test_not_possible_to_use_favorite_program(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+) -> None:
+    """Raise a MultipleInvalid when trying to use a favorite program."""
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "HA_ID")},
+    )
+
+    with pytest.raises(MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_program_and_options",
+            {
+                "device_id": device_entry.id,
+                "affects_to": "selected_program",
+                "program": bsh_key_to_translation_key(
+                    ProgramKey.BSH_COMMON_FAVORITE_001.value
+                ),
+            },
+            blocking=True,
+        )

--- a/tests/components/home_connect/test_services.py
+++ b/tests/components/home_connect/test_services.py
@@ -422,6 +422,7 @@ async def test_services_appliance_not_found(
     assert config_entry.state is ConfigEntryState.LOADED
 
     service_call = service_call.copy()
+    service_call["service_data"] = dict(service_call.get("service_data", {}))
 
     service_call["service_data"]["device_id"] = "DOES_NOT_EXISTS"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many users have requested a way to start the program that previously has been selected, a feature that it is in the app and in the appliances' physical control.

This PR attempts to do that by adding an action called `start_selected_program`, which fetches the selected program and options data from the appliance to then use it to start the program. The following keys that can be used when starting the program uniquely can be also set while calling the action:

- BSH.Common.Option.StartInRelative ([source](https://api-docs.home-connect.com/programs-and-options/#dishwasher_start-in-relative-option))
- BSH.Common.Option.FinishInRelative ([source](https://api-docs.home-connect.com/programs-and-options/?#washer_finish-in-relative-option))

At both keys' description is mentioned the following:
>Please note that this option can't be used in a program selection command. This is only supported by the program start command.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #155375
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44068
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
