### PR TITLE
Add Bitvis Power Hub integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -117,6 +117,7 @@ homeassistant.components.bang_olufsen.*
 homeassistant.components.bayesian.*
 homeassistant.components.binary_sensor.*
 homeassistant.components.bitcoin.*
+homeassistant.components.bitvis.*
 homeassistant.components.blockchain.*
 homeassistant.components.blue_current.*
 homeassistant.components.blueprint.*

--- a/.strict-typing
+++ b/.strict-typing
@@ -118,6 +118,7 @@ homeassistant.components.bayesian.*
 homeassistant.components.besen.*
 homeassistant.components.binary_sensor.*
 homeassistant.components.bitcoin.*
+homeassistant.components.bitvis.*
 homeassistant.components.blockchain.*
 homeassistant.components.blue_current.*
 homeassistant.components.blueprint.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -233,6 +233,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/besen/ @moryoav
 /homeassistant/components/binary_sensor/ @home-assistant/core
 /tests/components/binary_sensor/ @home-assistant/core
+/homeassistant/components/bitvis/ @MandusBorjesson @real-tintin @simontegelid
+/tests/components/bitvis/ @MandusBorjesson @real-tintin @simontegelid
 /homeassistant/components/bizkaibus/ @UgaitzEtxebarria
 /homeassistant/components/blebox/ @bbx-a @swistakm @bkobus-bbx
 /tests/components/blebox/ @bbx-a @swistakm @bkobus-bbx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -231,6 +231,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/bayesian/ @HarvsG
 /homeassistant/components/binary_sensor/ @home-assistant/core
 /tests/components/binary_sensor/ @home-assistant/core
+/homeassistant/components/bitvis/ @MandusBorjesson @real-tintin @simontegelid
+/tests/components/bitvis/ @MandusBorjesson @real-tintin @simontegelid
 /homeassistant/components/bizkaibus/ @UgaitzEtxebarria
 /homeassistant/components/blebox/ @bbx-a @swistakm @bkobus-bbx
 /tests/components/blebox/ @bbx-a @swistakm @bkobus-bbx

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -1,0 +1,33 @@
+"""The Bitvis Power Hub integration."""
+
+import logging
+
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import BitvisConfigEntry, BitvisDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
+    """Set up Bitvis Power Hub from a config entry."""
+    coordinator = BitvisDataUpdateCoordinator(
+        hass, entry, entry.data[CONF_HOST], entry.data[CONF_PORT]
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+    entry.async_on_unload(coordinator.async_stop)
+
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -1,13 +1,9 @@
 """The Bitvis Power Hub integration."""
 
-import logging
-
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import BitvisConfigEntry, BitvisDataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
 

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -1,6 +1,6 @@
 """The Bitvis Power Hub integration."""
 
-from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.const import CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
 from .coordinator import BitvisConfigEntry, BitvisDataUpdateCoordinator
@@ -15,7 +15,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bo
     coordinator = BitvisDataUpdateCoordinator(
         hass,
         entry,
-        entry.data[CONF_HOST],
         entry.data[CONF_PORT],
         unique_id,
     )

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -1,0 +1,39 @@
+"""The Bitvis Power Hub integration."""
+
+import logging
+
+from homeassistant.const import CONF_HOST, CONF_PORT, Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import BitvisConfigEntry, BitvisDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+_PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
+    """Set up Bitvis Power Hub from a config entry."""
+    unique_id = entry.unique_id
+    assert unique_id is not None
+    coordinator = BitvisDataUpdateCoordinator(
+        hass,
+        entry,
+        entry.data[CONF_HOST],
+        entry.data[CONF_PORT],
+        unique_id,
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+    entry.async_on_unload(coordinator.async_stop)
+
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -1,5 +1,7 @@
 """The Bitvis Power Hub integration."""
 
+from typing import TYPE_CHECKING
+
 from homeassistant.const import CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
@@ -26,6 +28,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
     """Set up Bitvis Power Hub from a config entry."""
     async_get_listener_registry(hass)
+    if TYPE_CHECKING:
+        assert entry.unique_id is not None
     coordinator = BitvisDataUpdateCoordinator(
         hass,
         entry,
@@ -45,8 +49,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bo
 async def async_unload_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
-    if unload_ok and hasattr(entry, "runtime_data"):
+    if unload_ok:
         await entry.runtime_data.async_stop()
-    if not hass.config_entries.async_loaded_entries(DOMAIN):
-        hass.data.pop(DATA_LISTENER_REGISTRY, None)
+        if not hass.config_entries.async_loaded_entries(DOMAIN):
+            hass.data.pop(DATA_LISTENER_REGISTRY, None)
     return unload_ok

--- a/homeassistant/components/bitvis/__init__.py
+++ b/homeassistant/components/bitvis/__init__.py
@@ -2,27 +2,40 @@
 
 from homeassistant.const import CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 
-from .coordinator import BitvisConfigEntry, BitvisDataUpdateCoordinator
+from .const import DATA_LISTENER_REGISTRY, DOMAIN
+from .coordinator import (
+    BitvisConfigEntry,
+    BitvisDataUpdateCoordinator,
+    async_get_listener_registry,
+)
 
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Bitvis Power Hub integration."""
+    async_get_listener_registry(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
     """Set up Bitvis Power Hub from a config entry."""
-    unique_id = entry.unique_id
-    assert unique_id is not None
+    async_get_listener_registry(hass)
     coordinator = BitvisDataUpdateCoordinator(
         hass,
         entry,
         entry.data[CONF_PORT],
-        unique_id,
+        entry.unique_id,
     )
 
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
-    entry.async_on_unload(coordinator.async_stop)
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
@@ -31,4 +44,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BitvisConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    if unload_ok and hasattr(entry, "runtime_data"):
+        await entry.runtime_data.async_stop()
+    if not hass.config_entries.async_loaded_entries(DOMAIN):
+        hass.data.pop(DATA_LISTENER_REGISTRY, None)
+    return unload_ok

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import logging
-from typing import Any, override
+from typing import Any, Self, override
 
 from bitvis_protobuf.listener import FilterIp
 from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
 from bitvis_protobuf.utils import (
+    InvalidMacAddressError,
     async_resolve_host,
     async_verify_udp_port_bindable,
     normalize_host,
@@ -16,14 +17,21 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .const import DEFAULT_NAME, DEFAULT_PORT, DISCOVERY_TIMEOUT, DOMAIN, MODEL_NAME
+from .const import DEFAULT_NAME, DEFAULT_PORT, DISCOVERY_TIMEOUT, DOMAIN
 from .coordinator import async_get_listener_registry
 
 _LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+    }
+)
 
 
 async def _async_test_port(hass: HomeAssistant, port: int) -> None:
@@ -52,16 +60,31 @@ async def _async_discover_mac_address(hass: HomeAssistant, host: str, port: int)
             future.set_result(payload.mac_address)
 
     filters: list[FilterIp] = []
+    original_dispatch = listener.dispatch
+
+    def dispatch(data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            original_dispatch(data, addr)
+        except InvalidMacAddressError as err:
+            if not future.done():
+                future.set_exception(err)
+
+    listener.dispatch = dispatch  # type: ignore[method-assign]
     try:
         for ip in resolved_ips:
             filt = FilterIp(ip)
-            listener.register(filt, _on_payload)
+            try:
+                listener.register(filt, _on_payload)
+            except RuntimeError as err:
+                raise AbortFlow("already_in_progress") from err
             filters.append(filt)
 
         return await asyncio.wait_for(future, timeout=DISCOVERY_TIMEOUT)
     finally:
+        listener.dispatch = original_dispatch  # type: ignore[method-assign]
         for filt in filters:
             listener.unregister(filt)
+        await listener_registry.async_remove_if_unused(port)
 
 
 class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -71,6 +94,16 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovery_info: ZeroconfServiceInfo | None = None
         self._validated_host: str | None = None
+        self._host: str | None = None
+
+    @override
+    def is_matching(self, other_flow: Self) -> bool:
+        """Return True if other_flow is matching this flow."""
+        return (
+            self._host is not None
+            and other_flow._host is not None
+            and normalize_host(self._host) == normalize_host(other_flow._host)
+        )
 
     def _get_friendly_name(self, name: str | None) -> str:
         """Return a user-friendly name derived from the zeroconf name."""
@@ -88,24 +121,39 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         self, host: str, title: str
     ) -> ConfigFlowResult:
         """Validate connectivity, discover MAC address, and create the entry."""
+        self._host = host
+        if self.hass.config_entries.flow.async_has_matching_flow(self):
+            return self.async_abort(reason="already_in_progress")
+
         try:
             mac_address = await self._async_validate_host(host)
         except TimeoutError:
             return self.async_show_form(
                 step_id="user",
-                data_schema=vol.Schema({vol.Required(CONF_HOST): cv.string}),
+                data_schema=self.add_suggested_values_to_schema(
+                    STEP_USER_DATA_SCHEMA, {CONF_HOST: host}
+                ),
                 errors={"base": "timeout_connect"},
+            )
+        except InvalidMacAddressError:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.add_suggested_values_to_schema(
+                    STEP_USER_DATA_SCHEMA, {CONF_HOST: host}
+                ),
+                errors={"base": "invalid_mac"},
             )
         except OSError:
             return self.async_show_form(
                 step_id="user",
-                data_schema=vol.Schema({vol.Required(CONF_HOST): cv.string}),
+                data_schema=self.add_suggested_values_to_schema(
+                    STEP_USER_DATA_SCHEMA, {CONF_HOST: host}
+                ),
                 errors={"base": "cannot_connect"},
             )
 
         await self.async_set_unique_id(format_mac(mac_address))
         self._abort_if_unique_id_configured()
-        self._async_abort_entries_match({CONF_HOST: host})
 
         return self.async_create_entry(
             title=title,
@@ -122,17 +170,14 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if user_input is not None:
             host = normalize_host(user_input[CONF_HOST])
-            return await self._async_create_entry_from_host(host, MODEL_NAME)
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_HOST): cv.string,
-            }
-        )
+            self._async_abort_entries_match({CONF_HOST: host})
+            return await self._async_create_entry_from_host(host, DEFAULT_NAME)
 
         return self.async_show_form(
             step_id="user",
-            data_schema=data_schema,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
         )
 
     @override
@@ -143,13 +188,19 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Discovered Bitvis Power Hub via Zeroconf: %s", discovery_info)
 
         host = discovery_info.host
+        self._host = host
 
         self._async_abort_entries_match({CONF_HOST: host})
+
+        if self.hass.config_entries.flow.async_has_matching_flow(self):
+            return self.async_abort(reason="already_in_progress")
 
         try:
             mac_address = await self._async_validate_host(host)
         except TimeoutError:
             return self.async_abort(reason="timeout_connect")
+        except InvalidMacAddressError:
+            return self.async_abort(reason="invalid_mac")
         except OSError:
             return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -3,11 +3,7 @@
 import logging
 from typing import Any, override
 
-from bitvis_protobuf.utils import (
-    async_verify_udp_port_bindable,
-    get_mac_address_for_host,
-    normalize_host,
-)
+from bitvis_protobuf.utils import async_verify_udp_port_bindable, normalize_host
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -21,6 +17,8 @@ from .coordinator import async_get_listener_registry
 
 _LOGGER = logging.getLogger(__name__)
 
+_SINGLE_INSTANCE_UNIQUE_ID = DOMAIN
+
 
 async def _async_test_port(hass: HomeAssistant, port: int) -> None:
     """Verify the UDP port can be bound."""
@@ -29,11 +27,6 @@ async def _async_test_port(hass: HomeAssistant, port: int) -> None:
         return
 
     await async_verify_udp_port_bindable(port)
-
-
-async def _async_get_device_unique_id(hass: HomeAssistant, host: str) -> str:
-    """Resolve *host* and look up a MAC address for the config entry unique ID."""
-    return await hass.async_add_executor_job(get_mac_address_for_host, host)
 
 
 class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -59,30 +52,27 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             host = normalize_host(user_input[CONF_HOST])
-            port = user_input[CONF_PORT]
+
+            await self.async_set_unique_id(_SINGLE_INSTANCE_UNIQUE_ID)
+            self._abort_if_unique_id_configured()
+            self._async_abort_entries_match({CONF_HOST: host})
 
             try:
-                await _async_test_port(self.hass, port)
+                await _async_test_port(self.hass, DEFAULT_PORT)
             except OSError:
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(
-                    await _async_get_device_unique_id(self.hass, host)
-                )
-                self._abort_if_unique_id_configured()
-
                 return self.async_create_entry(
                     title=MODEL_NAME,
                     data={
                         CONF_HOST: host,
-                        CONF_PORT: port,
+                        CONF_PORT: DEFAULT_PORT,
                     },
                 )
 
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_HOST): cv.string,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
             }
         )
 
@@ -101,10 +91,9 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
 
         host = discovery_info.host
 
-        await self.async_set_unique_id(
-            await _async_get_device_unique_id(self.hass, host)
-        )
+        await self.async_set_unique_id(_SINGLE_INSTANCE_UNIQUE_ID)
         self._abort_if_unique_id_configured()
+        self._async_abort_entries_match({CONF_HOST: host})
 
         self._discovery_info = discovery_info
 
@@ -123,10 +112,9 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             assert self._discovery_info is not None
             host = self._discovery_info.host
-            port = self._discovery_info.port or DEFAULT_PORT
 
             try:
-                await _async_test_port(self.hass, port)
+                await _async_test_port(self.hass, DEFAULT_PORT)
             except OSError:
                 return self.async_abort(reason="cannot_connect")
 
@@ -134,7 +122,7 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
                 title=self._get_friendly_name(self._discovery_info.name),
                 data={
                     CONF_HOST: host,
-                    CONF_PORT: port,
+                    CONF_PORT: DEFAULT_PORT,
                 },
             )
 

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -1,0 +1,149 @@
+"""Config flow for the Bitvis Power Hub integration."""
+
+import logging
+from typing import Any, override
+
+from bitvis_protobuf.utils import (
+    async_verify_udp_port_bindable,
+    get_mac_address_for_host,
+    normalize_host,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN, MODEL_NAME
+from .coordinator import async_get_listener_registry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_test_port(hass: HomeAssistant, port: int) -> None:
+    """Verify the UDP port can be bound."""
+
+    if async_get_listener_registry(hass).has_listener(port):
+        return
+
+    await async_verify_udp_port_bindable(port)
+
+
+async def _async_get_device_unique_id(hass: HomeAssistant, host: str) -> str:
+    """Resolve *host* and look up a MAC address for the config entry unique ID."""
+    return await hass.async_add_executor_job(get_mac_address_for_host, host)
+
+
+class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Bitvis Power Hub."""
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: ZeroconfServiceInfo | None = None
+
+    def _get_friendly_name(self, name: str | None) -> str:
+        """Return a user-friendly name derived from the zeroconf name."""
+        if not name:
+            return DEFAULT_NAME
+        instance = name.split(".", 1)[0]
+        return instance or DEFAULT_NAME
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = normalize_host(user_input[CONF_HOST])
+            port = user_input[CONF_PORT]
+
+            try:
+                await _async_test_port(self.hass, port)
+            except OSError:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(
+                    await _async_get_device_unique_id(self.hass, host)
+                )
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=MODEL_NAME,
+                    data={
+                        CONF_HOST: host,
+                        CONF_PORT: port,
+                    },
+                )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    @override
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        _LOGGER.debug("Discovered Bitvis Power Hub via Zeroconf: %s", discovery_info)
+
+        host = discovery_info.host
+
+        await self.async_set_unique_id(
+            await _async_get_device_unique_id(self.hass, host)
+        )
+        self._abort_if_unique_id_configured()
+
+        self._discovery_info = discovery_info
+
+        # Show confirmation to user
+        self.context["title_placeholders"] = {
+            "name": self._get_friendly_name(discovery_info.name),
+            "host": host,
+        }
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovery."""
+        if user_input is not None:
+            assert self._discovery_info is not None
+            host = self._discovery_info.host
+            port = self._discovery_info.port or DEFAULT_PORT
+
+            try:
+                await _async_test_port(self.hass, port)
+            except OSError:
+                return self.async_abort(reason="cannot_connect")
+
+            return self.async_create_entry(
+                title=self._get_friendly_name(self._discovery_info.name),
+                data={
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={
+                "name": self._get_friendly_name(
+                    self._discovery_info.name if self._discovery_info else None
+                ),
+                "host": self._discovery_info.host if self._discovery_info else "",
+            },
+        )

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -34,6 +34,14 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+def _get_friendly_name(name: str | None) -> str:
+    """Return a user-friendly name derived from the zeroconf name."""
+    if not name:
+        return DEFAULT_NAME
+    instance = name.split(".", 1)[0]
+    return instance or DEFAULT_NAME
+
+
 async def _async_test_port(hass: HomeAssistant, port: int) -> None:
     """Verify the UDP port can be bound."""
 
@@ -59,17 +67,13 @@ async def _async_discover_mac_address(hass: HomeAssistant, host: str, port: int)
         if not future.done():
             future.set_result(payload.mac_address)
 
+    @callback
+    def _on_error(err: Exception, _addr: tuple[str, int]) -> None:
+        if not future.done() and isinstance(err, InvalidMacAddressError):
+            future.set_exception(err)
+
     filters: list[FilterIp] = []
-    original_dispatch = listener.dispatch
-
-    def dispatch(data: bytes, addr: tuple[str, int]) -> None:
-        try:
-            original_dispatch(data, addr)
-        except InvalidMacAddressError as err:
-            if not future.done():
-                future.set_exception(err)
-
-    listener.dispatch = dispatch  # type: ignore[method-assign]
+    listener.register_error_callback(_on_error)
     try:
         for ip in resolved_ips:
             filt = FilterIp(ip)
@@ -81,7 +85,7 @@ async def _async_discover_mac_address(hass: HomeAssistant, host: str, port: int)
 
         return await asyncio.wait_for(future, timeout=DISCOVERY_TIMEOUT)
     finally:
-        listener.dispatch = original_dispatch  # type: ignore[method-assign]
+        listener.unregister_error_callback(_on_error)
         for filt in filters:
             listener.unregister(filt)
         await listener_registry.async_remove_if_unused(port)
@@ -99,18 +103,7 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
     @override
     def is_matching(self, other_flow: Self) -> bool:
         """Return True if other_flow is matching this flow."""
-        return (
-            self._host is not None
-            and other_flow._host is not None
-            and normalize_host(self._host) == normalize_host(other_flow._host)
-        )
-
-    def _get_friendly_name(self, name: str | None) -> str:
-        """Return a user-friendly name derived from the zeroconf name."""
-        if not name:
-            return DEFAULT_NAME
-        instance = name.split(".", 1)[0]
-        return instance or DEFAULT_NAME
+        return self._host is not None and self._host == other_flow._host
 
     async def _async_validate_host(self, host: str) -> str:
         """Verify port availability and discover the device MAC address."""
@@ -175,9 +168,7 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, user_input
-            ),
+            data_schema=STEP_USER_DATA_SCHEMA,
         )
 
     @override
@@ -205,13 +196,13 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_connect")
 
         await self.async_set_unique_id(format_mac(mac_address))
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
         self._discovery_info = discovery_info
         self._validated_host = host
 
         self.context["title_placeholders"] = {
-            "name": self._get_friendly_name(discovery_info.name),
+            "name": _get_friendly_name(discovery_info.name),
             "host": host,
         }
 
@@ -221,12 +212,13 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm discovery."""
+        assert self._discovery_info is not None
+
         if user_input is not None:
-            assert self._discovery_info is not None
             assert self._validated_host is not None
 
             return self.async_create_entry(
-                title=self._get_friendly_name(self._discovery_info.name),
+                title=_get_friendly_name(self._discovery_info.name),
                 data={
                     CONF_HOST: self._validated_host,
                     CONF_PORT: DEFAULT_PORT,
@@ -236,9 +228,7 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="zeroconf_confirm",
             description_placeholders={
-                "name": self._get_friendly_name(
-                    self._discovery_info.name if self._discovery_info else None
-                ),
-                "host": self._discovery_info.host if self._discovery_info else "",
+                "name": _get_friendly_name(self._discovery_info.name),
+                "host": self._discovery_info.host,
             },
         )

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -1,0 +1,193 @@
+"""Config flow for the Bitvis Power Hub integration."""
+
+import asyncio
+import logging
+from typing import Any, override
+
+from bitvis_protobuf.listener import FilterIp
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+from bitvis_protobuf.utils import (
+    async_resolve_host,
+    async_verify_udp_port_bindable,
+    normalize_host,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .const import DEFAULT_NAME, DEFAULT_PORT, DISCOVERY_TIMEOUT, DOMAIN, MODEL_NAME
+from .coordinator import async_get_listener_registry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_test_port(hass: HomeAssistant, port: int) -> None:
+    """Verify the UDP port can be bound."""
+
+    if async_get_listener_registry(hass).has_listener(port):
+        return
+
+    await async_verify_udp_port_bindable(port)
+
+
+async def _async_discover_mac_address(hass: HomeAssistant, host: str, port: int) -> str:
+    """Wait for a UDP message from the device and return its MAC address."""
+    resolved_ips = await async_resolve_host(host)
+    listener_registry = async_get_listener_registry(hass)
+    listener = await listener_registry.async_get_or_create(port)
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[str] = loop.create_future()
+
+    @callback
+    def _on_payload(
+        payload: PayloadSample | PayloadDiagnostic, _addr: tuple[str, int]
+    ) -> None:
+        if not future.done():
+            future.set_result(payload.mac_address)
+
+    filters: list[FilterIp] = []
+    try:
+        for ip in resolved_ips:
+            filt = FilterIp(ip)
+            listener.register(filt, _on_payload)
+            filters.append(filt)
+
+        return await asyncio.wait_for(future, timeout=DISCOVERY_TIMEOUT)
+    finally:
+        for filt in filters:
+            listener.unregister(filt)
+
+
+class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Bitvis Power Hub."""
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovery_info: ZeroconfServiceInfo | None = None
+        self._validated_host: str | None = None
+
+    def _get_friendly_name(self, name: str | None) -> str:
+        """Return a user-friendly name derived from the zeroconf name."""
+        if not name:
+            return DEFAULT_NAME
+        instance = name.split(".", 1)[0]
+        return instance or DEFAULT_NAME
+
+    async def _async_validate_host(self, host: str) -> str:
+        """Verify port availability and discover the device MAC address."""
+        await _async_test_port(self.hass, DEFAULT_PORT)
+        return await _async_discover_mac_address(self.hass, host, DEFAULT_PORT)
+
+    async def _async_create_entry_from_host(
+        self, host: str, title: str
+    ) -> ConfigFlowResult:
+        """Validate connectivity, discover MAC address, and create the entry."""
+        try:
+            mac_address = await self._async_validate_host(host)
+        except TimeoutError:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema({vol.Required(CONF_HOST): cv.string}),
+                errors={"base": "timeout_connect"},
+            )
+        except OSError:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema({vol.Required(CONF_HOST): cv.string}),
+                errors={"base": "cannot_connect"},
+            )
+
+        await self.async_set_unique_id(format_mac(mac_address))
+        self._abort_if_unique_id_configured()
+        self._async_abort_entries_match({CONF_HOST: host})
+
+        return self.async_create_entry(
+            title=title,
+            data={
+                CONF_HOST: host,
+                CONF_PORT: DEFAULT_PORT,
+            },
+        )
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            host = normalize_host(user_input[CONF_HOST])
+            return await self._async_create_entry_from_host(host, MODEL_NAME)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=data_schema,
+        )
+
+    @override
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        _LOGGER.debug("Discovered Bitvis Power Hub via Zeroconf: %s", discovery_info)
+
+        host = discovery_info.host
+
+        self._async_abort_entries_match({CONF_HOST: host})
+
+        try:
+            mac_address = await self._async_validate_host(host)
+        except TimeoutError:
+            return self.async_abort(reason="timeout_connect")
+        except OSError:
+            return self.async_abort(reason="cannot_connect")
+
+        await self.async_set_unique_id(format_mac(mac_address))
+        self._abort_if_unique_id_configured()
+
+        self._discovery_info = discovery_info
+        self._validated_host = host
+
+        self.context["title_placeholders"] = {
+            "name": self._get_friendly_name(discovery_info.name),
+            "host": host,
+        }
+
+        return await self.async_step_zeroconf_confirm()
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm discovery."""
+        if user_input is not None:
+            assert self._discovery_info is not None
+            assert self._validated_host is not None
+
+            return self.async_create_entry(
+                title=self._get_friendly_name(self._discovery_info.name),
+                data={
+                    CONF_HOST: self._validated_host,
+                    CONF_PORT: DEFAULT_PORT,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={
+                "name": self._get_friendly_name(
+                    self._discovery_info.name if self._discovery_info else None
+                ),
+                "host": self._discovery_info.host if self._discovery_info else "",
+            },
+        )

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -68,8 +68,12 @@ async def _async_discover_mac_address(hass: HomeAssistant, host: str, port: int)
             future.set_result(payload.mac_address)
 
     @callback
-    def _on_error(err: Exception, _addr: tuple[str, int]) -> None:
-        if not future.done() and isinstance(err, InvalidMacAddressError):
+    def _on_error(err: Exception, addr: tuple[str, int]) -> None:
+        if (
+            addr[0] in resolved_ips
+            and not future.done()
+            and isinstance(err, InvalidMacAddressError)
+        ):
             future.set_exception(err)
 
     filters: list[FilterIp] = []

--- a/homeassistant/components/bitvis/config_flow.py
+++ b/homeassistant/components/bitvis/config_flow.py
@@ -163,7 +163,6 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if user_input is not None:
             host = normalize_host(user_input[CONF_HOST])
-            self._async_abort_entries_match({CONF_HOST: host})
             return await self._async_create_entry_from_host(host, DEFAULT_NAME)
 
         return self.async_show_form(
@@ -180,8 +179,6 @@ class BitvisConfigFlow(ConfigFlow, domain=DOMAIN):
 
         host = discovery_info.host
         self._host = host
-
-        self._async_abort_entries_match({CONF_HOST: host})
 
         if self.hass.config_entries.flow.async_has_matching_flow(self):
             return self.async_abort(reason="already_in_progress")

--- a/homeassistant/components/bitvis/const.py
+++ b/homeassistant/components/bitvis/const.py
@@ -1,0 +1,19 @@
+"""Constants for the Bitvis Power Hub integration."""
+
+from typing import TYPE_CHECKING
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .coordinator import BitvisListenerRegistry
+
+DOMAIN = "bitvis"
+MANUFACTURER = "Bitvis"
+MODEL_NAME = "Power Hub"
+
+ZEROCONF_SERVICE_TYPE = "_powerhub._udp.local."
+
+DEFAULT_NAME = "Bitvis Power Hub"
+DEFAULT_PORT = 58220
+
+DATA_LISTENER_REGISTRY: HassKey[BitvisListenerRegistry] = HassKey(DOMAIN)

--- a/homeassistant/components/bitvis/const.py
+++ b/homeassistant/components/bitvis/const.py
@@ -11,8 +11,6 @@ DOMAIN = "bitvis"
 MANUFACTURER = "Bitvis"
 MODEL_NAME = "Power Hub"
 
-ZEROCONF_SERVICE_TYPE = "_powerhub._udp.local."
-
 DEFAULT_NAME = "Bitvis Power Hub"
 DEFAULT_PORT = 58220
 DISCOVERY_TIMEOUT = 30

--- a/homeassistant/components/bitvis/const.py
+++ b/homeassistant/components/bitvis/const.py
@@ -1,0 +1,20 @@
+"""Constants for the Bitvis Power Hub integration."""
+
+from typing import TYPE_CHECKING
+
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .coordinator import BitvisListenerRegistry
+
+DOMAIN = "bitvis"
+MANUFACTURER = "Bitvis"
+MODEL_NAME = "Power Hub"
+
+ZEROCONF_SERVICE_TYPE = "_powerhub._udp.local."
+
+DEFAULT_NAME = "Bitvis Power Hub"
+DEFAULT_PORT = 58220
+DISCOVERY_TIMEOUT = 30
+
+DATA_LISTENER_REGISTRY: HassKey[BitvisListenerRegistry] = HassKey(DOMAIN)

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -8,15 +8,17 @@ from typing import override
 
 from bitvis_protobuf.listener import FilterMac, SharedListener
 from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+from bitvis_protobuf.powerhub_pb2 import Diagnostic
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 from homeassistant.util.variance import ignore_variance
 
-from .const import DATA_LISTENER_REGISTRY, DOMAIN
+from .const import DATA_LISTENER_REGISTRY, DOMAIN, MODEL_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,9 +36,6 @@ class BitvisData:
 
     sample: PayloadSample | None = None
     diagnostic: PayloadDiagnostic | None = None
-    mac_address: str | None = None
-    model_name: str | None = None
-    sw_version: str | None = None
     boot_time: datetime | None = None
 
 
@@ -91,6 +90,8 @@ def async_get_listener_registry(hass: HomeAssistant) -> BitvisListenerRegistry:
 class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
     """Coordinator to manage data updates from UDP packets."""
 
+    config_entry: BitvisConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -110,6 +111,7 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         self.port = port
         self.mac_address = mac_address
         self._filter = FilterMac(mac_address)
+        self._registered = False
         self._stable_boot_time = ignore_variance(
             _uptime_to_boot_time, timedelta(minutes=5)
         )
@@ -122,24 +124,27 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
             listener_registry = async_get_listener_registry(self.hass)
             listener = await listener_registry.async_get_or_create(self.port)
             listener.register(self._filter, self._handle_payload)
+            self._registered = True
         except OSError as err:
-            await self.async_stop()
             raise UpdateFailed(
                 f"Failed to start UDP listener on port {self.port}"
             ) from err
         except RuntimeError as err:
-            await self.async_stop()
             raise ConfigEntryError(
                 f"Failed to start UDP listener on port {self.port}"
             ) from err
 
     async def async_stop(self) -> None:
         """Unregister from the shared listener, stopping it when no longer needed."""
+        if not self._registered:
+            return
+
         if listener_registry := self.hass.data.get(DATA_LISTENER_REGISTRY):
             if listener := listener_registry.get(self.port):
                 listener.unregister(self._filter)
                 await listener_registry.async_remove_if_unused(self.port)
 
+        self._registered = False
         _LOGGER.debug(
             "Unregistered coordinator from shared UDP listener for port %s", self.port
         )
@@ -168,17 +173,34 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         """Update diagnostic data and notify listeners."""
         self.data.diagnostic = payload
         diagnostic = payload.diagnostic
-        self.data.mac_address = payload.mac_address
-        if diagnostic.HasField("device_info"):
-            device_info = diagnostic.device_info
-            self.data.model_name = device_info.model_name
-            self.data.sw_version = device_info.sw_version
-        else:
-            self.data.model_name = None
-            self.data.sw_version = None
+        self._update_device_registry(diagnostic)
         self.data.boot_time = self._stable_boot_time(diagnostic.uptime_s)
 
         self.async_set_updated_data(self.data)
+
+    @callback
+    def _update_device_registry(self, diagnostic: Diagnostic) -> None:
+        """Update device registry with model and firmware from diagnostics."""
+        device_reg = dr.async_get(self.hass)
+        if not (
+            device := device_reg.async_get_device_by_identifier(
+                (DOMAIN, self.mac_address), self.config_entry.entry_id
+            )
+        ):
+            return
+
+        if diagnostic.HasField("device_info"):
+            device_info = diagnostic.device_info
+            model = device_info.model_name or MODEL_NAME
+            sw_version = device_info.sw_version or None
+        else:
+            model = MODEL_NAME
+            sw_version = None
+
+        if device.model != model or device.sw_version != sw_version:
+            device_reg.async_update_device(
+                device.id, model=model, sw_version=sw_version
+            )
 
     @override
     async def _async_update_data(self) -> BitvisData:

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -1,0 +1,184 @@
+"""Data coordinator for Bitvis Power Hub."""
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
+from typing import override
+
+from bitvis_protobuf.listener import SharedListener
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+from bitvis_protobuf.utils import async_resolve_host
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+from homeassistant.util.variance import ignore_variance
+
+from .const import DATA_LISTENER_REGISTRY, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+type BitvisConfigEntry = ConfigEntry[BitvisDataUpdateCoordinator]
+
+
+def _uptime_to_boot_time(uptime_s: int) -> datetime:
+    """Convert uptime in seconds to an absolute boot datetime."""
+    return dt_util.utcnow().replace(microsecond=0) - timedelta(seconds=uptime_s)
+
+
+@dataclass(kw_only=True)
+class BitvisData:
+    """Data structure for Bitvis measurements."""
+
+    sample: PayloadSample | None = None
+    diagnostic: PayloadDiagnostic | None = None
+    mac_address: str | None = None
+    model_name: str | None = None
+    sw_version: str | None = None
+    boot_time: datetime | None = None
+
+
+class BitvisListenerRegistry:
+    """Registry that manages one shared UDP listener per port.
+
+    Stored at hass.data[DATA_LISTENER_REGISTRY] so all coordinators can
+    look it up without duplicating state-management logic.
+    """
+
+    def __init__(self) -> None:
+        """Initialize registry storage."""
+        self._listeners: dict[int, SharedListener] = {}
+        self._locks: dict[int, asyncio.Lock] = {}
+
+    async def async_get_or_create(self, port: int) -> SharedListener:
+        """Return the listener for *port*, creating and starting it if needed."""
+        port_lock = self._locks.setdefault(port, asyncio.Lock())
+        async with port_lock:
+            if port not in self._listeners:
+                listener = SharedListener()
+                await listener.start(port)
+                self._listeners[port] = listener
+            return self._listeners[port]
+
+    async def async_remove_if_unused(self, port: int) -> None:
+        """Stop and remove the listener for *port* when no coordinators remain."""
+        port_lock = self._locks.setdefault(port, asyncio.Lock())
+        async with port_lock:
+            listener = self._listeners.get(port)
+            if listener is None or not listener.is_empty:
+                return
+            await listener.stop()
+            del self._listeners[port]
+
+    def get(self, port: int) -> SharedListener | None:
+        """Return an existing listener for *port*, or None."""
+        return self._listeners.get(port)
+
+    def has_listener(self, port: int) -> bool:
+        """Return True if a listener is already active on *port*."""
+        return port in self._listeners
+
+
+def async_get_listener_registry(hass: HomeAssistant) -> BitvisListenerRegistry:
+    """Return (creating if needed) the Bitvis listener registry for this HA instance."""
+    if DATA_LISTENER_REGISTRY not in hass.data:
+        hass.data[DATA_LISTENER_REGISTRY] = BitvisListenerRegistry()
+    return hass.data[DATA_LISTENER_REGISTRY]
+
+
+class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
+    """Coordinator to manage data updates from UDP packets."""
+
+    def __init__(
+        self, hass: HomeAssistant, config_entry: BitvisConfigEntry, host: str, port: int
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            config_entry=config_entry,
+        )
+        self.host = host
+        self.port = port
+        self._registered_ips: set[str] = set()
+        self._stable_boot_time = ignore_variance(
+            _uptime_to_boot_time, timedelta(minutes=5)
+        )
+        self.data = BitvisData()
+
+    @override
+    async def _async_setup(self) -> None:
+        """Set up the coordinator by registering with the shared UDP listener."""
+        try:
+            self._registered_ips = await async_resolve_host(self.host)
+            listener_registry = async_get_listener_registry(self.hass)
+            listener = await listener_registry.async_get_or_create(self.port)
+            listener.register(self._registered_ips, self._handle_payload)
+        except (OSError, ValueError) as err:
+            await self.async_stop()
+            raise UpdateFailed(
+                f"Failed to start UDP listener on port {self.port}"
+            ) from err
+        except RuntimeError as err:
+            await self.async_stop()
+            raise ConfigEntryError(
+                f"Failed to start UDP listener on port {self.port}"
+            ) from err
+
+    async def async_stop(self) -> None:
+        """Unregister from the shared listener, stopping it when no longer needed."""
+        if listener_registry := self.hass.data.get(DATA_LISTENER_REGISTRY):
+            if listener := listener_registry.get(self.port):
+                listener.unregister(self._registered_ips)
+                await listener_registry.async_remove_if_unused(self.port)
+
+        self._registered_ips = set()
+        _LOGGER.debug(
+            "Unregistered coordinator from shared UDP listener for port %s", self.port
+        )
+
+    @callback
+    def _handle_payload(
+        self,
+        payload: PayloadSample | PayloadDiagnostic,
+        addr: tuple[str, int],
+    ) -> None:
+        """Handle a parsed payload dispatched by the shared listener."""
+        _LOGGER.debug("Received payload from %s", addr)
+        if isinstance(payload, PayloadSample):
+            self._handle_sample(payload)
+        else:
+            self._handle_diagnostic(payload)
+
+    @callback
+    def _handle_sample(self, payload: PayloadSample) -> None:
+        """Update sample data and notify listeners."""
+        self.data.sample = payload
+        self.async_set_updated_data(self.data)
+
+    @callback
+    def _handle_diagnostic(self, payload: PayloadDiagnostic) -> None:
+        """Update diagnostic data and notify listeners."""
+        self.data.diagnostic = payload
+        diagnostic = payload.diagnostic
+        if diagnostic.HasField("device_info"):
+            device_info = diagnostic.device_info
+            self.data.mac_address = device_info.mac_address.hex(sep=":")
+            self.data.model_name = device_info.model_name
+            self.data.sw_version = device_info.sw_version
+        else:
+            self.data.mac_address = None
+            self.data.model_name = None
+            self.data.sw_version = None
+        self.data.boot_time = self._stable_boot_time(diagnostic.uptime_s)
+
+        self.async_set_updated_data(self.data)
+
+    @override
+    async def _async_update_data(self) -> BitvisData:
+        """Return current data (updates are push-based via UDP datagrams)."""
+        return self.data

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -129,7 +129,8 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
             ) from err
         except RuntimeError as err:
             raise ConfigEntryError(
-                f"Failed to start UDP listener on port {self.port}"
+                f"Failed to register MAC filter for {self.mac_address} "
+                f"on port {self.port}"
             ) from err
 
     async def async_stop(self) -> None:
@@ -137,10 +138,10 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         if not self._registered:
             return
 
-        if listener_registry := self.hass.data.get(DATA_LISTENER_REGISTRY):
-            if listener := listener_registry.get(self.port):
-                listener.unregister(self._filter)
-                await listener_registry.async_remove_if_unused(self.port)
+        listener_registry = async_get_listener_registry(self.hass)
+        if listener := listener_registry.get(self.port):
+            listener.unregister(self._filter)
+            await listener_registry.async_remove_if_unused(self.port)
 
         self._registered = False
         _LOGGER.debug(
@@ -187,13 +188,12 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         ):
             return
 
-        if diagnostic.HasField("device_info"):
-            device_info = diagnostic.device_info
-            model = device_info.model_name or MODEL_NAME
-            sw_version = device_info.sw_version or None
-        else:
-            model = MODEL_NAME
-            sw_version = None
+        if not diagnostic.HasField("device_info"):
+            return
+
+        device_info = diagnostic.device_info
+        model = device_info.model_name or MODEL_NAME
+        sw_version = device_info.sw_version or None
 
         if device.model != model or device.sw_version != sw_version:
             device_reg.async_update_device(

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -1,0 +1,186 @@
+"""Data coordinator for Bitvis Power Hub."""
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import logging
+from typing import override
+
+from bitvis_protobuf.listener import FilterMac, SharedListener
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+from homeassistant.util.variance import ignore_variance
+
+from .const import DATA_LISTENER_REGISTRY, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+type BitvisConfigEntry = ConfigEntry[BitvisDataUpdateCoordinator]
+
+
+def _uptime_to_boot_time(uptime_s: int) -> datetime:
+    """Convert uptime in seconds to an absolute boot datetime."""
+    return dt_util.utcnow().replace(microsecond=0) - timedelta(seconds=uptime_s)
+
+
+@dataclass(kw_only=True)
+class BitvisData:
+    """Data structure for Bitvis measurements."""
+
+    sample: PayloadSample | None = None
+    diagnostic: PayloadDiagnostic | None = None
+    mac_address: str | None = None
+    model_name: str | None = None
+    sw_version: str | None = None
+    boot_time: datetime | None = None
+
+
+class BitvisListenerRegistry:
+    """Registry that manages one shared UDP listener per port.
+
+    Stored at hass.data[DATA_LISTENER_REGISTRY] so all coordinators can
+    look it up without duplicating state-management logic.
+    """
+
+    def __init__(self) -> None:
+        """Initialize registry storage."""
+        self._listeners: dict[int, SharedListener] = {}
+        self._locks: dict[int, asyncio.Lock] = {}
+
+    async def async_get_or_create(self, port: int) -> SharedListener:
+        """Return the listener for *port*, creating and starting it if needed."""
+        port_lock = self._locks.setdefault(port, asyncio.Lock())
+        async with port_lock:
+            if port not in self._listeners:
+                listener = SharedListener()
+                await listener.start(port)
+                self._listeners[port] = listener
+            return self._listeners[port]
+
+    async def async_remove_if_unused(self, port: int) -> None:
+        """Stop and remove the listener for *port* when no coordinators remain."""
+        port_lock = self._locks.setdefault(port, asyncio.Lock())
+        async with port_lock:
+            listener = self._listeners.get(port)
+            if listener is None or not listener.is_empty:
+                return
+            await listener.stop()
+            del self._listeners[port]
+
+    def get(self, port: int) -> SharedListener | None:
+        """Return an existing listener for *port*, or None."""
+        return self._listeners.get(port)
+
+    def has_listener(self, port: int) -> bool:
+        """Return True if a listener is already active on *port*."""
+        return port in self._listeners
+
+
+def async_get_listener_registry(hass: HomeAssistant) -> BitvisListenerRegistry:
+    """Return (creating if needed) the Bitvis listener registry for this HA instance."""
+    if DATA_LISTENER_REGISTRY not in hass.data:
+        hass.data[DATA_LISTENER_REGISTRY] = BitvisListenerRegistry()
+    return hass.data[DATA_LISTENER_REGISTRY]
+
+
+class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
+    """Coordinator to manage data updates from UDP packets."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: BitvisConfigEntry,
+        host: str,
+        port: int,
+        mac_address: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            config_entry=config_entry,
+        )
+        self.host = host
+        self.port = port
+        self.mac_address = mac_address
+        self._filter = FilterMac(mac_address)
+        self._stable_boot_time = ignore_variance(
+            _uptime_to_boot_time, timedelta(minutes=5)
+        )
+        self.data = BitvisData()
+
+    @override
+    async def _async_setup(self) -> None:
+        """Set up the coordinator by registering with the shared UDP listener."""
+        try:
+            listener_registry = async_get_listener_registry(self.hass)
+            listener = await listener_registry.async_get_or_create(self.port)
+            listener.register(self._filter, self._handle_payload)
+        except OSError as err:
+            await self.async_stop()
+            raise UpdateFailed(
+                f"Failed to start UDP listener on port {self.port}"
+            ) from err
+        except RuntimeError as err:
+            await self.async_stop()
+            raise ConfigEntryError(
+                f"Failed to start UDP listener on port {self.port}"
+            ) from err
+
+    async def async_stop(self) -> None:
+        """Unregister from the shared listener, stopping it when no longer needed."""
+        if listener_registry := self.hass.data.get(DATA_LISTENER_REGISTRY):
+            if listener := listener_registry.get(self.port):
+                listener.unregister(self._filter)
+                await listener_registry.async_remove_if_unused(self.port)
+
+        _LOGGER.debug(
+            "Unregistered coordinator from shared UDP listener for port %s", self.port
+        )
+
+    @callback
+    def _handle_payload(
+        self,
+        payload: PayloadSample | PayloadDiagnostic,
+        addr: tuple[str, int],
+    ) -> None:
+        """Handle a parsed payload dispatched by the shared listener."""
+        _LOGGER.debug("Received payload from %s", addr)
+        if isinstance(payload, PayloadSample):
+            self._handle_sample(payload)
+        else:
+            self._handle_diagnostic(payload)
+
+    @callback
+    def _handle_sample(self, payload: PayloadSample) -> None:
+        """Update sample data and notify listeners."""
+        self.data.sample = payload
+        self.async_set_updated_data(self.data)
+
+    @callback
+    def _handle_diagnostic(self, payload: PayloadDiagnostic) -> None:
+        """Update diagnostic data and notify listeners."""
+        self.data.diagnostic = payload
+        diagnostic = payload.diagnostic
+        self.data.mac_address = payload.mac_address
+        if diagnostic.HasField("device_info"):
+            device_info = diagnostic.device_info
+            self.data.model_name = device_info.model_name
+            self.data.sw_version = device_info.sw_version
+        else:
+            self.data.model_name = None
+            self.data.sw_version = None
+        self.data.boot_time = self._stable_boot_time(diagnostic.uptime_s)
+
+        self.async_set_updated_data(self.data)
+
+    @override
+    async def _async_update_data(self) -> BitvisData:
+        """Return current data (updates are push-based via UDP datagrams)."""
+        return self.data

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -96,7 +96,6 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         self,
         hass: HomeAssistant,
         config_entry: BitvisConfigEntry,
-        host: str,
         port: int,
         mac_address: str,
     ) -> None:
@@ -107,7 +106,6 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
             name=DOMAIN,
             config_entry=config_entry,
         )
-        self.host = host
         self.port = port
         self.mac_address = mac_address
         self._filter = FilterMac(mac_address)

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -21,6 +21,8 @@ from .const import DATA_LISTENER_REGISTRY, DOMAIN, MODEL_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
+type BitvisConfigEntry = ConfigEntry[BitvisDataUpdateCoordinator]
+
 
 def _uptime_to_boot_time(uptime_s: int) -> datetime:
     """Convert uptime in seconds to an absolute boot datetime."""
@@ -193,9 +195,3 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
     async def _async_update_data(self) -> BitvisData:
         """Return current data (updates are push-based via UDP datagrams)."""
         return self.data
-
-
-class BitvisConfigEntry(ConfigEntry[BitvisDataUpdateCoordinator]):
-    """Config entry for a Bitvis Power Hub with a MAC unique_id."""
-
-    unique_id: str

--- a/homeassistant/components/bitvis/coordinator.py
+++ b/homeassistant/components/bitvis/coordinator.py
@@ -8,7 +8,6 @@ from typing import override
 
 from bitvis_protobuf.listener import FilterMac, SharedListener
 from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
-from bitvis_protobuf.powerhub_pb2 import Diagnostic
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -21,8 +20,6 @@ from homeassistant.util.variance import ignore_variance
 from .const import DATA_LISTENER_REGISTRY, DOMAIN, MODEL_NAME
 
 _LOGGER = logging.getLogger(__name__)
-
-type BitvisConfigEntry = ConfigEntry[BitvisDataUpdateCoordinator]
 
 
 def _uptime_to_boot_time(uptime_s: int) -> datetime:
@@ -119,8 +116,9 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
     async def _async_setup(self) -> None:
         """Set up the coordinator by registering with the shared UDP listener."""
         try:
-            listener_registry = async_get_listener_registry(self.hass)
-            listener = await listener_registry.async_get_or_create(self.port)
+            listener = await self.hass.data[DATA_LISTENER_REGISTRY].async_get_or_create(
+                self.port
+            )
             listener.register(self._filter, self._handle_payload)
             self._registered = True
         except OSError as err:
@@ -138,7 +136,7 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         if not self._registered:
             return
 
-        listener_registry = async_get_listener_registry(self.hass)
+        listener_registry = self.hass.data[DATA_LISTENER_REGISTRY]
         if listener := listener_registry.get(self.port):
             listener.unregister(self._filter)
             await listener_registry.async_remove_if_unused(self.port)
@@ -172,35 +170,32 @@ class BitvisDataUpdateCoordinator(DataUpdateCoordinator[BitvisData]):
         """Update diagnostic data and notify listeners."""
         self.data.diagnostic = payload
         diagnostic = payload.diagnostic
-        self._update_device_registry(diagnostic)
         self.data.boot_time = self._stable_boot_time(diagnostic.uptime_s)
 
-        self.async_set_updated_data(self.data)
-
-    @callback
-    def _update_device_registry(self, diagnostic: Diagnostic) -> None:
-        """Update device registry with model and firmware from diagnostics."""
-        device_reg = dr.async_get(self.hass)
-        if not (
-            device := device_reg.async_get_device_by_identifier(
+        if diagnostic.HasField("device_info"):
+            device_reg = dr.async_get(self.hass)
+            if device := device_reg.async_get_device_by_identifier(
                 (DOMAIN, self.mac_address), self.config_entry.entry_id
-            )
-        ):
-            return
+            ):
+                device_info = diagnostic.device_info
+                model = device_info.model_name or MODEL_NAME
+                sw_version = device_info.sw_version or None
+                if device.model != model or device.sw_version != sw_version:
+                    device_reg.async_update_device(
+                        device.id,
+                        model=model,
+                        sw_version=sw_version,
+                    )
 
-        if not diagnostic.HasField("device_info"):
-            return
-
-        device_info = diagnostic.device_info
-        model = device_info.model_name or MODEL_NAME
-        sw_version = device_info.sw_version or None
-
-        if device.model != model or device.sw_version != sw_version:
-            device_reg.async_update_device(
-                device.id, model=model, sw_version=sw_version
-            )
+        self.async_set_updated_data(self.data)
 
     @override
     async def _async_update_data(self) -> BitvisData:
         """Return current data (updates are push-based via UDP datagrams)."""
         return self.data
+
+
+class BitvisConfigEntry(ConfigEntry[BitvisDataUpdateCoordinator]):
+    """Config entry for a Bitvis Power Hub with a MAC unique_id."""
+
+    unique_id: str

--- a/homeassistant/components/bitvis/errors.py
+++ b/homeassistant/components/bitvis/errors.py
@@ -1,0 +1,5 @@
+"""Errors for the Bitvis Power Hub integration."""
+
+
+class InvalidMacAddress(Exception):
+    """Error to indicate the device did not provide a valid MAC address."""

--- a/homeassistant/components/bitvis/errors.py
+++ b/homeassistant/components/bitvis/errors.py
@@ -1,5 +1,0 @@
-"""Errors for the Bitvis Power Hub integration."""
-
-
-class InvalidMacAddress(Exception):
-    """Error to indicate the device did not provide a valid MAC address."""

--- a/homeassistant/components/bitvis/manifest.json
+++ b/homeassistant/components/bitvis/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "bitvis",
+  "name": "Bitvis Power Hub",
+  "codeowners": ["@MandusBorjesson", "@real-tintin", "@simontegelid"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/bitvis",
+  "integration_type": "device",
+  "iot_class": "local_push",
+  "quality_scale": "bronze",
+  "requirements": ["bitvis-protobuf==0.2.7"],
+  "zeroconf": ["_powerhub._udp.local."]
+}

--- a/homeassistant/components/bitvis/manifest.json
+++ b/homeassistant/components/bitvis/manifest.json
@@ -3,7 +3,6 @@
   "name": "Bitvis Power Hub",
   "codeowners": ["@MandusBorjesson", "@real-tintin", "@simontegelid"],
   "config_flow": true,
-  "dependencies": [],
   "documentation": "https://www.home-assistant.io/integrations/bitvis",
   "integration_type": "device",
   "iot_class": "local_push",

--- a/homeassistant/components/bitvis/manifest.json
+++ b/homeassistant/components/bitvis/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["bitvis-protobuf==2.0.2"],
+  "requirements": ["bitvis-protobuf==2.0.4"],
   "zeroconf": ["_powerhub._udp.local."]
 }

--- a/homeassistant/components/bitvis/manifest.json
+++ b/homeassistant/components/bitvis/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["bitvis-protobuf==1.0.1"],
+  "requirements": ["bitvis-protobuf==2.0.2"],
   "zeroconf": ["_powerhub._udp.local."]
 }

--- a/homeassistant/components/bitvis/manifest.json
+++ b/homeassistant/components/bitvis/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "bitvis",
+  "name": "Bitvis Power Hub",
+  "codeowners": ["@MandusBorjesson", "@real-tintin", "@simontegelid"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://www.home-assistant.io/integrations/bitvis",
+  "integration_type": "device",
+  "iot_class": "local_push",
+  "quality_scale": "bronze",
+  "requirements": ["bitvis-protobuf==1.0.1"],
+  "zeroconf": ["_powerhub._udp.local."]
+}

--- a/homeassistant/components/bitvis/quality_scale.yaml
+++ b/homeassistant/components/bitvis/quality_scale.yaml
@@ -1,0 +1,74 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling:
+    status: exempt
+    comment: "The integration does not poll."
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: "The integration does not have actions."
+  docs-conditions:
+    status: exempt
+    comment: "The integration does not have conditions."
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: "The integration does not have triggers."
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: "The integration does not have any service actions."
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: "The integration does not use any credentials. It connects to a local device using only host and port via unauthenticated UDP push."
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: done

--- a/homeassistant/components/bitvis/quality_scale.yaml
+++ b/homeassistant/components/bitvis/quality_scale.yaml
@@ -1,6 +1,8 @@
 rules:
   # Bronze
-  action-setup: done
+  action-setup:
+    status: exempt
+    comment: "The integration does not have any actions."
   appropriate-polling:
     status: exempt
     comment: "The integration does not poll."
@@ -36,7 +38,7 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
-  entity-unavailable: done
+  entity-unavailable: todo
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: done
@@ -57,10 +59,12 @@ rules:
   docs-supported-functions: todo
   docs-troubleshooting: todo
   docs-use-cases: todo
-  dynamic-devices: done
+  dynamic-devices:
+    status: exempt
+    comment: "The integration connects to a single device."
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default: todo
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: todo
   icon-translations: todo
@@ -69,6 +73,8 @@ rules:
   stale-devices: todo
 
   # Platinum
-  async-dependency: todo
-  inject-websession: todo
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: "The integration does not use HTTP."
   strict-typing: done

--- a/homeassistant/components/bitvis/quality_scale.yaml
+++ b/homeassistant/components/bitvis/quality_scale.yaml
@@ -1,0 +1,74 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling:
+    status: exempt
+    comment: "The integration does not poll."
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: "The integration does not have actions."
+  docs-conditions:
+    status: exempt
+    comment: "The integration does not have conditions."
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: "The integration does not have triggers."
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: "The integration does not have any service actions."
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: "The integration does not use any credentials. It connects to a local device using only host and port via unauthenticated UDP push."
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: done

--- a/homeassistant/components/bitvis/quality_scale.yaml
+++ b/homeassistant/components/bitvis/quality_scale.yaml
@@ -36,7 +36,9 @@ rules:
     status: exempt
     comment: "The integration does not have any service actions."
   config-entry-unloading: done
-  docs-configuration-parameters: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: "The integration has no options flow."
   docs-installation-parameters: done
   entity-unavailable: todo
   integration-owner: done
@@ -50,7 +52,7 @@ rules:
   # Gold
   devices: done
   diagnostics: todo
-  discovery-update-info: todo
+  discovery-update-info: done
   discovery: done
   docs-data-update: todo
   docs-examples: todo

--- a/homeassistant/components/bitvis/sensor.py
+++ b/homeassistant/components/bitvis/sensor.py
@@ -36,28 +36,6 @@ from .coordinator import BitvisDataUpdateCoordinator
 PARALLEL_UPDATES = 0
 
 
-def _build_device_info(
-    coordinator: BitvisDataUpdateCoordinator,
-    device_identifier: str,
-) -> DeviceInfo:
-    """Build DeviceInfo shared by all Bitvis entities."""
-    payload = coordinator.data.diagnostic
-    mac_address: str | None = None
-    model_name: str | None = None
-    sw_version: str | None = None
-    if payload is not None and payload.diagnostic.HasField("device_info"):
-        mac_address = coordinator.data.mac_address or None
-        model_name = payload.diagnostic.device_info.model_name or None
-        sw_version = payload.diagnostic.device_info.sw_version or None
-    return DeviceInfo(
-        identifiers={(DOMAIN, device_identifier)},
-        connections={(CONNECTION_NETWORK_MAC, mac_address)} if mac_address else set(),
-        manufacturer=MANUFACTURER,
-        model=model_name or MODEL_NAME,
-        sw_version=sw_version,
-    )
-
-
 @dataclass(frozen=True, kw_only=True)
 class BitvisSensorEntityDescription(SensorEntityDescription):
     """Describes Bitvis sensor entity."""
@@ -82,6 +60,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.phase_voltage_l1_v if data.HasField("phase_voltage_l1_v") else None
         ),
@@ -94,6 +73,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.phase_voltage_l2_v if data.HasField("phase_voltage_l2_v") else None
         ),
@@ -106,6 +86,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.phase_voltage_l3_v if data.HasField("phase_voltage_l3_v") else None
         ),
@@ -182,6 +163,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_delivered_to_client_kvar
             if data.HasField("power_reactive_delivered_to_client_kvar")
@@ -195,6 +177,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_delivered_by_client_kvar
             if data.HasField("power_reactive_delivered_by_client_kvar")
@@ -210,6 +193,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l1_delivered_to_client_kw
             if data.HasField("power_active_l1_delivered_to_client_kw")
@@ -224,6 +208,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l2_delivered_to_client_kw
             if data.HasField("power_active_l2_delivered_to_client_kw")
@@ -238,6 +223,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l3_delivered_to_client_kw
             if data.HasField("power_active_l3_delivered_to_client_kw")
@@ -253,6 +239,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l1_delivered_by_client_kw
             if data.HasField("power_active_l1_delivered_by_client_kw")
@@ -267,6 +254,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l2_delivered_by_client_kw
             if data.HasField("power_active_l2_delivered_by_client_kw")
@@ -281,6 +269,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_active_l3_delivered_by_client_kw
             if data.HasField("power_active_l3_delivered_by_client_kw")
@@ -296,6 +285,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l1_delivered_to_client_kvar
             if data.HasField("power_reactive_l1_delivered_to_client_kvar")
@@ -310,6 +300,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l2_delivered_to_client_kvar
             if data.HasField("power_reactive_l2_delivered_to_client_kvar")
@@ -324,6 +315,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l3_delivered_to_client_kvar
             if data.HasField("power_reactive_l3_delivered_to_client_kvar")
@@ -339,6 +331,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l1_delivered_by_client_kvar
             if data.HasField("power_reactive_l1_delivered_by_client_kvar")
@@ -353,6 +346,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l2_delivered_by_client_kvar
             if data.HasField("power_reactive_l2_delivered_by_client_kvar")
@@ -367,6 +361,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.power_reactive_l3_delivered_by_client_kvar
             if data.HasField("power_reactive_l3_delivered_by_client_kvar")
@@ -381,6 +376,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.energy_active_delivered_to_client_kwh
             if data.HasField("energy_active_delivered_to_client_kwh")
@@ -394,6 +390,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.energy_active_delivered_by_client_kwh
             if data.HasField("energy_active_delivered_by_client_kwh")
@@ -408,6 +405,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.energy_reactive_delivered_to_client_kvarh
             if data.HasField("energy_reactive_delivered_to_client_kvarh")
@@ -421,6 +419,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
+        entity_registry_enabled_default=False,
         value_fn=lambda data: (
             data.energy_reactive_delivered_by_client_kvarh
             if data.HasField("energy_reactive_delivered_by_client_kvarh")
@@ -523,12 +522,12 @@ class BitvisBaseSensorEntity(
             assert entry.unique_id is not None
         self._device_identifier = entry.unique_id
         self._attr_unique_id = f"{self._device_identifier}_{description.key}"
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information."""
-        return _build_device_info(self.coordinator, self._device_identifier)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_identifier)},
+            connections={(CONNECTION_NETWORK_MAC, coordinator.mac_address)},
+            manufacturer=MANUFACTURER,
+            model=MODEL_NAME,
+        )
 
 
 class BitvisSensorEntity(BitvisBaseSensorEntity):

--- a/homeassistant/components/bitvis/sensor.py
+++ b/homeassistant/components/bitvis/sensor.py
@@ -1,0 +1,559 @@
+"""Sensor platform for Bitvis Power Hub."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, override
+
+from bitvis_protobuf.han_port_pb2 import HanPortSample
+from bitvis_protobuf.powerhub_pb2 import Diagnostic
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfReactiveEnergy,
+    UnitOfReactivePower,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import BitvisConfigEntry
+from .const import DOMAIN, MANUFACTURER, MODEL_NAME
+from .coordinator import BitvisDataUpdateCoordinator
+
+PARALLEL_UPDATES = 0
+
+
+def _build_device_info(
+    coordinator: BitvisDataUpdateCoordinator,
+    device_identifier: str,
+) -> DeviceInfo:
+    """Build DeviceInfo shared by all Bitvis entities."""
+    payload = coordinator.data.diagnostic
+    mac_address: str | None = None
+    model_name: str | None = None
+    sw_version: str | None = None
+    if payload is not None and payload.diagnostic.HasField("device_info"):
+        mac_address = coordinator.data.mac_address or None
+        model_name = payload.diagnostic.device_info.model_name or None
+        sw_version = payload.diagnostic.device_info.sw_version or None
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_identifier)},
+        connections={(CONNECTION_NETWORK_MAC, mac_address)} if mac_address else set(),
+        manufacturer=MANUFACTURER,
+        model=model_name or MODEL_NAME,
+        sw_version=sw_version,
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class BitvisSensorEntityDescription(SensorEntityDescription):
+    """Describes Bitvis sensor entity."""
+
+    value_fn: Callable[[HanPortSample], float | None]
+
+
+@dataclass(frozen=True, kw_only=True)
+class BitvisDiagnosticSensorEntityDescription(SensorEntityDescription):
+    """Describes Bitvis diagnostic sensor entity."""
+
+    value_fn: Callable[[Diagnostic], float | int | str | datetime | None]
+
+
+SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
+    # Phase voltages
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l1",
+        translation_key="phase_voltage_l1",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l1_v if data.HasField("phase_voltage_l1_v") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l2",
+        translation_key="phase_voltage_l2",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l2_v if data.HasField("phase_voltage_l2_v") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l3",
+        translation_key="phase_voltage_l3",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l3_v if data.HasField("phase_voltage_l3_v") else None
+        ),
+    ),
+    # Phase currents
+    BitvisSensorEntityDescription(
+        key="phase_current_l1",
+        translation_key="phase_current_l1",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l1_a if data.HasField("phase_current_l1_a") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_current_l2",
+        translation_key="phase_current_l2",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l2_a if data.HasField("phase_current_l2_a") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_current_l3",
+        translation_key="phase_current_l3",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l3_a if data.HasField("phase_current_l3_a") else None
+        ),
+    ),
+    # Total active power
+    BitvisSensorEntityDescription(
+        key="power_active_delivered_to_client",
+        translation_key="power_active_delivered_to_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_delivered_to_client_kw
+            if data.HasField("power_active_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_delivered_by_client",
+        translation_key="power_active_delivered_by_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_delivered_by_client_kw
+            if data.HasField("power_active_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    # Total reactive power
+    BitvisSensorEntityDescription(
+        key="power_reactive_delivered_to_client",
+        translation_key="power_reactive_delivered_to_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_delivered_to_client_kvar
+            if data.HasField("power_reactive_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_delivered_by_client",
+        translation_key="power_reactive_delivered_by_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_delivered_by_client_kvar
+            if data.HasField("power_reactive_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    # Per-phase active power (to client)
+    BitvisSensorEntityDescription(
+        key="power_active_l1_delivered_to_client",
+        translation_key="power_active_l1_delivered_to_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l1_delivered_to_client_kw
+            if data.HasField("power_active_l1_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l2_delivered_to_client",
+        translation_key="power_active_l2_delivered_to_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l2_delivered_to_client_kw
+            if data.HasField("power_active_l2_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l3_delivered_to_client",
+        translation_key="power_active_l3_delivered_to_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l3_delivered_to_client_kw
+            if data.HasField("power_active_l3_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    # Per-phase active power (by client)
+    BitvisSensorEntityDescription(
+        key="power_active_l1_delivered_by_client",
+        translation_key="power_active_l1_delivered_by_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l1_delivered_by_client_kw
+            if data.HasField("power_active_l1_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l2_delivered_by_client",
+        translation_key="power_active_l2_delivered_by_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l2_delivered_by_client_kw
+            if data.HasField("power_active_l2_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l3_delivered_by_client",
+        translation_key="power_active_l3_delivered_by_client",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l3_delivered_by_client_kw
+            if data.HasField("power_active_l3_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    # Per-phase reactive power (to client)
+    BitvisSensorEntityDescription(
+        key="power_reactive_l1_delivered_to_client",
+        translation_key="power_reactive_l1_delivered_to_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l1_delivered_to_client_kvar
+            if data.HasField("power_reactive_l1_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l2_delivered_to_client",
+        translation_key="power_reactive_l2_delivered_to_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l2_delivered_to_client_kvar
+            if data.HasField("power_reactive_l2_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l3_delivered_to_client",
+        translation_key="power_reactive_l3_delivered_to_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l3_delivered_to_client_kvar
+            if data.HasField("power_reactive_l3_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    # Per-phase reactive power (by client)
+    BitvisSensorEntityDescription(
+        key="power_reactive_l1_delivered_by_client",
+        translation_key="power_reactive_l1_delivered_by_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l1_delivered_by_client_kvar
+            if data.HasField("power_reactive_l1_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l2_delivered_by_client",
+        translation_key="power_reactive_l2_delivered_by_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l2_delivered_by_client_kvar
+            if data.HasField("power_reactive_l2_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l3_delivered_by_client",
+        translation_key="power_reactive_l3_delivered_by_client",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l3_delivered_by_client_kvar
+            if data.HasField("power_reactive_l3_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    # Energy - active
+    BitvisSensorEntityDescription(
+        key="energy_active_delivered_to_client",
+        translation_key="energy_active_delivered_to_client",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_active_delivered_to_client_kwh
+            if data.HasField("energy_active_delivered_to_client_kwh")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="energy_active_delivered_by_client",
+        translation_key="energy_active_delivered_by_client",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_active_delivered_by_client_kwh
+            if data.HasField("energy_active_delivered_by_client_kwh")
+            else None
+        ),
+    ),
+    # Energy - reactive
+    BitvisSensorEntityDescription(
+        key="energy_reactive_delivered_to_client",
+        translation_key="energy_reactive_delivered_to_client",
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
+        native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_reactive_delivered_to_client_kvarh
+            if data.HasField("energy_reactive_delivered_to_client_kvarh")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="energy_reactive_delivered_by_client",
+        translation_key="energy_reactive_delivered_by_client",
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
+        native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_reactive_delivered_by_client_kvarh
+            if data.HasField("energy_reactive_delivered_by_client_kvarh")
+            else None
+        ),
+    ),
+)
+
+UPTIME_DESCRIPTION = SensorEntityDescription(
+    key="uptime",
+    translation_key="uptime",
+    device_class=SensorDeviceClass.UPTIME,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    entity_registry_enabled_default=False,
+)
+
+DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[BitvisDiagnosticSensorEntityDescription, ...] = (
+    BitvisDiagnosticSensorEntityDescription(
+        key="wifi_rssi",
+        translation_key="wifi_rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.wifi_rssi_dbm,
+    ),
+    BitvisDiagnosticSensorEntityDescription(
+        key="han_msg_successfully_parsed",
+        translation_key="han_msg_successfully_parsed",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.han_msg_successfully_parsed,
+    ),
+    BitvisDiagnosticSensorEntityDescription(
+        key="han_msg_buffer_overflow",
+        translation_key="han_msg_buffer_overflow",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.han_msg_buffer_overflow,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: BitvisConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Bitvis sensor platform."""
+    coordinator = entry.runtime_data
+
+    entities: list[SensorEntity] = [
+        BitvisSensorEntity(coordinator, description, entry)
+        for description in SENSOR_DESCRIPTIONS
+    ]
+
+    entities.append(BitvisUptimeSensorEntity(coordinator, UPTIME_DESCRIPTION, entry))
+    entities.extend(
+        BitvisDiagnosticSensorEntity(coordinator, description, entry)
+        for description in DIAGNOSTIC_SENSOR_DESCRIPTIONS
+    )
+
+    async_add_entities(entities)
+
+
+class BitvisBaseSensorEntity(
+    CoordinatorEntity[BitvisDataUpdateCoordinator], SensorEntity
+):
+    """Base class for Bitvis sensor entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BitvisDataUpdateCoordinator,
+        description: SensorEntityDescription,
+        entry: BitvisConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        if TYPE_CHECKING:
+            assert entry.unique_id is not None
+        self._device_identifier = entry.unique_id
+        self._attr_unique_id = f"{self._device_identifier}_{description.key}"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return _build_device_info(self.coordinator, self._device_identifier)
+
+
+class BitvisSensorEntity(BitvisBaseSensorEntity):
+    """Representation of a Bitvis sensor."""
+
+    entity_description: BitvisSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the state of the sensor."""
+        if self.coordinator.data.sample is None:
+            return None
+        return self.entity_description.value_fn(self.coordinator.data.sample.sample)
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.sample is not None
+
+
+class BitvisDiagnosticSensorEntity(BitvisBaseSensorEntity):
+    """Representation of a Bitvis diagnostic sensor."""
+
+    entity_description: BitvisDiagnosticSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> float | int | str | datetime | None:
+        """Return the state of the sensor."""
+        if self.coordinator.data.diagnostic is None:
+            return None
+        return self.entity_description.value_fn(
+            self.coordinator.data.diagnostic.diagnostic
+        )
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.diagnostic is not None
+
+
+class BitvisUptimeSensorEntity(BitvisBaseSensorEntity):
+    """Sensor entity for device uptime (boot time)."""
+
+    entity_description: SensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> datetime | None:
+        """Return the stable boot time computed by the coordinator."""
+        return self.coordinator.data.boot_time
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.boot_time is not None

--- a/homeassistant/components/bitvis/sensor.py
+++ b/homeassistant/components/bitvis/sensor.py
@@ -76,7 +76,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Phase voltages
     BitvisSensorEntityDescription(
         key="phase_voltage_l1",
-        translation_key="phase_voltage_l1",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L1"},
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -87,7 +88,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="phase_voltage_l2",
-        translation_key="phase_voltage_l2",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L2"},
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -98,7 +100,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="phase_voltage_l3",
-        translation_key="phase_voltage_l3",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L3"},
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -110,7 +113,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Phase currents
     BitvisSensorEntityDescription(
         key="phase_current_l1",
-        translation_key="phase_current_l1",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L1"},
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -121,7 +125,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="phase_current_l2",
-        translation_key="phase_current_l2",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L2"},
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -132,7 +137,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="phase_current_l3",
-        translation_key="phase_current_l3",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L3"},
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -144,7 +150,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Total active power
     BitvisSensorEntityDescription(
         key="power_active_delivered_to_client",
-        translation_key="power_active_delivered_to_client",
+        translation_key="power_active",
+        translation_placeholders={"direction": "import"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -157,7 +164,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_active_delivered_by_client",
-        translation_key="power_active_delivered_by_client",
+        translation_key="power_active",
+        translation_placeholders={"direction": "export"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -171,7 +179,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Total reactive power
     BitvisSensorEntityDescription(
         key="power_reactive_delivered_to_client",
-        translation_key="power_reactive_delivered_to_client",
+        translation_key="power_reactive",
+        translation_placeholders={"direction": "import"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -184,7 +193,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_delivered_by_client",
-        translation_key="power_reactive_delivered_by_client",
+        translation_key="power_reactive",
+        translation_placeholders={"direction": "export"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -198,7 +208,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Per-phase active power (to client)
     BitvisSensorEntityDescription(
         key="power_active_l1_delivered_to_client",
-        translation_key="power_active_l1_delivered_to_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "import", "phase": "L1"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -211,7 +222,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_active_l2_delivered_to_client",
-        translation_key="power_active_l2_delivered_to_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "import", "phase": "L2"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -224,7 +236,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_active_l3_delivered_to_client",
-        translation_key="power_active_l3_delivered_to_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "import", "phase": "L3"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -238,7 +251,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Per-phase active power (by client)
     BitvisSensorEntityDescription(
         key="power_active_l1_delivered_by_client",
-        translation_key="power_active_l1_delivered_by_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "export", "phase": "L1"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -251,7 +265,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_active_l2_delivered_by_client",
-        translation_key="power_active_l2_delivered_by_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "export", "phase": "L2"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -264,7 +279,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_active_l3_delivered_by_client",
-        translation_key="power_active_l3_delivered_by_client",
+        translation_key="power_active_phase",
+        translation_placeholders={"direction": "export", "phase": "L3"},
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -278,7 +294,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Per-phase reactive power (to client)
     BitvisSensorEntityDescription(
         key="power_reactive_l1_delivered_to_client",
-        translation_key="power_reactive_l1_delivered_to_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "import", "phase": "L1"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -291,7 +308,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l2_delivered_to_client",
-        translation_key="power_reactive_l2_delivered_to_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "import", "phase": "L2"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -304,7 +322,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l3_delivered_to_client",
-        translation_key="power_reactive_l3_delivered_to_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "import", "phase": "L3"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -318,7 +337,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Per-phase reactive power (by client)
     BitvisSensorEntityDescription(
         key="power_reactive_l1_delivered_by_client",
-        translation_key="power_reactive_l1_delivered_by_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "export", "phase": "L1"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -331,7 +351,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l2_delivered_by_client",
-        translation_key="power_reactive_l2_delivered_by_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "export", "phase": "L2"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -344,7 +365,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l3_delivered_by_client",
-        translation_key="power_reactive_l3_delivered_by_client",
+        translation_key="power_reactive_phase",
+        translation_placeholders={"direction": "export", "phase": "L3"},
         device_class=SensorDeviceClass.REACTIVE_POWER,
         native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
         state_class=SensorStateClass.MEASUREMENT,
@@ -358,7 +380,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Energy - active
     BitvisSensorEntityDescription(
         key="energy_active_delivered_to_client",
-        translation_key="energy_active_delivered_to_client",
+        translation_key="energy_active",
+        translation_placeholders={"direction": "import"},
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -371,7 +394,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="energy_active_delivered_by_client",
-        translation_key="energy_active_delivered_by_client",
+        translation_key="energy_active",
+        translation_placeholders={"direction": "export"},
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -385,7 +409,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     # Energy - reactive
     BitvisSensorEntityDescription(
         key="energy_reactive_delivered_to_client",
-        translation_key="energy_reactive_delivered_to_client",
+        translation_key="energy_reactive",
+        translation_placeholders={"direction": "import"},
         device_class=SensorDeviceClass.REACTIVE_ENERGY,
         native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -398,7 +423,8 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
     ),
     BitvisSensorEntityDescription(
         key="energy_reactive_delivered_by_client",
-        translation_key="energy_reactive_delivered_by_client",
+        translation_key="energy_reactive",
+        translation_placeholders={"direction": "export"},
         device_class=SensorDeviceClass.REACTIVE_ENERGY,
         native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -413,7 +439,6 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
 
 UPTIME_DESCRIPTION = SensorEntityDescription(
     key="uptime",
-    translation_key="uptime",
     device_class=SensorDeviceClass.UPTIME,
     entity_category=EntityCategory.DIAGNOSTIC,
     entity_registry_enabled_default=False,
@@ -508,9 +533,10 @@ class BitvisSensorEntity(BitvisBaseSensorEntity):
     @override
     def native_value(self) -> float | None:
         """Return the state of the sensor."""
-        if self.coordinator.data.sample is None:
-            return None
-        return self.entity_description.value_fn(self.coordinator.data.sample.sample)
+        payload = self.coordinator.data.sample
+        if TYPE_CHECKING:
+            assert payload is not None
+        return self.entity_description.value_fn(payload.sample)
 
     @property
     @override
@@ -528,11 +554,10 @@ class BitvisDiagnosticSensorEntity(BitvisBaseSensorEntity):
     @override
     def native_value(self) -> float | int | str | datetime | None:
         """Return the state of the sensor."""
-        if self.coordinator.data.diagnostic is None:
-            return None
-        return self.entity_description.value_fn(
-            self.coordinator.data.diagnostic.diagnostic
-        )
+        payload = self.coordinator.data.diagnostic
+        if TYPE_CHECKING:
+            assert payload is not None
+        return self.entity_description.value_fn(payload.diagnostic)
 
     @property
     @override

--- a/homeassistant/components/bitvis/sensor.py
+++ b/homeassistant/components/bitvis/sensor.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, cast, override
 
 from bitvis_protobuf.han_port_pb2 import HanPortSample
 from bitvis_protobuf.powerhub_pb2 import Diagnostic
@@ -30,10 +30,21 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BitvisConfigEntry
-from .const import DOMAIN, MANUFACTURER, MODEL_NAME
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import BitvisDataUpdateCoordinator
 
 PARALLEL_UPDATES = 0
+
+
+def _optional(field: str) -> Callable[[HanPortSample], float | None]:
+    """Return a getter that yields None when a protobuf field is unset."""
+
+    def _get(data: HanPortSample) -> float | None:
+        if data.HasField(field):
+            return cast(float, getattr(data, field))
+        return None
+
+    return _get
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -61,9 +72,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.phase_voltage_l1_v if data.HasField("phase_voltage_l1_v") else None
-        ),
+        value_fn=_optional("phase_voltage_l1_v"),
     ),
     BitvisSensorEntityDescription(
         key="phase_voltage_l2",
@@ -74,9 +83,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.phase_voltage_l2_v if data.HasField("phase_voltage_l2_v") else None
-        ),
+        value_fn=_optional("phase_voltage_l2_v"),
     ),
     BitvisSensorEntityDescription(
         key="phase_voltage_l3",
@@ -87,9 +94,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.phase_voltage_l3_v if data.HasField("phase_voltage_l3_v") else None
-        ),
+        value_fn=_optional("phase_voltage_l3_v"),
     ),
     # Phase currents
     BitvisSensorEntityDescription(
@@ -100,9 +105,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: (
-            data.phase_current_l1_a if data.HasField("phase_current_l1_a") else None
-        ),
+        value_fn=_optional("phase_current_l1_a"),
     ),
     BitvisSensorEntityDescription(
         key="phase_current_l2",
@@ -112,9 +115,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: (
-            data.phase_current_l2_a if data.HasField("phase_current_l2_a") else None
-        ),
+        value_fn=_optional("phase_current_l2_a"),
     ),
     BitvisSensorEntityDescription(
         key="phase_current_l3",
@@ -124,9 +125,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=2,
-        value_fn=lambda data: (
-            data.phase_current_l3_a if data.HasField("phase_current_l3_a") else None
-        ),
+        value_fn=_optional("phase_current_l3_a"),
     ),
     # Total active power
     BitvisSensorEntityDescription(
@@ -136,11 +135,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
-        value_fn=lambda data: (
-            data.power_active_delivered_to_client_kw
-            if data.HasField("power_active_delivered_to_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_delivered_to_client_kw"),
     ),
     BitvisSensorEntityDescription(
         key="power_active_delivered_by_client",
@@ -149,11 +144,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
-        value_fn=lambda data: (
-            data.power_active_delivered_by_client_kw
-            if data.HasField("power_active_delivered_by_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_delivered_by_client_kw"),
     ),
     # Total reactive power
     BitvisSensorEntityDescription(
@@ -164,11 +155,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_delivered_to_client_kvar
-            if data.HasField("power_reactive_delivered_to_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_delivered_to_client_kvar"),
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_delivered_by_client",
@@ -178,11 +165,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_delivered_by_client_kvar
-            if data.HasField("power_reactive_delivered_by_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_delivered_by_client_kvar"),
     ),
     # Per-phase active power (to client)
     BitvisSensorEntityDescription(
@@ -194,11 +177,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l1_delivered_to_client_kw
-            if data.HasField("power_active_l1_delivered_to_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l1_delivered_to_client_kw"),
     ),
     BitvisSensorEntityDescription(
         key="power_active_l2_delivered_to_client",
@@ -209,11 +188,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l2_delivered_to_client_kw
-            if data.HasField("power_active_l2_delivered_to_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l2_delivered_to_client_kw"),
     ),
     BitvisSensorEntityDescription(
         key="power_active_l3_delivered_to_client",
@@ -224,11 +199,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l3_delivered_to_client_kw
-            if data.HasField("power_active_l3_delivered_to_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l3_delivered_to_client_kw"),
     ),
     # Per-phase active power (by client)
     BitvisSensorEntityDescription(
@@ -240,11 +211,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l1_delivered_by_client_kw
-            if data.HasField("power_active_l1_delivered_by_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l1_delivered_by_client_kw"),
     ),
     BitvisSensorEntityDescription(
         key="power_active_l2_delivered_by_client",
@@ -255,11 +222,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l2_delivered_by_client_kw
-            if data.HasField("power_active_l2_delivered_by_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l2_delivered_by_client_kw"),
     ),
     BitvisSensorEntityDescription(
         key="power_active_l3_delivered_by_client",
@@ -270,11 +233,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_active_l3_delivered_by_client_kw
-            if data.HasField("power_active_l3_delivered_by_client_kw")
-            else None
-        ),
+        value_fn=_optional("power_active_l3_delivered_by_client_kw"),
     ),
     # Per-phase reactive power (to client)
     BitvisSensorEntityDescription(
@@ -286,11 +245,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l1_delivered_to_client_kvar
-            if data.HasField("power_reactive_l1_delivered_to_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l1_delivered_to_client_kvar"),
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l2_delivered_to_client",
@@ -301,11 +256,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l2_delivered_to_client_kvar
-            if data.HasField("power_reactive_l2_delivered_to_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l2_delivered_to_client_kvar"),
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l3_delivered_to_client",
@@ -316,11 +267,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l3_delivered_to_client_kvar
-            if data.HasField("power_reactive_l3_delivered_to_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l3_delivered_to_client_kvar"),
     ),
     # Per-phase reactive power (by client)
     BitvisSensorEntityDescription(
@@ -332,11 +279,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l1_delivered_by_client_kvar
-            if data.HasField("power_reactive_l1_delivered_by_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l1_delivered_by_client_kvar"),
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l2_delivered_by_client",
@@ -347,11 +290,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l2_delivered_by_client_kvar
-            if data.HasField("power_reactive_l2_delivered_by_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l2_delivered_by_client_kvar"),
     ),
     BitvisSensorEntityDescription(
         key="power_reactive_l3_delivered_by_client",
@@ -362,11 +301,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=3,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.power_reactive_l3_delivered_by_client_kvar
-            if data.HasField("power_reactive_l3_delivered_by_client_kvar")
-            else None
-        ),
+        value_fn=_optional("power_reactive_l3_delivered_by_client_kvar"),
     ),
     # Energy - active
     BitvisSensorEntityDescription(
@@ -376,12 +311,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.energy_active_delivered_to_client_kwh
-            if data.HasField("energy_active_delivered_to_client_kwh")
-            else None
-        ),
+        value_fn=_optional("energy_active_delivered_to_client_kwh"),
     ),
     BitvisSensorEntityDescription(
         key="energy_active_delivered_by_client",
@@ -390,12 +320,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
-        entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.energy_active_delivered_by_client_kwh
-            if data.HasField("energy_active_delivered_by_client_kwh")
-            else None
-        ),
+        value_fn=_optional("energy_active_delivered_by_client_kwh"),
     ),
     # Energy - reactive
     BitvisSensorEntityDescription(
@@ -406,11 +331,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.energy_reactive_delivered_to_client_kvarh
-            if data.HasField("energy_reactive_delivered_to_client_kvarh")
-            else None
-        ),
+        value_fn=_optional("energy_reactive_delivered_to_client_kvarh"),
     ),
     BitvisSensorEntityDescription(
         key="energy_reactive_delivered_by_client",
@@ -420,11 +341,7 @@ SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
         state_class=SensorStateClass.TOTAL_INCREASING,
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
-        value_fn=lambda data: (
-            data.energy_reactive_delivered_by_client_kvarh
-            if data.HasField("energy_reactive_delivered_by_client_kvarh")
-            else None
-        ),
+        value_fn=_optional("energy_reactive_delivered_by_client_kvarh"),
     ),
 )
 
@@ -476,9 +393,9 @@ async def async_setup_entry(
 
     async_add_entities(
         [
-            BitvisUptimeSensorEntity(coordinator, UPTIME_DESCRIPTION, entry),
+            BitvisUptimeSensorEntity(coordinator, UPTIME_DESCRIPTION),
             *(
-                BitvisDiagnosticSensorEntity(coordinator, description, entry)
+                BitvisDiagnosticSensorEntity(coordinator, description)
                 for description in DIAGNOSTIC_SENSOR_DESCRIPTIONS
             ),
         ]
@@ -489,7 +406,7 @@ async def async_setup_entry(
         if (payload := coordinator.data.sample) is None:
             return
         entities = [
-            BitvisSensorEntity(coordinator, description, entry)
+            BitvisSensorEntity(coordinator, description)
             for description in SENSOR_DESCRIPTIONS
             if description.key not in known_keys
             and description.value_fn(payload.sample) is not None
@@ -513,20 +430,16 @@ class BitvisBaseSensorEntity(
         self,
         coordinator: BitvisDataUpdateCoordinator,
         description: SensorEntityDescription,
-        entry: BitvisConfigEntry,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        if TYPE_CHECKING:
-            assert entry.unique_id is not None
-        self._device_identifier = entry.unique_id
-        self._attr_unique_id = f"{self._device_identifier}_{description.key}"
+        mac_address = coordinator.mac_address
+        self._attr_unique_id = f"{mac_address}_{description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_identifier)},
-            connections={(CONNECTION_NETWORK_MAC, coordinator.mac_address)},
+            identifiers={(DOMAIN, mac_address)},
+            connections={(CONNECTION_NETWORK_MAC, mac_address)},
             manufacturer=MANUFACTURER,
-            model=MODEL_NAME,
         )
 
 
@@ -574,8 +487,6 @@ class BitvisDiagnosticSensorEntity(BitvisBaseSensorEntity):
 
 class BitvisUptimeSensorEntity(BitvisBaseSensorEntity):
     """Sensor entity for device uptime (boot time)."""
-
-    entity_description: SensorEntityDescription
 
     @property
     @override

--- a/homeassistant/components/bitvis/sensor.py
+++ b/homeassistant/components/bitvis/sensor.py
@@ -1,0 +1,591 @@
+"""Sensor platform for Bitvis Power Hub."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, override
+
+from bitvis_protobuf.han_port_pb2 import HanPortSample
+from bitvis_protobuf.powerhub_pb2 import Diagnostic
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfReactiveEnergy,
+    UnitOfReactivePower,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import BitvisConfigEntry
+from .const import DOMAIN, MANUFACTURER, MODEL_NAME
+from .coordinator import BitvisDataUpdateCoordinator
+
+PARALLEL_UPDATES = 0
+
+
+def _build_device_info(
+    coordinator: BitvisDataUpdateCoordinator,
+    device_identifier: str,
+) -> DeviceInfo:
+    """Build DeviceInfo shared by all Bitvis entities."""
+    payload = coordinator.data.diagnostic
+    mac_address: str | None = None
+    model_name: str | None = None
+    sw_version: str | None = None
+    if payload is not None and payload.diagnostic.HasField("device_info"):
+        mac_address = coordinator.data.mac_address or None
+        model_name = payload.diagnostic.device_info.model_name or None
+        sw_version = payload.diagnostic.device_info.sw_version or None
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_identifier)},
+        connections={(CONNECTION_NETWORK_MAC, mac_address)} if mac_address else set(),
+        manufacturer=MANUFACTURER,
+        model=model_name or MODEL_NAME,
+        sw_version=sw_version,
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
+class BitvisSensorEntityDescription(SensorEntityDescription):
+    """Describes Bitvis sensor entity."""
+
+    value_fn: Callable[[HanPortSample], float | None]
+
+
+@dataclass(frozen=True, kw_only=True)
+class BitvisDiagnosticSensorEntityDescription(SensorEntityDescription):
+    """Describes Bitvis diagnostic sensor entity."""
+
+    value_fn: Callable[[Diagnostic], float | int | str | datetime | None]
+
+
+SENSOR_DESCRIPTIONS: tuple[BitvisSensorEntityDescription, ...] = (
+    # Phase voltages
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l1",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l1_v if data.HasField("phase_voltage_l1_v") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l2",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l2_v if data.HasField("phase_voltage_l2_v") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_voltage_l3",
+        translation_key="phase_voltage",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda data: (
+            data.phase_voltage_l3_v if data.HasField("phase_voltage_l3_v") else None
+        ),
+    ),
+    # Phase currents
+    BitvisSensorEntityDescription(
+        key="phase_current_l1",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l1_a if data.HasField("phase_current_l1_a") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_current_l2",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l2_a if data.HasField("phase_current_l2_a") else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="phase_current_l3",
+        translation_key="phase_current",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.phase_current_l3_a if data.HasField("phase_current_l3_a") else None
+        ),
+    ),
+    # Total active power
+    BitvisSensorEntityDescription(
+        key="power_active_delivered_to_client",
+        translation_key="power_active_import",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_delivered_to_client_kw
+            if data.HasField("power_active_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_delivered_by_client",
+        translation_key="power_active_export",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_delivered_by_client_kw
+            if data.HasField("power_active_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    # Total reactive power
+    BitvisSensorEntityDescription(
+        key="power_reactive_delivered_to_client",
+        translation_key="power_reactive_import",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_delivered_to_client_kvar
+            if data.HasField("power_reactive_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_delivered_by_client",
+        translation_key="power_reactive_export",
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_delivered_by_client_kvar
+            if data.HasField("power_reactive_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    # Per-phase active power (to client)
+    BitvisSensorEntityDescription(
+        key="power_active_l1_delivered_to_client",
+        translation_key="power_active_phase_import",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l1_delivered_to_client_kw
+            if data.HasField("power_active_l1_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l2_delivered_to_client",
+        translation_key="power_active_phase_import",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l2_delivered_to_client_kw
+            if data.HasField("power_active_l2_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l3_delivered_to_client",
+        translation_key="power_active_phase_import",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l3_delivered_to_client_kw
+            if data.HasField("power_active_l3_delivered_to_client_kw")
+            else None
+        ),
+    ),
+    # Per-phase active power (by client)
+    BitvisSensorEntityDescription(
+        key="power_active_l1_delivered_by_client",
+        translation_key="power_active_phase_export",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l1_delivered_by_client_kw
+            if data.HasField("power_active_l1_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l2_delivered_by_client",
+        translation_key="power_active_phase_export",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l2_delivered_by_client_kw
+            if data.HasField("power_active_l2_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_active_l3_delivered_by_client",
+        translation_key="power_active_phase_export",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_active_l3_delivered_by_client_kw
+            if data.HasField("power_active_l3_delivered_by_client_kw")
+            else None
+        ),
+    ),
+    # Per-phase reactive power (to client)
+    BitvisSensorEntityDescription(
+        key="power_reactive_l1_delivered_to_client",
+        translation_key="power_reactive_phase_import",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l1_delivered_to_client_kvar
+            if data.HasField("power_reactive_l1_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l2_delivered_to_client",
+        translation_key="power_reactive_phase_import",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l2_delivered_to_client_kvar
+            if data.HasField("power_reactive_l2_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l3_delivered_to_client",
+        translation_key="power_reactive_phase_import",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l3_delivered_to_client_kvar
+            if data.HasField("power_reactive_l3_delivered_to_client_kvar")
+            else None
+        ),
+    ),
+    # Per-phase reactive power (by client)
+    BitvisSensorEntityDescription(
+        key="power_reactive_l1_delivered_by_client",
+        translation_key="power_reactive_phase_export",
+        translation_placeholders={"phase": "L1"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l1_delivered_by_client_kvar
+            if data.HasField("power_reactive_l1_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l2_delivered_by_client",
+        translation_key="power_reactive_phase_export",
+        translation_placeholders={"phase": "L2"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l2_delivered_by_client_kvar
+            if data.HasField("power_reactive_l2_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="power_reactive_l3_delivered_by_client",
+        translation_key="power_reactive_phase_export",
+        translation_placeholders={"phase": "L3"},
+        device_class=SensorDeviceClass.REACTIVE_POWER,
+        native_unit_of_measurement=UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=3,
+        value_fn=lambda data: (
+            data.power_reactive_l3_delivered_by_client_kvar
+            if data.HasField("power_reactive_l3_delivered_by_client_kvar")
+            else None
+        ),
+    ),
+    # Energy - active
+    BitvisSensorEntityDescription(
+        key="energy_active_delivered_to_client",
+        translation_key="energy_active_import",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_active_delivered_to_client_kwh
+            if data.HasField("energy_active_delivered_to_client_kwh")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="energy_active_delivered_by_client",
+        translation_key="energy_active_export",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_active_delivered_by_client_kwh
+            if data.HasField("energy_active_delivered_by_client_kwh")
+            else None
+        ),
+    ),
+    # Energy - reactive
+    BitvisSensorEntityDescription(
+        key="energy_reactive_delivered_to_client",
+        translation_key="energy_reactive_import",
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
+        native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_reactive_delivered_to_client_kvarh
+            if data.HasField("energy_reactive_delivered_to_client_kvarh")
+            else None
+        ),
+    ),
+    BitvisSensorEntityDescription(
+        key="energy_reactive_delivered_by_client",
+        translation_key="energy_reactive_export",
+        device_class=SensorDeviceClass.REACTIVE_ENERGY,
+        native_unit_of_measurement=UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda data: (
+            data.energy_reactive_delivered_by_client_kvarh
+            if data.HasField("energy_reactive_delivered_by_client_kvarh")
+            else None
+        ),
+    ),
+)
+
+UPTIME_DESCRIPTION = SensorEntityDescription(
+    key="uptime",
+    device_class=SensorDeviceClass.UPTIME,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    entity_registry_enabled_default=False,
+)
+
+DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[BitvisDiagnosticSensorEntityDescription, ...] = (
+    BitvisDiagnosticSensorEntityDescription(
+        key="wifi_rssi",
+        translation_key="wifi_rssi",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.wifi_rssi_dbm,
+    ),
+    BitvisDiagnosticSensorEntityDescription(
+        key="han_msg_successfully_parsed",
+        translation_key="han_msg_successfully_parsed",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.han_msg_successfully_parsed,
+    ),
+    BitvisDiagnosticSensorEntityDescription(
+        key="han_msg_buffer_overflow",
+        translation_key="han_msg_buffer_overflow",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda data: data.han_msg_buffer_overflow,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: BitvisConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Bitvis sensor platform."""
+    coordinator = entry.runtime_data
+    known_keys: set[str] = set()
+
+    async_add_entities(
+        [
+            BitvisUptimeSensorEntity(coordinator, UPTIME_DESCRIPTION, entry),
+            *(
+                BitvisDiagnosticSensorEntity(coordinator, description, entry)
+                for description in DIAGNOSTIC_SENSOR_DESCRIPTIONS
+            ),
+        ]
+    )
+
+    @callback
+    def _check_entities() -> None:
+        if (payload := coordinator.data.sample) is None:
+            return
+        entities = [
+            BitvisSensorEntity(coordinator, description, entry)
+            for description in SENSOR_DESCRIPTIONS
+            if description.key not in known_keys
+            and description.value_fn(payload.sample) is not None
+        ]
+        if entities:
+            known_keys.update(entity.entity_description.key for entity in entities)
+            async_add_entities(entities)
+
+    _check_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_check_entities))
+
+
+class BitvisBaseSensorEntity(
+    CoordinatorEntity[BitvisDataUpdateCoordinator], SensorEntity
+):
+    """Base class for Bitvis sensor entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: BitvisDataUpdateCoordinator,
+        description: SensorEntityDescription,
+        entry: BitvisConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        if TYPE_CHECKING:
+            assert entry.unique_id is not None
+        self._device_identifier = entry.unique_id
+        self._attr_unique_id = f"{self._device_identifier}_{description.key}"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return _build_device_info(self.coordinator, self._device_identifier)
+
+
+class BitvisSensorEntity(BitvisBaseSensorEntity):
+    """Representation of a Bitvis sensor."""
+
+    entity_description: BitvisSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the state of the sensor."""
+        payload = self.coordinator.data.sample
+        if TYPE_CHECKING:
+            assert payload is not None
+        return self.entity_description.value_fn(payload.sample)
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.sample is not None
+
+
+class BitvisDiagnosticSensorEntity(BitvisBaseSensorEntity):
+    """Representation of a Bitvis diagnostic sensor."""
+
+    entity_description: BitvisDiagnosticSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> float | int | str | datetime | None:
+        """Return the state of the sensor."""
+        payload = self.coordinator.data.diagnostic
+        if TYPE_CHECKING:
+            assert payload is not None
+        return self.entity_description.value_fn(payload.diagnostic)
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.diagnostic is not None
+
+
+class BitvisUptimeSensorEntity(BitvisBaseSensorEntity):
+    """Sensor entity for device uptime (boot time)."""
+
+    entity_description: SensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> datetime | None:
+        """Return the stable boot time computed by the coordinator."""
+        return self.coordinator.data.boot_time
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.data.boot_time is not None

--- a/homeassistant/components/bitvis/strings.json
+++ b/homeassistant/components/bitvis/strings.json
@@ -1,0 +1,123 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP address of your Bitvis Power Hub device.",
+          "port": "UDP port the Bitvis Power Hub sends data to."
+        },
+        "description": "Enter the network details for your Bitvis Power Hub device",
+        "title": "Set up Bitvis Power Hub"
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to add the discovered Bitvis Power Hub ({name}) at {host} to Home Assistant?",
+        "title": "Discovered Bitvis Power Hub"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "energy_active_delivered_by_client": {
+        "name": "Active energy export"
+      },
+      "energy_active_delivered_to_client": {
+        "name": "Active energy import"
+      },
+      "energy_reactive_delivered_by_client": {
+        "name": "Reactive energy export"
+      },
+      "energy_reactive_delivered_to_client": {
+        "name": "Reactive energy import"
+      },
+      "han_msg_buffer_overflow": {
+        "name": "HAN buffer overflows"
+      },
+      "han_msg_successfully_parsed": {
+        "name": "HAN messages successfully parsed"
+      },
+      "phase_current_l1": {
+        "name": "Current L1"
+      },
+      "phase_current_l2": {
+        "name": "Current L2"
+      },
+      "phase_current_l3": {
+        "name": "Current L3"
+      },
+      "phase_voltage_l1": {
+        "name": "Voltage L1"
+      },
+      "phase_voltage_l2": {
+        "name": "Voltage L2"
+      },
+      "phase_voltage_l3": {
+        "name": "Voltage L3"
+      },
+      "power_active_delivered_by_client": {
+        "name": "Active power export"
+      },
+      "power_active_delivered_to_client": {
+        "name": "Active power import"
+      },
+      "power_active_l1_delivered_by_client": {
+        "name": "Active power export L1"
+      },
+      "power_active_l1_delivered_to_client": {
+        "name": "Active power import L1"
+      },
+      "power_active_l2_delivered_by_client": {
+        "name": "Active power export L2"
+      },
+      "power_active_l2_delivered_to_client": {
+        "name": "Active power import L2"
+      },
+      "power_active_l3_delivered_by_client": {
+        "name": "Active power export L3"
+      },
+      "power_active_l3_delivered_to_client": {
+        "name": "Active power import L3"
+      },
+      "power_reactive_delivered_by_client": {
+        "name": "Reactive power export"
+      },
+      "power_reactive_delivered_to_client": {
+        "name": "Reactive power import"
+      },
+      "power_reactive_l1_delivered_by_client": {
+        "name": "Reactive power export L1"
+      },
+      "power_reactive_l1_delivered_to_client": {
+        "name": "Reactive power import L1"
+      },
+      "power_reactive_l2_delivered_by_client": {
+        "name": "Reactive power export L2"
+      },
+      "power_reactive_l2_delivered_to_client": {
+        "name": "Reactive power import L2"
+      },
+      "power_reactive_l3_delivered_by_client": {
+        "name": "Reactive power export L3"
+      },
+      "power_reactive_l3_delivered_to_client": {
+        "name": "Reactive power import L3"
+      },
+      "uptime": {
+        "name": "Uptime"
+      },
+      "wifi_rssi": {
+        "name": "Wi-Fi signal strength"
+      }
+    }
+  }
+}

--- a/homeassistant/components/bitvis/strings.json
+++ b/homeassistant/components/bitvis/strings.json
@@ -2,11 +2,14 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_mac": "The device did not provide a valid MAC address. Update the Power Hub to the latest firmware and try again.",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_mac": "The device did not provide a valid MAC address. Update the Power Hub to the latest firmware and try again.",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
     "step": {

--- a/homeassistant/components/bitvis/strings.json
+++ b/homeassistant/components/bitvis/strings.json
@@ -10,12 +10,10 @@
     "step": {
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "Hostname or IP address of your Bitvis Power Hub device.",
-          "port": "UDP port the Bitvis Power Hub sends data to."
+          "host": "Hostname or IP address of your Bitvis Power Hub device."
         },
         "description": "Enter the network details for your Bitvis Power Hub device",
         "title": "Set up Bitvis Power Hub"
@@ -28,17 +26,11 @@
   },
   "entity": {
     "sensor": {
-      "energy_active_delivered_by_client": {
-        "name": "Active energy export"
+      "energy_active": {
+        "name": "Active energy {direction}"
       },
-      "energy_active_delivered_to_client": {
-        "name": "Active energy import"
-      },
-      "energy_reactive_delivered_by_client": {
-        "name": "Reactive energy export"
-      },
-      "energy_reactive_delivered_to_client": {
-        "name": "Reactive energy import"
+      "energy_reactive": {
+        "name": "Reactive energy {direction}"
       },
       "han_msg_buffer_overflow": {
         "name": "HAN buffer overflows"
@@ -46,74 +38,23 @@
       "han_msg_successfully_parsed": {
         "name": "HAN messages successfully parsed"
       },
-      "phase_current_l1": {
-        "name": "Current L1"
+      "phase_current": {
+        "name": "Current {phase}"
       },
-      "phase_current_l2": {
-        "name": "Current L2"
+      "phase_voltage": {
+        "name": "Voltage {phase}"
       },
-      "phase_current_l3": {
-        "name": "Current L3"
+      "power_active": {
+        "name": "Active power {direction}"
       },
-      "phase_voltage_l1": {
-        "name": "Voltage L1"
+      "power_active_phase": {
+        "name": "Active power {direction} {phase}"
       },
-      "phase_voltage_l2": {
-        "name": "Voltage L2"
+      "power_reactive": {
+        "name": "Reactive power {direction}"
       },
-      "phase_voltage_l3": {
-        "name": "Voltage L3"
-      },
-      "power_active_delivered_by_client": {
-        "name": "Active power export"
-      },
-      "power_active_delivered_to_client": {
-        "name": "Active power import"
-      },
-      "power_active_l1_delivered_by_client": {
-        "name": "Active power export L1"
-      },
-      "power_active_l1_delivered_to_client": {
-        "name": "Active power import L1"
-      },
-      "power_active_l2_delivered_by_client": {
-        "name": "Active power export L2"
-      },
-      "power_active_l2_delivered_to_client": {
-        "name": "Active power import L2"
-      },
-      "power_active_l3_delivered_by_client": {
-        "name": "Active power export L3"
-      },
-      "power_active_l3_delivered_to_client": {
-        "name": "Active power import L3"
-      },
-      "power_reactive_delivered_by_client": {
-        "name": "Reactive power export"
-      },
-      "power_reactive_delivered_to_client": {
-        "name": "Reactive power import"
-      },
-      "power_reactive_l1_delivered_by_client": {
-        "name": "Reactive power export L1"
-      },
-      "power_reactive_l1_delivered_to_client": {
-        "name": "Reactive power import L1"
-      },
-      "power_reactive_l2_delivered_by_client": {
-        "name": "Reactive power export L2"
-      },
-      "power_reactive_l2_delivered_to_client": {
-        "name": "Reactive power import L2"
-      },
-      "power_reactive_l3_delivered_by_client": {
-        "name": "Reactive power export L3"
-      },
-      "power_reactive_l3_delivered_to_client": {
-        "name": "Reactive power import L3"
-      },
-      "uptime": {
-        "name": "Uptime"
+      "power_reactive_phase": {
+        "name": "Reactive power {direction} {phase}"
       },
       "wifi_rssi": {
         "name": "Wi-Fi signal strength"

--- a/homeassistant/components/bitvis/strings.json
+++ b/homeassistant/components/bitvis/strings.json
@@ -1,0 +1,84 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP address of your Bitvis Power Hub device."
+        },
+        "description": "Enter the network details for your Bitvis Power Hub device",
+        "title": "Set up Bitvis Power Hub"
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to add the discovered Bitvis Power Hub ({name}) at {host} to Home Assistant?",
+        "title": "Discovered Bitvis Power Hub"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "energy_active_export": {
+        "name": "Active energy export"
+      },
+      "energy_active_import": {
+        "name": "Active energy import"
+      },
+      "energy_reactive_export": {
+        "name": "Reactive energy export"
+      },
+      "energy_reactive_import": {
+        "name": "Reactive energy import"
+      },
+      "han_msg_buffer_overflow": {
+        "name": "HAN buffer overflows"
+      },
+      "han_msg_successfully_parsed": {
+        "name": "HAN messages successfully parsed"
+      },
+      "phase_current": {
+        "name": "Current {phase}"
+      },
+      "phase_voltage": {
+        "name": "Voltage {phase}"
+      },
+      "power_active_export": {
+        "name": "Active power export"
+      },
+      "power_active_import": {
+        "name": "Active power import"
+      },
+      "power_active_phase_export": {
+        "name": "Active power export {phase}"
+      },
+      "power_active_phase_import": {
+        "name": "Active power import {phase}"
+      },
+      "power_reactive_export": {
+        "name": "Reactive power export"
+      },
+      "power_reactive_import": {
+        "name": "Reactive power import"
+      },
+      "power_reactive_phase_export": {
+        "name": "Reactive power export {phase}"
+      },
+      "power_reactive_phase_import": {
+        "name": "Reactive power import {phase}"
+      },
+      "wifi_rssi": {
+        "name": "Wi-Fi signal strength"
+      }
+    }
+  }
+}

--- a/homeassistant/components/bitvis/strings.json
+++ b/homeassistant/components/bitvis/strings.json
@@ -20,7 +20,7 @@
         "data_description": {
           "host": "Hostname or IP address of your Bitvis Power Hub device."
         },
-        "description": "Enter the network details for your Bitvis Power Hub device",
+        "description": "Enter the hostname or IP address of your Bitvis Power Hub. Setup waits for a UDP packet from the device.",
         "title": "Set up Bitvis Power Hub"
       },
       "zeroconf_confirm": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -102,6 +102,7 @@ FLOWS = {
         "bang_olufsen",
         "bayesian",
         "besen",
+        "bitvis",
         "blebox",
         "blink",
         "blue_current",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -101,6 +101,7 @@ FLOWS = {
         "balboa",
         "bang_olufsen",
         "bayesian",
+        "bitvis",
         "blebox",
         "blink",
         "blue_current",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -756,6 +756,12 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
+    "bitvis": {
+      "name": "Bitvis Power Hub",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "bizkaibus": {
       "name": "Bizkaibus",
       "integration_type": "hub",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -740,6 +740,12 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
+    "bitvis": {
+      "name": "Bitvis Power Hub",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_push"
+    },
     "bizkaibus": {
       "name": "Bizkaibus",
       "integration_type": "hub",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -874,6 +874,11 @@ ZEROCONF = {
             "domain": "plugwise",
         },
     ],
+    "_powerhub._udp.local.": [
+        {
+            "domain": "bitvis",
+        },
+    ],
     "_powerview._tcp.local.": [
         {
             "domain": "hunterdouglas_powerview",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -883,6 +883,11 @@ ZEROCONF = {
             "domain": "plugwise",
         },
     ],
+    "_powerhub._udp.local.": [
+        {
+            "domain": "bitvis",
+        },
+    ],
     "_powerview._tcp.local.": [
         {
             "domain": "hunterdouglas_powerview",

--- a/mypy.ini
+++ b/mypy.ini
@@ -937,6 +937,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.bitvis.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.blockchain.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -926,6 +926,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.bitvis.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.blockchain.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -669,6 +669,9 @@ beautifulsoup4==4.13.3
 # homeassistant.components.besen
 besen==0.4.0
 
+# homeassistant.components.bitvis
+bitvis-protobuf==1.0.1
+
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -670,7 +670,7 @@ beautifulsoup4==4.13.3
 besen==0.4.0
 
 # homeassistant.components.bitvis
-bitvis-protobuf==1.0.1
+bitvis-protobuf==2.0.2
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -670,7 +670,7 @@ beautifulsoup4==4.13.3
 besen==0.4.0
 
 # homeassistant.components.bitvis
-bitvis-protobuf==2.0.2
+bitvis-protobuf==2.0.4
 
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -653,6 +653,9 @@ batinfo==0.4.2
 # homeassistant.components.scrape
 beautifulsoup4==4.13.3
 
+# homeassistant.components.bitvis
+bitvis-protobuf==0.2.7
+
 # homeassistant.components.bizkaibus
 bizkaibus==0.1.1
 

--- a/tests/components/bitvis/__init__.py
+++ b/tests/components/bitvis/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Bitvis Power Hub integration."""

--- a/tests/components/bitvis/__init__.py
+++ b/tests/components/bitvis/__init__.py
@@ -1,0 +1,35 @@
+"""Tests for the Bitvis Power Hub integration."""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from bitvis_protobuf.listener import FilterMac
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the integration."""
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def find_listener_callback(
+    mock: MagicMock,
+    mac_address: str,
+) -> Callable[[PayloadSample | PayloadDiagnostic, tuple[str, int]], None]:
+    """Find the listener callback registered for a MAC address."""
+    for call in mock.register.call_args_list:
+        filt = call[0][0]
+        if (
+            isinstance(filt, FilterMac)
+            and filt.mac_address.lower() == mac_address.lower()
+        ):
+            return call[0][1]
+    pytest.fail(f"Callback for MAC {mac_address} not found")

--- a/tests/components/bitvis/__init__.py
+++ b/tests/components/bitvis/__init__.py
@@ -1,7 +1,6 @@
 """Tests for the Bitvis Power Hub integration."""
 
 from collections.abc import Callable
-from unittest.mock import MagicMock
 
 from bitvis_protobuf.listener import FilterMac
 from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
@@ -21,11 +20,12 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
 
 
 def find_listener_callback(
-    mock: MagicMock,
+    listener: object,
     mac_address: str,
 ) -> Callable[[PayloadSample | PayloadDiagnostic, tuple[str, int]], None]:
     """Find the listener callback registered for a MAC address."""
-    for call in mock.register.call_args_list:
+    register = listener.register
+    for call in register.call_args_list:
         filt = call[0][0]
         if (
             isinstance(filt, FilterMac)

--- a/tests/components/bitvis/conftest.py
+++ b/tests/components/bitvis/conftest.py
@@ -1,0 +1,50 @@
+"""Common fixtures for Bitvis Power Hub tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.bitvis.const import DOMAIN, MODEL_NAME
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TEST_DEVICE_MAC = "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PORT: 5000},
+        unique_id=TEST_DEVICE_MAC,
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.bitvis.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> MockConfigEntry:
+    """Set up the integration with a mocked UDP listener."""
+    mock_config_entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.bitvis.coordinator.BitvisDataUpdateCoordinator._async_setup",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/bitvis/conftest.py
+++ b/tests/components/bitvis/conftest.py
@@ -4,30 +4,19 @@ from collections.abc import Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from bitvis_protobuf.listener import FilterMac
-from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+from bitvis_protobuf.listener import FilterIp, FilterMac
+from bitvis_protobuf.parse import PayloadSample, parse_payload
+from bitvis_protobuf.powerhub_pb2 import Payload
 import pytest
 
-from homeassistant.components.bitvis.const import DEFAULT_PORT, DOMAIN, MODEL_NAME
+from homeassistant.components.bitvis.const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-
-from . import find_listener_callback
 
 from tests.common import MockConfigEntry
 
 TEST_DEVICE_MAC = "aa:bb:cc:dd:ee:ff"
 SECOND_DEVICE_MAC = "11:22:33:44:55:66"
-
-
-def deliver_listener_payload(
-    listener: MagicMock,
-    mac_address: str,
-    payload: PayloadSample | PayloadDiagnostic,
-    addr: tuple[str, int] = ("192.168.1.100", 1234),
-) -> None:
-    """Deliver a payload through a mocked SharedListener registered callback."""
-    find_listener_callback(listener, mac_address)(payload, addr)
 
 
 @contextmanager
@@ -36,21 +25,79 @@ def patch_config_flow_connectivity(
     *,
     mac_address: str = TEST_DEVICE_MAC,
     deliver_mac: bool = True,
+    invalid_mac: bool = False,
     port_bind_side_effect: BaseException | None = None,
     discovery_timeout: bool = False,
+    register_side_effect: BaseException | None = None,
+    use_real_listener_registry: bool = False,
+    shared_listener: MagicMock | None = None,
 ) -> Iterator[AsyncMock]:
     """Patch library connectivity helpers used by the config flow."""
-    mock_listener = MagicMock()
-    if deliver_mac and not discovery_timeout:
+    mock_listener = shared_listener or MagicMock()
+    mock_listener.start = AsyncMock()
+    mock_listener.stop = AsyncMock()
 
-        def _on_register(_filt: MagicMock, callback: MagicMock) -> None:
-            payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
-            callback(payload, (resolved_host, 1234))
+    if shared_listener is None:
+        if register_side_effect is not None:
+            mock_listener.register = MagicMock(side_effect=register_side_effect)
+        elif invalid_mac:
+
+            def _dispatch(data: bytes, addr: tuple[str, int]) -> None:
+                parse_payload(data)
+
+            mock_listener.dispatch = MagicMock(side_effect=_dispatch)
+
+            def _on_register(_filt: MagicMock, _callback: MagicMock) -> None:
+                payload = Payload()
+                payload.sample.SetInParent()
+                mock_listener.dispatch(
+                    payload.SerializeToString(), (resolved_host, 1234)
+                )
+
+            mock_listener.register = MagicMock(side_effect=_on_register)
+        elif deliver_mac and not discovery_timeout:
+
+            def _on_register(_filt: MagicMock, callback: MagicMock) -> None:
+                payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
+                callback(payload, (resolved_host, 1234))
+
+            mock_listener.register = MagicMock(side_effect=_on_register)
+        else:
+            mock_listener.register = MagicMock()
+        mock_listener.unregister = MagicMock()
+        type(mock_listener).is_empty = PropertyMock(return_value=True)
+    elif invalid_mac:
+
+        def _dispatch(data: bytes, addr: tuple[str, int]) -> None:
+            parse_payload(data)
+
+        mock_listener.dispatch = MagicMock(side_effect=_dispatch)
+        original_register = mock_listener.register.side_effect
+
+        def _on_register(filt: FilterIp | FilterMac, callback: MagicMock) -> None:
+            if isinstance(filt, FilterIp):
+                payload = Payload()
+                payload.sample.SetInParent()
+                mock_listener.dispatch(
+                    payload.SerializeToString(), (resolved_host, 1234)
+                )
+                return
+            if original_register is not None:
+                original_register(filt, callback)
 
         mock_listener.register = MagicMock(side_effect=_on_register)
-    else:
-        mock_listener.register = MagicMock()
-    mock_listener.unregister = MagicMock()
+    elif deliver_mac and not discovery_timeout:
+        original_register = mock_listener.register.side_effect
+
+        def _on_register(filt: FilterIp | FilterMac, callback: MagicMock) -> None:
+            if isinstance(filt, FilterIp):
+                payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
+                callback(payload, (resolved_host, 1234))
+                return
+            if original_register is not None:
+                original_register(filt, callback)
+
+        mock_listener.register = MagicMock(side_effect=_on_register)
 
     with ExitStack() as stack:
         mock_verify = stack.enter_context(
@@ -67,11 +114,24 @@ def patch_config_flow_connectivity(
                 return_value={resolved_host},
             )
         )
-        mock_registry = stack.enter_context(
-            patch(
-                "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+        if not use_real_listener_registry:
+            mock_registry = stack.enter_context(
+                patch(
+                    "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+                )
             )
-        )
+            mock_registry.return_value.has_listener.return_value = False
+            mock_registry.return_value.async_get_or_create = AsyncMock(
+                return_value=mock_listener
+            )
+            mock_registry.return_value.async_remove_if_unused = AsyncMock()
+        else:
+            stack.enter_context(
+                patch(
+                    "homeassistant.components.bitvis.coordinator.SharedListener",
+                    return_value=mock_listener,
+                )
+            )
         if discovery_timeout:
             stack.enter_context(
                 patch(
@@ -79,10 +139,6 @@ def patch_config_flow_connectivity(
                     0,
                 )
             )
-        mock_registry.return_value.has_listener.return_value = False
-        mock_registry.return_value.async_get_or_create = AsyncMock(
-            return_value=mock_listener
-        )
         yield mock_verify
 
 
@@ -93,7 +149,7 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         data={CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT},
         unique_id=TEST_DEVICE_MAC,
-        title=MODEL_NAME,
+        title=DEFAULT_NAME,
     )
 
 
@@ -104,7 +160,7 @@ def mock_zeroconf_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         data={CONF_HOST: "192.168.1.200", CONF_PORT: DEFAULT_PORT},
         unique_id=TEST_DEVICE_MAC,
-        title=MODEL_NAME,
+        title=DEFAULT_NAME,
     )
 
 
@@ -115,7 +171,7 @@ def mock_ipv6_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         data={CONF_HOST: "2001:db8::10", CONF_PORT: DEFAULT_PORT},
         unique_id="11:22:33:44:55:66",
-        title=MODEL_NAME,
+        title=DEFAULT_NAME,
     )
 
 
@@ -126,7 +182,7 @@ def mock_second_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         data={CONF_HOST: "192.168.1.101", CONF_PORT: DEFAULT_PORT},
         unique_id=SECOND_DEVICE_MAC,
-        title=MODEL_NAME,
+        title=DEFAULT_NAME,
     )
 
 

--- a/tests/components/bitvis/conftest.py
+++ b/tests/components/bitvis/conftest.py
@@ -29,7 +29,6 @@ def patch_config_flow_connectivity(
     port_bind_side_effect: BaseException | None = None,
     discovery_timeout: bool = False,
     register_side_effect: BaseException | None = None,
-    use_real_listener_registry: bool = False,
     shared_listener: MagicMock | None = None,
 ) -> Iterator[AsyncMock]:
     """Patch library connectivity helpers used by the config flow."""
@@ -114,24 +113,12 @@ def patch_config_flow_connectivity(
                 return_value={resolved_host},
             )
         )
-        if not use_real_listener_registry:
-            mock_registry = stack.enter_context(
-                patch(
-                    "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
-                )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.bitvis.coordinator.SharedListener",
+                return_value=mock_listener,
             )
-            mock_registry.return_value.has_listener.return_value = False
-            mock_registry.return_value.async_get_or_create = AsyncMock(
-                return_value=mock_listener
-            )
-            mock_registry.return_value.async_remove_if_unused = AsyncMock()
-        else:
-            stack.enter_context(
-                patch(
-                    "homeassistant.components.bitvis.coordinator.SharedListener",
-                    return_value=mock_listener,
-                )
-            )
+        )
         if discovery_timeout:
             stack.enter_context(
                 patch(

--- a/tests/components/bitvis/conftest.py
+++ b/tests/components/bitvis/conftest.py
@@ -1,22 +1,87 @@
 """Common fixtures for Bitvis Power Hub tests."""
 
-from collections.abc import Generator, Iterator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from bitvis_protobuf.listener import FilterIp, FilterMac
-from bitvis_protobuf.parse import PayloadSample, parse_payload
+from bitvis_protobuf.listener import Filter, FilterIp
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample, parse_payload
 from bitvis_protobuf.powerhub_pb2 import Payload
+from bitvis_protobuf.utils import InvalidMacAddressError
 import pytest
 
 from homeassistant.components.bitvis.const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
+from . import setup_integration
+
 from tests.common import MockConfigEntry
 
 TEST_DEVICE_MAC = "aa:bb:cc:dd:ee:ff"
 SECOND_DEVICE_MAC = "11:22:33:44:55:66"
+
+type ListenerCallback = Callable[
+    [PayloadSample | PayloadDiagnostic, tuple[str, int]], None
+]
+type ErrorCallback = Callable[[Exception, tuple[str, int]], None]
+
+
+class FakeListener:
+    """In-memory SharedListener stand-in for config-flow and coordinator tests."""
+
+    def __init__(self) -> None:
+        """Initialize callback storage and async start/stop mocks."""
+        self._callbacks: dict[Filter, ListenerCallback] = {}
+        self._error_callbacks: list[ErrorCallback] = []
+        self.start = AsyncMock()
+        self.stop = AsyncMock()
+        self.register = MagicMock(side_effect=self._register)
+        self.unregister = MagicMock(side_effect=self._unregister)
+        self.register_error_callback = MagicMock(
+            side_effect=self._error_callbacks.append
+        )
+        self.unregister_error_callback = MagicMock(side_effect=self._unregister_error)
+        self.dispatch = MagicMock(side_effect=self._dispatch)
+
+    @property
+    def is_empty(self) -> bool:
+        """Return True when no payload callbacks are registered."""
+        return not self._callbacks
+
+    def _register(self, filt: Filter, callback: ListenerCallback) -> None:
+        if filt in self._callbacks:
+            raise RuntimeError(f"Filter already registered: {filt}")
+        self._callbacks[filt] = callback
+
+    def _unregister(self, filt: Filter) -> None:
+        self._callbacks.pop(filt, None)
+
+    def _unregister_error(self, callback: ErrorCallback) -> None:
+        if callback in self._error_callbacks:
+            self._error_callbacks.remove(callback)
+
+    def _dispatch(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            payload = parse_payload(data)
+        except InvalidMacAddressError as err:
+            for callback in self._error_callbacks:
+                callback(err, addr)
+            return
+        if payload is None:
+            return
+        self.deliver(payload, addr)
+
+    def deliver(
+        self,
+        payload: PayloadSample | PayloadDiagnostic,
+        addr: tuple[str, int],
+    ) -> None:
+        """Deliver an already-parsed payload to matching callbacks."""
+        host = addr[0]
+        for filt, callback in self._callbacks.items():
+            if filt.match(payload, host):
+                callback(payload, addr)
 
 
 @contextmanager
@@ -29,74 +94,31 @@ def patch_config_flow_connectivity(
     port_bind_side_effect: BaseException | None = None,
     discovery_timeout: bool = False,
     register_side_effect: BaseException | None = None,
-    shared_listener: MagicMock | None = None,
+    shared_listener: FakeListener | None = None,
 ) -> Iterator[AsyncMock]:
     """Patch library connectivity helpers used by the config flow."""
-    mock_listener = shared_listener or MagicMock()
-    mock_listener.start = AsyncMock()
-    mock_listener.stop = AsyncMock()
+    listener = shared_listener or FakeListener()
 
-    if shared_listener is None:
-        if register_side_effect is not None:
-            mock_listener.register = MagicMock(side_effect=register_side_effect)
-        elif invalid_mac:
+    if register_side_effect is not None:
+        listener.register.side_effect = register_side_effect
+    else:
+        original_register = listener.register.side_effect
 
-            def _dispatch(data: bytes, addr: tuple[str, int]) -> None:
-                parse_payload(data)
-
-            mock_listener.dispatch = MagicMock(side_effect=_dispatch)
-
-            def _on_register(_filt: MagicMock, _callback: MagicMock) -> None:
+        def _on_register(filt: Filter, callback: ListenerCallback) -> None:
+            original_register(filt, callback)
+            if not isinstance(filt, FilterIp):
+                return
+            if invalid_mac:
                 payload = Payload()
                 payload.sample.SetInParent()
-                mock_listener.dispatch(
-                    payload.SerializeToString(), (resolved_host, 1234)
+                listener.dispatch(payload.SerializeToString(), (resolved_host, 1234))
+            elif deliver_mac and not discovery_timeout:
+                callback(
+                    PayloadSample(mac_address=mac_address, sample=MagicMock()),
+                    (resolved_host, 1234),
                 )
 
-            mock_listener.register = MagicMock(side_effect=_on_register)
-        elif deliver_mac and not discovery_timeout:
-
-            def _on_register(_filt: MagicMock, callback: MagicMock) -> None:
-                payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
-                callback(payload, (resolved_host, 1234))
-
-            mock_listener.register = MagicMock(side_effect=_on_register)
-        else:
-            mock_listener.register = MagicMock()
-        mock_listener.unregister = MagicMock()
-        type(mock_listener).is_empty = PropertyMock(return_value=True)
-    elif invalid_mac:
-
-        def _dispatch(data: bytes, addr: tuple[str, int]) -> None:
-            parse_payload(data)
-
-        mock_listener.dispatch = MagicMock(side_effect=_dispatch)
-        original_register = mock_listener.register.side_effect
-
-        def _on_register(filt: FilterIp | FilterMac, callback: MagicMock) -> None:
-            if isinstance(filt, FilterIp):
-                payload = Payload()
-                payload.sample.SetInParent()
-                mock_listener.dispatch(
-                    payload.SerializeToString(), (resolved_host, 1234)
-                )
-                return
-            if original_register is not None:
-                original_register(filt, callback)
-
-        mock_listener.register = MagicMock(side_effect=_on_register)
-    elif deliver_mac and not discovery_timeout:
-        original_register = mock_listener.register.side_effect
-
-        def _on_register(filt: FilterIp | FilterMac, callback: MagicMock) -> None:
-            if isinstance(filt, FilterIp):
-                payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
-                callback(payload, (resolved_host, 1234))
-                return
-            if original_register is not None:
-                original_register(filt, callback)
-
-        mock_listener.register = MagicMock(side_effect=_on_register)
+        listener.register.side_effect = _on_register
 
     with ExitStack() as stack:
         mock_verify = stack.enter_context(
@@ -116,7 +138,7 @@ def patch_config_flow_connectivity(
         stack.enter_context(
             patch(
                 "homeassistant.components.bitvis.coordinator.SharedListener",
-                return_value=mock_listener,
+                return_value=listener,
             )
         )
         if discovery_timeout:
@@ -157,7 +179,7 @@ def mock_ipv6_config_entry() -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "2001:db8::10", CONF_PORT: DEFAULT_PORT},
-        unique_id="11:22:33:44:55:66",
+        unique_id=SECOND_DEVICE_MAC,
         title=DEFAULT_NAME,
     )
 
@@ -174,27 +196,15 @@ def mock_second_config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_shared_listener() -> MagicMock:
-    """Return a mocked bitvis_protobuf SharedListener."""
-    listener = MagicMock()
-    listener._callbacks: dict[FilterMac, MagicMock] = {}
-    listener.start = AsyncMock()
-    listener.stop = AsyncMock()
-
-    def register(filt: FilterMac, callback: MagicMock) -> None:
-        listener._callbacks[filt] = callback
-
-    def unregister(filt: FilterMac) -> None:
-        listener._callbacks.pop(filt, None)
-
-    listener.register = MagicMock(side_effect=register)
-    listener.unregister = MagicMock(side_effect=unregister)
-    type(listener).is_empty = PropertyMock(side_effect=lambda: not listener._callbacks)
-    return listener
+def mock_shared_listener() -> FakeListener:
+    """Return a fake bitvis_protobuf SharedListener."""
+    return FakeListener()
 
 
 @pytest.fixture
-def patch_shared_listener(mock_shared_listener: MagicMock) -> Generator[MagicMock]:
+def patch_shared_listener(
+    mock_shared_listener: FakeListener,
+) -> Generator[FakeListener]:
     """Patch SharedListener to return a mocked instance."""
     with patch(
         "homeassistant.components.bitvis.coordinator.SharedListener",
@@ -216,10 +226,8 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 async def init_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> MockConfigEntry:
     """Set up the integration with a mocked UDP listener."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await setup_integration(hass, mock_config_entry)
     return mock_config_entry

--- a/tests/components/bitvis/conftest.py
+++ b/tests/components/bitvis/conftest.py
@@ -1,0 +1,182 @@
+"""Common fixtures for Bitvis Power Hub tests."""
+
+from collections.abc import Generator, Iterator
+from contextlib import ExitStack, contextmanager
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from bitvis_protobuf.listener import FilterMac
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+
+from homeassistant.components.bitvis.const import DEFAULT_PORT, DOMAIN, MODEL_NAME
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from . import find_listener_callback
+
+from tests.common import MockConfigEntry
+
+TEST_DEVICE_MAC = "aa:bb:cc:dd:ee:ff"
+SECOND_DEVICE_MAC = "11:22:33:44:55:66"
+
+
+def deliver_listener_payload(
+    listener: MagicMock,
+    mac_address: str,
+    payload: PayloadSample | PayloadDiagnostic,
+    addr: tuple[str, int] = ("192.168.1.100", 1234),
+) -> None:
+    """Deliver a payload through a mocked SharedListener registered callback."""
+    find_listener_callback(listener, mac_address)(payload, addr)
+
+
+@contextmanager
+def patch_config_flow_connectivity(
+    resolved_host: str,
+    *,
+    mac_address: str = TEST_DEVICE_MAC,
+    deliver_mac: bool = True,
+    port_bind_side_effect: BaseException | None = None,
+    discovery_timeout: bool = False,
+) -> Iterator[AsyncMock]:
+    """Patch library connectivity helpers used by the config flow."""
+    mock_listener = MagicMock()
+    if deliver_mac and not discovery_timeout:
+
+        def _on_register(_filt: MagicMock, callback: MagicMock) -> None:
+            payload = PayloadSample(mac_address=mac_address, sample=MagicMock())
+            callback(payload, (resolved_host, 1234))
+
+        mock_listener.register = MagicMock(side_effect=_on_register)
+    else:
+        mock_listener.register = MagicMock()
+    mock_listener.unregister = MagicMock()
+
+    with ExitStack() as stack:
+        mock_verify = stack.enter_context(
+            patch(
+                "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
+                new_callable=AsyncMock,
+                side_effect=port_bind_side_effect,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "homeassistant.components.bitvis.config_flow.async_resolve_host",
+                new_callable=AsyncMock,
+                return_value={resolved_host},
+            )
+        )
+        mock_registry = stack.enter_context(
+            patch(
+                "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+            )
+        )
+        if discovery_timeout:
+            stack.enter_context(
+                patch(
+                    "homeassistant.components.bitvis.config_flow.DISCOVERY_TIMEOUT",
+                    0,
+                )
+            )
+        mock_registry.return_value.has_listener.return_value = False
+        mock_registry.return_value.async_get_or_create = AsyncMock(
+            return_value=mock_listener
+        )
+        yield mock_verify
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT},
+        unique_id=TEST_DEVICE_MAC,
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def mock_zeroconf_config_entry() -> MockConfigEntry:
+    """Return a mocked config entry for zeroconf discovery host."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.200", CONF_PORT: DEFAULT_PORT},
+        unique_id=TEST_DEVICE_MAC,
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def mock_ipv6_config_entry() -> MockConfigEntry:
+    """Return a mocked config entry with an IPv6 host."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "2001:db8::10", CONF_PORT: DEFAULT_PORT},
+        unique_id="11:22:33:44:55:66",
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def mock_second_config_entry() -> MockConfigEntry:
+    """Return a second mocked config entry on the same UDP port."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.101", CONF_PORT: DEFAULT_PORT},
+        unique_id=SECOND_DEVICE_MAC,
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def mock_shared_listener() -> MagicMock:
+    """Return a mocked bitvis_protobuf SharedListener."""
+    listener = MagicMock()
+    listener._callbacks: dict[FilterMac, MagicMock] = {}
+    listener.start = AsyncMock()
+    listener.stop = AsyncMock()
+
+    def register(filt: FilterMac, callback: MagicMock) -> None:
+        listener._callbacks[filt] = callback
+
+    def unregister(filt: FilterMac) -> None:
+        listener._callbacks.pop(filt, None)
+
+    listener.register = MagicMock(side_effect=register)
+    listener.unregister = MagicMock(side_effect=unregister)
+    type(listener).is_empty = PropertyMock(side_effect=lambda: not listener._callbacks)
+    return listener
+
+
+@pytest.fixture
+def patch_shared_listener(mock_shared_listener: MagicMock) -> Generator[MagicMock]:
+    """Patch SharedListener to return a mocked instance."""
+    with patch(
+        "homeassistant.components.bitvis.coordinator.SharedListener",
+        return_value=mock_shared_listener,
+    ):
+        yield mock_shared_listener
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.bitvis.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> MockConfigEntry:
+    """Set up the integration with a mocked UDP listener."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/bitvis/snapshots/test_sensor.ambr
+++ b/tests/components/bitvis/snapshots/test_sensor.ambr
@@ -1,0 +1,1721 @@
+# serializer version: 1
+# name: test_all_entities[sensor.power_hub_active_energy_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_energy_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active energy export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Active energy export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_active_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_by_client',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_energy_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '789.119995117188',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_energy_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active energy import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Active energy import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_active_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_to_client',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_energy_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1234.56005859375',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l1_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l2_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l3_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.41499996185303',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l1_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.800000011920929',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l2_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.699999988079071',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_l3_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.915000021457672',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current_l1',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l1',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current_l2',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l2',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.30000019073486',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current_l3',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l3',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.1000003814697',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_buffer_overflows-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'HAN buffer overflows',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'HAN buffer overflows',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'han_msg_buffer_overflow',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_han_msg_buffer_overflow',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_buffer_overflows-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN buffer overflows',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'HAN messages successfully parsed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'HAN messages successfully parsed',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'han_msg_successfully_parsed',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_han_msg_successfully_parsed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN messages successfully parsed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive energy export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_ENERGY: 'reactive_energy'>,
+    'original_icon': None,
+    'original_name': 'Reactive energy export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_reactive_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '23.4500007629395',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive energy import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_ENERGY: 'reactive_energy'>,
+    'original_icon': None,
+    'original_name': 'Reactive energy import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_reactive_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45.6699981689453',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l1_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l2_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l3_delivered_by_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l1_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.200000002980232',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l2_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.150000005960464',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_l3_delivered_to_client',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.150000005960464',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'uptime',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'uptime',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-12-31T12:00:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage_l1',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '230.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage_l2',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l2',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '229.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage_l3',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l3',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '231.199996948242',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi signal strength',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Wi-Fi signal strength',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_rssi',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_wifi_rssi',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Wi-Fi signal strength',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-65',
+  })
+# ---

--- a/tests/components/bitvis/snapshots/test_sensor.ambr
+++ b/tests/components/bitvis/snapshots/test_sensor.ambr
@@ -36,7 +36,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'energy_active_delivered_by_client',
+    'translation_key': 'energy_active',
     'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_by_client',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
@@ -94,7 +94,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'energy_active_delivered_to_client',
+    'translation_key': 'energy_active',
     'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_to_client',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
@@ -152,7 +152,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_delivered_by_client',
+    'translation_key': 'power_active',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_by_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -210,7 +210,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l1_delivered_by_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_by_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -268,7 +268,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l2_delivered_by_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_by_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -326,7 +326,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l3_delivered_by_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_by_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -384,7 +384,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_delivered_to_client',
+    'translation_key': 'power_active',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_to_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -442,7 +442,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l1_delivered_to_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_to_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -500,7 +500,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l2_delivered_to_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_to_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -558,7 +558,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_active_l3_delivered_to_client',
+    'translation_key': 'power_active_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_to_client',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
@@ -616,7 +616,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_current_l1',
+    'translation_key': 'phase_current',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l1',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
@@ -674,7 +674,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_current_l2',
+    'translation_key': 'phase_current',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l2',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
@@ -732,7 +732,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_current_l3',
+    'translation_key': 'phase_current',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l3',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
@@ -896,7 +896,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'energy_reactive_delivered_by_client',
+    'translation_key': 'energy_reactive',
     'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_by_client',
     'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
   })
@@ -954,7 +954,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'energy_reactive_delivered_to_client',
+    'translation_key': 'energy_reactive',
     'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_to_client',
     'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
   })
@@ -1012,7 +1012,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_delivered_by_client',
+    'translation_key': 'power_reactive',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_by_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1070,7 +1070,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l1_delivered_by_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_by_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1128,7 +1128,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l2_delivered_by_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_by_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1186,7 +1186,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l3_delivered_by_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_by_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1244,7 +1244,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_delivered_to_client',
+    'translation_key': 'power_reactive',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_to_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1302,7 +1302,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l1_delivered_to_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_to_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1360,7 +1360,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l2_delivered_to_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_to_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1418,7 +1418,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'power_reactive_l3_delivered_to_client',
+    'translation_key': 'power_reactive_phase',
     'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_to_client',
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
@@ -1471,7 +1471,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'uptime',
+    'translation_key': None,
     'unique_id': 'aa:bb:cc:dd:ee:ff_uptime',
     'unit_of_measurement': None,
   })
@@ -1527,7 +1527,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_voltage_l1',
+    'translation_key': 'phase_voltage',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l1',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
@@ -1585,7 +1585,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_voltage_l2',
+    'translation_key': 'phase_voltage',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l2',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
@@ -1643,7 +1643,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'phase_voltage_l3',
+    'translation_key': 'phase_voltage',
     'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l3',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })

--- a/tests/components/bitvis/snapshots/test_sensor.ambr
+++ b/tests/components/bitvis/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[sensor.power_hub_active_energy_export-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_energy_export-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_energy_export',
+    'entity_id': 'sensor.bitvis_power_hub_active_energy_export',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -41,23 +41,23 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_energy_export-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_energy_export-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy export',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active energy export',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_energy_export',
+    'entity_id': 'sensor.bitvis_power_hub_active_energy_export',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '789.119995117188',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_energy_import-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_energy_import-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -73,7 +73,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_energy_import',
+    'entity_id': 'sensor.bitvis_power_hub_active_energy_import',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -99,23 +99,23 @@
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_energy_import-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_energy_import-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy import',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active energy import',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_energy_import',
+    'entity_id': 'sensor.bitvis_power_hub_active_energy_import',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1234.56005859375',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -131,7 +131,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_export',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -157,23 +157,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power export',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_export',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -189,7 +189,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -215,23 +215,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power export L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -247,7 +247,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -273,23 +273,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power export L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -305,7 +305,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -331,23 +331,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_export_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_export_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power export L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_export_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -363,7 +363,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_import',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -389,23 +389,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power import',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_import',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2.41499996185303',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -421,7 +421,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -447,23 +447,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power import L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.800000011920929',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -479,7 +479,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -505,23 +505,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power import L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.699999988079071',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -537,7 +537,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -563,23 +563,23 @@
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_active_power_import_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_active_power_import_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Active power import L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'entity_id': 'sensor.bitvis_power_hub_active_power_import_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.915000021457672',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -595,7 +595,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_current_l1',
+    'entity_id': 'sensor.bitvis_power_hub_current_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -621,23 +621,23 @@
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Current L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_current_l1',
+    'entity_id': 'sensor.bitvis_power_hub_current_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10.5',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -653,7 +653,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_current_l2',
+    'entity_id': 'sensor.bitvis_power_hub_current_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -679,23 +679,23 @@
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Current L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_current_l2',
+    'entity_id': 'sensor.bitvis_power_hub_current_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '8.30000019073486',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -711,7 +711,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_current_l3',
+    'entity_id': 'sensor.bitvis_power_hub_current_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -737,23 +737,23 @@
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_current_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_current_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Current L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_current_l3',
+    'entity_id': 'sensor.bitvis_power_hub_current_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '12.1000003814697',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_han_buffer_overflows-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_han_buffer_overflows-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -769,7 +769,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'entity_id': 'sensor.bitvis_power_hub_han_buffer_overflows',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -792,21 +792,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_han_buffer_overflows-state]
+# name: test_all_entities[sensor.bitvis_power_hub_han_buffer_overflows-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN buffer overflows',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub HAN buffer overflows',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'entity_id': 'sensor.bitvis_power_hub_han_buffer_overflows',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_han_messages_successfully_parsed-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -822,7 +822,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'entity_id': 'sensor.bitvis_power_hub_han_messages_successfully_parsed',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -845,21 +845,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-state]
+# name: test_all_entities[sensor.bitvis_power_hub_han_messages_successfully_parsed-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN messages successfully parsed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub HAN messages successfully parsed',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'entity_id': 'sensor.bitvis_power_hub_han_messages_successfully_parsed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1000',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_energy_export-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_energy_export-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -875,7 +875,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_energy_export',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -901,23 +901,23 @@
     'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_energy_export-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_energy_export-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy export',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive energy export',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_energy_export',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '23.4500007629395',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_energy_import-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_energy_import-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -933,7 +933,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_energy_import',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -959,23 +959,23 @@
     'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_energy_import-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_energy_import-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy import',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive energy import',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_energy_import',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '45.6699981689453',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -991,7 +991,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1017,23 +1017,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power export',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1049,7 +1049,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1075,23 +1075,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power export L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1107,7 +1107,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1133,23 +1133,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power export L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1165,7 +1165,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1191,23 +1191,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_export_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power export L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_export_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1223,7 +1223,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1249,23 +1249,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power import',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.5',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1281,7 +1281,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1307,23 +1307,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power import L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.200000002980232',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1339,7 +1339,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1365,23 +1365,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power import L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.150000005960464',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1397,7 +1397,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1423,23 +1423,23 @@
     'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_reactive_power_import_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Reactive power import L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'entity_id': 'sensor.bitvis_power_hub_reactive_power_import_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.150000005960464',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_uptime-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_uptime-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1453,7 +1453,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.power_hub_uptime',
+    'entity_id': 'sensor.bitvis_power_hub_uptime',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1476,21 +1476,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_uptime-state]
+# name: test_all_entities[sensor.bitvis_power_hub_uptime-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'uptime',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Uptime',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Uptime',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_uptime',
+    'entity_id': 'sensor.bitvis_power_hub_uptime',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2025-12-31T12:00:00+00:00',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l1-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1506,7 +1506,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_voltage_l1',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1532,23 +1532,23 @@
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l1-state]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Voltage L1',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_voltage_l1',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '230.0',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l2-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1564,7 +1564,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_voltage_l2',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1590,23 +1590,23 @@
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l2-state]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L2',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Voltage L2',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_voltage_l2',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '229.5',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l3-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1622,7 +1622,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.power_hub_voltage_l3',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1648,23 +1648,23 @@
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
-# name: test_all_entities[sensor.power_hub_voltage_l3-state]
+# name: test_all_entities[sensor.bitvis_power_hub_voltage_l3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Voltage L3',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_voltage_l3',
+    'entity_id': 'sensor.bitvis_power_hub_voltage_l3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '231.199996948242',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-entry]
+# name: test_all_entities[sensor.bitvis_power_hub_wi_fi_signal_strength-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1680,7 +1680,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'entity_id': 'sensor.bitvis_power_hub_wi_fi_signal_strength',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1703,16 +1703,16 @@
     'unit_of_measurement': 'dBm',
   })
 # ---
-# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-state]
+# name: test_all_entities[sensor.bitvis_power_hub_wi_fi_signal_strength-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Wi-Fi signal strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bitvis Power Hub Wi-Fi signal strength',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'entity_id': 'sensor.bitvis_power_hub_wi_fi_signal_strength',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/bitvis/snapshots/test_sensor.ambr
+++ b/tests/components/bitvis/snapshots/test_sensor.ambr
@@ -1,0 +1,1721 @@
+# serializer version: 1
+# name: test_all_entities[sensor.power_hub_active_energy_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_energy_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active energy export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Active energy export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_active_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_by_client',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_energy_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '789.119995117188',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_energy_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active energy import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Active energy import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_active_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_active_delivered_to_client',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_energy_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active energy import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_energy_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1234.56005859375',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power export L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power export L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_by_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_export_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power export L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_export_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.41499996185303',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l1_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.800000011920929',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l2_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.699999988079071',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active power import L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Active power import L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_active_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_active_l3_delivered_to_client',
+    'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_active_power_import_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Active power import L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_active_power_import_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.915000021457672',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l1',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l2',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.30000019073486',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_current_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_current',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_current_l3',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_current_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Current L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_current_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.1000003814697',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_buffer_overflows-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'HAN buffer overflows',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'HAN buffer overflows',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'han_msg_buffer_overflow',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_han_msg_buffer_overflow',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_buffer_overflows-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN buffer overflows',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_han_buffer_overflows',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'HAN messages successfully parsed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'HAN messages successfully parsed',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'han_msg_successfully_parsed',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_han_msg_successfully_parsed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_han_messages_successfully_parsed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub HAN messages successfully parsed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_han_messages_successfully_parsed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1000',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive energy export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_ENERGY: 'reactive_energy'>,
+    'original_icon': None,
+    'original_name': 'Reactive energy export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_reactive_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_energy_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '23.4500007629395',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive energy import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_ENERGY: 'reactive_energy'>,
+    'original_icon': None,
+    'original_name': 'Reactive energy import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'energy_reactive_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_energy_reactive_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_energy_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive energy import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactiveEnergy.KILO_VOLT_AMPERE_REACTIVE_HOUR: 'kvarh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_energy_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45.6699981689453',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power export L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power export L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_export',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_by_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_export_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power export L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_export_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l1_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.200000002980232',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l2_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.150000005960464',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Reactive power import L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 3,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.REACTIVE_POWER: 'reactive_power'>,
+    'original_icon': None,
+    'original_name': 'Reactive power import L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_reactive_phase_import',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_power_reactive_l3_delivered_to_client',
+    'unit_of_measurement': <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_reactive_power_import_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'reactive_power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Reactive power import L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfReactivePower.KILO_VOLT_AMPERE_REACTIVE: 'kvar'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_reactive_power_import_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.150000005960464',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_uptime-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_uptime',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Uptime',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.UPTIME: 'uptime'>,
+    'original_icon': None,
+    'original_name': 'Uptime',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_uptime',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_uptime-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'uptime',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Uptime',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_uptime',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2025-12-31T12:00:00+00:00',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L1',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L1',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L1',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '230.0',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L2',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L2',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l2',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L2',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '229.5',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.power_hub_voltage_l3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Voltage L3',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Voltage L3',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'phase_voltage',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_phase_voltage_l3',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_voltage_l3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Voltage L3',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_voltage_l3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '231.199996948242',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wi-Fi signal strength',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Wi-Fi signal strength',
+    'platform': 'bitvis',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wifi_rssi',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_wifi_rssi',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_all_entities[sensor.power_hub_wi_fi_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Power Hub Wi-Fi signal strength',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.power_hub_wi_fi_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-65',
+  })
+# ---

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -1,0 +1,559 @@
+"""Tests for the Bitvis Power Hub config flow."""
+
+import asyncio
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.bitvis.config_flow import _async_test_port
+from homeassistant.components.bitvis.const import (
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DOMAIN,
+    MODEL_NAME,
+)
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .conftest import TEST_DEVICE_MAC
+
+from tests.common import MockConfigEntry
+
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
+    ip_address=ip_address("192.168.1.200"),
+    ip_addresses=[ip_address("192.168.1.200")],
+    hostname="powerhub.local.",
+    name="Bitvis Power Hub._powerhub._udp.local.",
+    port=DEFAULT_PORT,
+    properties={},
+    type="_powerhub._udp.local.",
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_get_mac_address_for_host() -> None:
+    """Mock MAC address lookup for config flow tests."""
+    with patch(
+        "homeassistant.components.bitvis.config_flow.get_mac_address_for_host",
+        return_value=TEST_DEVICE_MAC,
+    ):
+        yield
+
+
+async def test_user_form(hass: HomeAssistant) -> None:
+    """Test we get the user form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_user_form_create_entry(hass: HomeAssistant) -> None:
+    """Test creating an entry via user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: 5000,
+    }
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
+
+
+@pytest.mark.parametrize("recover", [False, True])
+async def test_user_form_cannot_connect(hass: HomeAssistant, recover: bool) -> None:
+    """Test user form error on port bind failure, optionally with recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.bitvis.config_flow._async_test_port",
+        side_effect=OSError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    if recover:
+        with (
+            patch(
+                "homeassistant.components.bitvis.config_flow._async_test_port",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "homeassistant.components.bitvis.async_setup_entry",
+                return_value=True,
+            ),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_HOST: "192.168.1.100",
+                    CONF_PORT: 5000,
+                },
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == MODEL_NAME
+        assert result["data"] == {
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 5000,
+        }
+
+
+async def test_user_form_duplicate(hass: HomeAssistant) -> None:
+    """Test duplicate detection."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 5000,
+        },
+        unique_id=TEST_DEVICE_MAC,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.bitvis.config_flow._async_test_port",
+        new_callable=AsyncMock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_confirm_creates_entry(hass: HomeAssistant) -> None:
+    """Test that zeroconf discovery shows confirmation form and creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: "192.168.1.200",
+        CONF_PORT: DEFAULT_PORT,
+    }
+
+
+@pytest.mark.parametrize("recover", [False, True])
+async def test_zeroconf_confirm_cannot_connect(
+    hass: HomeAssistant, recover: bool
+) -> None:
+    """Test zeroconf confirm abort on port bind failure, optionally with recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    with patch(
+        "homeassistant.components.bitvis.config_flow._async_test_port",
+        side_effect=OSError,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+    if recover:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+        with (
+            patch(
+                "homeassistant.components.bitvis.config_flow._async_test_port",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "homeassistant.components.bitvis.async_setup_entry",
+                return_value=True,
+            ),
+        ):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], user_input={}
+            )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"] == {
+            CONF_HOST: "192.168.1.200",
+            CONF_PORT: DEFAULT_PORT,
+        }
+
+
+async def test_zeroconf_duplicate(hass: HomeAssistant) -> None:
+    """Test that a duplicate zeroconf discovery is aborted."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.200", CONF_PORT: DEFAULT_PORT},
+        unique_id=TEST_DEVICE_MAC,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_none_port_uses_default(hass: HomeAssistant) -> None:
+    """Test that a zeroconf discovery with port=None falls back to DEFAULT_PORT."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
+        hostname="powerhub.local.",
+        name="Bitvis Power Hub._powerhub._udp.local.",
+        port=None,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery,
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+
+
+async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
+    """Test creating an entry with an IPv6 host via user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "2001:db8::10",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: "2001:db8::10",
+        CONF_PORT: 5000,
+    }
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_duplicate_mac(hass: HomeAssistant) -> None:
+    """Test duplicate detection uses the device MAC address."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "2001:db8::10",
+            CONF_PORT: 5000,
+        },
+        unique_id=TEST_DEVICE_MAC,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.bitvis.config_flow._async_test_port",
+        new_callable=AsyncMock,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "2001:db8::10",
+                CONF_PORT: 5001,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_form_resolve_host_failure_uses_host_for_mac_lookup(
+    hass: HomeAssistant,
+) -> None:
+    """Test that user flow falls back to raw host when DNS resolution fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "my-powerhub.local",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"][CONF_HOST] == "my-powerhub.local"
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_normalize_bracketed_ipv6(
+    hass: HomeAssistant,
+) -> None:
+    """Test that bracketed IPv6 host is normalized (brackets stripped)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "[2001:db8::10]",
+                CONF_PORT: 5000,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"][CONF_HOST] == "2001:db8::10"
+
+
+async def test_zeroconf_confirm_uses_friendly_name(hass: HomeAssistant) -> None:
+    """Test that zeroconf confirm creates entry with friendly name from discovery."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
+        hostname="powerhub.local.",
+        name="My Custom Hub._powerhub._udp.local.",
+        port=DEFAULT_PORT,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery,
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Custom Hub"
+
+
+async def test_zeroconf_empty_name_uses_default(hass: HomeAssistant) -> None:
+    """Test that zeroconf with empty name falls back to DEFAULT_NAME."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.201"),
+        ip_addresses=[ip_address("192.168.1.201")],
+        hostname="powerhub.local.",
+        name="",
+        port=DEFAULT_PORT,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=discovery,
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow._async_test_port",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+
+
+async def test_async_test_port_skips_when_listener_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Test _async_test_port returns immediately when a listener already exists."""
+    with patch(
+        "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+    ) as mock_registry:
+        mock_registry.return_value.has_listener.return_value = True
+        # Should return without attempting to bind
+        await _async_test_port(hass, 5000)
+
+    mock_registry.return_value.has_listener.assert_called_once_with(5000)
+
+
+async def test_async_test_port_binds_and_closes(hass: HomeAssistant) -> None:
+    """Test _async_test_port binds transports and closes them."""
+    mock_transport = MagicMock(spec=asyncio.DatagramTransport)
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+        ) as mock_registry,
+        patch.object(
+            hass.loop,
+            "create_datagram_endpoint",
+            new_callable=AsyncMock,
+            return_value=(mock_transport, MagicMock()),
+        ),
+    ):
+        mock_registry.return_value.has_listener.return_value = False
+        await _async_test_port(hass, 5000)
+
+    mock_transport.close.assert_called()
+
+
+async def test_async_test_port_raises_when_all_binds_fail(
+    hass: HomeAssistant,
+) -> None:
+    """Test _async_test_port raises OSError when no binds succeed."""
+    with patch(
+        "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+    ) as mock_registry:
+        mock_registry.return_value.has_listener.return_value = False
+        with (
+            patch.object(
+                hass.loop,
+                "create_datagram_endpoint",
+                new_callable=AsyncMock,
+                side_effect=OSError("bind failed"),
+            ),
+            pytest.raises(OSError, match="UDP port is unavailable"),
+        ):
+            await _async_test_port(hass, 5000)

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -19,8 +19,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .conftest import TEST_DEVICE_MAC
-
 from tests.common import MockConfigEntry
 
 ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
@@ -32,16 +30,6 @@ ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
     properties={},
     type="_powerhub._udp.local.",
 )
-
-
-@pytest.fixture(autouse=True)
-def mock_get_mac_address_for_host() -> None:
-    """Mock MAC address lookup for config flow tests."""
-    with patch(
-        "homeassistant.components.bitvis.config_flow.get_mac_address_for_host",
-        return_value=TEST_DEVICE_MAC,
-    ):
-        yield
 
 
 async def test_user_form(hass: HomeAssistant) -> None:
@@ -73,7 +61,6 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
             result["flow_id"],
             {
                 CONF_HOST: "192.168.1.100",
-                CONF_PORT: 5000,
             },
         )
 
@@ -81,9 +68,9 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
     assert result["title"] == MODEL_NAME
     assert result["data"] == {
         CONF_HOST: "192.168.1.100",
-        CONF_PORT: 5000,
+        CONF_PORT: DEFAULT_PORT,
     }
-    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == DOMAIN
 
 
 @pytest.mark.parametrize("recover", [False, True])
@@ -101,7 +88,6 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, recover: bool) -> N
             result["flow_id"],
             {
                 CONF_HOST: "192.168.1.100",
-                CONF_PORT: 5000,
             },
         )
 
@@ -123,7 +109,6 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, recover: bool) -> N
                 result["flow_id"],
                 {
                     CONF_HOST: "192.168.1.100",
-                    CONF_PORT: 5000,
                 },
             )
 
@@ -131,7 +116,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, recover: bool) -> N
         assert result["title"] == MODEL_NAME
         assert result["data"] == {
             CONF_HOST: "192.168.1.100",
-            CONF_PORT: 5000,
+            CONF_PORT: DEFAULT_PORT,
         }
 
 
@@ -141,9 +126,8 @@ async def test_user_form_duplicate(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         data={
             CONF_HOST: "192.168.1.100",
-            CONF_PORT: 5000,
+            CONF_PORT: DEFAULT_PORT,
         },
-        unique_id=TEST_DEVICE_MAC,
     )
     entry.add_to_hass(hass)
 
@@ -159,7 +143,6 @@ async def test_user_form_duplicate(hass: HomeAssistant) -> None:
             result["flow_id"],
             {
                 CONF_HOST: "192.168.1.100",
-                CONF_PORT: 5000,
             },
         )
 
@@ -196,6 +179,7 @@ async def test_zeroconf_confirm_creates_entry(hass: HomeAssistant) -> None:
         CONF_HOST: "192.168.1.200",
         CONF_PORT: DEFAULT_PORT,
     }
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == DOMAIN
 
 
 @pytest.mark.parametrize("recover", [False, True])
@@ -253,7 +237,6 @@ async def test_zeroconf_duplicate(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_HOST: "192.168.1.200", CONF_PORT: DEFAULT_PORT},
-        unique_id=TEST_DEVICE_MAC,
     )
     entry.add_to_hass(hass)
 
@@ -323,7 +306,6 @@ async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
             result["flow_id"],
             {
                 CONF_HOST: "2001:db8::10",
-                CONF_PORT: 5000,
             },
         )
 
@@ -331,21 +313,20 @@ async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
     assert result["title"] == MODEL_NAME
     assert result["data"] == {
         CONF_HOST: "2001:db8::10",
-        CONF_PORT: 5000,
+        CONF_PORT: DEFAULT_PORT,
     }
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == DOMAIN
 
 
-async def test_user_form_duplicate_mac(hass: HomeAssistant) -> None:
-    """Test duplicate detection uses the device MAC address."""
+async def test_user_form_duplicate_host(hass: HomeAssistant) -> None:
+    """Test duplicate detection uses the configured host."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_HOST: "2001:db8::10",
-            CONF_PORT: 5000,
+            CONF_PORT: DEFAULT_PORT,
         },
-        unique_id=TEST_DEVICE_MAC,
     )
     entry.add_to_hass(hass)
 
@@ -361,7 +342,6 @@ async def test_user_form_duplicate_mac(hass: HomeAssistant) -> None:
             result["flow_id"],
             {
                 CONF_HOST: "2001:db8::10",
-                CONF_PORT: 5001,
             },
         )
 
@@ -369,10 +349,10 @@ async def test_user_form_duplicate_mac(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_user_form_resolve_host_failure_uses_host_for_mac_lookup(
+async def test_user_form_keeps_hostname(
     hass: HomeAssistant,
 ) -> None:
-    """Test that user flow falls back to raw host when DNS resolution fails."""
+    """Test that user flow keeps the configured hostname."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -391,14 +371,12 @@ async def test_user_form_resolve_host_failure_uses_host_for_mac_lookup(
             result["flow_id"],
             {
                 CONF_HOST: "my-powerhub.local",
-                CONF_PORT: 5000,
             },
         )
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"][CONF_HOST] == "my-powerhub.local"
-    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == TEST_DEVICE_MAC
 
 
 async def test_user_form_normalize_bracketed_ipv6(
@@ -423,7 +401,6 @@ async def test_user_form_normalize_bracketed_ipv6(
             result["flow_id"],
             {
                 CONF_HOST: "[2001:db8::10]",
-                CONF_PORT: 5000,
             },
         )
 

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -49,7 +49,7 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
     with patch_config_flow_connectivity(USER_HOST):
@@ -60,7 +60,7 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"] == {
         CONF_HOST: USER_HOST,
@@ -85,7 +85,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
     with patch_config_flow_connectivity(USER_HOST):
@@ -96,7 +96,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"] == {
         CONF_HOST: USER_HOST,
@@ -106,7 +106,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
 
 
 async def test_user_form_discovery_timeout(hass: HomeAssistant) -> None:
-    """Test user form error when no UDP message is received in time."""
+    """Test user form error when no UDP message is received in time and recovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -121,8 +121,24 @@ async def test_user_form_discovery_timeout(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "timeout_connect"}
+
+    with patch_config_flow_connectivity(USER_HOST):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: USER_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
 async def test_user_form_duplicate(
@@ -143,35 +159,12 @@ async def test_user_form_duplicate(
             },
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_confirm_creates_entry(hass: HomeAssistant) -> None:
-    """Test that zeroconf discovery shows confirmation form and creates entry."""
-    with patch_config_flow_connectivity(ZEROCONF_HOST):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZEROCONF_DISCOVERY,
-        )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["data"] == {
-        CONF_HOST: ZEROCONF_HOST,
-        CONF_PORT: DEFAULT_PORT,
-    }
-    assert result["result"].unique_id == TEST_DEVICE_MAC
-
-
 async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
-    """Test zeroconf discovery abort on port bind failure and recovery."""
+    """Test zeroconf discovery abort on port bind failure."""
     with patch_config_flow_connectivity(
         ZEROCONF_HOST, port_bind_side_effect=OSError("UDP port is unavailable")
     ):
@@ -181,29 +174,8 @@ async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
             data=ZEROCONF_DISCOVERY,
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
-
-    with patch_config_flow_connectivity(ZEROCONF_HOST):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZEROCONF_DISCOVERY,
-        )
-
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "zeroconf_confirm"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["data"] == {
-        CONF_HOST: ZEROCONF_HOST,
-        CONF_PORT: DEFAULT_PORT,
-    }
-    assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
 async def test_zeroconf_confirm_discovery_timeout(hass: HomeAssistant) -> None:
@@ -217,7 +189,7 @@ async def test_zeroconf_confirm_discovery_timeout(hass: HomeAssistant) -> None:
             data=ZEROCONF_DISCOVERY,
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "timeout_connect"
 
 
@@ -233,7 +205,7 @@ async def test_zeroconf_duplicate(
         data=ZEROCONF_DISCOVERY,
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -260,7 +232,7 @@ async def test_zeroconf_none_port_uses_default(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_PORT] == DEFAULT_PORT
 
 
@@ -279,7 +251,7 @@ async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"] == {
         CONF_HOST: ipv6_host,
@@ -307,7 +279,7 @@ async def test_user_form_duplicate_host(
             },
         )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
@@ -327,7 +299,7 @@ async def test_user_form_keeps_hostname(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"][CONF_HOST] == hostname
 
@@ -347,7 +319,7 @@ async def test_user_form_normalize_bracketed_ipv6(hass: HomeAssistant) -> None:
             },
         )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == MODEL_NAME
     assert result["data"][CONF_HOST] == ipv6_host
 
@@ -375,7 +347,7 @@ async def test_zeroconf_confirm_uses_friendly_name(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "My Custom Hub"
 
 
@@ -402,7 +374,7 @@ async def test_zeroconf_empty_name_uses_default(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
 
 

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -2,21 +2,12 @@
 
 import asyncio
 from ipaddress import ip_address
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
-from bitvis_protobuf.parse import PayloadSample
 import pytest
 
-from homeassistant.components.bitvis.config_flow import (
-    _async_discover_mac_address,
-    _async_test_port,
-)
-from homeassistant.components.bitvis.const import (
-    DEFAULT_NAME,
-    DEFAULT_PORT,
-    DOMAIN,
-    MODEL_NAME,
-)
+from homeassistant.components.bitvis.const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
+from homeassistant.components.bitvis.coordinator import async_get_listener_registry
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -61,7 +52,7 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"] == {
         CONF_HOST: USER_HOST,
         CONF_PORT: DEFAULT_PORT,
@@ -97,11 +88,40 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"] == {
         CONF_HOST: USER_HOST,
         CONF_PORT: DEFAULT_PORT,
     }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_invalid_mac(hass: HomeAssistant) -> None:
+    """Test user form error when device sends payload without MAC and recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(USER_HOST, invalid_mac=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_mac"}
+
+    with patch_config_flow_connectivity(USER_HOST):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
@@ -133,7 +153,7 @@ async def test_user_form_discovery_timeout(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"] == {
         CONF_HOST: USER_HOST,
         CONF_PORT: DEFAULT_PORT,
@@ -176,6 +196,19 @@ async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+
+async def test_zeroconf_confirm_invalid_mac(hass: HomeAssistant) -> None:
+    """Test zeroconf discovery abort when device sends payload without MAC."""
+    with patch_config_flow_connectivity(ZEROCONF_HOST, invalid_mac=True):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_mac"
 
 
 async def test_zeroconf_confirm_discovery_timeout(hass: HomeAssistant) -> None:
@@ -252,7 +285,7 @@ async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"] == {
         CONF_HOST: ipv6_host,
         CONF_PORT: DEFAULT_PORT,
@@ -300,7 +333,7 @@ async def test_user_form_keeps_hostname(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_HOST] == hostname
 
 
@@ -320,7 +353,7 @@ async def test_user_form_normalize_bracketed_ipv6(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == MODEL_NAME
+    assert result["title"] == DEFAULT_NAME
     assert result["data"][CONF_HOST] == ipv6_host
 
 
@@ -378,86 +411,138 @@ async def test_zeroconf_empty_name_uses_default(hass: HomeAssistant) -> None:
     assert result["title"] == DEFAULT_NAME
 
 
-async def test_async_test_port_skips_when_listener_exists(
+async def test_aborted_flow_removes_listener(
     hass: HomeAssistant,
+    mock_shared_listener: MagicMock,
 ) -> None:
-    """Test _async_test_port returns immediately when a listener already exists."""
-    with patch(
-        "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
-    ) as mock_registry:
-        mock_registry.return_value.has_listener.return_value = True
-        await _async_test_port(hass, 5000)
-
-    mock_registry.return_value.has_listener.assert_called_once_with(5000)
-
-
-async def test_async_test_port_binds_and_closes(hass: HomeAssistant) -> None:
-    """Test _async_test_port delegates to the library port bind check."""
-    with (
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
-        ) as mock_registry,
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
-            new_callable=AsyncMock,
-        ) as mock_verify,
+    """Test listener is stopped after an aborted config flow."""
+    with patch_config_flow_connectivity(
+        USER_HOST,
+        deliver_mac=False,
+        discovery_timeout=True,
+        use_real_listener_registry=True,
+        shared_listener=mock_shared_listener,
     ):
-        mock_registry.return_value.has_listener.return_value = False
-        await _async_test_port(hass, 5000)
-
-    mock_verify.assert_awaited_once_with(5000)
-
-
-async def test_async_test_port_raises_when_all_binds_fail(
-    hass: HomeAssistant,
-) -> None:
-    """Test _async_test_port raises OSError when the library port bind check fails."""
-    with (
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
-        ) as mock_registry,
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
-            new_callable=AsyncMock,
-            side_effect=OSError("UDP port is unavailable"),
-        ),
-    ):
-        mock_registry.return_value.has_listener.return_value = False
-        with pytest.raises(OSError, match="UDP port is unavailable"):
-            await _async_test_port(hass, 5000)
-
-
-async def test_async_discover_mac_address(hass: HomeAssistant) -> None:
-    """Test _async_discover_mac_address registers IP filters and returns MAC."""
-    mock_listener = MagicMock()
-    mock_listener.register = MagicMock()
-    mock_listener.unregister = MagicMock()
-
-    with (
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_resolve_host",
-            new_callable=AsyncMock,
-            return_value={USER_HOST},
-        ),
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
-        ) as mock_registry,
-    ):
-        mock_registry.return_value.async_get_or_create = AsyncMock(
-            return_value=mock_listener
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
         )
 
-        discover_task = asyncio.create_task(
-            _async_discover_mac_address(hass, USER_HOST, DEFAULT_PORT)
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "timeout_connect"}
+    mock_shared_listener.stop.assert_awaited_once()
+    assert not async_get_listener_registry(hass).has_listener(DEFAULT_PORT)
+
+
+async def test_concurrent_flow_same_host_aborts(hass: HomeAssistant) -> None:
+    """Test concurrent flows for the same host abort with already_in_progress."""
+    with patch_config_flow_connectivity(USER_HOST, deliver_mac=False):
+        first_result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        first_task = asyncio.create_task(
+            hass.config_entries.flow.async_configure(
+                first_result["flow_id"],
+                {
+                    CONF_HOST: USER_HOST,
+                },
+            )
         )
         await hass.async_block_till_done()
 
-        callback = mock_listener.register.call_args[0][1]
+        second_result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        second_result = await hass.config_entries.flow.async_configure(
+            second_result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
 
-        payload = PayloadSample(mac_address=TEST_DEVICE_MAC, sample=MagicMock())
-        callback(payload, (USER_HOST, 1234))
+        first_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_task
 
-        mac_address = await discover_task
+    assert second_result["type"] is FlowResultType.ABORT
+    assert second_result["reason"] == "already_in_progress"
 
-    assert mac_address == TEST_DEVICE_MAC
-    mock_listener.unregister.assert_called_once()
+
+async def test_discovery_register_runtime_error_aborts(hass: HomeAssistant) -> None:
+    """Test discovery aborts when filter registration raises RuntimeError."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(
+        USER_HOST,
+        deliver_mac=False,
+        register_side_effect=RuntimeError("Filter already registered"),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_in_progress"
+
+
+async def test_zeroconf_dot_prefixed_name_uses_default(hass: HomeAssistant) -> None:
+    """Test zeroconf with empty instance name falls back to DEFAULT_NAME."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address(ZEROCONF_HOST),
+        ip_addresses=[ip_address(ZEROCONF_HOST)],
+        hostname="powerhub.local.",
+        name="._powerhub._udp.local.",
+        port=DEFAULT_PORT,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=discovery,
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+
+
+async def test_zeroconf_concurrent_flow_same_host_aborts(hass: HomeAssistant) -> None:
+    """Test concurrent zeroconf flows for the same host abort."""
+    with patch_config_flow_connectivity(ZEROCONF_HOST, deliver_mac=False):
+        first_task = asyncio.create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_ZEROCONF},
+                data=ZEROCONF_DISCOVERY,
+            )
+        )
+        await hass.async_block_till_done()
+
+        second_result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+        first_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_task
+
+    assert second_result["type"] is FlowResultType.ABORT
+    assert second_result["reason"] == "already_in_progress"

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -420,7 +420,6 @@ async def test_aborted_flow_removes_listener(
         USER_HOST,
         deliver_mac=False,
         discovery_timeout=True,
-        use_real_listener_registry=True,
         shared_listener=mock_shared_listener,
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from ipaddress import ip_address
-from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -14,7 +14,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
-from .conftest import TEST_DEVICE_MAC, patch_config_flow_connectivity
+from .conftest import (
+    SECOND_DEVICE_MAC,
+    TEST_DEVICE_MAC,
+    FakeListener,
+    patch_config_flow_connectivity,
+)
 
 from tests.common import MockConfigEntry
 
@@ -23,18 +28,45 @@ pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 ZEROCONF_HOST = "192.168.1.200"
 USER_HOST = "192.168.1.100"
 
-ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
-    ip_address=ip_address(ZEROCONF_HOST),
-    ip_addresses=[ip_address(ZEROCONF_HOST)],
-    hostname="powerhub.local.",
-    name="Bitvis Power Hub._powerhub._udp.local.",
-    port=DEFAULT_PORT,
-    properties={},
-    type="_powerhub._udp.local.",
+
+def _zeroconf_discovery(
+    host: str = ZEROCONF_HOST,
+    name: str = "Bitvis Power Hub._powerhub._udp.local.",
+    port: int | None = DEFAULT_PORT,
+) -> ZeroconfServiceInfo:
+    return ZeroconfServiceInfo(
+        ip_address=ip_address(host),
+        ip_addresses=[ip_address(host)],
+        hostname="powerhub.local.",
+        name=name,
+        port=port,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+
+ZEROCONF_DISCOVERY = _zeroconf_discovery()
+
+
+@pytest.mark.parametrize(
+    ("input_host", "resolved_ip", "expected_host"),
+    [
+        pytest.param(USER_HOST, USER_HOST, USER_HOST, id="ipv4"),
+        pytest.param("2001:db8::10", "2001:db8::10", "2001:db8::10", id="ipv6"),
+        pytest.param(
+            "my-powerhub.local", "10.0.0.5", "my-powerhub.local", id="hostname"
+        ),
+        pytest.param(
+            "[2001:db8::10]", "2001:db8::10", "2001:db8::10", id="bracketed-ipv6"
+        ),
+    ],
 )
-
-
-async def test_user_form_create_entry(hass: HomeAssistant) -> None:
+async def test_user_form_create_entry(
+    hass: HomeAssistant,
+    input_host: str,
+    resolved_ip: str,
+    expected_host: str,
+) -> None:
     """Test creating an entry via user flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -43,32 +75,50 @@ async def test_user_form_create_entry(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    with patch_config_flow_connectivity(USER_HOST):
+    with patch_config_flow_connectivity(resolved_ip):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: USER_HOST,
+                CONF_HOST: input_host,
             },
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == DEFAULT_NAME
     assert result["data"] == {
-        CONF_HOST: USER_HOST,
+        CONF_HOST: expected_host,
         CONF_PORT: DEFAULT_PORT,
     }
     assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
-async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test user form error on port bind failure and recovery."""
+@pytest.mark.parametrize(
+    ("connectivity_kwargs", "error_key"),
+    [
+        pytest.param(
+            {"port_bind_side_effect": OSError("UDP port is unavailable")},
+            "cannot_connect",
+            id="cannot-connect",
+        ),
+        pytest.param({"invalid_mac": True}, "invalid_mac", id="invalid-mac"),
+        pytest.param(
+            {"deliver_mac": False, "discovery_timeout": True},
+            "timeout_connect",
+            id="timeout",
+        ),
+    ],
+)
+async def test_user_form_error_and_recovery(
+    hass: HomeAssistant,
+    connectivity_kwargs: dict[str, object],
+    error_key: str,
+) -> None:
+    """Test user form error then successful recovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch_config_flow_connectivity(
-        USER_HOST, port_bind_side_effect=OSError("UDP port is unavailable")
-    ):
+    with patch_config_flow_connectivity(USER_HOST, **connectivity_kwargs):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -77,72 +127,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "cannot_connect"}
-
-    with patch_config_flow_connectivity(USER_HOST):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: USER_HOST,
-            },
-        )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"] == {
-        CONF_HOST: USER_HOST,
-        CONF_PORT: DEFAULT_PORT,
-    }
-    assert result["result"].unique_id == TEST_DEVICE_MAC
-
-
-async def test_user_form_invalid_mac(hass: HomeAssistant) -> None:
-    """Test user form error when device sends payload without MAC and recovery."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with patch_config_flow_connectivity(USER_HOST, invalid_mac=True):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: USER_HOST,
-            },
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "invalid_mac"}
-
-    with patch_config_flow_connectivity(USER_HOST):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: USER_HOST,
-            },
-        )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"].unique_id == TEST_DEVICE_MAC
-
-
-async def test_user_form_discovery_timeout(hass: HomeAssistant) -> None:
-    """Test user form error when no UDP message is received in time and recovery."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with patch_config_flow_connectivity(
-        USER_HOST, deliver_mac=False, discovery_timeout=True
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: USER_HOST,
-            },
-        )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "timeout_connect"}
+    assert result["errors"] == {"base": error_key}
 
     with patch_config_flow_connectivity(USER_HOST):
         result = await hass.config_entries.flow.async_configure(
@@ -183,116 +168,6 @@ async def test_user_form_duplicate(
     assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
-    """Test zeroconf discovery abort on port bind failure."""
-    with patch_config_flow_connectivity(
-        ZEROCONF_HOST, port_bind_side_effect=OSError("UDP port is unavailable")
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZEROCONF_DISCOVERY,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-
-async def test_zeroconf_confirm_invalid_mac(hass: HomeAssistant) -> None:
-    """Test zeroconf discovery abort when device sends payload without MAC."""
-    with patch_config_flow_connectivity(ZEROCONF_HOST, invalid_mac=True):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZEROCONF_DISCOVERY,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "invalid_mac"
-
-
-async def test_zeroconf_confirm_discovery_timeout(hass: HomeAssistant) -> None:
-    """Test zeroconf discovery abort when no UDP message is received in time."""
-    with patch_config_flow_connectivity(
-        ZEROCONF_HOST, deliver_mac=False, discovery_timeout=True
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=ZEROCONF_DISCOVERY,
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "timeout_connect"
-
-
-async def test_zeroconf_duplicate(
-    hass: HomeAssistant, mock_zeroconf_config_entry: MockConfigEntry
-) -> None:
-    """Test that a duplicate zeroconf discovery is aborted."""
-    mock_zeroconf_config_entry.add_to_hass(hass)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=ZEROCONF_DISCOVERY,
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-async def test_zeroconf_none_port_uses_default(hass: HomeAssistant) -> None:
-    """Test that a zeroconf discovery with port=None falls back to DEFAULT_PORT."""
-    discovery = ZeroconfServiceInfo(
-        ip_address=ip_address(ZEROCONF_HOST),
-        ip_addresses=[ip_address(ZEROCONF_HOST)],
-        hostname="powerhub.local.",
-        name="Bitvis Power Hub._powerhub._udp.local.",
-        port=None,
-        properties={},
-        type="_powerhub._udp.local.",
-    )
-
-    with patch_config_flow_connectivity(ZEROCONF_HOST):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=discovery,
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_PORT] == DEFAULT_PORT
-
-
-async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
-    """Test creating an entry with an IPv6 host via user flow."""
-    ipv6_host = "2001:db8::10"
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with patch_config_flow_connectivity(ipv6_host):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: ipv6_host,
-            },
-        )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"] == {
-        CONF_HOST: ipv6_host,
-        CONF_PORT: DEFAULT_PORT,
-    }
-    assert result["result"].unique_id == TEST_DEVICE_MAC
-
-
 async def test_user_form_duplicate_host(
     hass: HomeAssistant, mock_ipv6_config_entry: MockConfigEntry
 ) -> None:
@@ -316,58 +191,90 @@ async def test_user_form_duplicate_host(
     assert result["reason"] == "already_configured"
 
 
-async def test_user_form_keeps_hostname(hass: HomeAssistant) -> None:
-    """Test that user flow keeps the configured hostname."""
-    hostname = "my-powerhub.local"
-    resolved_ip = "10.0.0.5"
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with patch_config_flow_connectivity(resolved_ip):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: hostname,
-            },
+@pytest.mark.parametrize(
+    ("connectivity_kwargs", "reason"),
+    [
+        pytest.param(
+            {"port_bind_side_effect": OSError("UDP port is unavailable")},
+            "cannot_connect",
+            id="cannot-connect",
+        ),
+        pytest.param({"invalid_mac": True}, "invalid_mac", id="invalid-mac"),
+        pytest.param(
+            {"deliver_mac": False, "discovery_timeout": True},
+            "timeout_connect",
+            id="timeout",
+        ),
+    ],
+)
+async def test_zeroconf_abort(
+    hass: HomeAssistant,
+    connectivity_kwargs: dict[str, object],
+    reason: str,
+) -> None:
+    """Test zeroconf discovery abort reasons."""
+    with patch_config_flow_connectivity(ZEROCONF_HOST, **connectivity_kwargs):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
         )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"][CONF_HOST] == hostname
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
 
 
-async def test_user_form_normalize_bracketed_ipv6(hass: HomeAssistant) -> None:
-    """Test that bracketed IPv6 host is normalized (brackets stripped)."""
-    ipv6_host = "2001:db8::10"
+async def test_zeroconf_duplicate(
+    hass: HomeAssistant, mock_zeroconf_config_entry: MockConfigEntry
+) -> None:
+    """Test that a duplicate zeroconf discovery is aborted."""
+    mock_zeroconf_config_entry.add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
     )
 
-    with patch_config_flow_connectivity(ipv6_host):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: f"[{ipv6_host}]",
-            },
-        )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-    assert result["data"][CONF_HOST] == ipv6_host
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
-async def test_zeroconf_confirm_uses_friendly_name(hass: HomeAssistant) -> None:
-    """Test that zeroconf confirm creates entry with friendly name from discovery."""
-    discovery = ZeroconfServiceInfo(
-        ip_address=ip_address(ZEROCONF_HOST),
-        ip_addresses=[ip_address(ZEROCONF_HOST)],
-        hostname="powerhub.local.",
-        name="My Custom Hub._powerhub._udp.local.",
-        port=DEFAULT_PORT,
-        properties={},
-        type="_powerhub._udp.local.",
-    )
+@pytest.mark.parametrize(
+    ("name", "port", "expected_title"),
+    [
+        pytest.param(
+            "Bitvis Power Hub._powerhub._udp.local.",
+            DEFAULT_PORT,
+            "Bitvis Power Hub",
+            id="happy-path",
+        ),
+        pytest.param(
+            "Bitvis Power Hub._powerhub._udp.local.",
+            None,
+            "Bitvis Power Hub",
+            id="none-port",
+        ),
+        pytest.param(
+            "My Custom Hub._powerhub._udp.local.",
+            DEFAULT_PORT,
+            "My Custom Hub",
+            id="friendly-name",
+        ),
+        pytest.param("", DEFAULT_PORT, DEFAULT_NAME, id="empty-name"),
+        pytest.param(
+            "._powerhub._udp.local.", DEFAULT_PORT, DEFAULT_NAME, id="dot-prefixed"
+        ),
+    ],
+)
+async def test_zeroconf_create_entry(
+    hass: HomeAssistant,
+    name: str,
+    port: int | None,
+    expected_title: str,
+) -> None:
+    """Test zeroconf confirm creates an entry with title, data, and unique_id."""
+    discovery = _zeroconf_discovery(name=name, port=port)
 
     with patch_config_flow_connectivity(ZEROCONF_HOST):
         result = await hass.config_entries.flow.async_init(
@@ -376,44 +283,44 @@ async def test_zeroconf_confirm_uses_friendly_name(hass: HomeAssistant) -> None:
             data=discovery,
         )
 
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={}
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "My Custom Hub"
+    assert result["title"] == expected_title
+    assert result["data"] == {
+        CONF_HOST: ZEROCONF_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
-async def test_zeroconf_empty_name_uses_default(hass: HomeAssistant) -> None:
-    """Test that zeroconf with empty name falls back to DEFAULT_NAME."""
-    discovery = ZeroconfServiceInfo(
-        ip_address=ip_address("192.168.1.201"),
-        ip_addresses=[ip_address("192.168.1.201")],
-        hostname="powerhub.local.",
-        name="",
-        port=DEFAULT_PORT,
-        properties={},
-        type="_powerhub._udp.local.",
-    )
+async def test_zeroconf_updates_host_on_new_ip(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test rediscovery on a new IP updates the stored host and aborts."""
+    mock_config_entry.add_to_hass(hass)
+    assert mock_config_entry.data[CONF_HOST] != ZEROCONF_HOST
 
-    with patch_config_flow_connectivity("192.168.1.201"):
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_ZEROCONF},
-            data=discovery,
+            data=ZEROCONF_DISCOVERY,
         )
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_HOST] == ZEROCONF_HOST
 
 
 async def test_aborted_flow_removes_listener(
     hass: HomeAssistant,
-    mock_shared_listener: MagicMock,
+    mock_shared_listener: FakeListener,
 ) -> None:
     """Test listener is stopped after an aborted config flow."""
     with patch_config_flow_connectivity(
@@ -494,33 +401,6 @@ async def test_discovery_register_runtime_error_aborts(hass: HomeAssistant) -> N
     assert result["reason"] == "already_in_progress"
 
 
-async def test_zeroconf_dot_prefixed_name_uses_default(hass: HomeAssistant) -> None:
-    """Test zeroconf with empty instance name falls back to DEFAULT_NAME."""
-    discovery = ZeroconfServiceInfo(
-        ip_address=ip_address(ZEROCONF_HOST),
-        ip_addresses=[ip_address(ZEROCONF_HOST)],
-        hostname="powerhub.local.",
-        name="._powerhub._udp.local.",
-        port=DEFAULT_PORT,
-        properties={},
-        type="_powerhub._udp.local.",
-    )
-
-    with patch_config_flow_connectivity(ZEROCONF_HOST):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_ZEROCONF},
-            data=discovery,
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == DEFAULT_NAME
-
-
 async def test_zeroconf_concurrent_flow_same_host_aborts(hass: HomeAssistant) -> None:
     """Test concurrent zeroconf flows for the same host abort."""
     with patch_config_flow_connectivity(ZEROCONF_HOST, deliver_mac=False):
@@ -545,3 +425,48 @@ async def test_zeroconf_concurrent_flow_same_host_aborts(hass: HomeAssistant) ->
 
     assert second_result["type"] is FlowResultType.ABORT
     assert second_result["reason"] == "already_in_progress"
+
+
+@pytest.mark.parametrize(
+    ("listener_already_running", "expected_awaits"),
+    [
+        pytest.param(True, 0, id="listener-exists"),
+        pytest.param(False, 1, id="no-listener"),
+    ],
+)
+async def test_user_form_port_bind_check(
+    hass: HomeAssistant,
+    mock_shared_listener: FakeListener,
+    listener_already_running: bool,
+    expected_awaits: int,
+) -> None:
+    """Test user flow skips the port bind check only when a listener exists."""
+    if listener_already_running:
+        with patch(
+            "homeassistant.components.bitvis.coordinator.SharedListener",
+            return_value=mock_shared_listener,
+        ):
+            await async_get_listener_registry(hass).async_get_or_create(DEFAULT_PORT)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    kwargs: dict[str, object] = {
+        "mac_address": SECOND_DEVICE_MAC
+        if listener_already_running
+        else TEST_DEVICE_MAC
+    }
+    if listener_already_running:
+        kwargs["shared_listener"] = mock_shared_listener
+
+    with patch_config_flow_connectivity("192.168.1.101", **kwargs) as mock_verify:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.101",
+            },
+        )
+
+    assert mock_verify.await_count == expected_awaits
+    assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -1,0 +1,491 @@
+"""Tests for the Bitvis Power Hub config flow."""
+
+import asyncio
+from ipaddress import ip_address
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bitvis_protobuf.parse import PayloadSample
+import pytest
+
+from homeassistant.components.bitvis.config_flow import (
+    _async_discover_mac_address,
+    _async_test_port,
+)
+from homeassistant.components.bitvis.const import (
+    DEFAULT_NAME,
+    DEFAULT_PORT,
+    DOMAIN,
+    MODEL_NAME,
+)
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+
+from .conftest import TEST_DEVICE_MAC, patch_config_flow_connectivity
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+ZEROCONF_HOST = "192.168.1.200"
+USER_HOST = "192.168.1.100"
+
+ZEROCONF_DISCOVERY = ZeroconfServiceInfo(
+    ip_address=ip_address(ZEROCONF_HOST),
+    ip_addresses=[ip_address(ZEROCONF_HOST)],
+    hostname="powerhub.local.",
+    name="Bitvis Power Hub._powerhub._udp.local.",
+    port=DEFAULT_PORT,
+    properties={},
+    type="_powerhub._udp.local.",
+)
+
+
+async def test_user_form_create_entry(hass: HomeAssistant) -> None:
+    """Test creating an entry via user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch_config_flow_connectivity(USER_HOST):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: USER_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test user form error on port bind failure and recovery."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(
+        USER_HOST, port_bind_side_effect=OSError("UDP port is unavailable")
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    with patch_config_flow_connectivity(USER_HOST):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: USER_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_discovery_timeout(hass: HomeAssistant) -> None:
+    """Test user form error when no UDP message is received in time."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(
+        USER_HOST, deliver_mac=False, discovery_timeout=True
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: USER_HOST,
+            },
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "timeout_connect"}
+
+
+async def test_user_form_duplicate(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test duplicate detection by MAC address."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(USER_HOST):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: mock_config_entry.data[CONF_HOST],
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_confirm_creates_entry(hass: HomeAssistant) -> None:
+    """Test that zeroconf discovery shows confirmation form and creates entry."""
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: ZEROCONF_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
+    """Test zeroconf discovery abort on port bind failure and recovery."""
+    with patch_config_flow_connectivity(
+        ZEROCONF_HOST, port_bind_side_effect=OSError("UDP port is unavailable")
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: ZEROCONF_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_zeroconf_confirm_discovery_timeout(hass: HomeAssistant) -> None:
+    """Test zeroconf discovery abort when no UDP message is received in time."""
+    with patch_config_flow_connectivity(
+        ZEROCONF_HOST, deliver_mac=False, discovery_timeout=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "timeout_connect"
+
+
+async def test_zeroconf_duplicate(
+    hass: HomeAssistant, mock_zeroconf_config_entry: MockConfigEntry
+) -> None:
+    """Test that a duplicate zeroconf discovery is aborted."""
+    mock_zeroconf_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=ZEROCONF_DISCOVERY,
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_none_port_uses_default(hass: HomeAssistant) -> None:
+    """Test that a zeroconf discovery with port=None falls back to DEFAULT_PORT."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address(ZEROCONF_HOST),
+        ip_addresses=[ip_address(ZEROCONF_HOST)],
+        hostname="powerhub.local.",
+        name="Bitvis Power Hub._powerhub._udp.local.",
+        port=None,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=discovery,
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_PORT] == DEFAULT_PORT
+
+
+async def test_user_form_create_entry_ipv6_host(hass: HomeAssistant) -> None:
+    """Test creating an entry with an IPv6 host via user flow."""
+    ipv6_host = "2001:db8::10"
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(ipv6_host):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: ipv6_host,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"] == {
+        CONF_HOST: ipv6_host,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_user_form_duplicate_host(
+    hass: HomeAssistant, mock_ipv6_config_entry: MockConfigEntry
+) -> None:
+    """Test duplicate detection uses the configured host."""
+    ipv6_host = mock_ipv6_config_entry.data[CONF_HOST]
+    mock_ipv6_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(ipv6_host):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: ipv6_host,
+            },
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_form_keeps_hostname(hass: HomeAssistant) -> None:
+    """Test that user flow keeps the configured hostname."""
+    hostname = "my-powerhub.local"
+    resolved_ip = "10.0.0.5"
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(resolved_ip):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: hostname,
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"][CONF_HOST] == hostname
+
+
+async def test_user_form_normalize_bracketed_ipv6(hass: HomeAssistant) -> None:
+    """Test that bracketed IPv6 host is normalized (brackets stripped)."""
+    ipv6_host = "2001:db8::10"
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch_config_flow_connectivity(ipv6_host):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: f"[{ipv6_host}]",
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == MODEL_NAME
+    assert result["data"][CONF_HOST] == ipv6_host
+
+
+async def test_zeroconf_confirm_uses_friendly_name(hass: HomeAssistant) -> None:
+    """Test that zeroconf confirm creates entry with friendly name from discovery."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address(ZEROCONF_HOST),
+        ip_addresses=[ip_address(ZEROCONF_HOST)],
+        hostname="powerhub.local.",
+        name="My Custom Hub._powerhub._udp.local.",
+        port=DEFAULT_PORT,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=discovery,
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My Custom Hub"
+
+
+async def test_zeroconf_empty_name_uses_default(hass: HomeAssistant) -> None:
+    """Test that zeroconf with empty name falls back to DEFAULT_NAME."""
+    discovery = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.201"),
+        ip_addresses=[ip_address("192.168.1.201")],
+        hostname="powerhub.local.",
+        name="",
+        port=DEFAULT_PORT,
+        properties={},
+        type="_powerhub._udp.local.",
+    )
+
+    with patch_config_flow_connectivity("192.168.1.201"):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=discovery,
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == DEFAULT_NAME
+
+
+async def test_async_test_port_skips_when_listener_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Test _async_test_port returns immediately when a listener already exists."""
+    with patch(
+        "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+    ) as mock_registry:
+        mock_registry.return_value.has_listener.return_value = True
+        await _async_test_port(hass, 5000)
+
+    mock_registry.return_value.has_listener.assert_called_once_with(5000)
+
+
+async def test_async_test_port_binds_and_closes(hass: HomeAssistant) -> None:
+    """Test _async_test_port delegates to the library port bind check."""
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+        ) as mock_registry,
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
+            new_callable=AsyncMock,
+        ) as mock_verify,
+    ):
+        mock_registry.return_value.has_listener.return_value = False
+        await _async_test_port(hass, 5000)
+
+    mock_verify.assert_awaited_once_with(5000)
+
+
+async def test_async_test_port_raises_when_all_binds_fail(
+    hass: HomeAssistant,
+) -> None:
+    """Test _async_test_port raises OSError when the library port bind check fails."""
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+        ) as mock_registry,
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
+            new_callable=AsyncMock,
+            side_effect=OSError("UDP port is unavailable"),
+        ),
+    ):
+        mock_registry.return_value.has_listener.return_value = False
+        with pytest.raises(OSError, match="UDP port is unavailable"):
+            await _async_test_port(hass, 5000)
+
+
+async def test_async_discover_mac_address(hass: HomeAssistant) -> None:
+    """Test _async_discover_mac_address registers IP filters and returns MAC."""
+    mock_listener = MagicMock()
+    mock_listener.register = MagicMock()
+    mock_listener.unregister = MagicMock()
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_resolve_host",
+            new_callable=AsyncMock,
+            return_value={USER_HOST},
+        ),
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_get_listener_registry",
+        ) as mock_registry,
+    ):
+        mock_registry.return_value.async_get_or_create = AsyncMock(
+            return_value=mock_listener
+        )
+
+        discover_task = asyncio.create_task(
+            _async_discover_mac_address(hass, USER_HOST, DEFAULT_PORT)
+        )
+        await hass.async_block_till_done()
+
+        callback = mock_listener.register.call_args[0][1]
+
+        payload = PayloadSample(mac_address=TEST_DEVICE_MAC, sample=MagicMock())
+        callback(payload, (USER_HOST, 1234))
+
+        mac_address = await discover_task
+
+    assert mac_address == TEST_DEVICE_MAC
+    mock_listener.unregister.assert_called_once()

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -2,8 +2,10 @@
 
 import asyncio
 from ipaddress import ip_address
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from bitvis_protobuf.parse import PayloadSample
+from bitvis_protobuf.powerhub_pb2 import Payload
 import pytest
 
 from homeassistant.components.bitvis.const import DEFAULT_NAME, DEFAULT_PORT, DOMAIN
@@ -46,6 +48,13 @@ def _zeroconf_discovery(
 
 
 ZEROCONF_DISCOVERY = _zeroconf_discovery()
+UNRELATED_HOST = "10.9.9.9"
+
+
+def _invalid_mac_datagram() -> bytes:
+    payload = Payload()
+    payload.sample.SetInParent()
+    return payload.SerializeToString()
 
 
 @pytest.mark.parametrize(
@@ -382,6 +391,99 @@ async def test_aborted_flow_removes_listener(
     assert result["errors"] == {"base": "timeout_connect"}
     mock_shared_listener.stop.assert_awaited_once()
     assert not async_get_listener_registry(hass).has_listener(DEFAULT_PORT)
+
+
+async def test_invalid_mac_from_other_host_is_ignored(
+    hass: HomeAssistant, mock_shared_listener: FakeListener
+) -> None:
+    """Test an invalid-MAC datagram from another host does not fail the flow."""
+    with patch_config_flow_connectivity(
+        USER_HOST, deliver_mac=False, shared_listener=mock_shared_listener
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        configure_task = asyncio.create_task(
+            hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    CONF_HOST: USER_HOST,
+                },
+            )
+        )
+        await hass.async_block_till_done()
+
+        mock_shared_listener.dispatch(_invalid_mac_datagram(), (UNRELATED_HOST, 1234))
+        mock_shared_listener.deliver(
+            PayloadSample(mac_address=TEST_DEVICE_MAC, sample=MagicMock()),
+            (USER_HOST, 1234),
+        )
+        result = await configure_task
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == TEST_DEVICE_MAC
+
+
+async def test_invalid_mac_does_not_fail_other_flow(
+    hass: HomeAssistant, mock_shared_listener: FakeListener
+) -> None:
+    """Test an invalid-MAC datagram only fails the flow waiting for that host."""
+
+    async def resolve_host(host: str) -> set[str]:
+        return {host}
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_resolve_host",
+            side_effect=resolve_host,
+        ),
+        patch(
+            "homeassistant.components.bitvis.coordinator.SharedListener",
+            return_value=mock_shared_listener,
+        ),
+    ):
+        first_result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        first_task = asyncio.create_task(
+            hass.config_entries.flow.async_configure(
+                first_result["flow_id"],
+                {
+                    CONF_HOST: USER_HOST,
+                },
+            )
+        )
+        await hass.async_block_till_done()
+
+        second_result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        second_task = asyncio.create_task(
+            hass.config_entries.flow.async_configure(
+                second_result["flow_id"],
+                {
+                    CONF_HOST: ZEROCONF_HOST,
+                },
+            )
+        )
+        await hass.async_block_till_done()
+
+        mock_shared_listener.dispatch(_invalid_mac_datagram(), (ZEROCONF_HOST, 1234))
+        mock_shared_listener.deliver(
+            PayloadSample(mac_address=TEST_DEVICE_MAC, sample=MagicMock()),
+            (USER_HOST, 1234),
+        )
+        first_result = await first_task
+        second_result = await second_task
+
+    assert first_result["type"] is FlowResultType.CREATE_ENTRY
+    assert first_result["result"].unique_id == TEST_DEVICE_MAC
+    assert second_result["type"] is FlowResultType.FORM
+    assert second_result["errors"] == {"base": "invalid_mac"}
 
 
 async def test_concurrent_flow_same_host_aborts(hass: HomeAssistant) -> None:

--- a/tests/components/bitvis/test_config_flow.py
+++ b/tests/components/bitvis/test_config_flow.py
@@ -146,21 +146,28 @@ async def test_user_form_error_and_recovery(
     assert result["result"].unique_id == TEST_DEVICE_MAC
 
 
-async def test_user_form_duplicate(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+@pytest.mark.parametrize(
+    "input_host",
+    [
+        pytest.param(USER_HOST, id="same-host"),
+        pytest.param("192.168.1.101", id="different-host"),
+    ],
+)
+async def test_user_form_duplicate_mac(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, input_host: str
 ) -> None:
-    """Test duplicate detection by MAC address."""
+    """Test duplicate detection is based on MAC address, not host."""
     mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch_config_flow_connectivity(USER_HOST):
+    with patch_config_flow_connectivity(input_host):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: mock_config_entry.data[CONF_HOST],
+                CONF_HOST: input_host,
             },
         )
 
@@ -168,27 +175,30 @@ async def test_user_form_duplicate(
     assert result["reason"] == "already_configured"
 
 
-async def test_user_form_duplicate_host(
-    hass: HomeAssistant, mock_ipv6_config_entry: MockConfigEntry
+async def test_user_form_reused_ip_new_device(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test duplicate detection uses the configured host."""
-    ipv6_host = mock_ipv6_config_entry.data[CONF_HOST]
-    mock_ipv6_config_entry.add_to_hass(hass)
+    """Test a new device can be added at an IP already stored on another entry."""
+    mock_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    with patch_config_flow_connectivity(ipv6_host):
+    with patch_config_flow_connectivity(USER_HOST, mac_address=SECOND_DEVICE_MAC):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                CONF_HOST: ipv6_host,
+                CONF_HOST: USER_HOST,
             },
         )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: USER_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == SECOND_DEVICE_MAC
 
 
 @pytest.mark.parametrize(
@@ -227,17 +237,46 @@ async def test_zeroconf_abort(
 async def test_zeroconf_duplicate(
     hass: HomeAssistant, mock_zeroconf_config_entry: MockConfigEntry
 ) -> None:
-    """Test that a duplicate zeroconf discovery is aborted."""
+    """Test that a duplicate zeroconf discovery is aborted by MAC address."""
     mock_zeroconf_config_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=ZEROCONF_DISCOVERY,
-    )
+    with patch_config_flow_connectivity(ZEROCONF_HOST):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_zeroconf_reused_ip_new_device(
+    hass: HomeAssistant, mock_zeroconf_config_entry: MockConfigEntry
+) -> None:
+    """Test zeroconf can add a new device at an IP already stored on another entry."""
+    mock_zeroconf_config_entry.add_to_hass(hass)
+
+    with patch_config_flow_connectivity(ZEROCONF_HOST, mac_address=SECOND_DEVICE_MAC):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_ZEROCONF},
+            data=ZEROCONF_DISCOVERY,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "zeroconf_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_HOST: ZEROCONF_HOST,
+        CONF_PORT: DEFAULT_PORT,
+    }
+    assert result["result"].unique_id == SECOND_DEVICE_MAC
 
 
 @pytest.mark.parametrize(

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -1,0 +1,314 @@
+"""Tests for the Bitvis Power Hub coordinator."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bitvis_protobuf import powerhub_pb2
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+
+from homeassistant.components.bitvis.const import DOMAIN, MODEL_NAME
+from homeassistant.components.bitvis.coordinator import (
+    BitvisDataUpdateCoordinator,
+    BitvisListenerRegistry,
+    async_get_listener_registry,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from .conftest import TEST_DEVICE_MAC
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Return a config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "192.168.1.100", "port": 5000},
+        unique_id=TEST_DEVICE_MAC,
+        title=MODEL_NAME,
+    )
+
+
+@pytest.fixture
+def coordinator(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> BitvisDataUpdateCoordinator:
+    """Return a coordinator instance (not started)."""
+    config_entry.add_to_hass(hass)
+    return BitvisDataUpdateCoordinator(hass, config_entry, "192.168.1.100", 5000)
+
+
+# ---------------------------------------------------------------------------
+# BitvisDataUpdateCoordinator._handle_payload tests
+# ---------------------------------------------------------------------------
+
+
+def test_handle_payload_sample(
+    coordinator: BitvisDataUpdateCoordinator,
+) -> None:
+    """Test that a PayloadSample is dispatched to _handle_sample."""
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 1.5
+    parsed = PayloadSample(sample=payload.sample)
+
+    with patch.object(coordinator, "_handle_sample") as mock_handle:
+        coordinator._handle_payload(parsed, ("192.168.1.100", 1234))
+
+    mock_handle.assert_called_once_with(parsed)
+
+
+def test_handle_payload_diagnostic(
+    coordinator: BitvisDataUpdateCoordinator,
+) -> None:
+    """Test that a PayloadDiagnostic is dispatched to _handle_diagnostic."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 42
+    parsed = PayloadDiagnostic(diagnostic=payload.diagnostic)
+
+    with patch.object(coordinator, "_handle_diagnostic") as mock_handle:
+        coordinator._handle_payload(parsed, ("192.168.1.100", 1234))
+
+    mock_handle.assert_called_once_with(parsed)
+
+
+# ---------------------------------------------------------------------------
+# BitvisDataUpdateCoordinator._async_setup / async_stop tests
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_async_setup_registers_callback(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that _async_setup registers callback with listener."""
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock()
+    mock_listener.stop = AsyncMock()
+    mock_listener.is_empty = True
+
+    with patch(
+        "homeassistant.components.bitvis.coordinator.SharedListener",
+        return_value=mock_listener,
+    ):
+        await coordinator._async_setup()
+
+    mock_listener.register.assert_called_once()
+    registered_callback = mock_listener.register.call_args[0][1]
+    assert callable(registered_callback)
+
+    await coordinator.async_stop()
+
+
+async def test_coordinator_async_setup_reuses_existing_listener(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that a second coordinator on the same port reuses the shared listener."""
+    config_entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "192.168.1.101", "port": 5000},
+        unique_id="11:22:33:44:55:66",
+    )
+    config_entry2.add_to_hass(hass)
+    coordinator2 = BitvisDataUpdateCoordinator(
+        hass, config_entry2, "192.168.1.101", 5000
+    )
+
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock()
+    mock_listener.stop = AsyncMock()
+    mock_listener.is_empty = False
+
+    with patch(
+        "homeassistant.components.bitvis.coordinator.SharedListener",
+        return_value=mock_listener,
+    ):
+        await coordinator._async_setup()
+        await coordinator2._async_setup()
+
+    # SharedListener() should only be instantiated once
+    mock_listener.start.assert_called_once()
+
+    registry = async_get_listener_registry(hass)
+    assert isinstance(registry, BitvisListenerRegistry)
+    assert registry.get(5000) is not None
+
+    # Stop first — listener stays (still registered by coordinator2)
+    mock_listener.is_empty = False
+    await coordinator.async_stop()
+    mock_listener.stop.assert_not_called()
+
+    # Stop second — listener torn down
+    mock_listener.is_empty = True
+    await coordinator2.async_stop()
+    mock_listener.stop.assert_called_once()
+
+    assert registry.get(5000) is None
+
+
+async def test_coordinator_async_setup_oserror_raises_update_failed(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that OSError from listener.start raises UpdateFailed."""
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock(side_effect=OSError("port in use"))
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.coordinator.SharedListener",
+            return_value=mock_listener,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator._async_setup()
+
+
+async def test_coordinator_async_setup_runtime_error_raises_entry_error(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that RuntimeError from listener.register raises ConfigEntryError."""
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock()
+    mock_listener.stop = AsyncMock()
+    mock_listener.is_empty = True
+    mock_listener.register.side_effect = RuntimeError("duplicate IP")
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.coordinator.SharedListener",
+            return_value=mock_listener,
+        ),
+        pytest.raises(ConfigEntryError),
+    ):
+        await coordinator._async_setup()
+
+
+# ---------------------------------------------------------------------------
+# _async_update_data
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_update_data_returns_data(
+    coordinator: BitvisDataUpdateCoordinator,
+) -> None:
+    """Test that _async_update_data returns current data (push-based coordinator)."""
+    result = await coordinator._async_update_data()
+    assert result is coordinator.data
+
+
+# ---------------------------------------------------------------------------
+# _handle_sample tests
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_handle_sample(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that _handle_sample updates coordinator data and notifies listeners."""
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.5
+    parsed = PayloadSample(sample=payload.sample)
+
+    ha_listener = MagicMock()
+    coordinator.async_add_listener(ha_listener)
+
+    coordinator._handle_sample(parsed)
+    await hass.async_block_till_done()
+
+    assert coordinator.data.sample is parsed
+    assert coordinator.last_update_success is True
+    ha_listener.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_diagnostic tests
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_handle_diagnostic(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that _handle_diagnostic updates coordinator data and notifies listeners."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 999
+    parsed = PayloadDiagnostic(diagnostic=payload.diagnostic)
+
+    ha_listener = MagicMock()
+    coordinator.async_add_listener(ha_listener)
+
+    coordinator._handle_diagnostic(parsed)
+    await hass.async_block_till_done()
+
+    assert coordinator.data.diagnostic is parsed
+    assert coordinator.data.boot_time is not None
+    ha_listener.assert_called()
+
+
+async def test_coordinator_handle_diagnostic_with_device_info(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that device_info fields are extracted and stored from diagnostic payload."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
+    payload.diagnostic.device_info.sw_version = "1.2.3"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+
+    coordinator._handle_diagnostic(PayloadDiagnostic(diagnostic=payload.diagnostic))
+    await hass.async_block_till_done()
+
+    assert coordinator.data.model_name == "PowerHub Gen2"
+    assert coordinator.data.sw_version == "1.2.3"
+    assert coordinator.data.mac_address == "aa:bb:cc:dd:ee:ff"
+
+
+async def test_coordinator_handle_diagnostic_clears_device_info(
+    hass: HomeAssistant, coordinator: BitvisDataUpdateCoordinator
+) -> None:
+    """Test that device_info fields are cleared when diagnostic has no device_info."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub"
+    payload.diagnostic.device_info.sw_version = "1.0"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    coordinator._handle_diagnostic(PayloadDiagnostic(diagnostic=payload.diagnostic))
+    assert coordinator.data.model_name == "PowerHub"
+
+    payload2 = powerhub_pb2.Payload()
+    payload2.diagnostic.uptime_s = 20
+    coordinator._handle_diagnostic(PayloadDiagnostic(diagnostic=payload2.diagnostic))
+
+    assert coordinator.data.mac_address is None
+    assert coordinator.data.model_name is None
+    assert coordinator.data.sw_version is None
+
+
+# ---------------------------------------------------------------------------
+# async_stop edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_coordinator_async_stop_without_listener(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that async_stop works when no listener is registered."""
+    config_entry.add_to_hass(hass)
+    coordinator = BitvisDataUpdateCoordinator(hass, config_entry, "192.168.1.100", 5000)
+
+    await coordinator.async_stop()
+
+    assert coordinator._registered_ips == set()
+
+
+async def test_coordinator_async_stop_without_domain_data(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that async_stop works when hass.data has no domain data."""
+    config_entry.add_to_hass(hass)
+    coordinator = BitvisDataUpdateCoordinator(hass, config_entry, "192.168.1.100", 5000)
+    hass.data.pop(DOMAIN, None)
+
+    await coordinator.async_stop()
+
+    assert coordinator._registered_ips == set()

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -1,15 +1,17 @@
 """Tests for the Bitvis Power Hub coordinator."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from bitvis_protobuf.listener import FilterMac
 import pytest
 
-from homeassistant.components.bitvis.const import DEFAULT_PORT
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.bitvis.const import DEFAULT_PORT, DOMAIN
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import TEST_DEVICE_MAC
+from .conftest import SECOND_DEVICE_MAC, TEST_DEVICE_MAC, patch_config_flow_connectivity
 
 from tests.common import MockConfigEntry
 
@@ -56,6 +58,39 @@ async def test_two_entries_share_listener(
     patch_shared_listener.stop.assert_awaited_once()
 
 
+async def test_user_form_skips_port_bind_when_listener_exists(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test user flow skips port bind check when a listener already exists."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
+            new_callable=AsyncMock,
+        ) as mock_verify,
+        patch_config_flow_connectivity(
+            "192.168.1.101",
+            mac_address=SECOND_DEVICE_MAC,
+            use_real_listener_registry=True,
+            shared_listener=patch_shared_listener,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.101",
+            },
+        )
+
+    mock_verify.assert_not_awaited()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
 async def test_setup_oserror_results_in_setup_retry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -84,3 +119,4 @@ async def test_setup_runtime_error_results_in_setup_error(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_shared_listener.unregister.assert_not_called()

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -2,17 +2,14 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
-from bitvis_protobuf import powerhub_pb2
 from bitvis_protobuf.listener import FilterMac
-from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
 import pytest
 
 from homeassistant.components.bitvis.const import DEFAULT_PORT
-from homeassistant.components.bitvis.coordinator import async_get_listener_registry
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from .conftest import TEST_DEVICE_MAC, deliver_listener_payload
+from .conftest import TEST_DEVICE_MAC
 
 from tests.common import MockConfigEntry
 
@@ -20,138 +17,16 @@ pytestmark = pytest.mark.usefixtures("patch_shared_listener")
 
 
 async def test_setup_registers_mac_filter_on_listener(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
+    init_integration: MockConfigEntry,
     patch_shared_listener: MagicMock,
 ) -> None:
     """Test integration setup registers a MAC filter on the shared listener."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_config_entry.runtime_data is not None
+    assert init_integration.state is ConfigEntryState.LOADED
     patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
     patch_shared_listener.register.assert_called_once()
     registered_filter = patch_shared_listener.register.call_args[0][0]
     assert isinstance(registered_filter, FilterMac)
     assert registered_filter.mac_address == TEST_DEVICE_MAC
-
-    registry = async_get_listener_registry(hass)
-    assert registry.get(DEFAULT_PORT) is patch_shared_listener
-
-
-async def test_sample_payload_updates_coordinator_data(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test that a sample payload updates coordinator data after setup."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    payload = powerhub_pb2.Payload()
-    payload.sample.power_active_delivered_to_client_kw = 2.5
-    parsed = PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample)
-
-    deliver_listener_payload(patch_shared_listener, TEST_DEVICE_MAC, parsed)
-    await hass.async_block_till_done()
-
-    assert coordinator.data.sample is parsed
-    assert coordinator.last_update_success is True
-
-
-async def test_diagnostic_payload_updates_coordinator_data(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test that a diagnostic payload updates coordinator data after setup."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    payload = powerhub_pb2.Payload()
-    payload.diagnostic.uptime_s = 999
-    parsed = PayloadDiagnostic(
-        mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic
-    )
-
-    deliver_listener_payload(patch_shared_listener, TEST_DEVICE_MAC, parsed)
-    await hass.async_block_till_done()
-
-    assert coordinator.data.diagnostic is parsed
-    assert coordinator.data.boot_time is not None
-
-
-async def test_diagnostic_payload_extracts_device_info(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test that device_info fields are stored from a diagnostic payload."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    payload = powerhub_pb2.Payload()
-    payload.diagnostic.uptime_s = 10
-    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
-    payload.diagnostic.device_info.sw_version = "1.2.3"
-    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
-
-    deliver_listener_payload(
-        patch_shared_listener,
-        TEST_DEVICE_MAC,
-        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
-    )
-    await hass.async_block_till_done()
-
-    assert coordinator.data.model_name == "PowerHub Gen2"
-    assert coordinator.data.sw_version == "1.2.3"
-    assert coordinator.data.mac_address == TEST_DEVICE_MAC
-
-
-async def test_diagnostic_payload_clears_device_info_when_absent(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test that device_info fields are cleared when absent in a later diagnostic."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    payload = powerhub_pb2.Payload()
-    payload.diagnostic.uptime_s = 10
-    payload.diagnostic.device_info.model_name = "PowerHub"
-    payload.diagnostic.device_info.sw_version = "1.0"
-    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
-    deliver_listener_payload(
-        patch_shared_listener,
-        TEST_DEVICE_MAC,
-        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
-    )
-    await hass.async_block_till_done()
-    assert coordinator.data.model_name == "PowerHub"
-
-    payload2 = powerhub_pb2.Payload()
-    payload2.diagnostic.uptime_s = 20
-    deliver_listener_payload(
-        patch_shared_listener,
-        TEST_DEVICE_MAC,
-        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload2.diagnostic),
-    )
-    await hass.async_block_till_done()
-
-    assert coordinator.data.mac_address == TEST_DEVICE_MAC
-    assert coordinator.data.model_name is None
-    assert coordinator.data.sw_version is None
 
 
 async def test_two_entries_share_listener(
@@ -174,15 +49,11 @@ async def test_two_entries_share_listener(
     patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
     assert patch_shared_listener.register.call_count == 2
 
-    registry = async_get_listener_registry(hass)
-    assert registry.get(DEFAULT_PORT) is patch_shared_listener
-
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     patch_shared_listener.stop.assert_not_called()
 
     assert await hass.config_entries.async_unload(mock_second_config_entry.entry_id)
     patch_shared_listener.stop.assert_awaited_once()
-    assert registry.get(DEFAULT_PORT) is None
 
 
 async def test_setup_oserror_results_in_setup_retry(

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -76,7 +76,6 @@ async def test_user_form_skips_port_bind_when_listener_exists(
         patch_config_flow_connectivity(
             "192.168.1.101",
             mac_address=SECOND_DEVICE_MAC,
-            use_real_listener_registry=True,
             shared_listener=patch_shared_listener,
         ),
     ):

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -1,99 +1,23 @@
 """Tests for the Bitvis Power Hub coordinator."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
-from bitvis_protobuf.listener import FilterMac
 import pytest
 
-from homeassistant.components.bitvis.const import DEFAULT_PORT, DOMAIN
-from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
-from homeassistant.const import CONF_HOST
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import SECOND_DEVICE_MAC, TEST_DEVICE_MAC, patch_config_flow_connectivity
+from .conftest import FakeListener
 
 from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("patch_shared_listener")
 
 
-async def test_setup_registers_mac_filter_on_listener(
-    init_integration: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test integration setup registers a MAC filter on the shared listener."""
-    assert init_integration.state is ConfigEntryState.LOADED
-    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
-    patch_shared_listener.register.assert_called_once()
-    registered_filter = patch_shared_listener.register.call_args[0][0]
-    assert isinstance(registered_filter, FilterMac)
-    assert registered_filter.mac_address == TEST_DEVICE_MAC
-
-
-async def test_two_entries_share_listener(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_second_config_entry: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test that two entries on the same port share one library listener."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    mock_second_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_second_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_second_config_entry.state is ConfigEntryState.LOADED
-    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
-    assert patch_shared_listener.register.call_count == 2
-
-    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    patch_shared_listener.stop.assert_not_called()
-
-    assert await hass.config_entries.async_unload(mock_second_config_entry.entry_id)
-    patch_shared_listener.stop.assert_awaited_once()
-
-
-async def test_user_form_skips_port_bind_when_listener_exists(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    patch_shared_listener: MagicMock,
-) -> None:
-    """Test user flow skips port bind check when a listener already exists."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with (
-        patch(
-            "homeassistant.components.bitvis.config_flow.async_verify_udp_port_bindable",
-            new_callable=AsyncMock,
-        ) as mock_verify,
-        patch_config_flow_connectivity(
-            "192.168.1.101",
-            mac_address=SECOND_DEVICE_MAC,
-            shared_listener=patch_shared_listener,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.101",
-            },
-        )
-
-    mock_verify.assert_not_awaited()
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-
-
 async def test_setup_oserror_results_in_setup_retry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_shared_listener: MagicMock,
+    mock_shared_listener: FakeListener,
 ) -> None:
     """Test that OSError from SharedListener.start results in SETUP_RETRY."""
     mock_shared_listener.start = AsyncMock(side_effect=OSError("port in use"))
@@ -108,7 +32,7 @@ async def test_setup_oserror_results_in_setup_retry(
 async def test_setup_runtime_error_results_in_setup_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_shared_listener: MagicMock,
+    mock_shared_listener: FakeListener,
 ) -> None:
     """Test that RuntimeError from SharedListener.register results in SETUP_ERROR."""
     mock_shared_listener.register.side_effect = RuntimeError("duplicate filter")

--- a/tests/components/bitvis/test_coordinator.py
+++ b/tests/components/bitvis/test_coordinator.py
@@ -1,0 +1,215 @@
+"""Tests for the Bitvis Power Hub coordinator."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from bitvis_protobuf import powerhub_pb2
+from bitvis_protobuf.listener import FilterMac
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+
+from homeassistant.components.bitvis.const import DEFAULT_PORT
+from homeassistant.components.bitvis.coordinator import async_get_listener_registry
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import TEST_DEVICE_MAC, deliver_listener_payload
+
+from tests.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("patch_shared_listener")
+
+
+async def test_setup_registers_mac_filter_on_listener(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test integration setup registers a MAC filter on the shared listener."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.runtime_data is not None
+    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
+    patch_shared_listener.register.assert_called_once()
+    registered_filter = patch_shared_listener.register.call_args[0][0]
+    assert isinstance(registered_filter, FilterMac)
+    assert registered_filter.mac_address == TEST_DEVICE_MAC
+
+    registry = async_get_listener_registry(hass)
+    assert registry.get(DEFAULT_PORT) is patch_shared_listener
+
+
+async def test_sample_payload_updates_coordinator_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that a sample payload updates coordinator data after setup."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.5
+    parsed = PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample)
+
+    deliver_listener_payload(patch_shared_listener, TEST_DEVICE_MAC, parsed)
+    await hass.async_block_till_done()
+
+    assert coordinator.data.sample is parsed
+    assert coordinator.last_update_success is True
+
+
+async def test_diagnostic_payload_updates_coordinator_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that a diagnostic payload updates coordinator data after setup."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 999
+    parsed = PayloadDiagnostic(
+        mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic
+    )
+
+    deliver_listener_payload(patch_shared_listener, TEST_DEVICE_MAC, parsed)
+    await hass.async_block_till_done()
+
+    assert coordinator.data.diagnostic is parsed
+    assert coordinator.data.boot_time is not None
+
+
+async def test_diagnostic_payload_extracts_device_info(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that device_info fields are stored from a diagnostic payload."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
+    payload.diagnostic.device_info.sw_version = "1.2.3"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+
+    deliver_listener_payload(
+        patch_shared_listener,
+        TEST_DEVICE_MAC,
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.data.model_name == "PowerHub Gen2"
+    assert coordinator.data.sw_version == "1.2.3"
+    assert coordinator.data.mac_address == TEST_DEVICE_MAC
+
+
+async def test_diagnostic_payload_clears_device_info_when_absent(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that device_info fields are cleared when absent in a later diagnostic."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub"
+    payload.diagnostic.device_info.sw_version = "1.0"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    deliver_listener_payload(
+        patch_shared_listener,
+        TEST_DEVICE_MAC,
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
+    )
+    await hass.async_block_till_done()
+    assert coordinator.data.model_name == "PowerHub"
+
+    payload2 = powerhub_pb2.Payload()
+    payload2.diagnostic.uptime_s = 20
+    deliver_listener_payload(
+        patch_shared_listener,
+        TEST_DEVICE_MAC,
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload2.diagnostic),
+    )
+    await hass.async_block_till_done()
+
+    assert coordinator.data.mac_address == TEST_DEVICE_MAC
+    assert coordinator.data.model_name is None
+    assert coordinator.data.sw_version is None
+
+
+async def test_two_entries_share_listener(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_second_config_entry: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that two entries on the same port share one library listener."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_second_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_second_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_second_config_entry.state is ConfigEntryState.LOADED
+    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
+    assert patch_shared_listener.register.call_count == 2
+
+    registry = async_get_listener_registry(hass)
+    assert registry.get(DEFAULT_PORT) is patch_shared_listener
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    patch_shared_listener.stop.assert_not_called()
+
+    assert await hass.config_entries.async_unload(mock_second_config_entry.entry_id)
+    patch_shared_listener.stop.assert_awaited_once()
+    assert registry.get(DEFAULT_PORT) is None
+
+
+async def test_setup_oserror_results_in_setup_retry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_shared_listener: MagicMock,
+) -> None:
+    """Test that OSError from SharedListener.start results in SETUP_RETRY."""
+    mock_shared_listener.start = AsyncMock(side_effect=OSError("port in use"))
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_runtime_error_results_in_setup_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_shared_listener: MagicMock,
+) -> None:
+    """Test that RuntimeError from SharedListener.register results in SETUP_ERROR."""
+    mock_shared_listener.register.side_effect = RuntimeError("duplicate filter")
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/bitvis/test_init.py
+++ b/tests/components/bitvis/test_init.py
@@ -1,0 +1,63 @@
+"""Tests for the Bitvis Power Hub integration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test successful integration setup."""
+    assert init_integration.state is ConfigEntryState.LOADED
+    assert init_integration.runtime_data is not None
+
+
+async def test_setup_entry_oserror(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that OSError from SharedListener.start results in SETUP_RETRY."""
+    mock_config_entry.add_to_hass(hass)
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock(side_effect=OSError("port in use"))
+    mock_listener.stop = AsyncMock()
+    mock_listener.is_empty = True
+    with patch(
+        "homeassistant.components.bitvis.coordinator.SharedListener",
+        return_value=mock_listener,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_entry_runtime_error(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test that RuntimeError from SharedListener.register results in SETUP_ERROR."""
+    mock_config_entry.add_to_hass(hass)
+    mock_listener = MagicMock()
+    mock_listener.start = AsyncMock()
+    mock_listener.stop = AsyncMock()
+    mock_listener.is_empty = True
+    mock_listener.register.side_effect = RuntimeError("duplicate IP registration")
+    with patch(
+        "homeassistant.components.bitvis.coordinator.SharedListener",
+        return_value=mock_listener,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test that unloading stops the coordinator and unloads platforms."""
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    assert init_integration.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/bitvis/test_init.py
+++ b/tests/components/bitvis/test_init.py
@@ -1,8 +1,5 @@
 """Tests for the Bitvis Power Hub integration."""
 
-from unittest.mock import MagicMock
-
-from homeassistant.components.bitvis.const import DEFAULT_PORT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -10,14 +7,10 @@ from tests.common import MockConfigEntry
 
 
 async def test_setup_entry(
-    hass: HomeAssistant,
     init_integration: MockConfigEntry,
-    patch_shared_listener: MagicMock,
 ) -> None:
     """Test successful integration setup."""
     assert init_integration.state is ConfigEntryState.LOADED
-    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
-    patch_shared_listener.register.assert_called_once()
 
 
 async def test_unload_entry(

--- a/tests/components/bitvis/test_init.py
+++ b/tests/components/bitvis/test_init.py
@@ -1,0 +1,28 @@
+"""Tests for the Bitvis Power Hub integration."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.bitvis.const import DEFAULT_PORT
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test successful integration setup."""
+    assert init_integration.state is ConfigEntryState.LOADED
+    patch_shared_listener.start.assert_awaited_once_with(DEFAULT_PORT)
+    patch_shared_listener.register.assert_called_once()
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test that unloading stops the coordinator and unloads platforms."""
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    assert init_integration.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/bitvis/test_init.py
+++ b/tests/components/bitvis/test_init.py
@@ -1,7 +1,17 @@
 """Tests for the Bitvis Power Hub integration."""
 
+from bitvis_protobuf import powerhub_pb2
+from bitvis_protobuf.parse import PayloadSample
+import pytest
+
+from homeassistant.components.bitvis.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import find_listener_callback, setup_integration
+from .conftest import TEST_DEVICE_MAC, FakeListener
 
 from tests.common import MockConfigEntry
 
@@ -19,3 +29,67 @@ async def test_unload_entry(
     """Test that unloading stops the coordinator and unloads platforms."""
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     assert init_integration.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_two_entries_share_listener(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_second_config_entry: MockConfigEntry,
+    patch_shared_listener: FakeListener,
+) -> None:
+    """Test that two entries on the same port share one library listener."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_second_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_second_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_second_config_entry.state is ConfigEntryState.LOADED
+    patch_shared_listener.start.assert_awaited_once()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    patch_shared_listener.stop.assert_not_called()
+
+    assert await hass.config_entries.async_unload(mock_second_config_entry.entry_id)
+    patch_shared_listener.stop.assert_awaited_once()
+
+
+async def test_unload_after_dynamic_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    patch_shared_listener: FakeListener,
+) -> None:
+    """Test unload succeeds after HAN sensors have been created dynamically."""
+    await setup_integration(hass, mock_config_entry)
+
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.0
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities_unavailable_before_data(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test diagnostic entities are unavailable after setup before any packet."""
+    wifi_entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    )
+    assert wifi_entity_id is not None
+    state = hass.states.get(wifi_entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/bitvis/test_init.py
+++ b/tests/components/bitvis/test_init.py
@@ -4,7 +4,7 @@ from bitvis_protobuf import powerhub_pb2
 from bitvis_protobuf.parse import PayloadSample
 import pytest
 
-from homeassistant.components.bitvis.const import DOMAIN
+from homeassistant.components.bitvis.const import DATA_LISTENER_REGISTRY, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -27,8 +27,10 @@ async def test_unload_entry(
     hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test that unloading stops the coordinator and unloads platforms."""
+    assert DATA_LISTENER_REGISTRY in hass.data
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     assert init_integration.state is ConfigEntryState.NOT_LOADED
+    assert DATA_LISTENER_REGISTRY not in hass.data
 
 
 async def test_two_entries_share_listener(
@@ -52,9 +54,11 @@ async def test_two_entries_share_listener(
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     patch_shared_listener.stop.assert_not_called()
+    assert DATA_LISTENER_REGISTRY in hass.data
 
     assert await hass.config_entries.async_unload(mock_second_config_entry.entry_id)
     patch_shared_listener.stop.assert_awaited_once()
+    assert DATA_LISTENER_REGISTRY not in hass.data
 
 
 async def test_unload_after_dynamic_entities(

--- a/tests/components/bitvis/test_sensor.py
+++ b/tests/components/bitvis/test_sensor.py
@@ -1,0 +1,142 @@
+"""Tests for the Bitvis Power Hub sensor platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from bitvis_protobuf import powerhub_pb2
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
+    """Make sure all entities are enabled."""
+
+
+@pytest.fixture
+def sample_payload() -> PayloadSample:
+    """Return a sample payload with test data."""
+    payload = powerhub_pb2.Payload()
+    payload.sample.phase_voltage_l1_v = 230.0
+    payload.sample.phase_voltage_l2_v = 229.5
+    payload.sample.phase_voltage_l3_v = 231.2
+    payload.sample.phase_current_l1_a = 10.5
+    payload.sample.phase_current_l2_a = 8.3
+    payload.sample.phase_current_l3_a = 12.1
+    payload.sample.power_active_delivered_to_client_kw = 2.415
+    payload.sample.power_active_delivered_by_client_kw = 0.0
+    payload.sample.power_reactive_delivered_to_client_kvar = 0.5
+    payload.sample.power_reactive_delivered_by_client_kvar = 0.0
+    payload.sample.power_active_l1_delivered_to_client_kw = 0.8
+    payload.sample.power_active_l2_delivered_to_client_kw = 0.7
+    payload.sample.power_active_l3_delivered_to_client_kw = 0.915
+    payload.sample.power_active_l1_delivered_by_client_kw = 0.0
+    payload.sample.power_active_l2_delivered_by_client_kw = 0.0
+    payload.sample.power_active_l3_delivered_by_client_kw = 0.0
+    payload.sample.power_reactive_l1_delivered_to_client_kvar = 0.2
+    payload.sample.power_reactive_l2_delivered_to_client_kvar = 0.15
+    payload.sample.power_reactive_l3_delivered_to_client_kvar = 0.15
+    payload.sample.power_reactive_l1_delivered_by_client_kvar = 0.0
+    payload.sample.power_reactive_l2_delivered_by_client_kvar = 0.0
+    payload.sample.power_reactive_l3_delivered_by_client_kvar = 0.0
+    payload.sample.energy_active_delivered_to_client_kwh = 1234.56
+    payload.sample.energy_active_delivered_by_client_kwh = 789.12
+    payload.sample.energy_reactive_delivered_to_client_kvarh = 45.67
+    payload.sample.energy_reactive_delivered_by_client_kvarh = 23.45
+    return PayloadSample(sample=payload.sample)
+
+
+@pytest.fixture
+def diagnostic_payload() -> PayloadDiagnostic:
+    """Return a diagnostic payload with test data."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 86400
+    payload.diagnostic.wifi_rssi_dbm = -65
+    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
+    payload.diagnostic.device_info.sw_version = "2.0.0"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    payload.diagnostic.han_msg_successfully_parsed = 1000
+    payload.diagnostic.han_msg_buffer_overflow = 5
+    return PayloadDiagnostic(diagnostic=payload.diagnostic)
+
+
+@pytest.mark.freeze_time("2026-01-01 12:00:00")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    sample_payload: PayloadSample,
+    diagnostic_payload: PayloadDiagnostic,
+) -> None:
+    """Test all entities with snapshot."""
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.bitvis.coordinator.BitvisDataUpdateCoordinator._async_setup",
+            new_callable=AsyncMock,
+        ),
+        patch("homeassistant.components.bitvis._PLATFORMS", [Platform.SENSOR]),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = mock_config_entry.runtime_data
+        coordinator._handle_sample(sample_payload)
+        coordinator._handle_diagnostic(diagnostic_payload)
+        await hass.async_block_till_done()
+
+        await snapshot_platform(
+            hass, entity_registry, snapshot, mock_config_entry.entry_id
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_unavailable_without_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that sensors are unavailable when coordinator has no data."""
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    sensor_entity = next(e for e in entities if e.domain == "sensor")
+    state = hass.states.get(sensor_entity.entity_id)
+    assert state is not None
+    assert state.state == "unavailable"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_become_available_with_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that sensors become available when data arrives."""
+    coordinator = mock_config_entry.runtime_data
+
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.0
+    coordinator._handle_sample(PayloadSample(sample=payload.sample))
+    await hass.async_block_till_done()
+
+    base_unique_id = mock_config_entry.unique_id
+    expected_unique_id = f"{base_unique_id}_power_active_delivered_to_client"
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    matching = next(
+        (e for e in entity_entries if e.unique_id == expected_unique_id), None
+    )
+    assert matching is not None
+    state = hass.states.get(matching.entity_id)
+    assert state is not None
+    assert state.state != "unavailable"
+    assert float(state.state) == pytest.approx(2.0)

--- a/tests/components/bitvis/test_sensor.py
+++ b/tests/components/bitvis/test_sensor.py
@@ -7,9 +7,12 @@ from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.bitvis.const import DOMAIN, MODEL_NAME
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from . import find_listener_callback, setup_integration
 from .conftest import TEST_DEVICE_MAC
@@ -101,21 +104,6 @@ async def test_all_entities(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_diagnostic_entities_created_at_setup(
-    mock_config_entry: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test that diagnostic sensors are created at setup."""
-    unique_ids = {
-        entry.unique_id
-        for entry in er.async_entries_for_config_entry(
-            entity_registry, mock_config_entry.entry_id
-        )
-    }
-    assert unique_ids == DIAGNOSTIC_UNIQUE_IDS
-
-
-@pytest.mark.usefixtures("init_integration")
 async def test_entities_added_when_fields_become_available(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -192,3 +180,118 @@ async def test_sensors_become_available_with_data(
     assert state is not None
     assert state.state != "unavailable"
     assert float(state.state) == pytest.approx(2.0)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_diagnostic_sensors_update_with_data(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that diagnostic sensors update when a diagnostic payload arrives."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 999
+    payload.diagnostic.wifi_rssi_dbm = -70
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    wifi_entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    )
+    assert wifi_entity_id is not None
+    wifi_state = hass.states.get(wifi_entity_id)
+    assert wifi_state is not None
+    assert wifi_state.state != "unavailable"
+    assert float(wifi_state.state) == pytest.approx(-70)
+
+    uptime_entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{TEST_DEVICE_MAC}_uptime",
+    )
+    assert uptime_entity_id is not None
+    uptime_state = hass.states.get(uptime_entity_id)
+    assert uptime_state is not None
+    assert uptime_state.state != "unavailable"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_device_info_updated_from_diagnostic(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that device info is updated from a diagnostic payload."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
+    payload.diagnostic.device_info.sw_version = "1.2.3"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    )
+    assert entity_id is not None
+    entity = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
+    assert entity is not None
+    assert entity.device_info is not None
+    assert entity.device_info["model"] == "PowerHub Gen2"
+    assert entity.device_info["sw_version"] == "1.2.3"
+    assert (CONNECTION_NETWORK_MAC, TEST_DEVICE_MAC) in entity.device_info[
+        "connections"
+    ]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_device_info_cleared_when_absent_in_diagnostic(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that device info is cleared when absent in a later diagnostic."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 10
+    payload.diagnostic.device_info.model_name = "PowerHub"
+    payload.diagnostic.device_info.sw_version = "1.0"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    )
+    assert entity_id is not None
+    entity = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
+    assert entity is not None
+    assert entity.device_info is not None
+    assert entity.device_info["model"] == "PowerHub"
+    assert entity.device_info["sw_version"] == "1.0"
+
+    payload2 = powerhub_pb2.Payload()
+    payload2.diagnostic.uptime_s = 20
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload2.diagnostic),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    assert entity.device_info["model"] == MODEL_NAME
+    assert entity.device_info.get("sw_version") is None
+    assert not entity.device_info.get("connections")

--- a/tests/components/bitvis/test_sensor.py
+++ b/tests/components/bitvis/test_sensor.py
@@ -8,10 +8,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.bitvis.const import DOMAIN, MODEL_NAME
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from . import find_listener_callback, setup_integration
@@ -223,10 +222,19 @@ async def test_diagnostic_sensors_update_with_data(
 @pytest.mark.usefixtures("init_integration")
 async def test_device_info_updated_from_diagnostic(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
     patch_shared_listener: MagicMock,
 ) -> None:
     """Test that device info is updated from a diagnostic payload."""
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
+    )
+    assert device is not None
+    assert device.model == MODEL_NAME
+    assert device.sw_version is None
+    assert (CONNECTION_NETWORK_MAC, TEST_DEVICE_MAC) in device.connections
+
     payload = powerhub_pb2.Payload()
     payload.diagnostic.uptime_s = 10
     payload.diagnostic.device_info.model_name = "PowerHub Gen2"
@@ -238,26 +246,19 @@ async def test_device_info_updated_from_diagnostic(
     )
     await hass.async_block_till_done()
 
-    entity_id = entity_registry.async_get_entity_id(
-        "sensor",
-        DOMAIN,
-        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
     )
-    assert entity_id is not None
-    entity = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
-    assert entity is not None
-    assert entity.device_info is not None
-    assert entity.device_info["model"] == "PowerHub Gen2"
-    assert entity.device_info["sw_version"] == "1.2.3"
-    assert (CONNECTION_NETWORK_MAC, TEST_DEVICE_MAC) in entity.device_info[
-        "connections"
-    ]
+    assert device is not None
+    assert device.model == "PowerHub Gen2"
+    assert device.sw_version == "1.2.3"
 
 
 @pytest.mark.usefixtures("init_integration")
 async def test_device_info_cleared_when_absent_in_diagnostic(
     hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
     patch_shared_listener: MagicMock,
 ) -> None:
     """Test that device info is cleared when absent in a later diagnostic."""
@@ -272,17 +273,12 @@ async def test_device_info_cleared_when_absent_in_diagnostic(
     )
     await hass.async_block_till_done()
 
-    entity_id = entity_registry.async_get_entity_id(
-        "sensor",
-        DOMAIN,
-        f"{TEST_DEVICE_MAC}_wifi_rssi",
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
     )
-    assert entity_id is not None
-    entity = hass.data[SENSOR_DOMAIN].get_entity(entity_id)
-    assert entity is not None
-    assert entity.device_info is not None
-    assert entity.device_info["model"] == "PowerHub"
-    assert entity.device_info["sw_version"] == "1.0"
+    assert device is not None
+    assert device.model == "PowerHub"
+    assert device.sw_version == "1.0"
 
     payload2 = powerhub_pb2.Payload()
     payload2.diagnostic.uptime_s = 20
@@ -292,6 +288,9 @@ async def test_device_info_cleared_when_absent_in_diagnostic(
     )
     await hass.async_block_till_done()
 
-    assert entity.device_info["model"] == MODEL_NAME
-    assert entity.device_info.get("sw_version") is None
-    assert not entity.device_info.get("connections")
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
+    )
+    assert device is not None
+    assert device.model == MODEL_NAME
+    assert device.sw_version is None

--- a/tests/components/bitvis/test_sensor.py
+++ b/tests/components/bitvis/test_sensor.py
@@ -1,0 +1,194 @@
+"""Tests for the Bitvis Power Hub sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+from bitvis_protobuf import powerhub_pb2
+from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import find_listener_callback, setup_integration
+from .conftest import TEST_DEVICE_MAC
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+DIAGNOSTIC_UNIQUE_IDS = {
+    f"{TEST_DEVICE_MAC}_uptime",
+    f"{TEST_DEVICE_MAC}_wifi_rssi",
+    f"{TEST_DEVICE_MAC}_han_msg_successfully_parsed",
+    f"{TEST_DEVICE_MAC}_han_msg_buffer_overflow",
+}
+
+
+@pytest.fixture(autouse=True)
+def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
+    """Make sure all entities are enabled."""
+
+
+@pytest.fixture
+def sample_payload() -> PayloadSample:
+    """Return a sample payload with test data."""
+    payload = powerhub_pb2.Payload()
+    payload.sample.phase_voltage_l1_v = 230.0
+    payload.sample.phase_voltage_l2_v = 229.5
+    payload.sample.phase_voltage_l3_v = 231.2
+    payload.sample.phase_current_l1_a = 10.5
+    payload.sample.phase_current_l2_a = 8.3
+    payload.sample.phase_current_l3_a = 12.1
+    payload.sample.power_active_delivered_to_client_kw = 2.415
+    payload.sample.power_active_delivered_by_client_kw = 0.0
+    payload.sample.power_reactive_delivered_to_client_kvar = 0.5
+    payload.sample.power_reactive_delivered_by_client_kvar = 0.0
+    payload.sample.power_active_l1_delivered_to_client_kw = 0.8
+    payload.sample.power_active_l2_delivered_to_client_kw = 0.7
+    payload.sample.power_active_l3_delivered_to_client_kw = 0.915
+    payload.sample.power_active_l1_delivered_by_client_kw = 0.0
+    payload.sample.power_active_l2_delivered_by_client_kw = 0.0
+    payload.sample.power_active_l3_delivered_by_client_kw = 0.0
+    payload.sample.power_reactive_l1_delivered_to_client_kvar = 0.2
+    payload.sample.power_reactive_l2_delivered_to_client_kvar = 0.15
+    payload.sample.power_reactive_l3_delivered_to_client_kvar = 0.15
+    payload.sample.power_reactive_l1_delivered_by_client_kvar = 0.0
+    payload.sample.power_reactive_l2_delivered_by_client_kvar = 0.0
+    payload.sample.power_reactive_l3_delivered_by_client_kvar = 0.0
+    payload.sample.energy_active_delivered_to_client_kwh = 1234.56
+    payload.sample.energy_active_delivered_by_client_kwh = 789.12
+    payload.sample.energy_reactive_delivered_to_client_kvarh = 45.67
+    payload.sample.energy_reactive_delivered_by_client_kvarh = 23.45
+    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    return PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample)
+
+
+@pytest.fixture
+def diagnostic_payload() -> PayloadDiagnostic:
+    """Return a diagnostic payload with test data."""
+    payload = powerhub_pb2.Payload()
+    payload.diagnostic.uptime_s = 86400
+    payload.diagnostic.wifi_rssi_dbm = -65
+    payload.diagnostic.device_info.model_name = "PowerHub Gen2"
+    payload.diagnostic.device_info.sw_version = "2.0.0"
+    payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    payload.diagnostic.han_msg_successfully_parsed = 1000
+    payload.diagnostic.han_msg_buffer_overflow = 5
+    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    return PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic)
+
+
+@pytest.mark.freeze_time("2026-01-01 12:00:00")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    sample_payload: PayloadSample,
+    diagnostic_payload: PayloadDiagnostic,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test all entities with snapshot."""
+    with patch("homeassistant.components.bitvis._PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    callback = find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)
+    callback(sample_payload, ("192.168.1.100", 1234))
+    callback(diagnostic_payload, ("192.168.1.100", 1234))
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_diagnostic_entities_created_at_setup(
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that diagnostic sensors are created at setup."""
+    unique_ids = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
+    assert unique_ids == DIAGNOSTIC_UNIQUE_IDS
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_entities_added_when_fields_become_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that HAN sensors are created when their fields first appear."""
+    base_unique_id = mock_config_entry.unique_id
+
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.0
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    unique_ids = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
+    assert unique_ids == DIAGNOSTIC_UNIQUE_IDS | {
+        f"{base_unique_id}_power_active_delivered_to_client"
+    }
+
+    payload.sample.phase_voltage_l1_v = 230.0
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    unique_ids = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
+    assert unique_ids == DIAGNOSTIC_UNIQUE_IDS | {
+        f"{base_unique_id}_power_active_delivered_to_client",
+        f"{base_unique_id}_phase_voltage_l1",
+    }
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensors_become_available_with_data(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    patch_shared_listener: MagicMock,
+) -> None:
+    """Test that sensors become available when data arrives."""
+    payload = powerhub_pb2.Payload()
+    payload.sample.power_active_delivered_to_client_kw = 2.0
+    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
+    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+        PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample),
+        ("192.168.1.100", 1234),
+    )
+    await hass.async_block_till_done()
+
+    base_unique_id = mock_config_entry.unique_id
+    expected_unique_id = f"{base_unique_id}_power_active_delivered_to_client"
+    entity_entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    matching = next(
+        (e for e in entity_entries if e.unique_id == expected_unique_id), None
+    )
+    assert matching is not None
+    state = hass.states.get(matching.entity_id)
+    assert state is not None
+    assert state.state != "unavailable"
+    assert float(state.state) == pytest.approx(2.0)

--- a/tests/components/bitvis/test_sensor.py
+++ b/tests/components/bitvis/test_sensor.py
@@ -1,20 +1,20 @@
 """Tests for the Bitvis Power Hub sensor platform."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from bitvis_protobuf import powerhub_pb2
 from bitvis_protobuf.parse import PayloadDiagnostic, PayloadSample
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.bitvis.const import DOMAIN, MODEL_NAME
+from homeassistant.components.bitvis.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from . import find_listener_callback, setup_integration
-from .conftest import TEST_DEVICE_MAC
+from .conftest import TEST_DEVICE_MAC, FakeListener
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -61,7 +61,6 @@ def sample_payload() -> PayloadSample:
     payload.sample.energy_active_delivered_by_client_kwh = 789.12
     payload.sample.energy_reactive_delivered_to_client_kvarh = 45.67
     payload.sample.energy_reactive_delivered_by_client_kvarh = 23.45
-    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
     return PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample)
 
 
@@ -76,7 +75,6 @@ def diagnostic_payload() -> PayloadDiagnostic:
     payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
     payload.diagnostic.han_msg_successfully_parsed = 1000
     payload.diagnostic.han_msg_buffer_overflow = 5
-    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
     return PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic)
 
 
@@ -88,7 +86,7 @@ async def test_all_entities(
     entity_registry: er.EntityRegistry,
     sample_payload: PayloadSample,
     diagnostic_payload: PayloadDiagnostic,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> None:
     """Test all entities with snapshot."""
     with patch("homeassistant.components.bitvis._PLATFORMS", [Platform.SENSOR]):
@@ -107,7 +105,7 @@ async def test_entities_added_when_fields_become_available(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> None:
     """Test that HAN sensors are created when their fields first appear."""
     base_unique_id = mock_config_entry.unique_id
@@ -154,28 +152,24 @@ async def test_sensors_become_available_with_data(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> None:
     """Test that sensors become available when data arrives."""
     payload = powerhub_pb2.Payload()
     payload.sample.power_active_delivered_to_client_kw = 2.0
-    payload.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
     find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
         PayloadSample(mac_address=TEST_DEVICE_MAC, sample=payload.sample),
         ("192.168.1.100", 1234),
     )
     await hass.async_block_till_done()
 
-    base_unique_id = mock_config_entry.unique_id
-    expected_unique_id = f"{base_unique_id}_power_active_delivered_to_client"
-    entity_entries = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        f"{mock_config_entry.unique_id}_power_active_delivered_to_client",
     )
-    matching = next(
-        (e for e in entity_entries if e.unique_id == expected_unique_id), None
-    )
-    assert matching is not None
-    state = hass.states.get(matching.entity_id)
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
     assert state is not None
     assert state.state != "unavailable"
     assert float(state.state) == pytest.approx(2.0)
@@ -185,7 +179,7 @@ async def test_sensors_become_available_with_data(
 async def test_diagnostic_sensors_update_with_data(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> None:
     """Test that diagnostic sensors update when a diagnostic payload arrives."""
     payload = powerhub_pb2.Payload()
@@ -224,14 +218,14 @@ async def test_device_info_updated_from_diagnostic(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
-    patch_shared_listener: MagicMock,
+    patch_shared_listener: FakeListener,
 ) -> None:
     """Test that device info is updated from a diagnostic payload."""
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
     )
     assert device is not None
-    assert device.model == MODEL_NAME
+    assert device.model is None
     assert device.sw_version is None
     assert (CONNECTION_NETWORK_MAC, TEST_DEVICE_MAC) in device.connections
 
@@ -255,19 +249,21 @@ async def test_device_info_updated_from_diagnostic(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_device_info_cleared_when_absent_in_diagnostic(
+async def test_device_info_kept_when_absent_in_later_payload(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
-    patch_shared_listener: MagicMock,
+    sample_payload: PayloadSample,
+    patch_shared_listener: FakeListener,
 ) -> None:
-    """Test that device info is cleared when absent in a later diagnostic."""
+    """Test that known model/sw_version are kept when later payloads omit them."""
     payload = powerhub_pb2.Payload()
     payload.diagnostic.uptime_s = 10
     payload.diagnostic.device_info.model_name = "PowerHub"
     payload.diagnostic.device_info.sw_version = "1.0"
     payload.diagnostic.device_info.mac_address = b"\xaa\xbb\xcc\xdd\xee\xff"
-    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+    callback = find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)
+    callback(
         PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload.diagnostic),
         ("192.168.1.100", 1234),
     )
@@ -282,15 +278,16 @@ async def test_device_info_cleared_when_absent_in_diagnostic(
 
     payload2 = powerhub_pb2.Payload()
     payload2.diagnostic.uptime_s = 20
-    find_listener_callback(patch_shared_listener, TEST_DEVICE_MAC)(
+    callback(
         PayloadDiagnostic(mac_address=TEST_DEVICE_MAC, diagnostic=payload2.diagnostic),
         ("192.168.1.100", 1234),
     )
+    callback(sample_payload, ("192.168.1.100", 1234))
     await hass.async_block_till_done()
 
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, TEST_DEVICE_MAC), init_integration.entry_id
     )
     assert device is not None
-    assert device.model == MODEL_NAME
-    assert device.sw_version is None
+    assert device.model == "PowerHub"
+    assert device.sw_version == "1.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new integration for the Bitvis Power Hub HAN port reader. The device connects to smart energy meters through a HAN (Home Area Network) port and broadcasts the meter measurands over UDP.

The device is detected through zeroconf, or added manually using an IP address. For zeroconf, we validate that the device is sending data prior to presenting it to the user. When manually adding the device, we wait until a packet has been received before proceeding to add it. All packets have a MAC address attached to them, which allows Home Assistant to identify the device even if it changes network, IP address, etc.

After the device has been added to home assistant, the integration listens for the UDP packets and unpacks them. 

Not all meters provide all measurands (power/voltage/current/energy, per-phase and total), so sensor entries are instead created dynamically as they are published by the Power Hub.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/brands/pull/9974
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44082
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
  - https://github.com/bitvis-io/bitvis-protobuf
  - https://github.com/bitvis-io/bitvis-protobuf/releases/tag/2.0.4

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
