### PR TITLE
Fix optional static values in bsblan

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -32,7 +32,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_PASSKEY, DOMAIN
+from .const import CONF_PASSKEY, DOMAIN, LOGGER
 from .coordinator import BSBLanFastCoordinator, BSBLanSlowCoordinator
 from .services import async_setup_services
 
@@ -52,7 +52,7 @@ class BSBLanData:
     client: BSBLAN
     device: Device
     info: Info
-    static: StaticState
+    static: StaticState | None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -82,11 +82,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
         # the connection by fetching firmware version
         await bsblan.initialize()
 
-        # Fetch device metadata in parallel for faster startup
-        device, info, static = await asyncio.gather(
+        # Fetch required device metadata in parallel for faster startup
+        device, info = await asyncio.gather(
             bsblan.device(),
             bsblan.info(),
-            bsblan.static_values(),
         )
     except BSBLANConnectionError as err:
         raise ConfigEntryNotReady(
@@ -110,6 +109,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
             translation_domain=DOMAIN,
             translation_key="setup_general_error",
         ) from err
+
+    try:
+        static = await bsblan.static_values()
+    except BSBLANError as err:
+        LOGGER.debug(
+            "Static values not available for %s: %s",
+            entry.data[CONF_HOST],
+            err,
+        )
+        static = None
 
     # Create coordinators with the already-initialized client
     fast_coordinator = BSBLanFastCoordinator(hass, entry, bsblan)

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -112,7 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
 
     try:
         static = await bsblan.static_values()
-    except BSBLANError as err:
+    except (BSBLANError, TimeoutError) as err:
         LOGGER.debug(
             "Static values not available for %s: %s",
             entry.data[CONF_HOST],

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -90,10 +90,11 @@ class BSBLANClimate(BSBLanEntity, ClimateEntity):
         self._attr_unique_id = f"{format_mac(data.device.MAC)}-climate"
 
         # Set temperature range if available, otherwise use Home Assistant defaults
-        if data.static.min_temp is not None and data.static.min_temp.value is not None:
-            self._attr_min_temp = data.static.min_temp.value
-        if data.static.max_temp is not None and data.static.max_temp.value is not None:
-            self._attr_max_temp = data.static.max_temp.value
+        if (static := data.static) is not None:
+            if (min_temp := static.min_temp) is not None and min_temp.value is not None:
+                self._attr_min_temp = min_temp.value
+            if (max_temp := static.max_temp) is not None and max_temp.value is not None:
+                self._attr_max_temp = max_temp.value
         self._attr_temperature_unit = data.fast_coordinator.client.get_temperature_unit
 
     @property

--- a/homeassistant/components/bsblan/diagnostics.py
+++ b/homeassistant/components/bsblan/diagnostics.py
@@ -24,7 +24,7 @@ async def async_get_config_entry_diagnostics(
             "sensor": data.fast_coordinator.data.sensor.model_dump(),
             "dhw": data.fast_coordinator.data.dhw.model_dump(),
         },
-        "static": data.static.model_dump() if data.static else None,
+        "static": data.static.model_dump() if data.static is not None else None,
     }
 
     # Add DHW config and schedule from slow coordinator if available

--- a/homeassistant/components/bsblan/diagnostics.py
+++ b/homeassistant/components/bsblan/diagnostics.py
@@ -24,7 +24,7 @@ async def async_get_config_entry_diagnostics(
             "sensor": data.fast_coordinator.data.sensor.model_dump(),
             "dhw": data.fast_coordinator.data.dhw.model_dump(),
         },
-        "static": data.static.model_dump(),
+        "static": data.static.model_dump() if data.static else None,
     }
 
     # Add DHW config and schedule from slow coordinator if available

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -45,6 +45,21 @@ async def test_celsius_fahrenheit(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+async def test_climate_entity_loads_without_static_values(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the climate entity still loads when static values are unavailable."""
+    mock_bsblan.static_values.side_effect = BSBLANError("General error")
+
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["current_temperature"] is not None
+
+
 async def test_climate_entity_properties(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -57,7 +57,8 @@ async def test_climate_entity_loads_without_static_values(
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.attributes["current_temperature"] is not None
+    assert state.attributes["current_temperature"] == 18.6
+    assert state.attributes["temperature"] == 18.5
 
 
 async def test_climate_entity_properties(
@@ -134,20 +135,32 @@ async def _async_set_hvac_action(
     return state.attributes.get("hvac_action")
 
 
+def _mock_hvac_action_without_value() -> MagicMock:
+    """Return a mocked hvac action object with no value."""
+    mock_action = MagicMock()
+    mock_action.value = None
+    return mock_action
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(None, None, id="missing-action"),
+        pytest.param(_mock_hvac_action_without_value(), None, id="missing-value"),
+    ],
+)
 async def test_hvac_action_handles_none_inputs(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    value: MagicMock | None,
+    expected: HVACAction | None,
 ) -> None:
     """Ensure hvac_action gracefully handles None values."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, None) is None
-
-    mock_action = MagicMock()
-    mock_action.value = None
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
+    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, value) is expected
 
 
 async def test_hvac_action_uses_library_mapping(
@@ -171,48 +184,33 @@ async def test_hvac_action_uses_library_mapping(
     assert result == HVACAction.IDLE
 
 
-async def test_climate_without_current_temperature_sensor(
+@pytest.mark.parametrize(
+    ("state_attribute", "entity_attribute"),
+    [
+        pytest.param("current_temperature", "current_temperature", id="current"),
+        pytest.param("target_temperature", "temperature", id="target"),
+    ],
+)
+async def test_climate_without_temperature_sensor(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    state_attribute: str,
+    entity_attribute: str,
 ) -> None:
-    """Test climate entity when current temperature sensor is not available."""
+    """Test climate entity when a temperature sensor value is not available."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
-    # Set current_temperature to None to simulate no temperature sensor
-    mock_bsblan.state.return_value.current_temperature = None
+    setattr(mock_bsblan.state.return_value, state_attribute, None)
 
     freezer.tick(timedelta(minutes=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Should not crash and current_temperature should be None in attributes
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.attributes["current_temperature"] is None
-
-
-async def test_climate_without_target_temperature_sensor(
-    hass: HomeAssistant,
-    mock_bsblan: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test climate entity when target temperature sensor is not available."""
-    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
-
-    # Set target_temperature to None to simulate no temperature sensor
-    mock_bsblan.state.return_value.target_temperature = None
-
-    freezer.tick(timedelta(minutes=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    # Should not crash and target temperature should be None in attributes
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.attributes["temperature"] is None
+    assert state.attributes[entity_attribute] is None
 
 
 async def test_climate_hvac_mode_object_none(

--- a/tests/components/bsblan/test_climate.py
+++ b/tests/components/bsblan/test_climate.py
@@ -57,8 +57,7 @@ async def test_climate_entity_loads_without_static_values(
 
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.attributes["current_temperature"] == 18.6
-    assert state.attributes["temperature"] == 18.5
+    assert state.attributes["current_temperature"] is not None
 
 
 async def test_climate_entity_properties(
@@ -135,32 +134,20 @@ async def _async_set_hvac_action(
     return state.attributes.get("hvac_action")
 
 
-def _mock_hvac_action_without_value() -> MagicMock:
-    """Return a mocked hvac action object with no value."""
-    mock_action = MagicMock()
-    mock_action.value = None
-    return mock_action
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        pytest.param(None, None, id="missing-action"),
-        pytest.param(_mock_hvac_action_without_value(), None, id="missing-value"),
-    ],
-)
 async def test_hvac_action_handles_none_inputs(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
-    value: MagicMock | None,
-    expected: HVACAction | None,
 ) -> None:
     """Ensure hvac_action gracefully handles None values."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
-    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, value) is expected
+    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, None) is None
+
+    mock_action = MagicMock()
+    mock_action.value = None
+    assert await _async_set_hvac_action(hass, mock_bsblan, freezer, mock_action) is None
 
 
 async def test_hvac_action_uses_library_mapping(
@@ -184,33 +171,48 @@ async def test_hvac_action_uses_library_mapping(
     assert result == HVACAction.IDLE
 
 
-@pytest.mark.parametrize(
-    ("state_attribute", "entity_attribute"),
-    [
-        pytest.param("current_temperature", "current_temperature", id="current"),
-        pytest.param("target_temperature", "temperature", id="target"),
-    ],
-)
-async def test_climate_without_temperature_sensor(
+async def test_climate_without_current_temperature_sensor(
     hass: HomeAssistant,
     mock_bsblan: AsyncMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
-    state_attribute: str,
-    entity_attribute: str,
 ) -> None:
-    """Test climate entity when a temperature sensor value is not available."""
+    """Test climate entity when current temperature sensor is not available."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
-    setattr(mock_bsblan.state.return_value, state_attribute, None)
+    # Set current_temperature to None to simulate no temperature sensor
+    mock_bsblan.state.return_value.current_temperature = None
 
     freezer.tick(timedelta(minutes=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    # Should not crash and current_temperature should be None in attributes
     state = hass.states.get(ENTITY_ID)
     assert state is not None
-    assert state.attributes[entity_attribute] is None
+    assert state.attributes["current_temperature"] is None
+
+
+async def test_climate_without_target_temperature_sensor(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test climate entity when target temperature sensor is not available."""
+    await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
+
+    # Set target_temperature to None to simulate no temperature sensor
+    mock_bsblan.state.return_value.target_temperature = None
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # Should not crash and target temperature should be None in attributes
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["temperature"] is None
 
 
 async def test_climate_hvac_mode_object_none(

--- a/tests/components/bsblan/test_diagnostics.py
+++ b/tests/components/bsblan/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from bsblan import BSBLANError
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -27,3 +28,23 @@ async def test_diagnostics(
         hass, hass_client, mock_config_entry
     )
     assert diagnostics_data == snapshot
+
+
+async def test_diagnostics_without_static_values(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test diagnostics when static values are not available."""
+    mock_bsblan.static_values.side_effect = BSBLANError("General error")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    diagnostics_data = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics_data["static"] is None

--- a/tests/components/bsblan/test_diagnostics.py
+++ b/tests/components/bsblan/test_diagnostics.py
@@ -47,4 +47,7 @@ async def test_diagnostics_without_static_values(
         hass, hass_client, mock_config_entry
     )
 
+    assert "info" in diagnostics_data
+    assert "device" in diagnostics_data
+    assert "fast_coordinator_data" in diagnostics_data
     assert diagnostics_data["static"] is None

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -90,7 +90,7 @@ async def test_config_entry_auth_failed_triggers_reauth(
             BSBLANAuthError("Authentication failed"),
             ConfigEntryState.SETUP_ERROR,
         ),
-        ("static_values", BSBLANError("General error"), ConfigEntryState.SETUP_ERROR),
+        ("static_values", BSBLANError("General error"), ConfigEntryState.LOADED),
     ],
 )
 async def test_config_entry_static_data_errors(
@@ -110,6 +110,37 @@ async def test_config_entry_static_data_errors(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is expected_state
+
+
+async def test_entry_loads_without_static_values(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test the config entry still loads when static values are not available."""
+    mock_bsblan.static_values.side_effect = BSBLANError("General error")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.runtime_data.static is None
+
+
+async def test_config_entry_general_setup_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test a general BSBLAN setup error results in setup failure."""
+    mock_bsblan.initialize.side_effect = BSBLANError("General error")
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_coordinator_dhw_config_update_error(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -104,6 +104,12 @@ async def test_config_entry_auth_failed_triggers_reauth(
             ConfigEntryState.LOADED,
             True,
         ),
+        (
+            "static_values",
+            TimeoutError("Connection timeout"),
+            ConfigEntryState.LOADED,
+            True,
+        ),
     ],
 )
 async def test_config_entry_setup_errors(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -81,6 +81,12 @@ async def test_config_entry_auth_failed_triggers_reauth(
     ("method", "exception", "expected_state", "assert_static_fallback"),
     [
         (
+            "initialize",
+            BSBLANError("General error"),
+            ConfigEntryState.SETUP_ERROR,
+            False,
+        ),
+        (
             "device",
             BSBLANConnectionError("Connection failed"),
             ConfigEntryState.SETUP_RETRY,
@@ -100,7 +106,7 @@ async def test_config_entry_auth_failed_triggers_reauth(
         ),
     ],
 )
-async def test_config_entry_static_data_errors(
+async def test_config_entry_setup_errors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
@@ -109,7 +115,7 @@ async def test_config_entry_static_data_errors(
     expected_state: ConfigEntryState,
     assert_static_fallback: bool,
 ) -> None:
-    """Test various errors during static data fetching trigger appropriate config entry states."""
+    """Test setup errors trigger appropriate config entry states."""
     # Mock the specified method to raise the exception
     getattr(mock_bsblan, method).side_effect = exception
 
@@ -120,21 +126,6 @@ async def test_config_entry_static_data_errors(
     assert mock_config_entry.state is expected_state
     if assert_static_fallback:
         assert mock_config_entry.runtime_data.static is None
-
-
-async def test_config_entry_general_setup_error(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test a general BSBLAN setup error results in setup failure."""
-    mock_bsblan.initialize.side_effect = BSBLANError("General error")
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_coordinator_dhw_config_update_error(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -78,19 +78,26 @@ async def test_config_entry_auth_failed_triggers_reauth(
 
 
 @pytest.mark.parametrize(
-    ("method", "exception", "expected_state"),
+    ("method", "exception", "expected_state", "assert_static_fallback"),
     [
         (
             "device",
             BSBLANConnectionError("Connection failed"),
             ConfigEntryState.SETUP_RETRY,
+            False,
         ),
         (
             "info",
             BSBLANAuthError("Authentication failed"),
             ConfigEntryState.SETUP_ERROR,
+            False,
         ),
-        ("static_values", BSBLANError("General error"), ConfigEntryState.LOADED),
+        (
+            "static_values",
+            BSBLANError("General error"),
+            ConfigEntryState.LOADED,
+            True,
+        ),
     ],
 )
 async def test_config_entry_static_data_errors(
@@ -100,6 +107,7 @@ async def test_config_entry_static_data_errors(
     method: str,
     exception: Exception,
     expected_state: ConfigEntryState,
+    assert_static_fallback: bool,
 ) -> None:
     """Test various errors during static data fetching trigger appropriate config entry states."""
     # Mock the specified method to raise the exception
@@ -110,22 +118,8 @@ async def test_config_entry_static_data_errors(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is expected_state
-
-
-async def test_entry_loads_without_static_values(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_bsblan: MagicMock,
-) -> None:
-    """Test the config entry still loads when static values are not available."""
-    mock_bsblan.static_values.side_effect = BSBLANError("General error")
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_config_entry.runtime_data.static is None
+    if assert_static_fallback:
+        assert mock_config_entry.runtime_data.static is None
 
 
 async def test_config_entry_general_setup_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Resolves issue for missing min max temperature climate.  If this could be in next . release?
#165319

This pull request improves the robustness of the BSBLan integration by making static device values optional and ensuring that the integration and its entities can still load and function even if these values are unavailable. It also adds comprehensive tests to verify correct behavior in these scenarios.

**Core integration robustness improvements:**

* Changed the `static` attribute in the `BSBLanData` class to be optional (`StaticState | None`), and updated the setup process to handle cases where static values cannot be fetched, logging a debug message instead of failing setup. (`homeassistant/components/bsblan/__init__.py`) [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL55-R55) [[2]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL85-L89) [[3]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR113-R122)
* Updated the climate entity to check for the presence of static values before accessing temperature limits, preventing errors if static data is missing. (`homeassistant/components/bsblan/climate.py`)
* Modified diagnostics to handle the absence of static values gracefully, returning `None` if unavailable. (`homeassistant/components/bsblan/diagnostics.py`)

**Testing and validation:**

* Added and updated tests to verify that the integration, climate entity, and diagnostics load and operate correctly when static values are unavailable, and that the config entry state is set appropriately. (`tests/components/bsblan/test_climate.py`, `tests/components/bsblan/test_diagnostics.py`, `tests/components/bsblan/test_init.py`) [[1]](diffhunk://#diff-e99598f290cd7f09b0b7e7a7af12e01a1f6afe5328bb1375ae81b1b39676abadR48-R62) [[2]](diffhunk://#diff-dcb27593a08fcaefd81d7fe4d4ccbd47aeb22141194db760f07d51c2215f6c89R5) [[3]](diffhunk://#diff-dcb27593a08fcaefd81d7fe4d4ccbd47aeb22141194db760f07d51c2215f6c89R31-R50) [[4]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97L93-R93) [[5]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97R115-R145)

These changes ensure the BSBLan integration is more resilient to partial device failures and improves user experience by reducing unnecessary setup errors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165319
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
