### PR TITLE
Add missing ON_OFF support and target_temperature_step to ESPHome water heater

### DIFF
--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -63,7 +63,6 @@ class EsphomeWaterHeater(
         self._attr_target_temperature_step = static_info.target_temperature_step
         features = WaterHeaterEntityFeature.TARGET_TEMPERATURE
         if static_info.supported_modes:
-        if static_info.supported_modes:
             features |= WaterHeaterEntityFeature.OPERATION_MODE
             self._attr_operation_list = [
                 _WATER_HEATER_MODES.from_esphome(mode)

--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from functools import partial
 from typing import Any
 
-from aioesphomeapi import EntityInfo, WaterHeaterInfo, WaterHeaterMode, WaterHeaterState
+from aioesphomeapi import (
+    EntityInfo,
+    WaterHeaterFeature,
+    WaterHeaterInfo,
+    WaterHeaterMode,
+    WaterHeaterState,
+)
 
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
@@ -54,6 +60,8 @@ class EsphomeWaterHeater(
         static_info = self._static_info
         self._attr_min_temp = static_info.min_temperature
         self._attr_max_temp = static_info.max_temperature
+        if static_info.target_temperature_step:
+            self._attr_target_temperature_step = static_info.target_temperature_step
         features = WaterHeaterEntityFeature.TARGET_TEMPERATURE
         if static_info.supported_modes:
             features |= WaterHeaterEntityFeature.OPERATION_MODE
@@ -63,6 +71,8 @@ class EsphomeWaterHeater(
             ]
         else:
             self._attr_operation_list = None
+        if static_info.supported_features & WaterHeaterFeature.SUPPORTS_ON_OFF:
+            features |= WaterHeaterEntityFeature.ON_OFF
         self._attr_supported_features = features
 
     @property
@@ -98,6 +108,24 @@ class EsphomeWaterHeater(
         self._client.water_heater_command(
             key=self._key,
             mode=_WATER_HEATER_MODES.from_hass(operation_mode),
+            device_id=self._static_info.device_id,
+        )
+
+    @convert_api_error_ha_error
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the water heater on."""
+        self._client.water_heater_command(
+            key=self._key,
+            on=True,
+            device_id=self._static_info.device_id,
+        )
+
+    @convert_api_error_ha_error
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the water heater off."""
+        self._client.water_heater_command(
+            key=self._key,
+            on=False,
             device_id=self._static_info.device_id,
         )
 

--- a/homeassistant/components/esphome/water_heater.py
+++ b/homeassistant/components/esphome/water_heater.py
@@ -60,9 +60,9 @@ class EsphomeWaterHeater(
         static_info = self._static_info
         self._attr_min_temp = static_info.min_temperature
         self._attr_max_temp = static_info.max_temperature
-        if static_info.target_temperature_step:
-            self._attr_target_temperature_step = static_info.target_temperature_step
+        self._attr_target_temperature_step = static_info.target_temperature_step
         features = WaterHeaterEntityFeature.TARGET_TEMPERATURE
+        if static_info.supported_modes:
         if static_info.supported_modes:
             features |= WaterHeaterEntityFeature.OPERATION_MODE
             self._attr_operation_list = [

--- a/tests/components/esphome/test_water_heater.py
+++ b/tests/components/esphome/test_water_heater.py
@@ -2,13 +2,22 @@
 
 from unittest.mock import call
 
-from aioesphomeapi import APIClient, WaterHeaterInfo, WaterHeaterMode, WaterHeaterState
+from aioesphomeapi import (
+    APIClient,
+    WaterHeaterFeature,
+    WaterHeaterInfo,
+    WaterHeaterMode,
+    WaterHeaterState,
+)
 
 from homeassistant.components.water_heater import (
     ATTR_OPERATION_LIST,
     DOMAIN as WATER_HEATER_DOMAIN,
     SERVICE_SET_OPERATION_MODE,
     SERVICE_SET_TEMPERATURE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    WaterHeaterEntityFeature,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
@@ -182,4 +191,131 @@ async def test_water_heater_set_operation_mode(
 
     mock_client.water_heater_command.assert_has_calls(
         [call(key=1, mode=WaterHeaterMode.GAS, device_id=0)]
+    )
+
+
+async def test_water_heater_on_off(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test turning the water heater on and off."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            supported_features=WaterHeaterFeature.SUPPORTS_ON_OFF,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert state.attributes["supported_features"] & WaterHeaterEntityFeature.ON_OFF
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "water_heater.test_my_boiler"},
+        blocking=True,
+    )
+
+    mock_client.water_heater_command.assert_has_calls(
+        [call(key=1, on=True, device_id=0)]
+    )
+
+    mock_client.water_heater_command.reset_mock()
+
+    await hass.services.async_call(
+        WATER_HEATER_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "water_heater.test_my_boiler"},
+        blocking=True,
+    )
+
+    mock_client.water_heater_command.assert_has_calls(
+        [call(key=1, on=False, device_id=0)]
+    )
+
+
+async def test_water_heater_target_temperature_step(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test target temperature step is respected."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+            target_temperature_step=5.0,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert state.attributes["target_temp_step"] == 5.0
+
+
+async def test_water_heater_no_on_off_without_feature(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_generic_device_entry: MockGenericDeviceEntryType,
+) -> None:
+    """Test ON_OFF feature is not set when not supported."""
+    entity_info = [
+        WaterHeaterInfo(
+            object_id="my_boiler",
+            key=1,
+            name="My Boiler",
+            min_temperature=10.0,
+            max_temperature=85.0,
+        )
+    ]
+    states = [
+        WaterHeaterState(
+            key=1,
+            target_temperature=50.0,
+        )
+    ]
+
+    await mock_generic_device_entry(
+        mock_client=mock_client,
+        entity_info=entity_info,
+        states=states,
+    )
+
+    state = hass.states.get("water_heater.test_my_boiler")
+    assert state is not None
+    assert not (
+        state.attributes["supported_features"] & WaterHeaterEntityFeature.ON_OFF
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The ESPHome water heater integration was missing support for the ON_OFF feature flag and `target_temperature_step`, even though aioesphomeapi already provides both fields.

- Map `WaterHeaterFeature.SUPPORTS_ON_OFF` to `WaterHeaterEntityFeature.ON_OFF` so the water heater entity correctly reports on/off capability
- Read `target_temperature_step` from ESPHome static info so temperature step granularity is respected in the UI
- Add `async_turn_on` and `async_turn_off` methods that call `water_heater_command(on=True/False)`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes esphome/esphome#14605, fixes esphome/esphome#14602
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr