### PR TITLE
Fix Matter firmware update detection when version strings are identical

### DIFF
--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -132,11 +132,13 @@ class MatterUpdate(MatterEntity, UpdateEntity):
     ) -> str | None:
         """Return the version string to expose in Home Assistant."""
         latest_version = update_information.software_version_string
-        if (
-            latest_version == self._attr_installed_version
-            and self._installed_software_version is not None
-            and update_information.software_version != self._installed_software_version
-        ):
+        if self._installed_software_version is None:
+            return latest_version
+
+        if update_information.software_version == self._installed_software_version:
+            return self._attr_installed_version or latest_version
+
+        if latest_version == self._attr_installed_version:
             return f"{latest_version} ({update_information.software_version})"
 
         return latest_version

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -80,6 +80,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
     # Matter server.
     _attr_should_poll = True
     _software_update: MatterSoftwareVersion | None = None
+    _installed_software_version: int | None = None
     _cancel_update: CALLBACK_TYPE | None = None
     _attr_supported_features = (
         UpdateEntityFeature.INSTALL
@@ -92,6 +93,9 @@ class MatterUpdate(MatterEntity, UpdateEntity):
     def _update_from_device(self) -> None:
         """Update from device."""
 
+        self._installed_software_version = self.get_matter_attribute_value(
+            clusters.BasicInformation.Attributes.SoftwareVersion
+        )
         self._attr_installed_version = self.get_matter_attribute_value(
             clusters.BasicInformation.Attributes.SoftwareVersionString
         )
@@ -123,6 +127,20 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         else:
             self._attr_update_percentage = None
 
+    def _format_latest_version(
+        self, update_information: MatterSoftwareVersion
+    ) -> str | None:
+        """Return the version string to expose in Home Assistant."""
+        latest_version = update_information.software_version_string
+        if (
+            latest_version == self._attr_installed_version
+            and self._installed_software_version is not None
+            and update_information.software_version != self._installed_software_version
+        ):
+            return f"{latest_version} ({update_information.software_version})"
+
+        return latest_version
+
     async def async_update(self) -> None:
         """Call when the entity needs to be updated."""
         try:
@@ -130,11 +148,13 @@ class MatterUpdate(MatterEntity, UpdateEntity):
                 node_id=self._endpoint.node.node_id
             )
             if not update_information:
+                self._software_update = None
                 self._attr_latest_version = self._attr_installed_version
+                self._attr_release_url = None
                 return
 
             self._software_update = update_information
-            self._attr_latest_version = update_information.software_version_string
+            self._attr_latest_version = self._format_latest_version(update_information)
             self._attr_release_url = update_information.release_notes_url
 
         except UpdateCheckError as err:
@@ -212,7 +232,12 @@ class MatterUpdate(MatterEntity, UpdateEntity):
 
         software_version: str | int | None = version
         if self._software_update is not None and (
-            version is None or version == self._software_update.software_version_string
+            version is None
+            or version
+            in {
+                self._software_update.software_version_string,
+                self._attr_latest_version,
+            }
         ):
             # Update to the version previously fetched and shown.
             # We can pass the integer version directly to speedup download.

--- a/tests/components/matter/test_update.py
+++ b/tests/components/matter/test_update.py
@@ -142,6 +142,84 @@ async def test_update_check_service(
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
+async def test_update_check_with_same_version_string(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    check_node_update: AsyncMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test update detection when versions share the same display string."""
+    set_node_attribute_typed(
+        matter_node,
+        0,
+        clusters.BasicInformation.Attributes.SoftwareVersion,
+        115,
+    )
+    set_node_attribute_typed(
+        matter_node,
+        0,
+        clusters.BasicInformation.Attributes.SoftwareVersionString,
+        "1.1.5",
+    )
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get("update.mock_dimmable_light_firmware")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("installed_version") == "1.1.5"
+
+    await async_setup_component(hass, HA_DOMAIN, {})
+
+    check_node_update.return_value = MatterSoftwareVersion(
+        vid=65521,
+        pid=32768,
+        software_version=1150,
+        software_version_string="1.1.5",
+        firmware_information="",
+        min_applicable_software_version=0,
+        max_applicable_software_version=115,
+        release_notes_url="http://home-assistant.io/non-existing-product",
+        update_source=UpdateSource.LOCAL,
+    )
+
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {
+            ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("update.mock_dimmable_light_firmware")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes.get("installed_version") == "1.1.5"
+    assert state.attributes.get("latest_version") == "1.1.5 (1150)"
+    assert (
+        state.attributes.get("release_url")
+        == "http://home-assistant.io/non-existing-product"
+    )
+
+    check_node_update.return_value = None
+
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {
+            ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("update.mock_dimmable_light_firmware")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("latest_version") == "1.1.5"
+    assert state.attributes.get("release_url") is None
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
 async def test_update_install(
     hass: HomeAssistant,
     matter_client: MagicMock,

--- a/tests/components/matter/test_update.py
+++ b/tests/components/matter/test_update.py
@@ -220,6 +220,49 @@ async def test_update_check_with_same_version_string(
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
+async def test_update_check_with_same_numeric_version(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    check_node_update: AsyncMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test update detection when numeric version is unchanged."""
+    state = hass.states.get("update.mock_dimmable_light_firmware")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("installed_version") == "v1.0"
+
+    await async_setup_component(hass, HA_DOMAIN, {})
+
+    check_node_update.return_value = MatterSoftwareVersion(
+        vid=65521,
+        pid=32768,
+        software_version=1,
+        software_version_string="1.0.0",
+        firmware_information="",
+        min_applicable_software_version=0,
+        max_applicable_software_version=1,
+        release_notes_url="http://home-assistant.io/non-existing-product",
+        update_source=UpdateSource.LOCAL,
+    )
+
+    await hass.services.async_call(
+        HA_DOMAIN,
+        SERVICE_UPDATE_ENTITY,
+        {
+            ATTR_ENTITY_ID: "update.mock_dimmable_light_firmware",
+        },
+        blocking=True,
+    )
+
+    state = hass.states.get("update.mock_dimmable_light_firmware")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get("installed_version") == "v1.0"
+    assert state.attributes.get("latest_version") == "v1.0"
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
 async def test_update_install(
     hass: HomeAssistant,
     matter_client: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fixes Matter update detection for devices where `SoftwareVersionString` stays the same across different firmware builds.
- Uses the numeric Matter `SoftwareVersion` to distinguish updates that would otherwise appear identical in Home Assistant.
- Exposes a disambiguated `latest_version` only when needed, so update entities can correctly report an available firmware update.
- Clears stale update metadata when no update is available anymore.
- Adds a regression test covering devices with identical display version strings but different numeric firmware versions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165482
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
