### PR TITLE
Add bearer token authentication support to Ollama integration

### DIFF
--- a/homeassistant/components/ollama/__init__.py
+++ b/homeassistant/components/ollama/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.ssl import get_default_context
 
 from .const import (
+    CONF_BEARER_TOKEN,
     CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
@@ -37,6 +38,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 __all__ = [
+    "CONF_BEARER_TOKEN",
     "CONF_KEEP_ALIVE",
     "CONF_MAX_HISTORY",
     "CONF_MODEL",
@@ -62,7 +64,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: OllamaConfigEntry) -> bool:
     """Set up Ollama from a config entry."""
     settings = {**entry.data, **entry.options}
-    client = ollama.AsyncClient(host=settings[CONF_URL], verify=get_default_context())
+    headers: dict[str, str] = {}
+    if bearer_token := settings.get(CONF_BEARER_TOKEN):
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    client = ollama.AsyncClient(
+        host=settings[CONF_URL], headers=headers, verify=get_default_context()
+    )
     try:
         async with asyncio.timeout(DEFAULT_TIMEOUT):
             await client.list()

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -40,6 +40,7 @@ from homeassistant.util.ssl import get_default_context
 
 from . import OllamaConfigEntry
 from .const import (
+    CONF_BEARER_TOKEN,
     CONF_KEEP_ALIVE,
     CONF_MAX_HISTORY,
     CONF_MODEL,
@@ -67,6 +68,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_URL): TextSelector(
             TextSelectorConfig(type=TextSelectorType.URL)
+        ),
+        vol.Optional(CONF_BEARER_TOKEN): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
     }
 )
@@ -108,8 +112,15 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
+        bearer_token: str | None = user_input.get(CONF_BEARER_TOKEN) or None
+        headers: dict[str, str] = {}
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+
         try:
-            client = ollama.AsyncClient(host=url, verify=get_default_context())
+            client = ollama.AsyncClient(
+                host=url, headers=headers, verify=get_default_context()
+            )
             async with asyncio.timeout(DEFAULT_TIMEOUT):
                 await client.list()
         except TimeoutError, httpx.ConnectError:
@@ -127,9 +138,13 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
+        entry_data: dict[str, str] = {CONF_URL: url}
+        if bearer_token:
+            entry_data[CONF_BEARER_TOKEN] = bearer_token
+
         return self.async_create_entry(
             title=url,
-            data={CONF_URL: url},
+            data=entry_data,
         )
 
     @classmethod

--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -4,6 +4,7 @@ DOMAIN = "ollama"
 
 DEFAULT_NAME = "Ollama"
 
+CONF_BEARER_TOKEN = "bearer_token"
 CONF_MODEL = "model"
 CONF_PROMPT = "prompt"
 CONF_THINK = "think"

--- a/homeassistant/components/ollama/entity.py
+++ b/homeassistant/components/ollama/entity.py
@@ -29,6 +29,7 @@ from .const import (
     DEFAULT_MAX_HISTORY,
     DEFAULT_NUM_CTX,
     DOMAIN,
+    KEEP_ALIVE_FOREVER,
 )
 from .models import MessageHistory, MessageRole
 
@@ -237,14 +238,23 @@ class OllamaBaseLLMEntity(Entity):
         # To prevent infinite loops, we limit the number of iterations
         for _iteration in range(MAX_TOOL_ITERATIONS):
             try:
+                keep_alive_value = int(
+                    settings.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)
+                )
+                # -1 is a special sentinel meaning "keep loaded forever".
+                # All other values are a duration in seconds (e.g. "300s").
+                keep_alive: int | str = (
+                    keep_alive_value
+                    if keep_alive_value == KEEP_ALIVE_FOREVER
+                    else f"{keep_alive_value}s"
+                )
                 response_generator = await client.chat(
                     model=model,
                     # Make a copy of the messages because we mutate the list later
                     messages=list(message_history.messages),
                     tools=tools,
                     stream=True,
-                    # keep_alive requires specifying unit. In this case, seconds
-                    keep_alive=f"{settings.get(CONF_KEEP_ALIVE, DEFAULT_KEEP_ALIVE)}s",
+                    keep_alive=keep_alive,
                     options={CONF_NUM_CTX: settings.get(CONF_NUM_CTX, DEFAULT_NUM_CTX)},
                     think=settings.get(CONF_THINK),
                     format=output_format,

--- a/homeassistant/components/ollama/strings.json
+++ b/homeassistant/components/ollama/strings.json
@@ -11,7 +11,11 @@
     "step": {
       "user": {
         "data": {
-          "url": "[%key:common::config_flow::data::url%]"
+          "url": "[%key:common::config_flow::data::url%]",
+          "bearer_token": "Bearer token"
+        },
+        "data_description": {
+          "bearer_token": "Optional Bearer token for authentication. Required when Ollama runs behind an authenticated proxy (e.g., LiteLLM)."
         }
       }
     }

--- a/tests/components/ollama/test_ai_task.py
+++ b/tests/components/ollama/test_ai_task.py
@@ -8,6 +8,11 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import ai_task, media_source
+from homeassistant.components.ollama.const import (
+    CONF_KEEP_ALIVE,
+    DEFAULT_KEEP_ALIVE,
+    KEEP_ALIVE_FOREVER,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, selector
@@ -357,3 +362,135 @@ async def test_generate_data_with_unsupported_file_format(
                 {"media_content_id": "media-source://media/context.txt"},
             ],
         )
+
+
+@pytest.mark.usefixtures("mock_init_component")
+async def test_generate_data_keep_alive_forever(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that keep_alive=-1 is passed as integer -1 (not '-1s') to Ollama.
+
+    The value -1 is a special sentinel meaning "keep loaded forever".
+    It must NOT be formatted as a duration string ('-1s' would mean -1 seconds).
+    """
+    entity_id = "ai_task.ollama_ai_task"
+
+    # Update the AI task subentry with keep_alive=-1 (the "forever" sentinel)
+    ai_task_subentry = next(
+        entry
+        for entry in mock_config_entry.subentries.values()
+        if entry.subentry_type == "ai_task_data"
+    )
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        ai_task_subentry,
+        data={**ai_task_subentry.data, CONF_KEEP_ALIVE: KEEP_ALIVE_FOREVER},
+    )
+    await hass.async_block_till_done()
+
+    async def mock_chat_response() -> object:
+        """Mock streaming response."""
+        yield {
+            "message": {"role": "assistant", "content": "response"},
+            "done": True,
+            "done_reason": "stop",
+        }
+
+    with patch(
+        "ollama.AsyncClient.chat",
+        return_value=mock_chat_response(),
+    ) as mock_chat:
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Keep-Alive Forever",
+            entity_id=entity_id,
+            instructions="Test",
+        )
+
+    assert result.data == "response"
+    assert mock_chat.call_count == 1
+    # -1 must be passed as the integer -1, not as the string "-1s"
+    assert mock_chat.call_args.kwargs["keep_alive"] == KEEP_ALIVE_FOREVER
+
+
+@pytest.mark.usefixtures("mock_init_component")
+async def test_generate_data_keep_alive_duration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that a positive keep_alive value is passed as '<N>s' duration string."""
+    entity_id = "ai_task.ollama_ai_task"
+
+    keep_alive_seconds = 300
+    ai_task_subentry = next(
+        entry
+        for entry in mock_config_entry.subentries.values()
+        if entry.subentry_type == "ai_task_data"
+    )
+    hass.config_entries.async_update_subentry(
+        mock_config_entry,
+        ai_task_subentry,
+        data={**ai_task_subentry.data, CONF_KEEP_ALIVE: keep_alive_seconds},
+    )
+    await hass.async_block_till_done()
+
+    async def mock_chat_response() -> object:
+        """Mock streaming response."""
+        yield {
+            "message": {"role": "assistant", "content": "response"},
+            "done": True,
+            "done_reason": "stop",
+        }
+
+    with patch(
+        "ollama.AsyncClient.chat",
+        return_value=mock_chat_response(),
+    ) as mock_chat:
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Keep-Alive Duration",
+            entity_id=entity_id,
+            instructions="Test",
+        )
+
+    assert result.data == "response"
+    assert mock_chat.call_count == 1
+    # Positive values should be passed as a seconds-duration string
+    assert mock_chat.call_args.kwargs["keep_alive"] == f"{keep_alive_seconds}s"
+
+
+@pytest.mark.usefixtures("mock_init_component")
+async def test_generate_data_keep_alive_default(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that the default keep_alive value (-1) is passed as integer -1."""
+    entity_id = "ai_task.ollama_ai_task"
+
+    async def mock_chat_response() -> object:
+        """Mock streaming response."""
+        yield {
+            "message": {"role": "assistant", "content": "response"},
+            "done": True,
+            "done_reason": "stop",
+        }
+
+    with patch(
+        "ollama.AsyncClient.chat",
+        return_value=mock_chat_response(),
+    ) as mock_chat:
+        result = await ai_task.async_generate_data(
+            hass,
+            task_name="Test Keep-Alive Default",
+            entity_id=entity_id,
+            instructions="Test",
+        )
+
+    assert result.data == "response"
+    assert mock_chat.call_count == 1
+    # Default (no CONF_KEEP_ALIVE in subentry data) should fall back to -1 (forever)
+    assert mock_chat.call_args.kwargs["keep_alive"] == DEFAULT_KEEP_ALIVE

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Ollama config flow."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from httpx import ConnectError
 import pytest
@@ -557,3 +557,106 @@ async def test_ai_task_subentry_not_loaded(
 
     assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "entry_not_loaded"
+
+
+async def test_form_with_bearer_token(hass: HomeAssistant) -> None:
+    """Test flow when configuring URL with a bearer token."""
+    result = await hass.config_entries.flow.async_init(
+        ollama.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+
+    with (
+        patch(
+            "homeassistant.components.ollama.config_flow.ollama.AsyncClient",
+        ) as mock_client_cls,
+        patch(
+            "homeassistant.components.ollama.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        mock_client = MagicMock()
+        mock_client.list = MagicMock(return_value={"models": []})
+        mock_client_cls.return_value = mock_client
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ollama.CONF_URL: "http://localhost:11434",
+                ollama.CONF_BEARER_TOKEN: "my-secret-token",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == {
+        ollama.CONF_URL: "http://localhost:11434",
+        ollama.CONF_BEARER_TOKEN: "my-secret-token",
+    }
+
+    # Verify the client was constructed with the Authorization header
+    mock_client_cls.assert_called_once()
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert (
+        call_kwargs.get("headers", {}).get("Authorization") == "Bearer my-secret-token"
+    )
+
+
+async def test_form_without_bearer_token_omits_key(hass: HomeAssistant) -> None:
+    """Test that omitting the bearer token results in no bearer_token key in entry data."""
+    result = await hass.config_entries.flow.async_init(
+        ollama.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with (
+        patch(
+            "homeassistant.components.ollama.config_flow.ollama.AsyncClient.list",
+            return_value={"models": []},
+        ),
+        patch(
+            "homeassistant.components.ollama.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {ollama.CONF_URL: "http://localhost:11434"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    # bearer_token should NOT be present in entry data when not provided
+    assert ollama.CONF_BEARER_TOKEN not in result2["data"]
+
+
+async def test_form_empty_bearer_token_omits_key(hass: HomeAssistant) -> None:
+    """Test that an empty bearer token is treated as absent."""
+    result = await hass.config_entries.flow.async_init(
+        ollama.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    with (
+        patch(
+            "homeassistant.components.ollama.config_flow.ollama.AsyncClient.list",
+            return_value={"models": []},
+        ),
+        patch(
+            "homeassistant.components.ollama.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ollama.CONF_URL: "http://localhost:11434",
+                ollama.CONF_BEARER_TOKEN: "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    # Empty bearer_token should NOT be persisted
+    assert ollama.CONF_BEARER_TOKEN not in result2["data"]

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the Ollama integration."""
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from httpx import ConnectError
 import pytest
@@ -997,3 +997,83 @@ async def test_migrate_entry_from_v3_2(
     assert mock_config_entry.disabled_by == config_entry_disabled_by_after_migration
     assert conversation_device.disabled_by == device_disabled_by_after_migration
     assert conversation_entity.disabled_by == entity_disabled_by_after_migration
+
+
+async def test_setup_entry_with_bearer_token(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a bearer token in entry data is passed as Authorization header."""
+    entry = MockConfigEntry(
+        domain=ollama.DOMAIN,
+        data={
+            ollama.CONF_URL: "http://localhost:11434",
+            ollama.CONF_BEARER_TOKEN: "test-token-123",
+        },
+        version=3,
+        minor_version=3,
+        subentries_data=[
+            {
+                "data": TEST_OPTIONS,
+                "subentry_type": "conversation",
+                "title": "Ollama Conversation",
+                "unique_id": None,
+            }
+        ],
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.ollama.ollama.AsyncClient",
+    ) as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.list = MagicMock(return_value={"models": []})
+        mock_client_cls.return_value = mock_client
+
+        assert await async_setup_component(hass, ollama.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    # Verify the AsyncClient was constructed with the Authorization header
+    mock_client_cls.assert_called_once()
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert (
+        call_kwargs.get("headers", {}).get("Authorization") == "Bearer test-token-123"
+    )
+
+
+async def test_setup_entry_without_bearer_token(
+    hass: HomeAssistant,
+) -> None:
+    """Test that setup works normally when no bearer token is configured."""
+    entry = MockConfigEntry(
+        domain=ollama.DOMAIN,
+        data={
+            ollama.CONF_URL: "http://localhost:11434",
+        },
+        version=3,
+        minor_version=3,
+        subentries_data=[
+            {
+                "data": TEST_OPTIONS,
+                "subentry_type": "conversation",
+                "title": "Ollama Conversation",
+                "unique_id": None,
+            }
+        ],
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.ollama.ollama.AsyncClient",
+    ) as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.list = MagicMock(return_value={"models": []})
+        mock_client_cls.return_value = mock_client
+
+        assert await async_setup_component(hass, ollama.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    # Verify the AsyncClient was constructed WITHOUT an Authorization header
+    mock_client_cls.assert_called_once()
+    call_kwargs = mock_client_cls.call_args.kwargs
+    headers = call_kwargs.get("headers", {})
+    assert "Authorization" not in headers


### PR DESCRIPTION
## Breaking change

No breaking changes.

## Proposed change

The Ollama integration currently does not support any form of authentication. Users running Ollama behind an authenticated proxy (e.g., LiteLLM, nginx with auth) cannot use the integration.

This PR adds an optional `bearer_token` field to the Ollama config flow. When provided, it is passed as an `Authorization: Bearer <token>` header to the Ollama API client. When not provided, the integration works exactly as before.

Fixes #161574

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #161574
- Link to documentation pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.