### PR TITLE
Fix victron_ble warning sensor using duplicate alarm translation key

### DIFF
--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -398,7 +398,7 @@ SENSOR_DESCRIPTIONS = {
     Keys.WARNING: VictronBLESensorEntityDescription(
         key=Keys.WARNING,
         device_class=SensorDeviceClass.ENUM,
-        translation_key="alarm",
+        translation_key="warning",
         options=ALARM_OPTIONS,
     ),
     Keys.YIELD_TODAY: VictronBLESensorEntityDescription(

--- a/homeassistant/components/victron_ble/strings.json
+++ b/homeassistant/components/victron_ble/strings.json
@@ -248,7 +248,24 @@
         "name": "[%key:component::victron_ble::common::starter_voltage%]"
       },
       "warning": {
-        "name": "Warning"
+        "name": "Warning",
+        "state": {
+          "bms_lockout": "[%key:component::victron_ble::entity::sensor::alarm::state::bms_lockout%]",
+          "dc_ripple": "[%key:component::victron_ble::entity::sensor::alarm::state::dc_ripple%]",
+          "high_starter_voltage": "[%key:component::victron_ble::entity::sensor::alarm::state::high_starter_voltage%]",
+          "high_temperature": "[%key:component::victron_ble::entity::sensor::alarm::state::high_temperature%]",
+          "high_v_ac_out": "[%key:component::victron_ble::entity::sensor::alarm::state::high_v_ac_out%]",
+          "high_voltage": "[%key:component::victron_ble::entity::sensor::alarm::state::high_voltage%]",
+          "low_soc": "[%key:component::victron_ble::entity::sensor::alarm::state::low_soc%]",
+          "low_starter_voltage": "[%key:component::victron_ble::entity::sensor::alarm::state::low_starter_voltage%]",
+          "low_temperature": "[%key:component::victron_ble::entity::sensor::alarm::state::low_temperature%]",
+          "low_v_ac_out": "[%key:component::victron_ble::entity::sensor::alarm::state::low_v_ac_out%]",
+          "low_voltage": "[%key:component::victron_ble::entity::sensor::alarm::state::low_voltage%]",
+          "mid_voltage": "[%key:component::victron_ble::common::midpoint_voltage%]",
+          "no_alarm": "[%key:component::victron_ble::entity::sensor::alarm::state::no_alarm%]",
+          "overload": "[%key:component::victron_ble::entity::sensor::alarm::state::overload%]",
+          "short_circuit": "[%key:component::victron_ble::entity::sensor::alarm::state::short_circuit%]"
+        }
       },
       "yield_today": {
         "name": "Yield today"


### PR DESCRIPTION
## Proposed change

The `Keys.WARNING` sensor description used `translation_key="alarm"`, causing it to appear as a duplicate "Alarm" entity (e.g. `sensor.smart_battery_protect_alarm_2`). Changed to use the existing `"warning"` translation key and added state translations that reference the alarm state strings via `[%key:...]` references.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr