### PR TITLE
Add kPa as a valid unit of measurement for pressure in weather entity

### DIFF
--- a/homeassistant/components/weather/const.py
+++ b/homeassistant/components/weather/const.py
@@ -58,6 +58,7 @@ INTENT_GET_WEATHER = "HassGetWeather"
 
 VALID_UNITS_PRESSURE: set[str] = {
     UnitOfPressure.HPA,
+    UnitOfPressure.KPA,
     UnitOfPressure.MBAR,
     UnitOfPressure.INHG,
     UnitOfPressure.MMHG,

--- a/homeassistant/components/weather/const.py
+++ b/homeassistant/components/weather/const.py
@@ -81,6 +81,7 @@ INTENT_GET_WEATHER = "HassGetWeather"
 
 VALID_UNITS_PRESSURE: set[str] = {
     UnitOfPressure.HPA,
+    UnitOfPressure.KPA,
     UnitOfPressure.MBAR,
     UnitOfPressure.INHG,
     UnitOfPressure.MMHG,

--- a/homeassistant/components/weather/significant_change.py
+++ b/homeassistant/components/weather/significant_change.py
@@ -157,6 +157,8 @@ def async_check_significant_change(
                 UnitOfPressure.MMHG,  # 1hPa = 0.75mmHg
             ):
                 absolute_change = 1.0
+            elif unit == UnitOfPressure.KPA:  # 1hPa = 0.1 kPa
+                absolute_change = 0.1
             elif unit == UnitOfPressure.INHG:  # 1hPa = 0.03inHg
                 absolute_change = 0.05
 

--- a/homeassistant/components/weather/significant_change.py
+++ b/homeassistant/components/weather/significant_change.py
@@ -145,6 +145,8 @@ def async_check_significant_change(
                 UnitOfPressure.MMHG,  # 1hPa = 0.75mmHg
             ):
                 absolute_change = 1.0
+            elif unit == UnitOfPressure.KPA:  # 1hPa = 0.1 kPa
+                absolute_change = 0.1
             elif unit == UnitOfPressure.INHG:  # 1hPa = 0.03inHg
                 absolute_change = 0.05
 

--- a/tests/components/weather/test_significant_change.py
+++ b/tests/components/weather/test_significant_change.py
@@ -291,7 +291,7 @@ async def test_significant_state_change() -> None:
         (
             {ATTR_WEATHER_PRESSURE: 100},
             {
-                ATTR_WEATHER_PRESSURE: 100.1,
+                ATTR_WEATHER_PRESSURE: 100.11,
                 ATTR_WEATHER_PRESSURE_UNIT: UnitOfPressure.KPA,
             },
             True,

--- a/tests/components/weather/test_significant_change.py
+++ b/tests/components/weather/test_significant_change.py
@@ -169,6 +169,14 @@ async def test_significant_state_change() -> None:
             False,
         ),
         (
+            {ATTR_WEATHER_PRESSURE: 100},
+            {
+                ATTR_WEATHER_PRESSURE: 100.09,
+                ATTR_WEATHER_PRESSURE_UNIT: UnitOfPressure.KPA,
+            },
+            False,
+        ),
+        (
             {ATTR_WEATHER_PRESSURE: 29.5},
             {
                 ATTR_WEATHER_PRESSURE: 29.54,
@@ -277,6 +285,14 @@ async def test_significant_state_change() -> None:
             {
                 ATTR_WEATHER_PRESSURE: 749,
                 ATTR_WEATHER_PRESSURE_UNIT: UnitOfPressure.MMHG,
+            },
+            True,
+        ),
+        (
+            {ATTR_WEATHER_PRESSURE: 100},
+            {
+                ATTR_WEATHER_PRESSURE: 100.1,
+                ATTR_WEATHER_PRESSURE_UNIT: UnitOfPressure.KPA,
             },
             True,
         ),

--- a/tests/components/weather/test_websocket_api.py
+++ b/tests/components/weather/test_websocket_api.py
@@ -30,7 +30,7 @@ async def test_device_class_units(
     assert msg["result"] == {
         "units": {
             "precipitation_unit": ["in", "mm"],
-            "pressure_unit": ["hPa", "inHg", "mbar", "mmHg"],
+            "pressure_unit": ["hPa", "kPa", "inHg", "mbar", "mmHg"],
             "temperature_unit": ["°C", "°F"],
             "visibility_unit": ["km", "mi"],
             "wind_speed_unit": ["Beaufort", "ft/s", "km/h", "kn", "m/s", "mph"],

--- a/tests/components/weather/test_websocket_api.py
+++ b/tests/components/weather/test_websocket_api.py
@@ -30,7 +30,7 @@ async def test_device_class_units(
     assert msg["result"] == {
         "units": {
             "precipitation_unit": ["in", "mm"],
-            "pressure_unit": ["hPa", "kPa", "inHg", "mbar", "mmHg"],
+            "pressure_unit": ["hPa", "inHg", "kPa", "mbar", "mmHg"],
             "temperature_unit": ["°C", "°F"],
             "visibility_unit": ["km", "mi"],
             "wind_speed_unit": ["Beaufort", "ft/s", "km/h", "kn", "m/s", "mph"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add kPa as a valid unit of pressure in weather (most meteorological organizations in Canada use kPa as their default unit of measurement)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: home-assistant/developers.home-assistant#2998
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
