### PR TITLE
UPnP/IGD: Optionally recalculate rates on rolling-over 32-bit counters

### DIFF
--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .const import (
     CONFIG_ENTRY_FORCE_POLL,
+    CONFIG_ENTRY_ROLLOVER_DELTAS,
     CONFIG_ENTRY_HOST,
     CONFIG_ENTRY_MAC_ADDRESS,
     CONFIG_ENTRY_ORIGINAL_UDN,
@@ -80,9 +81,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: UpnpConfigEntry) -> bool
     assert discovery_info.ssdp_udn
     assert discovery_info.ssdp_all_locations
     force_poll = entry.options.get(CONFIG_ENTRY_FORCE_POLL, False)
+    rollover_deltas = entry.options.get(CONFIG_ENTRY_ROLLOVER_DELTAS, False)
     location = get_preferred_location(discovery_info.ssdp_all_locations)
     try:
-        device = await async_create_device(hass, location, force_poll)
+        device = await async_create_device(hass, location, force_poll, rollover_deltas)
     except UpnpConnectionError as err:
         raise ConfigEntryNotReady(
             f"Error connecting to device at location: {location}, err: {err}"

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.service_info.ssdp import (
 
 from .const import (
     CONFIG_ENTRY_FORCE_POLL,
+    CONFIG_ENTRY_ROLLOVER_DELTAS,
     CONFIG_ENTRY_HOST,
     CONFIG_ENTRY_LOCATION,
     CONFIG_ENTRY_MAC_ADDRESS,
@@ -33,6 +34,7 @@ from .const import (
     CONFIG_ENTRY_ST,
     CONFIG_ENTRY_UDN,
     DEFAULT_CONFIG_ENTRY_FORCE_POLL,
+    DEFAULT_CONFIG_ENTRY_ROLLOVER_DELTAS,
     DOMAIN,
     DOMAIN_DISCOVERIES,
     LOGGER,
@@ -272,6 +274,7 @@ class UpnpFlowHandler(ConfigFlow, domain=DOMAIN):
         }
         options = {
             CONFIG_ENTRY_FORCE_POLL: False,
+            CONFIG_ENTRY_ROLLOVER_DELTAS: False,
         }
 
         await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
@@ -301,6 +304,7 @@ class UpnpFlowHandler(ConfigFlow, domain=DOMAIN):
         }
         options = {
             CONFIG_ENTRY_FORCE_POLL: False,
+            CONFIG_ENTRY_ROLLOVER_DELTAS: False,
         }
         return self.async_create_entry(title=title, data=data, options=options)
 
@@ -321,6 +325,13 @@ class UpnpOptionsFlowHandler(OptionsFlow):
                     CONFIG_ENTRY_FORCE_POLL,
                     default=self.config_entry.options.get(
                         CONFIG_ENTRY_FORCE_POLL, DEFAULT_CONFIG_ENTRY_FORCE_POLL
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONFIG_ENTRY_ROLLOVER_DELTAS,
+                    default=self.config_entry.options.get(
+                        CONFIG_ENTRY_ROLLOVER_DELTAS,
+                        DEFAULT_CONFIG_ENTRY_ROLLOVER_DELTAS,
                     ),
                 ): bool,
             }

--- a/homeassistant/components/upnp/const.py
+++ b/homeassistant/components/upnp/const.py
@@ -25,6 +25,7 @@ PORT_MAPPING_NUMBER_OF_ENTRIES_IPV4 = "port_mapping_number_of_entries"
 ROUTER_IP = "ip"
 ROUTER_UPTIME = "uptime"
 CONFIG_ENTRY_FORCE_POLL = "force_poll"
+CONFIG_ENTRY_ROLLOVER_DELTAS = "rollover_deltas"
 CONFIG_ENTRY_ST = "st"
 CONFIG_ENTRY_UDN = "udn"
 CONFIG_ENTRY_ORIGINAL_UDN = "original_udn"
@@ -35,5 +36,6 @@ IDENTIFIER_HOST = "upnp_host"
 IDENTIFIER_SERIAL_NUMBER = "upnp_serial_number"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30).total_seconds()
 DEFAULT_CONFIG_ENTRY_FORCE_POLL = False
+DEFAULT_CONFIG_ENTRY_ROLLOVER_DELTAS = False
 ST_IGD_V1 = "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
 ST_IGD_V2 = "urn:schemas-upnp-org:device:InternetGatewayDevice:2"

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -84,7 +84,7 @@ async def async_get_mac_address_from_host(hass: HomeAssistant, host: str) -> str
 
 
 async def async_create_device(
-    hass: HomeAssistant, location: str, force_poll: bool
+    hass: HomeAssistant, location: str, force_poll: bool, rollover_deltas: bool
 ) -> Device:
     """Create UPnP/IGD device."""
     session = async_get_clientsession(hass, verify_ssl=False)
@@ -106,19 +106,25 @@ async def async_create_device(
 
     # Create profile wrapper.
     igd_device = IgdDevice(upnp_device, notify_server.event_handler)
-    return Device(hass, igd_device, force_poll)
+    return Device(hass, igd_device, force_poll, rollover_deltas)
 
 
 class Device:
     """Home Assistant representation of a UPnP/IGD device."""
 
     def __init__(
-        self, hass: HomeAssistant, igd_device: IgdDevice, force_poll: bool
+        self,
+        hass: HomeAssistant,
+        igd_device: IgdDevice,
+        force_poll: bool,
+        rollover_deltas: bool,
     ) -> None:
         """Initialize UPnP/IGD device."""
         self.hass = hass
         self._igd_device = igd_device
         self._force_poll = force_poll
+        self._rollover_deltas = rollover_deltas
+        self._prev_data: dict | None = None
 
         self.coordinator: (
             DataUpdateCoordinator[dict[str, str | datetime | int | float | None]] | None
@@ -246,7 +252,7 @@ class Device:
 
             return value
 
-        return {
+        data = {
             TIMESTAMP: igd_state.timestamp,
             BYTES_RECEIVED: get_value(igd_state.bytes_received),
             BYTES_SENT: get_value(igd_state.bytes_sent),
@@ -263,3 +269,76 @@ class Device:
                 igd_state.port_mapping_number_of_entries
             ),
         }
+
+        if self._rollover_deltas:
+            if self._prev_data:
+                data = self._recalc_rates(data)
+
+            self._prev_data = data
+
+        return data
+
+    def _recalc_rates(self, data: dict) -> dict | None:
+        """Recalculates rates, caring for 32-bit counter rollover"""
+
+        prev_uptime = self._prev_data[ROUTER_UPTIME]
+        cur_uptime = data[ROUTER_UPTIME]
+
+        if prev_uptime is None or cur_uptime is None or prev_uptime > cur_uptime:
+            _LOGGER.warning(
+                "Skipping rate recalc due to possible router reset: %s %s",
+                prev_uptime,
+                cur_uptime,
+            )
+
+            return data
+
+        delta_time = cur_uptime - prev_uptime
+
+        prev_bytes_recv = self._prev_data[BYTES_RECEIVED]
+        prev_bytes_sent = self._prev_data[BYTES_SENT]
+        prev_packets_recv = self._prev_data[PACKETS_RECEIVED]
+        prev_packets_sent = self._prev_data[PACKETS_SENT]
+
+        cur_bytes_recv = data[BYTES_RECEIVED]
+        cur_bytes_sent = data[BYTES_SENT]
+        cur_packets_recv = data[PACKETS_RECEIVED]
+        cur_packets_sent = data[PACKETS_SENT]
+
+        def rollover_rate(cur: int, prev: int, delta: int) -> int | None:
+            if cur < prev:
+                if (
+                    (1 << 31) < prev
+                    and prev < (1 << 32)
+                    and (0) < cur
+                    and cur < (1 << 31)
+                ):
+                    _LOGGER.debug("Rolling over 32-bit value: %s → %s", prev, cur)
+                    prev -= 1 << 32
+                else:
+                    _LOGGER.warning("Bad 32-bit rollover: %s → %s", prev, cur)
+                    return None
+
+            return (cur - prev) / delta
+
+        if prev_bytes_recv is not None and cur_bytes_recv is not None:
+            data[KIBIBYTES_PER_SEC_RECEIVED] = rollover_rate(
+                cur_bytes_recv, prev_bytes_recv, delta_time * 1024
+            )
+
+        if prev_bytes_sent is not None and cur_bytes_sent is not None:
+            data[KIBIBYTES_PER_SEC_SENT] = rollover_rate(
+                cur_bytes_sent, prev_bytes_sent, delta_time * 1024
+            )
+
+        if prev_packets_recv is not None and cur_packets_recv is not None:
+            data[PACKETS_PER_SEC_RECEIVED] = rollover_rate(
+                cur_packets_recv, prev_packets_recv, delta_time
+            )
+
+        if prev_packets_sent is not None and cur_packets_sent is not None:
+            data[PACKETS_PER_SEC_SENT] = rollover_rate(
+                cur_packets_sent, prev_packets_sent, delta_time
+            )
+
+        return data

--- a/homeassistant/components/upnp/strings.json
+++ b/homeassistant/components/upnp/strings.json
@@ -66,7 +66,8 @@
     "step": {
       "init": {
         "data": {
-          "force_poll": "Force polling of all data"
+          "force_poll": "Force polling of all data",
+          "rollover_deltas": "Calculate rates assuming 32-bit rollover counters"
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an optional per-device setting in the UPnP/IGD integration, in order to work around an edge case of the underlying `async_upnp_client` library: some routers use unsigned 32 bit counters for traffic and packet count, and when those roll over, the rates (i.e. KiB/s) are not calculated properly.

As per @StevenLooman 's advice in https://github.com/StevenLooman/async_upnp_client/pull/296 , this workaround is optional and disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
