### PR TITLE
Fix Matter update version comparison to include SoftwareVersion integer

### DIFF
--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -88,12 +88,34 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         | UpdateEntityFeature.RELEASE_NOTES
     )
 
+    @staticmethod
+    def _format_version(
+        version_string: str | None, version_int: int | None
+    ) -> str | None:
+        """Format a Matter version string including the integer software version.
+
+        The Matter spec allows different firmware builds to share the same
+        SoftwareVersionString while having distinct SoftwareVersion integers.
+        Including the integer in the display string ensures correct comparison
+        and gives users full visibility into the actual firmware build.
+        """
+        if version_string is None:
+            return None
+        if version_int is not None:
+            return f"{version_string} ({version_int})"
+        return version_string
+
     @callback
     def _update_from_device(self) -> None:
         """Update from device."""
 
-        self._attr_installed_version = self.get_matter_attribute_value(
-            clusters.BasicInformation.Attributes.SoftwareVersionString
+        self._attr_installed_version = self._format_version(
+            self.get_matter_attribute_value(
+                clusters.BasicInformation.Attributes.SoftwareVersionString
+            ),
+            self.get_matter_attribute_value(
+                clusters.BasicInformation.Attributes.SoftwareVersion
+            ),
         )
         update_state: clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum = (
             self.get_matter_attribute_value(
@@ -134,7 +156,10 @@ class MatterUpdate(MatterEntity, UpdateEntity):
                 return
 
             self._software_update = update_information
-            self._attr_latest_version = update_information.software_version_string
+            self._attr_latest_version = self._format_version(
+                update_information.software_version_string,
+                update_information.software_version,
+            )
             self._attr_release_url = update_information.release_notes_url
 
         except UpdateCheckError as err:
@@ -212,7 +237,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
 
         software_version: str | int | None = version
         if self._software_update is not None and (
-            version is None or version == self._software_update.software_version_string
+            version is None or version == self._attr_latest_version
         ):
             # Update to the version previously fetched and shown.
             # We can pass the integer version directly to speedup download.

--- a/tests/components/matter/test_update.py
+++ b/tests/components/matter/test_update.py
@@ -104,7 +104,7 @@ async def test_update_check_service(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get("installed_version") == "v1.0"
+    assert state.attributes.get("installed_version") == "v1.0 (1)"
 
     await async_setup_component(hass, HA_DOMAIN, {})
 
@@ -134,7 +134,7 @@ async def test_update_check_service(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_ON
-    assert state.attributes.get("latest_version") == "v2.0"
+    assert state.attributes.get("latest_version") == "v2.0 (2)"
     assert (
         state.attributes.get("release_url")
         == "http://home-assistant.io/non-existing-product"
@@ -153,7 +153,7 @@ async def test_update_install(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get("installed_version") == "v1.0"
+    assert state.attributes.get("installed_version") == "v1.0 (1)"
 
     check_node_update.return_value = MatterSoftwareVersion(
         vid=65521,
@@ -176,7 +176,7 @@ async def test_update_install(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_ON
-    assert state.attributes.get("latest_version") == "v2.0"
+    assert state.attributes.get("latest_version") == "v2.0 (2)"
     assert (
         state.attributes.get("release_url")
         == "http://home-assistant.io/non-existing-product"
@@ -241,7 +241,7 @@ async def test_update_install(
 
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state.state == STATE_OFF
-    assert state.attributes.get("installed_version") == "v2.0"
+    assert state.attributes.get("installed_version") == "v2.0 (2)"
 
 
 @pytest.mark.parametrize("node_fixture", ["mock_dimmable_light"])
@@ -257,7 +257,7 @@ async def test_update_install_failure(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get("installed_version") == "v1.0"
+    assert state.attributes.get("installed_version") == "v1.0 (1)"
 
     check_node_update.return_value = MatterSoftwareVersion(
         vid=65521,
@@ -280,7 +280,7 @@ async def test_update_install_failure(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_ON
-    assert state.attributes.get("latest_version") == "v2.0"
+    assert state.attributes.get("latest_version") == "v2.0 (2)"
     assert (
         state.attributes.get("release_url")
         == "http://home-assistant.io/non-existing-product"
@@ -326,7 +326,7 @@ async def test_update_state_save_and_restore(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes.get("installed_version") == "v1.0"
+    assert state.attributes.get("installed_version") == "v1.0 (1)"
 
     check_node_update.return_value = TEST_SOFTWARE_VERSION
 
@@ -339,7 +339,7 @@ async def test_update_state_save_and_restore(
     state = hass.states.get("update.mock_dimmable_light_firmware")
     assert state
     assert state.state == STATE_ON
-    assert state.attributes.get("latest_version") == "v2.0"
+    assert state.attributes.get("latest_version") == "v2.0 (2)"
     await hass.async_block_till_done()
     await async_mock_restore_state_shutdown_restart(hass)
 


### PR DESCRIPTION
## Summary

- Include the integer `SoftwareVersion` in the Matter update entity's version display string (formatted as `"<string> (<int>)"`, e.g. `"1.1.5 (115)"`)
- This ensures different firmware builds with identical `SoftwareVersionString` values but different `SoftwareVersion` integers are correctly distinguished
- Update the `async_install` version matching to use the formatted `_attr_latest_version` rather than the raw `software_version_string`

Fixes #165521
Related: #165482

## Details

The Matter specification allows different firmware builds to share the same `SoftwareVersionString` while having distinct `SoftwareVersion` integer values. The `UpdateEntity` base class compares `installed_version == latest_version` as strings to determine whether an update is available. When both versions have the same string representation (e.g. "1.1.5"), no update is shown, even though the underlying firmware is completely different.

By including the integer in the display string, the comparison correctly identifies different builds and users also gain visibility into the actual build number.

## Test plan

- [x] Updated all existing Matter update tests to reflect the new version format
- [x] Existing restore state test validates backwards compatibility (restoring from old-format strings still works correctly)
- [x] The `async_install` path correctly resolves to the integer version for known updates

Generated with [Claude Code](https://claude.com/claude-code)