### PR TITLE
Shorten "Power-on behavior" name in `matter` to be consistent

### DIFF
--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -325,11 +325,11 @@
         }
       },
       "startup_on_off": {
-        "name": "Power-on behavior on startup",
+        "name": "Power-on behavior",
         "state": {
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]",
-          "previous": "Previous",
+          "previous": "Previous state",
           "toggle": "[%key:common::action::toggle%]"
         }
       },

--- a/tests/components/matter/snapshots/test_select.ambr
+++ b/tests/components/matter/snapshots/test_select.ambr
@@ -355,7 +355,7 @@
     'state': 'Dark',
   })
 # ---
-# name: test_selects[color_temperature_light][select.mock_color_temperature_light_power_on_behavior_on_startup-entry]
+# name: test_selects[color_temperature_light][select.mock_color_temperature_light_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -375,7 +375,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_color_temperature_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_color_temperature_light_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -383,12 +383,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -398,10 +398,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[color_temperature_light][select.mock_color_temperature_light_power_on_behavior_on_startup-state]
+# name: test_selects[color_temperature_light][select.mock_color_temperature_light_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Color Temperature Light Power-on behavior on startup',
+      'friendly_name': 'Mock Color Temperature Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -410,7 +410,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_color_temperature_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_color_temperature_light_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -547,7 +547,7 @@
     'state': 'Auto Mop & Vacuum',
   })
 # ---
-# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_on_startup_bottom-entry]
+# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_bottom-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -567,7 +567,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_on_startup_bottom',
+    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_bottom',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -575,12 +575,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (bottom)',
+    'object_id_base': 'Power-on behavior (bottom)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (bottom)',
+    'original_name': 'Power-on behavior (bottom)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -590,10 +590,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_on_startup_bottom-state]
+# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_bottom-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior on startup (bottom)',
+      'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior (bottom)',
       'options': list([
         'on',
         'off',
@@ -602,14 +602,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_on_startup_bottom',
+    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_bottom',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_on_startup_top-entry]
+# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_top-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -629,7 +629,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_on_startup_top',
+    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_top',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -637,12 +637,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (top)',
+    'object_id_base': 'Power-on behavior (top)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (top)',
+    'original_name': 'Power-on behavior (top)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -652,10 +652,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_on_startup_top-state]
+# name: test_selects[eve_energy_20ecn4101][select.eve_energy_20ecn4101_power_on_behavior_top-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior on startup (top)',
+      'friendly_name': 'Eve Energy 20ECN4101 Power-on behavior (top)',
       'options': list([
         'on',
         'off',
@@ -664,14 +664,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_on_startup_top',
+    'entity_id': 'select.eve_energy_20ecn4101_power_on_behavior_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[eve_energy_plug][select.eve_energy_plug_power_on_behavior_on_startup-entry]
+# name: test_selects[eve_energy_plug][select.eve_energy_plug_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -691,7 +691,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.eve_energy_plug_power_on_behavior_on_startup',
+    'entity_id': 'select.eve_energy_plug_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -699,12 +699,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -714,10 +714,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[eve_energy_plug][select.eve_energy_plug_power_on_behavior_on_startup-state]
+# name: test_selects[eve_energy_plug][select.eve_energy_plug_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Eve Energy Plug Power-on behavior on startup',
+      'friendly_name': 'Eve Energy Plug Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -726,14 +726,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.eve_energy_plug_power_on_behavior_on_startup',
+    'entity_id': 'select.eve_energy_plug_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[eve_energy_plug_patched][select.eve_energy_plug_patched_power_on_behavior_on_startup-entry]
+# name: test_selects[eve_energy_plug_patched][select.eve_energy_plug_patched_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -753,7 +753,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.eve_energy_plug_patched_power_on_behavior_on_startup',
+    'entity_id': 'select.eve_energy_plug_patched_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -761,12 +761,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -776,10 +776,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[eve_energy_plug_patched][select.eve_energy_plug_patched_power_on_behavior_on_startup-state]
+# name: test_selects[eve_energy_plug_patched][select.eve_energy_plug_patched_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Eve Energy Plug Patched Power-on behavior on startup',
+      'friendly_name': 'Eve Energy Plug Patched Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -788,7 +788,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.eve_energy_plug_patched_power_on_behavior_on_startup',
+    'entity_id': 'select.eve_energy_plug_patched_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -971,7 +971,7 @@
     'state': 'Dark',
   })
 # ---
-# name: test_selects[extended_color_light][select.mock_extended_color_light_power_on_behavior_on_startup-entry]
+# name: test_selects[extended_color_light][select.mock_extended_color_light_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -991,7 +991,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_extended_color_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_extended_color_light_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -999,12 +999,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1014,10 +1014,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[extended_color_light][select.mock_extended_color_light_power_on_behavior_on_startup-state]
+# name: test_selects[extended_color_light][select.mock_extended_color_light_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Extended Color Light Power-on behavior on startup',
+      'friendly_name': 'Mock Extended Color Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -1026,7 +1026,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_extended_color_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_extended_color_light_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1531,7 +1531,7 @@
     'state': 'Local Timer Disable',
   })
 # ---
-# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_on_startup_load_control-entry]
+# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_load_control-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1551,7 +1551,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_on_startup_load_control',
+    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_load_control',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1559,12 +1559,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (Load Control)',
+    'object_id_base': 'Power-on behavior (Load Control)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (Load Control)',
+    'original_name': 'Power-on behavior (Load Control)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1574,10 +1574,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_on_startup_load_control-state]
+# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_load_control-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'White Series OnOff Switch Power-on behavior on startup (Load Control)',
+      'friendly_name': 'White Series OnOff Switch Power-on behavior (Load Control)',
       'options': list([
         'on',
         'off',
@@ -1586,14 +1586,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_on_startup_load_control',
+    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_load_control',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_on_startup_rgb_indicator-entry]
+# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_rgb_indicator-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -1613,7 +1613,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_on_startup_rgb_indicator',
+    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_rgb_indicator',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1621,12 +1621,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (RGB Indicator)',
+    'object_id_base': 'Power-on behavior (RGB Indicator)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (RGB Indicator)',
+    'original_name': 'Power-on behavior (RGB Indicator)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1636,10 +1636,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_on_startup_rgb_indicator-state]
+# name: test_selects[inovelli_vtm30][select.white_series_onoff_switch_power_on_behavior_rgb_indicator-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'White Series OnOff Switch Power-on behavior on startup (RGB Indicator)',
+      'friendly_name': 'White Series OnOff Switch Power-on behavior (RGB Indicator)',
       'options': list([
         'on',
         'off',
@@ -1648,7 +1648,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_on_startup_rgb_indicator',
+    'entity_id': 'select.white_series_onoff_switch_power_on_behavior_rgb_indicator',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1997,7 +1997,7 @@
     'state': 'Lemon',
   })
 # ---
-# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_on_startup_1-entry]
+# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2017,7 +2017,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.inovelli_power_on_behavior_on_startup_1',
+    'entity_id': 'select.inovelli_power_on_behavior_1',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2025,12 +2025,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (1)',
+    'object_id_base': 'Power-on behavior (1)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (1)',
+    'original_name': 'Power-on behavior (1)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2040,10 +2040,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_on_startup_1-state]
+# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_1-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Inovelli Power-on behavior on startup (1)',
+      'friendly_name': 'Inovelli Power-on behavior (1)',
       'options': list([
         'on',
         'off',
@@ -2052,14 +2052,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.inovelli_power_on_behavior_on_startup_1',
+    'entity_id': 'select.inovelli_power_on_behavior_1',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_on_startup_6-entry]
+# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_6-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2079,7 +2079,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.inovelli_power_on_behavior_on_startup_6',
+    'entity_id': 'select.inovelli_power_on_behavior_6',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2087,12 +2087,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup (6)',
+    'object_id_base': 'Power-on behavior (6)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup (6)',
+    'original_name': 'Power-on behavior (6)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2102,10 +2102,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_on_startup_6-state]
+# name: test_selects[inovelli_vtm31][select.inovelli_power_on_behavior_6-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Inovelli Power-on behavior on startup (6)',
+      'friendly_name': 'Inovelli Power-on behavior (6)',
       'options': list([
         'on',
         'off',
@@ -2114,7 +2114,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.inovelli_power_on_behavior_on_startup_6',
+    'entity_id': 'select.inovelli_power_on_behavior_6',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2503,7 +2503,7 @@
     'state': 'Aqua',
   })
 # ---
-# name: test_selects[mock_dimmable_light][select.mock_dimmable_light_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_dimmable_light][select.mock_dimmable_light_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2523,7 +2523,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_dimmable_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_dimmable_light_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2531,12 +2531,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2546,10 +2546,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_dimmable_light][select.mock_dimmable_light_power_on_behavior_on_startup-state]
+# name: test_selects[mock_dimmable_light][select.mock_dimmable_light_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Dimmable Light Power-on behavior on startup',
+      'friendly_name': 'Mock Dimmable Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -2558,14 +2558,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_dimmable_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_dimmable_light_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[mock_dimmable_plugin_unit][select.dimmable_plugin_unit_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_dimmable_plugin_unit][select.dimmable_plugin_unit_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2585,7 +2585,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.dimmable_plugin_unit_power_on_behavior_on_startup',
+    'entity_id': 'select.dimmable_plugin_unit_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2593,12 +2593,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2608,10 +2608,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_dimmable_plugin_unit][select.dimmable_plugin_unit_power_on_behavior_on_startup-state]
+# name: test_selects[mock_dimmable_plugin_unit][select.dimmable_plugin_unit_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Dimmable Plugin Unit Power-on behavior on startup',
+      'friendly_name': 'Dimmable Plugin Unit Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -2620,7 +2620,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.dimmable_plugin_unit_power_on_behavior_on_startup',
+    'entity_id': 'select.dimmable_plugin_unit_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2685,7 +2685,7 @@
     'state': 'normal',
   })
 # ---
-# name: test_selects[mock_door_lock][select.mock_door_lock_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_door_lock][select.mock_door_lock_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2705,7 +2705,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_door_lock_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_door_lock_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2713,12 +2713,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2728,10 +2728,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_door_lock][select.mock_door_lock_power_on_behavior_on_startup-state]
+# name: test_selects[mock_door_lock][select.mock_door_lock_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock Power-on behavior on startup',
+      'friendly_name': 'Mock Door Lock Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -2740,7 +2740,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_door_lock_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_door_lock_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2867,7 +2867,7 @@
     'state': 'normal',
   })
 # ---
-# name: test_selects[mock_door_lock_with_unbolt][select.mock_door_lock_with_unbolt_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_door_lock_with_unbolt][select.mock_door_lock_with_unbolt_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -2887,7 +2887,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_door_lock_with_unbolt_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_door_lock_with_unbolt_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2895,12 +2895,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2910,10 +2910,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_door_lock_with_unbolt][select.mock_door_lock_with_unbolt_power_on_behavior_on_startup-state]
+# name: test_selects[mock_door_lock_with_unbolt][select.mock_door_lock_with_unbolt_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Door Lock with unbolt Power-on behavior on startup',
+      'friendly_name': 'Mock Door Lock with unbolt Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -2922,7 +2922,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_door_lock_with_unbolt_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_door_lock_with_unbolt_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3245,7 +3245,7 @@
     'state': '1000',
   })
 # ---
-# name: test_selects[mock_mounted_dimmable_load_control_fixture][select.mock_mounted_dimmable_load_control_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_mounted_dimmable_load_control_fixture][select.mock_mounted_dimmable_load_control_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3265,7 +3265,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_mounted_dimmable_load_control_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_mounted_dimmable_load_control_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3273,12 +3273,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3288,10 +3288,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_mounted_dimmable_load_control_fixture][select.mock_mounted_dimmable_load_control_power_on_behavior_on_startup-state]
+# name: test_selects[mock_mounted_dimmable_load_control_fixture][select.mock_mounted_dimmable_load_control_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Mounted dimmable load control Power-on behavior on startup',
+      'friendly_name': 'Mock Mounted dimmable load control Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3300,14 +3300,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_mounted_dimmable_load_control_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_mounted_dimmable_load_control_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_selects[mock_on_off_plugin_unit][select.mock_onoffpluginunit_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_on_off_plugin_unit][select.mock_onoffpluginunit_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3327,7 +3327,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_onoffpluginunit_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_onoffpluginunit_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3335,12 +3335,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3350,10 +3350,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_on_off_plugin_unit][select.mock_onoffpluginunit_power_on_behavior_on_startup-state]
+# name: test_selects[mock_on_off_plugin_unit][select.mock_onoffpluginunit_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock OnOffPluginUnit Power-on behavior on startup',
+      'friendly_name': 'Mock OnOffPluginUnit Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3362,14 +3362,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_onoffpluginunit_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_onoffpluginunit_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[mock_onoff_light][select.mock_onoff_light_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_onoff_light][select.mock_onoff_light_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3389,7 +3389,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_onoff_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_onoff_light_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3397,12 +3397,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3412,10 +3412,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_onoff_light][select.mock_onoff_light_power_on_behavior_on_startup-state]
+# name: test_selects[mock_onoff_light][select.mock_onoff_light_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock OnOff Light Power-on behavior on startup',
+      'friendly_name': 'Mock OnOff Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3424,14 +3424,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_onoff_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_onoff_light_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[mock_onoff_light_alt_name][select.mock_onoff_light_power_on_behavior_on_startup_2-entry]
+# name: test_selects[mock_onoff_light_alt_name][select.mock_onoff_light_power_on_behavior_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3451,7 +3451,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_onoff_light_power_on_behavior_on_startup_2',
+    'entity_id': 'select.mock_onoff_light_power_on_behavior_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3459,12 +3459,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3474,10 +3474,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_onoff_light_alt_name][select.mock_onoff_light_power_on_behavior_on_startup_2-state]
+# name: test_selects[mock_onoff_light_alt_name][select.mock_onoff_light_power_on_behavior_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock OnOff Light Power-on behavior on startup',
+      'friendly_name': 'Mock OnOff Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3486,14 +3486,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_onoff_light_power_on_behavior_on_startup_2',
+    'entity_id': 'select.mock_onoff_light_power_on_behavior_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'previous',
   })
 # ---
-# name: test_selects[mock_onoff_light_no_name][select.mock_light_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_onoff_light_no_name][select.mock_light_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3513,7 +3513,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_light_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3521,12 +3521,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3536,10 +3536,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_onoff_light_no_name][select.mock_light_power_on_behavior_on_startup-state]
+# name: test_selects[mock_onoff_light_no_name][select.mock_light_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Light Power-on behavior on startup',
+      'friendly_name': 'Mock Light Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3548,7 +3548,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_light_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_light_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3749,7 +3749,7 @@
     'state': 'normal',
   })
 # ---
-# name: test_selects[mock_switch_unit][select.mock_switchunit_power_on_behavior_on_startup-entry]
+# name: test_selects[mock_switch_unit][select.mock_switchunit_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3769,7 +3769,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.mock_switchunit_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_switchunit_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3777,12 +3777,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3792,10 +3792,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[mock_switch_unit][select.mock_switchunit_power_on_behavior_on_startup-state]
+# name: test_selects[mock_switch_unit][select.mock_switchunit_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock SwitchUnit Power-on behavior on startup',
+      'friendly_name': 'Mock SwitchUnit Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3804,7 +3804,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.mock_switchunit_power_on_behavior_on_startup',
+    'entity_id': 'select.mock_switchunit_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3933,7 +3933,7 @@
     'state': 'Quick',
   })
 # ---
-# name: test_selects[onoff_light_with_levelcontrol_present][select.d215s_power_on_behavior_on_startup-entry]
+# name: test_selects[onoff_light_with_levelcontrol_present][select.d215s_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -3953,7 +3953,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.d215s_power_on_behavior_on_startup',
+    'entity_id': 'select.d215s_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -3961,12 +3961,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -3976,10 +3976,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[onoff_light_with_levelcontrol_present][select.d215s_power_on_behavior_on_startup-state]
+# name: test_selects[onoff_light_with_levelcontrol_present][select.d215s_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'D215S Power-on behavior on startup',
+      'friendly_name': 'D215S Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -3988,7 +3988,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.d215s_power_on_behavior_on_startup',
+    'entity_id': 'select.d215s_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4621,7 +4621,7 @@
     'state': 'Quick',
   })
 # ---
-# name: test_selects[yandex_smart_socket][select.yndx_00540_power_on_behavior_on_startup-entry]
+# name: test_selects[yandex_smart_socket][select.yndx_00540_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -4641,7 +4641,7 @@
     'disabled_by': None,
     'domain': 'select',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'select.yndx_00540_power_on_behavior_on_startup',
+    'entity_id': 'select.yndx_00540_power_on_behavior',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -4649,12 +4649,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power-on behavior on startup',
+    'object_id_base': 'Power-on behavior',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Power-on behavior on startup',
+    'original_name': 'Power-on behavior',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -4664,10 +4664,10 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_selects[yandex_smart_socket][select.yndx_00540_power_on_behavior_on_startup-state]
+# name: test_selects[yandex_smart_socket][select.yndx_00540_power_on_behavior-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'YNDX-00540 Power-on behavior on startup',
+      'friendly_name': 'YNDX-00540 Power-on behavior',
       'options': list([
         'on',
         'off',
@@ -4676,7 +4676,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'select.yndx_00540_power_on_behavior_on_startup',
+    'entity_id': 'select.yndx_00540_power_on_behavior',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -86,7 +86,7 @@ async def test_attribute_select_entities(
     matter_node: MatterNode,
 ) -> None:
     """Test select entities are created for attribute based discovery schema(s)."""
-    entity_id = "select.mock_dimmable_light_power_on_behavior_on_startup"
+    entity_id = "select.mock_dimmable_light_power_on_behavior"
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "previous"

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -93,7 +93,7 @@ async def test_attribute_select_entities(
     assert state.attributes["options"] == ["on", "off", "toggle", "previous"]
     assert (
         state.attributes["friendly_name"]
-        == "Mock Dimmable Light Power-on behavior on startup"
+        == "Mock Dimmable Light Power-on behavior"
     )
     set_node_attribute(matter_node, 1, 6, 16387, 1)
     await trigger_subscription_callback(hass, matter_client)

--- a/tests/components/matter/test_select.py
+++ b/tests/components/matter/test_select.py
@@ -91,10 +91,7 @@ async def test_attribute_select_entities(
     assert state
     assert state.state == "previous"
     assert state.attributes["options"] == ["on", "off", "toggle", "previous"]
-    assert (
-        state.attributes["friendly_name"]
-        == "Mock Dimmable Light Power-on behavior"
-    )
+    assert state.attributes["friendly_name"] == "Mock Dimmable Light Power-on behavior"
     set_node_attribute(matter_node, 1, 6, 16387, 1)
     await trigger_subscription_callback(hass, matter_client)
     state = hass.states.get(entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Following up on https://github.com/home-assistant/core/pull/164775  that  added the
- Power-on level

setting, this PR shortens the current "Power-on behavior at startup" to just 

- Power-on behavior

to better indicate that both settings are for the same context and to get matching translations in other languages.

This also makes it consistent with the corresponding setting in `tuya`.

For additional consistency the "Previous" option is changed to "Previous state" to clarify and ensure proper translations. It's then also consistent with the same option in `tuya`.

Will follow-up with similar PR for `zha` to make that consistent, too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
