### PR TITLE
Add reconfiguration flow to Whisker

### DIFF
--- a/homeassistant/components/litterrobot/config_flow.py
+++ b/homeassistant/components/litterrobot/config_flow.py
@@ -10,7 +10,7 @@ from pylitterbot import Account
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
 )
+STEP_REAUTH_RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 
 class LitterRobotConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -43,20 +44,18 @@ class LitterRobotConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         """Handle user's reauth credentials."""
-        errors = {}
+        errors: dict[str, str] = {}
         if user_input:
-            user_input = user_input | {CONF_USERNAME: self.username}
-            if not (error := await self._async_validate_input(user_input)):
-                await self.async_set_unique_id(self._account_user_id)
-                self._abort_if_unique_id_mismatch()
-                return self.async_update_reload_and_abort(
-                    self._get_reauth_entry(), data_updates=user_input
-                )
+            reauth_entry = self._get_reauth_entry()
+            result, errors = await self._async_validate_and_update_entry(
+                reauth_entry, user_input
+            )
+            if result is not None:
+                return result
 
-            errors["base"] = error
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            data_schema=STEP_REAUTH_RECONFIGURE_SCHEMA,
             description_placeholders={CONF_USERNAME: self.username},
             errors=errors,
         )
@@ -72,19 +71,15 @@ class LitterRobotConfigFlow(ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
         if user_input:
-            user_input = user_input | {CONF_USERNAME: self.username}
-            if not (error := await self._async_validate_input(user_input)):
-                await self.async_set_unique_id(self._account_user_id)
-                self._abort_if_unique_id_mismatch()
-                return self.async_update_reload_and_abort(
-                    reconfigure_entry, data_updates=user_input
-                )
-
-            errors["base"] = error
+            result, errors = await self._async_validate_and_update_entry(
+                reconfigure_entry, user_input
+            )
+            if result is not None:
+                return result
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            data_schema=STEP_REAUTH_RECONFIGURE_SCHEMA,
             errors=errors,
         )
 
@@ -107,6 +102,25 @@ class LitterRobotConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
+
+    async def _async_validate_and_update_entry(
+        self, entry: ConfigEntry, user_input: dict[str, Any]
+    ) -> tuple[ConfigFlowResult | None, dict[str, str]]:
+        """Validate credentials and update an existing entry if valid."""
+        errors: dict[str, str] = {}
+        full_input: dict[str, Any] = user_input | {CONF_USERNAME: self.username}
+        if not (error := await self._async_validate_input(full_input)):
+            await self.async_set_unique_id(self._account_user_id)
+            self._abort_if_unique_id_mismatch()
+            return (
+                self.async_update_reload_and_abort(
+                    entry,
+                    data_updates=full_input,
+                ),
+                errors,
+            )
+        errors["base"] = error
+        return None, errors
 
     async def _async_validate_input(self, user_input: Mapping[str, Any]) -> str:
         """Validate login credentials."""

--- a/homeassistant/components/litterrobot/config_flow.py
+++ b/homeassistant/components/litterrobot/config_flow.py
@@ -61,6 +61,33 @@ class LitterRobotConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow request."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        self.username = reconfigure_entry.data[CONF_USERNAME]
+
+        self._async_abort_entries_match({CONF_USERNAME: self.username})
+
+        errors: dict[str, str] = {}
+        if user_input:
+            user_input = user_input | {CONF_USERNAME: self.username}
+            if not (error := await self._async_validate_input(user_input)):
+                await self.async_set_unique_id(self._account_user_id)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            errors=errors,
+        )
+
     async def async_step_user(
         self, user_input: Mapping[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/litterrobot/quality_scale.yaml
+++ b/homeassistant/components/litterrobot/quality_scale.yaml
@@ -65,7 +65,7 @@ rules:
     comment: Make sure all translated states are in sentence case
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues:
     status: done
     comment: |

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unique_id_mismatch": "The Whisker account does not match the previously configured account. Please re-authenticate using the same account, or remove this integration and set it up again if you want to use a different account."
     },
     "error": {
@@ -20,6 +21,14 @@
         },
         "description": "Please update your password for {username}",
         "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "reconfigure": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "[%key:component::litterrobot::config::step::user::data_description::password%]"
+        }
       },
       "user": {
         "data": {

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -201,3 +201,54 @@ async def test_reauth_wrong_account(hass: HomeAssistant) -> None:
     assert result["reason"] == "unique_id_mismatch"
     assert entry.unique_id == ACCOUNT_USER_ID
     assert entry.data == CONFIG[DOMAIN]
+
+
+async def test_reconfigure(hass: HomeAssistant, mock_account: Account) -> None:
+    """Test reconfiguration flow (with fail and recover)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONFIG[DOMAIN],
+        unique_id=ACCOUNT_USER_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with patch(
+        "homeassistant.components.litterrobot.config_flow.Account.connect",
+        side_effect=LitterRobotLoginException,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_PASSWORD: CONFIG[DOMAIN][CONF_PASSWORD]},
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["errors"] == {"base": "invalid_auth"}
+
+    with (
+        patch(
+            "homeassistant.components.litterrobot.config_flow.Account.connect",
+            return_value=mock_account,
+        ),
+        patch(
+            "homeassistant.components.litterrobot.config_flow.Account.user_id",
+            new_callable=PropertyMock,
+            return_value=ACCOUNT_USER_ID,
+        ),
+        patch(
+            "homeassistant.components.litterrobot.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_PASSWORD: CONFIG[DOMAIN][CONF_PASSWORD]},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert entry.unique_id == ACCOUNT_USER_ID
+        assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -212,6 +212,9 @@ async def test_reconfigure(hass: HomeAssistant, mock_account: Account) -> None:
     )
     entry.add_to_hass(hass)
 
+    original_password = entry.data[CONF_PASSWORD]
+    new_password = f"{original_password}_new"
+
     result = await entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
@@ -223,11 +226,12 @@ async def test_reconfigure(hass: HomeAssistant, mock_account: Account) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_PASSWORD: CONFIG[DOMAIN][CONF_PASSWORD]},
+            user_input={CONF_PASSWORD: new_password},
         )
 
         assert result["type"] is FlowResultType.FORM
         assert result["errors"] == {"base": "invalid_auth"}
+        assert entry.data[CONF_PASSWORD] == original_password
 
     with (
         patch(
@@ -246,9 +250,10 @@ async def test_reconfigure(hass: HomeAssistant, mock_account: Account) -> None:
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={CONF_PASSWORD: CONFIG[DOMAIN][CONF_PASSWORD]},
+            user_input={CONF_PASSWORD: new_password},
         )
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "reconfigure_successful"
         assert entry.unique_id == ACCOUNT_USER_ID
+        assert entry.data[CONF_PASSWORD] == new_password
         assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
