### PR TITLE
Fix Firefly iii sensors not updating

### DIFF
--- a/homeassistant/components/firefly_iii/coordinator.py
+++ b/homeassistant/components/firefly_iii/coordinator.py
@@ -36,10 +36,10 @@ DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
 class FireflyCoordinatorData:
     """Data structure for Firefly III coordinator data."""
 
-    accounts: list[Account]
+    accounts: dict[str, Account]
     categories: list[Category]
-    category_details: list[Category]
-    budgets: list[Budget]
+    category_details: dict[str, Category]
+    budgets: dict[str, Budget]
     bills: list[Bill]
     primary_currency: Currency
 
@@ -142,10 +142,10 @@ class FireflyDataUpdateCoordinator(DataUpdateCoordinator[FireflyCoordinatorData]
             ) from err
 
         return FireflyCoordinatorData(
-            accounts=accounts,
+            accounts={account.id: account for account in accounts},
             categories=categories,
-            category_details=category_details,
-            budgets=budgets,
+            category_details={category.id: category for category in category_details},
+            budgets={budget.id: budget for budget in budgets},
             bills=bills,
             primary_currency=primary_currency,
         )

--- a/homeassistant/components/firefly_iii/entity.py
+++ b/homeassistant/components/firefly_iii/entity.py
@@ -58,6 +58,14 @@ class FireflyAccountBaseEntity(FireflyBaseEntity):
             f"{coordinator.config_entry.unique_id}_account_{account.id}_{key}"
         )
 
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for account in self.coordinator.data.accounts:
+            if account.id == self._account.id:
+                self._account = account
+                break
+        super()._handle_coordinator_update()
+
 
 class FireflyCategoryBaseEntity(FireflyBaseEntity):
     """Base class for Firefly III category entity."""
@@ -84,6 +92,14 @@ class FireflyCategoryBaseEntity(FireflyBaseEntity):
             f"{coordinator.config_entry.unique_id}_category_{category.id}_{key}"
         )
 
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for category in self.coordinator.data.category_details:
+            if category.id == self._category.id:
+                self._category = category
+                break
+        super()._handle_coordinator_update()
+
 
 class FireflyBudgetBaseEntity(FireflyBaseEntity):
     """Base class for Firefly III budget entity."""
@@ -109,3 +125,11 @@ class FireflyBudgetBaseEntity(FireflyBaseEntity):
         self._attr_unique_id = (
             f"{coordinator.config_entry.unique_id}_budget_{budget.id}_{key}"
         )
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        for budget in self.coordinator.data.budgets:
+            if budget.id == self._budget.id:
+                self._budget = budget
+                break
+        super()._handle_coordinator_update()

--- a/homeassistant/components/firefly_iii/entity.py
+++ b/homeassistant/components/firefly_iii/entity.py
@@ -44,7 +44,7 @@ class FireflyAccountBaseEntity(FireflyBaseEntity):
     ) -> None:
         """Initialize a Firefly account entity."""
         super().__init__(coordinator)
-        self._account = account
+        self._account_id = account.id
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=MANUFACTURER,
@@ -58,13 +58,9 @@ class FireflyAccountBaseEntity(FireflyBaseEntity):
             f"{coordinator.config_entry.unique_id}_account_{account.id}_{key}"
         )
 
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        for account in self.coordinator.data.accounts:
-            if account.id == self._account.id:
-                self._account = account
-                break
-        super()._handle_coordinator_update()
+    @property
+    def _account(self) -> Account:
+        return self.coordinator.data.accounts[self._account_id]
 
 
 class FireflyCategoryBaseEntity(FireflyBaseEntity):
@@ -78,7 +74,7 @@ class FireflyCategoryBaseEntity(FireflyBaseEntity):
     ) -> None:
         """Initialize a Firefly category entity."""
         super().__init__(coordinator)
-        self._category = category
+        self._category_id = category.id
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=MANUFACTURER,
@@ -92,13 +88,9 @@ class FireflyCategoryBaseEntity(FireflyBaseEntity):
             f"{coordinator.config_entry.unique_id}_category_{category.id}_{key}"
         )
 
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        for category in self.coordinator.data.category_details:
-            if category.id == self._category.id:
-                self._category = category
-                break
-        super()._handle_coordinator_update()
+    @property
+    def _category(self) -> Category:
+        return self.coordinator.data.category_details[self._category_id]
 
 
 class FireflyBudgetBaseEntity(FireflyBaseEntity):
@@ -112,7 +104,7 @@ class FireflyBudgetBaseEntity(FireflyBaseEntity):
     ) -> None:
         """Initialize a Firefly budget entity."""
         super().__init__(coordinator)
-        self._budget = budget
+        self._budget_id = budget.id
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             manufacturer=MANUFACTURER,
@@ -126,10 +118,6 @@ class FireflyBudgetBaseEntity(FireflyBaseEntity):
             f"{coordinator.config_entry.unique_id}_budget_{budget.id}_{key}"
         )
 
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        for budget in self.coordinator.data.budgets:
-            if budget.id == self._budget.id:
-                self._budget = budget
-                break
-        super()._handle_coordinator_update()
+    @property
+    def _budget(self) -> Budget:
+        return self.coordinator.data.budgets[self._budget_id]

--- a/homeassistant/components/firefly_iii/sensor.py
+++ b/homeassistant/components/firefly_iii/sensor.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
     entities: list[SensorEntity] = []
 
-    for account in coordinator.data.accounts:
+    for account in coordinator.data.accounts.values():
         entities.append(
             FireflyAccountBalanceSensor(coordinator, account, ACCOUNT_BALANCE)
         )
@@ -61,14 +61,14 @@ async def async_setup_entry(
     entities.extend(
         [
             FireflyCategorySensor(coordinator, category, CATEGORY)
-            for category in coordinator.data.category_details
+            for category in coordinator.data.category_details.values()
         ]
     )
 
     entities.extend(
         [
             FireflyBudgetSensor(coordinator, budget, BUDGET)
-            for budget in coordinator.data.budgets
+            for budget in coordinator.data.budgets.values()
         ]
     )
 
@@ -90,7 +90,6 @@ class FireflyAccountBalanceSensor(FireflyAccountBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the account balance sensor."""
         super().__init__(coordinator, account, key)
-        self._account = account
         self._attr_native_unit_of_measurement = (
             coordinator.data.primary_currency.attributes.code
         )
@@ -107,16 +106,6 @@ class FireflyAccountRoleSensor(FireflyAccountBaseEntity, SensorEntity):
     _attr_translation_key = "account_role"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = True
-
-    def __init__(
-        self,
-        coordinator: FireflyDataUpdateCoordinator,
-        account: Account,
-        key: str,
-    ) -> None:
-        """Initialize the account role sensor."""
-        super().__init__(coordinator, account, key)
-        self._account = account
 
     @property
     def native_value(self) -> StateType:
@@ -173,7 +162,6 @@ class FireflyCategorySensor(FireflyCategoryBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the category sensor."""
         super().__init__(coordinator, category, key)
-        self._category = category
         self._attr_native_unit_of_measurement = (
             coordinator.data.primary_currency.attributes.code
         )
@@ -205,7 +193,6 @@ class FireflyBudgetSensor(FireflyBudgetBaseEntity, SensorEntity):
     ) -> None:
         """Initialize the budget sensor."""
         super().__init__(coordinator, budget, key)
-        self._budget = budget
         self._attr_native_unit_of_measurement = (
             coordinator.data.primary_currency.attributes.code
         )

--- a/tests/components/firefly_iii/snapshots/test_sensor.ambr
+++ b/tests/components/firefly_iii/snapshots/test_sensor.ambr
@@ -181,7 +181,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:hand-coin',
+    'original_icon': 'mdi:cash-plus',
     'original_name': 'Account Type',
     'platform': 'firefly_iii',
     'previous_unique_id': None,
@@ -196,14 +196,14 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Credit Card Account Type',
-      'icon': 'mdi:hand-coin',
+      'icon': 'mdi:cash-plus',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.credit_card_account_type',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'liability',
+    'state': 'revenue',
   })
 # ---
 # name: test_all_entities[sensor.lunch_earned_spent-entry]

--- a/tests/components/firefly_iii/test_sensor.py
+++ b/tests/components/firefly_iii/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for the Firefly III  sensor platform."""
 
+from copy import deepcopy
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -8,9 +9,11 @@ from pyfirefly.exceptions import (
     FireflyConnectionError,
     FireflyTimeoutError,
 )
+from pyfirefly.models import Budget
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.firefly_iii.const import DOMAIN
 from homeassistant.components.firefly_iii.coordinator import DEFAULT_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
@@ -20,7 +23,12 @@ from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    load_json_array_fixture,
+    snapshot_platform,
+)
 
 
 async def test_all_entities(
@@ -69,3 +77,30 @@ async def test_refresh_exceptions(
     state = hass.states.get("sensor.credit_card_account_balance")
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
+
+
+async def test_budget_sensor_updates_after_refresh(
+    hass: HomeAssistant,
+    mock_firefly_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test budget sensor tracks refreshed coordinator budget objects."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.bills_budget")
+    assert state is not None
+    assert state.state == "123.45"
+
+    updated_budget_data = load_json_array_fixture("budgets.json", DOMAIN)
+    updated_budget = deepcopy(updated_budget_data[0])
+    updated_budget["attributes"]["spent"][0]["sum"] = "999.99"
+    mock_firefly_client.get_budgets.return_value = [Budget.from_dict(updated_budget)]
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    updated_state = hass.states.get("sensor.bills_budget")
+    assert updated_state is not None
+    assert updated_state.state == "999.99"

--- a/tests/components/firefly_iii/test_sensor.py
+++ b/tests/components/firefly_iii/test_sensor.py
@@ -26,7 +26,7 @@ from . import setup_integration
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
-    load_json_array_fixture,
+    async_load_json_array_fixture,
     snapshot_platform,
 )
 
@@ -92,7 +92,9 @@ async def test_budget_sensor_updates_after_refresh(
     assert state is not None
     assert state.state == "123.45"
 
-    updated_budget_data = load_json_array_fixture("budgets.json", DOMAIN)
+    updated_budget_data = await async_load_json_array_fixture(
+        hass, "budgets.json", DOMAIN
+    )
     updated_budget = deepcopy(updated_budget_data[0])
     updated_budget["attributes"]["spent"][0]["sum"] = "999.99"
     mock_firefly_client.get_budgets.return_value = [Budget.from_dict(updated_budget)]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request fixes a coordinator update bug in the Firefly III integration where some sensors could remain stale after refreshes, especially budget and category based values.
The root cause was that entities kept references to model objects created during initial setup, while the coordinator later replaced those objects on refresh. As a result, entities continued reading old data even though fresh API data was available.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #157359
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
