### PR TITLE
Suggest chat_id for subentry flow for Telegram bot

### DIFF
--- a/homeassistant/components/telegram_bot/bot.py
+++ b/homeassistant/components/telegram_bot/bot.py
@@ -142,6 +142,7 @@ class BaseTelegramBot:
         """Initialize the bot base class."""
         self.hass = hass
         self.config = config
+        self.most_recent_chat_id: int | None = None
         self._bot = bot
 
     @abstractmethod
@@ -151,8 +152,6 @@ class BaseTelegramBot:
     async def handle_update(self, update: Update, context: CallbackContext) -> bool:
         """Handle updates from bot application set up by the respective platform."""
         _LOGGER.debug("Handling update %s", update)
-        if not self.authorize_update(update):
-            return False
 
         # establish event type: text, command or callback_query
         if update.callback_query:
@@ -168,6 +167,11 @@ class BaseTelegramBot:
         else:
             _LOGGER.warning("Unhandled update: %s", update)
             return True
+
+        self.most_recent_chat_id = event_data[ATTR_CHAT_ID]
+
+        if not self.authorize_update(update):
+            return False
 
         event_data["bot"] = _get_bot_info(self._bot, self.config)
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -645,7 +645,7 @@ async def _get_most_recent_chat(
 ) -> tuple[int, str] | None:
     """Get the most recent chat ID and name.
 
-    For broadcast bot, this is retrieved using get_updates() to find the most recent message receivedd.
+    For broadcast bot, this is retrieved using get_updates() to find the most recent message received.
     For polling or webhook bot, this is retrieved from the runtime data which is updated whenever a message is received.
     """
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -619,12 +619,59 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
         description_placeholders["bot_username"] = f"@{service.bot.username}"
         description_placeholders["bot_url"] = f"https://t.me/{service.bot.username}"
 
+        # suggest chat id based on the most recent chat
+        suggested_values = {}
+        description_placeholders["most_recent_chat"] = ""
+        most_recent_chat = await _get_most_recent_chat(service)
+        if most_recent_chat is not None:
+            suggested_values[CONF_CHAT_ID] = most_recent_chat[0]
+            description_placeholders["most_recent_chat"] = (
+                f"{most_recent_chat[1]} ({most_recent_chat[0]})"
+            )
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_CHAT_ID): vol.Coerce(int)}),
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_CHAT_ID): vol.Coerce(int)}),
+                suggested_values,
+            ),
             description_placeholders=description_placeholders,
             errors=errors,
         )
+
+
+async def _get_most_recent_chat(
+    service: TelegramNotificationService,
+) -> tuple[int, str] | None:
+    """Get the most recent chat ID and name.
+
+    For broadcast bot, this is retrieved using get_updates() to find the most recent message receivedd.
+    For polling or webhook bot, this is retrieved from the runtime data which is updated whenever a message is received.
+    """
+
+    if service.app is not None:
+        # this is either polling or webhook bot
+
+        if service.app.most_recent_chat_id is None:
+            return None
+
+        most_recent_chat_name = await _async_get_chat_name(
+            service.bot, service.app.most_recent_chat_id
+        )
+        return (service.app.most_recent_chat_id, most_recent_chat_name)
+
+    # broadcast bot
+    updates = await service.bot.get_updates()
+    if updates:
+        last_update = updates[-1]
+        if last_update.effective_chat:
+            chat_name = last_update.effective_chat.effective_name or ""
+            return (
+                last_update.effective_chat.id,
+                chat_name,
+            )
+
+    return None
 
 
 async def _async_get_chat_name(bot: Bot, chat_id: int) -> str:

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -661,7 +661,7 @@ async def _get_most_recent_chat(
         return (service.app.most_recent_chat_id, most_recent_chat_name)
 
     # broadcast bot
-    updates = await service.bot.get_updates()
+    updates = await service.bot.get_updates(offset=0)
     if updates:
         last_update = updates[-1]
         if last_update.effective_chat:

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -621,7 +621,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
 
         # suggest chat id based on the most recent chat
         suggested_values = {}
-        description_placeholders["most_recent_chat"] = ""
+        description_placeholders["most_recent_chat"] = "Not available"
         most_recent_chat = await _get_most_recent_chat(service)
         if most_recent_chat is not None:
             suggested_values[CONF_CHAT_ID] = most_recent_chat[0]

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -661,7 +661,13 @@ async def _get_most_recent_chat(
         return (service.app.most_recent_chat_id, most_recent_chat_name)
 
     # broadcast bot
-    updates = await service.bot.get_updates(offset=0)
+
+    try:
+        updates = await service.bot.get_updates(offset=0)
+    except TelegramError as err:
+        _LOGGER.warning("Error occurred while fetching updates: %s", err)
+        return None
+
     if updates:
         last_update = updates[-1]
         if last_update.effective_chat:

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -622,7 +622,11 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
         # suggest chat id based on the most recent chat
         suggested_values = {}
         description_placeholders["most_recent_chat"] = "Not available"
-        most_recent_chat = await _get_most_recent_chat(service)
+        try:
+            most_recent_chat = await _get_most_recent_chat(service)
+        except TelegramError:
+            _LOGGER.warning("Error occurred while fetching recent chat", exc_info=True)
+            most_recent_chat = None
         if most_recent_chat is not None:
             suggested_values[CONF_CHAT_ID] = most_recent_chat[0]
             description_placeholders["most_recent_chat"] = (
@@ -661,13 +665,7 @@ async def _get_most_recent_chat(
         return (service.app.most_recent_chat_id, most_recent_chat_name)
 
     # broadcast bot
-
-    try:
-        updates = await service.bot.get_updates(offset=0)
-    except TelegramError as err:
-        _LOGGER.warning("Error occurred while fetching updates: %s", err)
-        return None
-
+    updates = await service.bot.get_updates(offset=0)
     if updates:
         last_update = updates[-1]
         if last_update.effective_chat:

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -624,8 +624,8 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
         description_placeholders["most_recent_chat"] = "Not available"
         try:
             most_recent_chat = await _get_most_recent_chat(service)
-        except TelegramError:
-            _LOGGER.warning("Error occurred while fetching recent chat", exc_info=True)
+        except TelegramError as err:
+            _LOGGER.warning("Error occurred while fetching recent chat: %s", err)
             most_recent_chat = None
         if most_recent_chat is not None:
             suggested_values[CONF_CHAT_ID] = most_recent_chat[0]
@@ -659,10 +659,11 @@ async def _get_most_recent_chat(
         if service.app.most_recent_chat_id is None:
             return None
 
-        most_recent_chat_name = await _async_get_chat_name(
-            service.bot, service.app.most_recent_chat_id
-        )
-        return (service.app.most_recent_chat_id, most_recent_chat_name)
+        chat = await service.bot.get_chat(service.app.most_recent_chat_id)
+        assert (
+            chat.effective_name is not None
+        )  # value is based on title for group chats and full_name for private chats, either of which should always be present
+        return (service.app.most_recent_chat_id, chat.effective_name)
 
     # broadcast bot
     updates = await service.bot.get_updates(offset=0)

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -629,8 +629,11 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
             most_recent_chat = None
         if most_recent_chat is not None:
             suggested_values[CONF_CHAT_ID] = most_recent_chat[0]
+
             description_placeholders["most_recent_chat"] = (
                 f"{most_recent_chat[1]} ({most_recent_chat[0]})"
+                if most_recent_chat[1]
+                else str(most_recent_chat[0])
             )
 
         return self.async_show_form(
@@ -646,7 +649,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
 
 async def _get_most_recent_chat(
     service: TelegramNotificationService,
-) -> tuple[int, str] | None:
+) -> tuple[int, str | None] | None:
     """Get the most recent chat ID and name.
 
     For broadcast bot, this is retrieved using get_updates() to find the most recent message received.
@@ -660,9 +663,6 @@ async def _get_most_recent_chat(
             return None
 
         chat = await service.bot.get_chat(service.app.most_recent_chat_id)
-        assert (
-            chat.effective_name is not None
-        )  # value is based on title for group chats and full_name for private chats, either of which should always be present
         return (service.app.most_recent_chat_id, chat.effective_name)
 
     # broadcast bot
@@ -670,7 +670,7 @@ async def _get_most_recent_chat(
     if updates:
         last_update = updates[-1]
         if last_update.effective_chat:
-            chat_name = last_update.effective_chat.effective_name or ""
+            chat_name = last_update.effective_chat.effective_name
             return (
                 last_update.effective_chat.id,
                 chat_name,

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -100,8 +100,7 @@
       "step": {
         "user": {
           "data": {
-            "chat_id": "Chat ID",
-            "most_recent_chat": "Most recent chat"
+            "chat_id": "Chat ID"
           },
           "data_description": {
             "chat_id": "ID representing the user or group chat to which messages can be sent."

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -100,12 +100,13 @@
       "step": {
         "user": {
           "data": {
-            "chat_id": "Chat ID"
+            "chat_id": "Chat ID",
+            "most_recent_chat": "Most recent chat"
           },
           "data_description": {
             "chat_id": "ID representing the user or group chat to which messages can be sent."
           },
-          "description": "Before you proceed, send any message to your bot: [{bot_username}]({bot_url}). This is required because Telegram prevents bots from initiating chats with users.\n\nThen follow these steps to get your chat ID:\n\n1. Open Telegram and start a chat with [{id_bot_username}]({id_bot_url}).\n1. Send any message to the bot.\n1. Your chat ID is in the `ID` field of the bot's response.",
+          "description": "Before you proceed, send any message to your bot: [{bot_username}]({bot_url}). This is required because Telegram prevents bots from initiating chats with users.\n\nThen follow these steps to get your chat ID:\n\n1. Open Telegram and start a chat with [{id_bot_username}]({id_bot_url}).\n1. Send any message to the bot.\n1. Your chat ID is in the `ID` field of the bot's response.\n\nMost recent chat: {most_recent_chat}",
           "title": "Add chat"
         }
       }

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -12,6 +12,7 @@ from telegram import (
     Chat,
     ChatFullInfo,
     Message,
+    Update,
     User,
     WebhookInfo,
 )
@@ -137,6 +138,24 @@ def mock_external_calls() -> Generator[None]:
         patch.object(BotMock, "send_animation", return_value=message),
         patch.object(BotMock, "send_location", return_value=message),
         patch.object(BotMock, "send_poll", return_value=message),
+        patch.object(
+            BotMock,
+            "get_updates",
+            return_value=(
+                Update(
+                    1,
+                    Message(
+                        1,
+                        datetime.now(),
+                        Chat(
+                            id=123456,
+                            type=ChatType.PRIVATE,
+                            first_name="mock first_name",
+                        ),
+                    ),
+                ),
+            ),
+        ),
         patch.object(BotMock, "log_out", return_value=True),
         patch("telegram.ext.Updater._bootstrap"),
     ):

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -23,12 +23,14 @@ from homeassistant.components.telegram_bot.const import (
     SECTION_ADVANCED_SETTINGS,
     SUBENTRY_TYPE_ALLOWED_CHAT_IDS,
 )
+from homeassistant.components.telegram_bot.webhooks import TELEGRAM_WEBHOOK_URL
 from homeassistant.config_entries import SOURCE_USER, ConfigSubentry
 from homeassistant.const import CONF_API_KEY, CONF_PLATFORM, CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry, pytest
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.fixture
@@ -621,11 +623,25 @@ async def test_subentry_flow_chat_error(
     assert result["reason"] == "already_configured"
 
 
-async def test_subentry_flow_webhook_no_update(
-    hass: HomeAssistant, webhook_bot: None
+async def test_subentry_flow_webhook_with_update(
+    hass: HomeAssistant,
+    webhook_bot,
+    hass_client: ClientSessionGenerator,
+    update_message_text,
+    mock_generate_secret_token,
 ) -> None:
     """Test subentry flow with webhook bot."""
 
+    # send a message to the webhook to create a recent chat
+    client = await hass_client()
+    response = await client.post(
+        f"{TELEGRAM_WEBHOOK_URL}_123456",
+        json=update_message_text,
+        headers={"X-Telegram-Bot-Api-Secret-Token": mock_generate_secret_token},
+    )
+    assert response.status == 200
+
+    # start the subentry flow
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     result = await hass.config_entries.subentries.async_init(
         (config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),
@@ -638,14 +654,15 @@ async def test_subentry_flow_webhook_no_update(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
-        "most_recent_chat": "",
+        "most_recent_chat": "mock title (1111111)",
     }
 
 
-async def test_subentry_flow_polling_bot(
+async def test_subentry_flow_polling_bot_without_update(
     hass: HomeAssistant,
     mock_polling_config_entry: MockConfigEntry,
     mock_external_calls: None,
+    mock_polling_calls: None,
 ) -> None:
     """Test subentry flow with polling bot."""
 
@@ -664,11 +681,11 @@ async def test_subentry_flow_polling_bot(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
-        "most_recent_chat": "mock title (123456)",
+        "most_recent_chat": "",
     }
 
 
-async def test_subentry_flow_broadcast_no_update(
+async def test_subentry_flow_broadcast_without_update(
     hass: HomeAssistant,
     mock_broadcast_config_entry: MockConfigEntry,
     mock_external_calls: None,
@@ -681,6 +698,36 @@ async def test_subentry_flow_broadcast_no_update(
 
     with patch(
         "homeassistant.components.telegram_bot.bot.Bot.get_updates", return_value=()
+    ):
+        result = await hass.config_entries.subentries.async_init(
+            (mock_broadcast_config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["description_placeholders"] == {
+        **DESCRIPTION_PLACEHOLDERS,
+        "bot_username": "@mock_bot",
+        "bot_url": "https://t.me/mock_bot",
+        "most_recent_chat": "",
+    }
+
+
+async def test_subentry_flow_broadcast_update_error(
+    hass: HomeAssistant,
+    mock_broadcast_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+) -> None:
+    """Test subentry flow where broadcast bot encounter error while receiving messages."""
+
+    mock_broadcast_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.telegram_bot.bot.Bot.get_updates",
+        side_effect=NetworkError("mock network error"),
     ):
         result = await hass.config_entries.subentries.async_init(
             (mock_broadcast_config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -541,6 +541,7 @@ async def test_subentry_flow(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
+        "most_recent_chat": "mock first_name (123456)",
     }
 
     result = await hass.config_entries.subentries.async_configure(
@@ -618,6 +619,82 @@ async def test_subentry_flow_chat_error(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_subentry_flow_webhook_no_update(
+    hass: HomeAssistant, webhook_bot: None
+) -> None:
+    """Test subentry flow with webhook bot."""
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    result = await hass.config_entries.subentries.async_init(
+        (config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["description_placeholders"] == {
+        **DESCRIPTION_PLACEHOLDERS,
+        "bot_username": "@mock_bot",
+        "bot_url": "https://t.me/mock_bot",
+        "most_recent_chat": "",
+    }
+
+
+async def test_subentry_flow_polling_bot(
+    hass: HomeAssistant,
+    mock_polling_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+) -> None:
+    """Test subentry flow with webhook bot."""
+
+    mock_polling_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_polling_config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["description_placeholders"] == {
+        **DESCRIPTION_PLACEHOLDERS,
+        "bot_username": "@mock_bot",
+        "bot_url": "https://t.me/mock_bot",
+        "most_recent_chat": "mock title (123456)",
+    }
+
+
+async def test_subentry_flow_broadcast_no_update(
+    hass: HomeAssistant,
+    mock_broadcast_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+) -> None:
+    """Test subentry flow where broadcast bot has did not receive any messages."""
+
+    mock_broadcast_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.telegram_bot.bot.Bot.get_updates", return_value=()
+    ):
+        result = await hass.config_entries.subentries.async_init(
+            (mock_broadcast_config_entry.entry_id, SUBENTRY_TYPE_ALLOWED_CHAT_IDS),
+            context={"source": SOURCE_USER},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["description_placeholders"] == {
+        **DESCRIPTION_PLACEHOLDERS,
+        "bot_username": "@mock_bot",
+        "bot_url": "https://t.me/mock_bot",
+        "most_recent_chat": "",
+    }
 
 
 async def test_duplicate_entry(hass: HomeAssistant) -> None:

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -647,7 +647,7 @@ async def test_subentry_flow_polling_bot(
     mock_polling_config_entry: MockConfigEntry,
     mock_external_calls: None,
 ) -> None:
-    """Test subentry flow with webhook bot."""
+    """Test subentry flow with polling bot."""
 
     mock_polling_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_polling_config_entry.entry_id)
@@ -673,7 +673,7 @@ async def test_subentry_flow_broadcast_no_update(
     mock_broadcast_config_entry: MockConfigEntry,
     mock_external_calls: None,
 ) -> None:
-    """Test subentry flow where broadcast bot has did not receive any messages."""
+    """Test subentry flow where broadcast bot did not receive any messages."""
 
     mock_broadcast_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -681,7 +681,7 @@ async def test_subentry_flow_polling_bot_without_update(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
-        "most_recent_chat": "",
+        "most_recent_chat": "Not available",
     }
 
 
@@ -710,7 +710,7 @@ async def test_subentry_flow_broadcast_without_update(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
-        "most_recent_chat": "",
+        "most_recent_chat": "Not available",
     }
 
 
@@ -740,7 +740,7 @@ async def test_subentry_flow_broadcast_update_error(
         **DESCRIPTION_PLACEHOLDERS,
         "bot_username": "@mock_bot",
         "bot_url": "https://t.me/mock_bot",
-        "most_recent_chat": "",
+        "most_recent_chat": "Not available",
     }
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Background

To enable the bot to send and receive messages with a chat, the subentry flow is used to allowlist the necessary chat IDs. This process is not user friendly because chat ids are not shown anywhere in the Telegram UI and users typically rely on third-party bots to discover their ID.

This PR streamlines the onboarding experience by suggesting the most recent chat ID the bot has interacted with, eliminating the need for other lookup tools.

### Changes

- Updated `bot.py` so that polling and webhook bots tracks the chat id of the most recent message.
- Added `get_updates()` for broadcast bot to find the most recent message received during the subentry flow.
- The subentry flow pre-populates the chat id based on the most recent chat found. The chat id and name is also shown to help users better identify the chat.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
