### PR TITLE
Bump pyintelliclima dependency for IntelliClima integration

### DIFF
--- a/homeassistant/components/intelliclima/fan.py
+++ b/homeassistant/components/intelliclima/fan.py
@@ -111,7 +111,7 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         infinitely.
         """
         percentage = 25 if percentage == 0 else percentage
-        await self.async_set_mode_speed(fan_mode=preset_mode, percentage=percentage)
+        await self.async_set_mode_speed(preset_mode=preset_mode, percentage=percentage)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the fan."""
@@ -124,10 +124,10 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode."""
-        await self.async_set_mode_speed(fan_mode=preset_mode)
+        await self.async_set_mode_speed(preset_mode=preset_mode)
 
     async def async_set_mode_speed(
-        self, fan_mode: str | None = None, percentage: int | None = None
+        self, preset_mode: str | None = None, percentage: int | None = None
     ) -> None:
         """Set mode and speed.
 
@@ -137,7 +137,7 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         percentage = self.percentage if percentage is None else percentage
         percentage = 25 if percentage is None else percentage
 
-        if fan_mode == "auto":
+        if preset_mode == "auto":
             # auto is a special case with special mode and speed setting
             await self.coordinator.api.ecocomfort.set_mode_speed_auto(self._device_sn)
             await self.coordinator.async_request_refresh()

--- a/homeassistant/components/intelliclima/fan.py
+++ b/homeassistant/components/intelliclima/fan.py
@@ -74,7 +74,7 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         """Return the current speed percentage."""
         device_data = self._device_data
 
-        if device_data.speed_set == FanSpeed.auto:
+        if device_data.speed_set == FanSpeed.auto_get:
             return None
 
         return ranged_value_to_percentage(self._speed_range, int(device_data.speed_set))
@@ -92,7 +92,7 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
         if device_data.mode_set == FanMode.off:
             return None
         if (
-            device_data.speed_set == FanSpeed.auto
+            device_data.speed_set == FanSpeed.auto_get
             and device_data.mode_set == FanMode.sensor
         ):
             return "auto"
@@ -148,21 +148,20 @@ class IntelliClimaVMCFan(IntelliClimaECOEntity, FanEntity):
             return
 
         # Determine the fan mode
-        if fan_mode is not None:
-            # Set to requested fan_mode
-            mode = fan_mode
-        elif not self.is_on:
+        if not self.is_on:
             # Default to alternate fan mode if not turned on
             mode = FanMode.alternate
         else:
             # Maintain current mode
             mode = self._device_data.mode_set
 
-        speed = str(
-            math.ceil(
-                percentage_to_ranged_value(
-                    self._speed_range,
-                    percentage,
+        speed = FanSpeed(
+            str(
+                math.ceil(
+                    percentage_to_ranged_value(
+                        self._speed_range,
+                        percentage,
+                    )
                 )
             )
         )

--- a/homeassistant/components/intelliclima/manifest.json
+++ b/homeassistant/components/intelliclima/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["pyintelliclima==0.2.2"]
+  "requirements": ["pyintelliclima==0.3.0"]
 }

--- a/homeassistant/components/intelliclima/manifest.json
+++ b/homeassistant/components/intelliclima/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["pyintelliclima==0.3.0"]
+  "requirements": ["pyintelliclima==0.3.1"]
 }

--- a/homeassistant/components/intelliclima/select.py
+++ b/homeassistant/components/intelliclima/select.py
@@ -68,12 +68,12 @@ class IntelliClimaVMCFanModeSelect(IntelliClimaECOEntity, SelectEntity):
 
         # If in auto mode (sensor mode with auto speed), return None (handled by fan entity preset mode)
         if (
-            device_data.speed_set == FanSpeed.auto
+            device_data.speed_set == FanSpeed.auto_get
             and device_data.mode_set == FanMode.sensor
         ):
             return None
 
-        return INTELLICLIMA_MODE_TO_FAN_MODE.get(FanMode(device_data.mode_set))
+        return INTELLICLIMA_MODE_TO_FAN_MODE.get(device_data.mode_set)
 
     async def async_select_option(self, option: str) -> None:
         """Set the fan mode."""
@@ -83,7 +83,7 @@ class IntelliClimaVMCFanModeSelect(IntelliClimaECOEntity, SelectEntity):
 
         # Determine speed: keep current speed if available, otherwise default to sleep
         if (
-            device_data.speed_set == FanSpeed.auto
+            device_data.speed_set == FanSpeed.auto_get
             or device_data.mode_set == FanMode.off
         ):
             speed = FanSpeed.sleep

--- a/homeassistant/components/intelliclima/strings.json
+++ b/homeassistant/components/intelliclima/strings.json
@@ -6,7 +6,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_devices": "No IntelliClima devices found in your account",
+      "no_devices": "No (supported) IntelliClima devices found in your account, check the docs for supported devices!",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/homeassistant/components/intelliclima/strings.json
+++ b/homeassistant/components/intelliclima/strings.json
@@ -6,7 +6,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_devices": "No (supported) IntelliClima devices found in your account, check the docs for supported devices!",
+      "no_devices": "No supported IntelliClima devices were found in your account.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/homeassistant/components/intelliclima/strings.json
+++ b/homeassistant/components/intelliclima/strings.json
@@ -6,7 +6,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "no_devices": "No supported IntelliClima devices were found in your account.",
+      "no_devices": "No supported IntelliClima devices were found in your account",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2155,7 +2155,7 @@ pyicloud==2.4.1
 pyinsteon==1.6.4
 
 # homeassistant.components.intelliclima
-pyintelliclima==0.2.2
+pyintelliclima==0.3.0
 
 # homeassistant.components.intesishome
 pyintesishome==1.8.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2155,7 +2155,7 @@ pyicloud==2.4.1
 pyinsteon==1.6.4
 
 # homeassistant.components.intelliclima
-pyintelliclima==0.3.0
+pyintelliclima==0.3.1
 
 # homeassistant.components.intesishome
 pyintesishome==1.8.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1844,7 +1844,7 @@ pyicloud==2.4.1
 pyinsteon==1.6.4
 
 # homeassistant.components.intelliclima
-pyintelliclima==0.2.2
+pyintelliclima==0.3.0
 
 # homeassistant.components.ipma
 pyipma==3.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1844,7 +1844,7 @@ pyicloud==2.4.1
 pyinsteon==1.6.4
 
 # homeassistant.components.intelliclima
-pyintelliclima==0.3.0
+pyintelliclima==0.3.1
 
 # homeassistant.components.ipma
 pyipma==3.0.9

--- a/tests/components/intelliclima/conftest.py
+++ b/tests/components/intelliclima/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from pyintelliclima.const import FanMode, FanSpeed
 from pyintelliclima.intelliclima_types import (
     IntelliClimaDevices,
     IntelliClimaECO,
@@ -50,9 +51,9 @@ def single_eco_device() -> IntelliClimaDevices:
         model=IntelliClimaModelType(modello="ECO", tipo="wifi"),
         name="Test VMC",
         houses_id="12345",
-        mode_set="1",
+        mode_set=FanMode.inward,
         mode_state="1",
-        speed_set="3",
+        speed_set=FanSpeed.medium,
         speed_state="3",
         last_online="2025-11-18 10:22:51",
         creation_date="2025-11-18 10:22:51",

--- a/tests/components/intelliclima/test_fan.py
+++ b/tests/components/intelliclima/test_fan.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, patch
 
+from pyintelliclima.const import FanMode, FanSpeed
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -103,7 +104,7 @@ async def test_fan_turn_on_service_calls_api(
 
     # Device serial from single_eco_device.crono_sn
     mock_cloud_interface.ecocomfort.set_mode_speed.assert_awaited_once_with(
-        "11223344", "1", "2"
+        "11223344", FanMode.inward, FanSpeed.low
     )
 
 
@@ -119,10 +120,10 @@ async def test_fan_set_percentage_maps_to_speed(
         {ATTR_ENTITY_ID: FAN_ENTITY_ID, ATTR_PERCENTAGE: 15},
         blocking=True,
     )
-    # Initial mode_set="1" (forward) from single_eco_device.
-    # Sleep speed is "1" (25%).
+    # Initial mode_set=FanMode.inward from single_eco_device.
+    # Sleep speed is FanSpeed.sleep (25%).
     mock_cloud_interface.ecocomfort.set_mode_speed.assert_awaited_once_with(
-        "11223344", "1", "1"
+        "11223344", FanMode.inward, FanSpeed.sleep
     )
 
 
@@ -165,10 +166,10 @@ async def test_fan_set_percentage_zero_turns_off(
     ("service_data", "expected_mode", "expected_speed"),
     [
         # percentage=None, preset_mode=None -> defaults to previous speed > 75% (medium),
-        # previous mode > "inward"
-        ({}, "1", "3"),
-        # percentage=0, preset_mode=None -> default 25% (sleep), previous mode (inward)
-        ({ATTR_PERCENTAGE: 0}, "1", "1"),
+        # previous mode > FanMode.inward
+        ({}, FanMode.inward, FanSpeed.medium),
+        # percentage=0, preset_mode=None -> default 25% (FanSpeed.sleep), previous mode (inward)
+        ({ATTR_PERCENTAGE: 0}, FanMode.inward, FanSpeed.sleep),
     ],
 )
 async def test_fan_turn_on_defaulting_behavior(

--- a/tests/components/intelliclima/test_fan.py
+++ b/tests/components/intelliclima/test_fan.py
@@ -176,9 +176,8 @@ async def test_fan_turn_on_defaulting_behavior(
     hass: HomeAssistant,
     mock_cloud_interface: AsyncMock,
     service_data: dict,
-    expected_mode: str,
-expected_mode: FanMode,
-expected_speed: FanSpeed,
+    expected_mode: FanMode,
+    expected_speed: FanSpeed,
 ) -> None:
     """turn_on defaults percentage/preset as expected."""
     data = {ATTR_ENTITY_ID: FAN_ENTITY_ID} | service_data

--- a/tests/components/intelliclima/test_fan.py
+++ b/tests/components/intelliclima/test_fan.py
@@ -177,7 +177,8 @@ async def test_fan_turn_on_defaulting_behavior(
     mock_cloud_interface: AsyncMock,
     service_data: dict,
     expected_mode: str,
-    expected_speed: str,
+expected_mode: FanMode,
+expected_speed: FanSpeed,
 ) -> None:
     """turn_on defaults percentage/preset as expected."""
     data = {ATTR_ENTITY_ID: FAN_ENTITY_ID} | service_data

--- a/tests/components/intelliclima/test_select.py
+++ b/tests/components/intelliclima/test_select.py
@@ -86,10 +86,10 @@ async def test_select_option_keeps_current_speed(
         {ATTR_ENTITY_ID: SELECT_ENTITY_ID, ATTR_OPTION: option},
         blocking=True,
     )
-    # Device starts with speed_set="3" (from single_eco_device in conftest),
+    # Device starts with speed_set=FanSpeed.medium (from single_eco_device in conftest),
     # mode is not off and not auto, so current speed is preserved.
     mock_cloud_interface.ecocomfort.set_mode_speed.assert_awaited_once_with(
-        "11223344", expected_mode, "3"
+        "11223344", expected_mode, FanSpeed.medium
     )
 
 

--- a/tests/components/intelliclima/test_select.py
+++ b/tests/components/intelliclima/test_select.py
@@ -119,9 +119,9 @@ async def test_select_option_in_auto_mode_defaults_speed_to_sleep(
     mock_cloud_interface: AsyncMock,
     single_eco_device,
 ) -> None:
-    """When speed_set is FanSpeed.auto (auto preset), selecting an option defaults to sleep speed."""
+    """When speed_set is FanSpeed.auto_get (auto preset), selecting an option defaults to sleep speed."""
     eco = list(single_eco_device.ecocomfort2_devices.values())[0]
-    eco.speed_set = FanSpeed.auto
+    eco.speed_set = FanSpeed.auto_get
     eco.mode_set = FanMode.sensor
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumped `pyintelliclima` dependency to [`0.3.1`](https://github.com/dvdinth/pyintelliclima/releases/tag/v0.3.1) (coming from `0.2.2`) and with that changed the fan and select entity to use the `FanSpeed` and `FanMode` `StrEnum` classes instead of also allowing simple `str` (included in the [`0.3.0`](https://github.com/dvdinth/pyintelliclima/releases/tag/v0.3.0) bump). This also includes a fix for users that reported crashes with the integration because of the device filter notification (included in the `0.3.1` bump).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
