### PR TITLE
Bump victron-ble-ha-parser to 0.5.0 and fix SmartLithium 8-cell support

### DIFF
--- a/homeassistant/components/victron_ble/manifest.json
+++ b/homeassistant/components/victron_ble/manifest.json
@@ -15,5 +15,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "bronze",
-  "requirements": ["victron-ble-ha-parser==0.4.9"]
+  "requirements": ["victron-ble-ha-parser==0.5.0"]
 }

--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -402,7 +402,7 @@ SENSOR_DESCRIPTIONS = {
     ),
 }
 
-for i in range(1, 8):
+for i in range(1, 9):
     cell_key = getattr(Keys, f"CELL_{i}_VOLTAGE")
     SENSOR_DESCRIPTIONS[cell_key] = VictronBLESensorEntityDescription(
         key=cell_key,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3139,7 +3139,7 @@ velbus-aio==2026.1.4
 venstarcolortouch==0.21
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.4.9
+victron-ble-ha-parser==0.5.0
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2630,7 +2630,7 @@ velbus-aio==2026.1.4
 venstarcolortouch==0.21
 
 # homeassistant.components.victron_ble
-victron-ble-ha-parser==0.4.9
+victron-ble-ha-parser==0.5.0
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.8


### PR DESCRIPTION
## What it does
- Bumps `victron-ble-ha-parser` from 0.4.9 to 0.5.0
- Fixes SmartLithium cell voltage range from 7 to 8 cells for 24V battery support

## Details
The updated parser library (v0.5.0) includes:
- **BatterySense device support** — adds voltage and temperature sensors for SmartBatterySense devices
- **SolarCharger `charger_error` sensor** — exposes charging error state
- **SmartLithium 8-cell support** — the parser now handles `CELL_8_VOLTAGE`

The `sensor.py` range change (`range(1, 8)` → `range(1, 9)`) ensures all 8 cells of a 24V SmartLithium battery are exposed as entities in Home Assistant.

Fixes #160833
Fixes #157963