### PR TITLE
Fix ESPHome cold/warm white brightness applied twice

### DIFF
--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -106,20 +106,6 @@ def _mired_to_kelvin(mired_temperature: float) -> int:
     return round(1000000 / mired_temperature)
 
 
-def _color_temp_to_cold_warm(
-    color_temp_mired: float, min_mireds: float, max_mireds: float
-) -> tuple[float, float]:
-    """Convert a color temperature in mireds to cold/warm white fractions.
-
-    Returns (cold_white, warm_white) normalized so the brighter channel is 1.0.
-    """
-    color_temp_clamped = min(max(color_temp_mired, min_mireds), max_mireds)
-    ww_frac = (color_temp_clamped - min_mireds) / (max_mireds - min_mireds)
-    cw_frac = 1 - ww_frac
-    max_frac = max(cw_frac, ww_frac)
-    return cw_frac / max_frac, ww_frac / max_frac
-
-
 @lru_cache
 def _color_mode_to_ha(mode: ESPHomeColorMode) -> ColorMode:
     """Convert an esphome color mode to a HA color mode constant.
@@ -173,6 +159,21 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
 
     _native_supported_color_modes: tuple[ESPHomeColorMode, ...]
     _supports_color_mode = False
+
+    def _color_temp_to_cold_warm(self, color_temp_mired: float) -> tuple[float, float]:
+        """Convert a color temperature in mireds to cold/warm white fractions.
+
+        Returns (cold_white, warm_white) normalized so the brighter channel
+        is 1.0.
+        """
+        static_info = self._static_info
+        min_mireds = static_info.min_mireds
+        max_mireds = static_info.max_mireds
+        color_temp_clamped = min(max(color_temp_mired, min_mireds), max_mireds)
+        ww_frac = (color_temp_clamped - min_mireds) / (max_mireds - min_mireds)
+        cw_frac = 1 - ww_frac
+        max_frac = max(cw_frac, ww_frac)
+        return cw_frac / max_frac, ww_frac / max_frac
 
     @property
     @esphome_state_property
@@ -265,9 +266,8 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
                 # Convert color temperature to explicit cold/warm white
                 # values to avoid ESPHome applying brightness to both
                 # master brightness and white channels (b² effect).
-                static_info = self._static_info
-                data["cold_white"], data["warm_white"] = _color_temp_to_cold_warm(
-                    color_temp_mired, static_info.min_mireds, static_info.max_mireds
+                data["cold_white"], data["warm_white"] = self._color_temp_to_cold_warm(
+                    color_temp_mired
                 )
                 color_modes = _filter_color_modes(
                     color_modes, LightColorCapability.COLD_WARM_WHITE
@@ -367,11 +367,8 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
             self._native_supported_color_modes, LightColorCapability.COLD_WARM_WHITE
         ):
             # Try to reverse white + color temp to cwww
-            static_info = self._static_info
             white = state.white
-            cw, ww = _color_temp_to_cold_warm(
-                state.color_temperature, static_info.min_mireds, static_info.max_mireds
-            )
+            cw, ww = self._color_temp_to_cold_warm(state.color_temperature)
 
             return (
                 *rgb,

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -106,6 +106,20 @@ def _mired_to_kelvin(mired_temperature: float) -> int:
     return round(1000000 / mired_temperature)
 
 
+def _color_temp_to_cold_warm(
+    color_temp_mired: float, min_mireds: float, max_mireds: float
+) -> tuple[float, float]:
+    """Convert a color temperature in mireds to cold/warm white fractions.
+
+    Returns (cold_white, warm_white) normalized so the brighter channel is 1.0.
+    """
+    color_temp_clamped = min(max(color_temp_mired, min_mireds), max_mireds)
+    ww_frac = (color_temp_clamped - min_mireds) / (max_mireds - min_mireds)
+    cw_frac = 1 - ww_frac
+    max_frac = max(cw_frac, ww_frac)
+    return cw_frac / max_frac, ww_frac / max_frac
+
+
 @lru_cache
 def _color_mode_to_ha(mode: ESPHomeColorMode) -> ColorMode:
     """Convert an esphome color mode to a HA color mode constant.
@@ -241,12 +255,20 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
 
         if (color_temp_k := kwargs.get(ATTR_COLOR_TEMP_KELVIN)) is not None:
             # Do not use kelvin_to_mired here to prevent precision loss
-            data["color_temperature"] = 1_000_000.0 / color_temp_k
+            color_temp_mired = 1_000_000.0 / color_temp_k
             if color_temp_modes := _filter_color_modes(
                 color_modes, LightColorCapability.COLOR_TEMPERATURE
             ):
+                data["color_temperature"] = color_temp_mired
                 color_modes = color_temp_modes
             else:
+                # Convert color temperature to explicit cold/warm white
+                # values to avoid ESPHome applying brightness to both
+                # master brightness and white channels (b² effect).
+                static_info = self._static_info
+                data["cold_white"], data["warm_white"] = _color_temp_to_cold_warm(
+                    color_temp_mired, static_info.min_mireds, static_info.max_mireds
+                )
                 color_modes = _filter_color_modes(
                     color_modes, LightColorCapability.COLD_WARM_WHITE
                 )
@@ -346,18 +368,15 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
         ):
             # Try to reverse white + color temp to cwww
             static_info = self._static_info
-            min_ct = static_info.min_mireds
-            max_ct = static_info.max_mireds
-            color_temp = min(max(state.color_temperature, min_ct), max_ct)
             white = state.white
-
-            ww_frac = (color_temp - min_ct) / (max_ct - min_ct)
-            cw_frac = 1 - ww_frac
+            cw, ww = _color_temp_to_cold_warm(
+                state.color_temperature, static_info.min_mireds, static_info.max_mireds
+            )
 
             return (
                 *rgb,
-                round(white * cw_frac / max(cw_frac, ww_frac) * 255),
-                round(white * ww_frac / max(cw_frac, ww_frac) * 255),
+                round(white * cw * 255),
+                round(white * ww * 255),
             )
         return (
             *rgb,

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -169,6 +169,8 @@ class EsphomeLight(EsphomeEntity[LightInfo, LightState], LightEntity):
         static_info = self._static_info
         min_mireds = static_info.min_mireds
         max_mireds = static_info.max_mireds
+        if max_mireds <= min_mireds:
+            return 1.0, 1.0
         color_temp_clamped = min(max(color_temp_mired, min_mireds), max_mireds)
         ww_frac = (color_temp_clamped - min_mireds) / (max_mireds - min_mireds)
         cw_frac = 1 - ww_frac

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -1953,6 +1953,70 @@ async def test_only_cold_warm_white_support(
     mock_client.light_command.reset_mock()
 
 
+async def test_cold_warm_white_no_mireds_set(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test cold/warm white light with no mireds set doesn't divide by zero."""
+    mock_client.api_version = APIVersion(1, 7)
+    color_modes = (
+        LightColorCapability.COLD_WARM_WHITE
+        | LightColorCapability.ON_OFF
+        | LightColorCapability.BRIGHTNESS
+    )
+    entity_info = [
+        LightInfo(
+            object_id="mylight",
+            key=1,
+            name="my light",
+            min_mireds=0,
+            max_mireds=0,
+            supported_color_modes=[color_modes],
+        )
+    ]
+    states = [
+        LightState(
+            key=1,
+            state=True,
+            brightness=100,
+            warm_white=1,
+            cold_white=1,
+            color_mode=color_modes,
+        )
+    ]
+    user_service = []
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        user_service=user_service,
+        states=states,
+    )
+    state = hass.states.get("light.test_my_light")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.test_my_light", ATTR_COLOR_TEMP_KELVIN: 3600},
+        blocking=True,
+    )
+    mock_client.light_command.assert_has_calls(
+        [
+            call(
+                key=1,
+                state=True,
+                color_mode=color_modes,
+                cold_white=1.0,
+                warm_white=1.0,
+                device_id=0,
+            )
+        ]
+    )
+    mock_client.light_command.reset_mock()
+
+
 async def test_light_no_color_modes(
     hass: HomeAssistant,
     mock_client: APIClient,

--- a/tests/components/esphome/test_light.py
+++ b/tests/components/esphome/test_light.py
@@ -1913,7 +1913,39 @@ async def test_only_cold_warm_white_support(
                 key=1,
                 state=True,
                 color_mode=color_modes,
-                color_temperature=400.0,
+                cold_white=pytest.approx(0.0),
+                warm_white=pytest.approx(1.0),
+                device_id=0,
+            )
+        ]
+    )
+    mock_client.light_command.reset_mock()
+
+    # Test setting brightness and color temp together does not
+    # result in brightness being applied twice (b² effect)
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.test_my_light",
+            ATTR_BRIGHTNESS: 127,
+            ATTR_COLOR_TEMP_KELVIN: 3600,
+        },
+        blocking=True,
+    )
+    # 3600K -> 277.78 mireds, min=153, max=400
+    # ww_frac = (277.78 - 153) / (400 - 153) = 0.505
+    # cw_frac = 0.495
+    # max_frac = 0.505, cold_white = 0.495/0.505, warm_white = 1.0
+    mock_client.light_command.assert_has_calls(
+        [
+            call(
+                key=1,
+                state=True,
+                brightness=pytest.approx(0.4980392156862745),
+                color_mode=color_modes,
+                cold_white=pytest.approx(0.9798, abs=1e-3),
+                warm_white=pytest.approx(1.0),
                 device_id=0,
             )
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When setting both brightness and color temperature on a cold/warm white ESPHome light, the brightness was applied twice: once as master brightness and once to the white channels via ESPHome's internal `color_temperature`-to-cwww conversion. This resulted in b² actual brightness instead of b (e.g., requesting 1% brightness yielded 0.01% output).

This converts color temperature to explicit `cold_white`/`warm_white` values on the Home Assistant side for `COLD_WARM_WHITE` devices, so ESPHome receives direct channel values and only applies master brightness once.

Also extracts the mired-to-cwww conversion into a shared helper `_color_temp_to_cold_warm` and reuses it in the `rgbww_color` property which performed the same calculation inline.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/esphome/esphome/issues/14672
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr