### PR TITLE
Add entity-unavailable and log-when-unavailable 

### DIFF
--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -46,11 +46,16 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
     async def _async_update_data(self) -> None:
         """Update all device states from the Litter-Robot API."""
-        await self.account.refresh_robots()
-        await self.account.load_pets()
-        for pet in self.account.pets:
-            # Need to fetch weight history for `get_visits_since`
-            await pet.fetch_weight_history()
+        try:
+            await self.account.refresh_robots()
+            await self.account.load_pets()
+            for pet in self.account.pets:
+                # Need to fetch weight history for `get_visits_since`
+                await pet.fetch_weight_history()
+        except LitterRobotLoginException as ex:
+            raise ConfigEntryAuthFailed("Invalid credentials") from ex
+        except LitterRobotException as ex:
+            raise UpdateFailed("Unable to connect to Whisker API") from ex
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""

--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -55,7 +55,9 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
         except LitterRobotLoginException as ex:
             raise ConfigEntryAuthFailed("Invalid credentials") from ex
         except LitterRobotException as ex:
-            raise UpdateFailed("Unable to connect to Whisker API") from ex
+            raise UpdateFailed(
+                f"Unable to fetch data from the Whisker API: {ex}"
+            ) from ex
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""

--- a/homeassistant/components/litterrobot/quality_scale.yaml
+++ b/homeassistant/components/litterrobot/quality_scale.yaml
@@ -29,9 +29,9 @@ rules:
     status: done
     comment: No options to configure
   docs-installation-parameters: done
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
   test-coverage:

--- a/tests/components/litterrobot/test_coordinator.py
+++ b/tests/components/litterrobot/test_coordinator.py
@@ -1,12 +1,12 @@
 """Tests for the Litter-Robot coordinator."""
 
-from datetime import timedelta
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
 from homeassistant.components.litterrobot.const import DOMAIN
+from homeassistant.components.litterrobot.coordinator import UPDATE_INTERVAL
 from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import STATE_UNAVAILABLE
@@ -31,7 +31,7 @@ async def test_coordinator_update_error(
 
     # Simulate an API error during update
     mock_account.refresh_robots.side_effect = LitterRobotException("Unable to connect")
-    freezer.tick(timedelta(minutes=5))
+    freezer.tick(UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -40,7 +40,7 @@ async def test_coordinator_update_error(
 
     # Recover
     mock_account.refresh_robots.side_effect = None
-    freezer.tick(timedelta(minutes=5))
+    freezer.tick(UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -63,7 +63,7 @@ async def test_coordinator_update_auth_error(
     mock_account.refresh_robots.side_effect = LitterRobotLoginException(
         "Invalid credentials"
     )
-    freezer.tick(timedelta(minutes=5))
+    freezer.tick(UPDATE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/litterrobot/test_coordinator.py
+++ b/tests/components/litterrobot/test_coordinator.py
@@ -1,0 +1,81 @@
+"""Tests for the Litter-Robot coordinator."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
+
+from homeassistant.components.litterrobot.const import DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from .common import VACUUM_ENTITY_ID
+from .conftest import setup_integration
+
+from tests.common import async_fire_time_changed
+
+
+async def test_coordinator_update_error(
+    hass: HomeAssistant,
+    mock_account: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test entities become unavailable when coordinator update fails."""
+    await setup_integration(hass, mock_account, VACUUM_DOMAIN)
+
+    assert (state := hass.states.get(VACUUM_ENTITY_ID))
+    assert state.state != STATE_UNAVAILABLE
+
+    # Simulate an API error during update
+    mock_account.refresh_robots.side_effect = LitterRobotException("Unable to connect")
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(VACUUM_ENTITY_ID))
+    assert state.state == STATE_UNAVAILABLE
+
+    # Recover
+    mock_account.refresh_robots.side_effect = None
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(VACUUM_ENTITY_ID))
+    assert state.state != STATE_UNAVAILABLE
+
+
+async def test_coordinator_update_auth_error(
+    hass: HomeAssistant,
+    mock_account: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test reauthentication flow is triggered on login error during update."""
+    entry = await setup_integration(hass, mock_account, VACUUM_DOMAIN)
+
+    assert (state := hass.states.get(VACUUM_ENTITY_ID))
+    assert state.state != STATE_UNAVAILABLE
+
+    # Simulate an authentication error during update
+    mock_account.refresh_robots.side_effect = LitterRobotLoginException(
+        "Invalid credentials"
+    )
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(VACUUM_ENTITY_ID))
+    assert state.state == STATE_UNAVAILABLE
+
+    # Ensure a reauthentication flow was triggered
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert flow["context"].get("source") == SOURCE_REAUTH
+    assert flow["context"].get("entry_id") == entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With this in place, we should now properly mark the entities as unavailable instead of showing stale data, including logging a clean message when it happens (and when they come back).

We already had this for _async_setup, we just needed to copy the same pattern for _async_update_data.

Wrap _async_update_data with exception handling to catch LitterRobotLoginException (triggers reauth) and LitterRobotException (raises UpdateFailed for proper unavailability logging and entity state management by the DataUpdateCoordinator).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
