### PR TITLE
Preserve reasoning_details in OpenRouter message history

### DIFF
--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -298,6 +298,7 @@ class OpenRouterEntity(Entity):
 
             result_message = result.choices[0].message
 
+            prev_message_count = len(model_args["messages"])
             model_args["messages"].extend(
                 [
                     msg
@@ -307,5 +308,17 @@ class OpenRouterEntity(Entity):
                     if (msg := _convert_content_to_chat_message(content))
                 ]
             )
+
+            # Preserve reasoning_details in the assistant message so that
+            # reasoning context is maintained across turns (required by OpenRouter
+            # for models like DeepSeek R1, Gemini reasoning, and Anthropic Claude
+            # extended thinking when tool calls are involved).
+            reasoning_details = getattr(result_message, "reasoning_details", None)
+            if reasoning_details:
+                for msg in model_args["messages"][prev_message_count:]:
+                    if msg.get("role") == "assistant":
+                        msg["reasoning_details"] = reasoning_details
+                        break
+
             if not chat_log.unresponded_tool_results:
                 break

--- a/tests/components/open_router/test_conversation.py
+++ b/tests/components/open_router/test_conversation.py
@@ -80,6 +80,211 @@ async def test_default_prompt(
 
 
 @pytest.mark.parametrize("enable_assist", [True])
+async def test_reasoning_details_preserved(
+    hass: HomeAssistant,
+    mock_chat_log: MockChatLog,  # noqa: F811
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test that reasoning_details from the model response are preserved in subsequent API calls.
+
+    OpenRouter requires reasoning_details to be passed back to the API when using
+    reasoning models (e.g. DeepSeek R1, Gemini thinking, Anthropic extended thinking)
+    so the model can continue its reasoning chain across tool-call turns.
+    """
+    await setup_integration(hass, mock_config_entry)
+
+    reasoning_details = [
+        {
+            "type": "reasoning.text",
+            "text": "Let me think through this step by step...",
+            "id": "reasoning-text-1",
+            "format": "anthropic-claude-v1",
+            "index": 0,
+        }
+    ]
+
+    # First response: assistant uses a tool and includes reasoning_details
+    first_message = ChatCompletionMessage(
+        content=None,
+        role="assistant",
+        function_call=None,
+        tool_calls=[
+            ChatCompletionMessageFunctionToolCall(
+                id="call_reasoning_1",
+                function=Function(
+                    arguments='{"param1":"value1"}',
+                    name="test_tool",
+                ),
+                type="function",
+            )
+        ],
+        reasoning_details=reasoning_details,
+    )
+
+    mock_chat_log.mock_tool_results({"call_reasoning_1": "tool_result_value"})
+
+    mock_openai_client.chat.completions.create.side_effect = (
+        ChatCompletion(
+            id="chatcmpl-reasoning-turn-1",
+            choices=[
+                Choice(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=first_message,
+                )
+            ],
+            created=1700000000,
+            model="deepseek/deepseek-r1",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=50, prompt_tokens=20, total_tokens=70
+            ),
+        ),
+        ChatCompletion(
+            id="chatcmpl-reasoning-turn-2",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content="I have completed the task using my reasoning.",
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="deepseek/deepseek-r1",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=15, prompt_tokens=30, total_tokens=45
+            ),
+        ),
+    )
+
+    result = await conversation.async_converse(
+        hass,
+        "Please use your reasoning to help me.",
+        mock_chat_log.conversation_id,
+        Context(),
+        agent_id="conversation.gpt_3_5_turbo",
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert mock_openai_client.chat.completions.create.call_count == 2
+
+    # Verify reasoning_details are included in the second API call's messages
+    second_call_messages = mock_openai_client.chat.completions.create.call_args_list[1][
+        1
+    ]["messages"]
+    assistant_messages = [
+        m for m in second_call_messages if m.get("role") == "assistant"
+    ]
+    assert len(assistant_messages) >= 1, "Expected at least one assistant message"
+    assert "reasoning_details" in assistant_messages[0], (
+        "reasoning_details must be preserved in assistant message for next turn"
+    )
+    assert assistant_messages[0]["reasoning_details"] == reasoning_details
+
+
+@pytest.mark.parametrize("enable_assist", [True])
+async def test_reasoning_details_not_present(
+    hass: HomeAssistant,
+    mock_chat_log: MockChatLog,  # noqa: F811
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+) -> None:
+    """Test that messages without reasoning_details are handled gracefully (backward compat)."""
+    await setup_integration(hass, mock_config_entry)
+
+    # First response: tool call but NO reasoning_details (standard model)
+    mock_chat_log.mock_tool_results({"call_no_reasoning": "some_result"})
+
+    mock_openai_client.chat.completions.create.side_effect = (
+        ChatCompletion(
+            id="chatcmpl-no-reasoning-1",
+            choices=[
+                Choice(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content=None,
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=[
+                            ChatCompletionMessageFunctionToolCall(
+                                id="call_no_reasoning",
+                                function=Function(
+                                    arguments='{"param1":"value1"}',
+                                    name="test_tool",
+                                ),
+                                type="function",
+                            )
+                        ],
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="openai/gpt-4o",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=9, prompt_tokens=8, total_tokens=17
+            ),
+        ),
+        ChatCompletion(
+            id="chatcmpl-no-reasoning-2",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(
+                        content="Done without reasoning.",
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=None,
+                    ),
+                )
+            ],
+            created=1700000000,
+            model="openai/gpt-4o",
+            object="chat.completion",
+            system_fingerprint=None,
+            usage=CompletionUsage(
+                completion_tokens=9, prompt_tokens=8, total_tokens=17
+            ),
+        ),
+    )
+
+    result = await conversation.async_converse(
+        hass,
+        "Please do the task.",
+        mock_chat_log.conversation_id,
+        Context(),
+        agent_id="conversation.gpt_3_5_turbo",
+    )
+
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert mock_openai_client.chat.completions.create.call_count == 2
+
+    # Verify no reasoning_details key is injected when the model didn't return any
+    second_call_messages = mock_openai_client.chat.completions.create.call_args_list[1][
+        1
+    ]["messages"]
+    assistant_messages = [
+        m for m in second_call_messages if m.get("role") == "assistant"
+    ]
+    assert len(assistant_messages) >= 1
+    assert "reasoning_details" not in assistant_messages[0], (
+        "reasoning_details should not be injected when the model did not return any"
+    )
+
+
+@pytest.mark.parametrize("enable_assist", [True])
 async def test_function_call(
     hass: HomeAssistant,
     mock_chat_log: MockChatLog,  # noqa: F811


### PR DESCRIPTION
## Breaking change

No breaking changes.

## Proposed change

When using reasoning models (DeepSeek R1, Gemini thinking, Claude extended thinking) through OpenRouter, the `reasoning_details` field returned in assistant messages was being discarded when rebuilding the message history between turns. OpenRouter requires this field to be sent back verbatim in subsequent API calls for reasoning models to function correctly.

This PR preserves `reasoning_details` from assistant responses and injects them back into the message history, similar to how tool calls are already preserved.

Fixes #159812

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #159812
- Link to documentation pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.