### PR TITLE
Remove connectable filter from victron_ble bluetooth matcher

### DIFF
--- a/homeassistant/components/victron_ble/manifest.json
+++ b/homeassistant/components/victron_ble/manifest.json
@@ -3,7 +3,6 @@
   "name": "Victron BLE",
   "bluetooth": [
     {
-      "connectable": false,
       "manufacturer_data_start": [16],
       "manufacturer_id": 737
     }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -870,7 +870,6 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "service_uuid": "0000cee0-0000-1000-8000-00805f9b34fb",
     },
     {
-        "connectable": False,
         "domain": "victron_ble",
         "manufacturer_data_start": [
             16,


### PR DESCRIPTION
## Proposed change

Remove the `"connectable": false` filter from the `victron_ble` bluetooth matcher.

The `victron_ble` integration only reads BLE advertisements passively and never establishes connections. The `connectable: false` filter was incorrectly preventing discovery of Victron devices that advertise as connectable, such as Blue Smart IP22/IP65 and Phoenix Smart IP43 chargers.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #162120
- This PR is related to issue: partially addresses #157417
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr