### PR TITLE
Deter use of stdlib datetime now/utcnow usage in HA code

### DIFF
--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -210,6 +210,12 @@ class HassImportsFormatChecker(BaseChecker):
             "hass-import-constant-unnecessary-alias",
             "Used when a constant alias is unnecessary",
         ),
+        "W7428": (
+            "`%s` is not allowed; use `%s` instead",
+            "hass-avoid-datetime-now",
+            "Used when datetime.datetime.now() or datetime.datetime.utcnow() "
+            "is called instead of homeassistant.util.dt equivalents",
+        ),
     }
     options = ()
 
@@ -425,6 +431,30 @@ class HassImportsFormatChecker(BaseChecker):
                             name[0],
                         ),
                     )
+
+    def visit_call(self, node: nodes.Call) -> None:
+        """Check for disallowed datetime.now() and datetime.utcnow() calls."""
+        if not isinstance(node.func, nodes.Attribute):
+            return
+        if node.func.attrname not in ("now", "utcnow"):
+            return
+        replacement = f"dt_util.{node.func.attrname}"
+        expr = node.func.expr
+        # Detect `datetime.now()` / `datetime.utcnow()` where datetime is the class
+        if isinstance(expr, nodes.Name) and expr.name == "datetime":
+            self.add_message(
+                "hass-avoid-datetime-now",
+                node=node,
+                args=(f"datetime.{node.func.attrname}()", replacement),
+            )
+            return
+        # Detect `X.datetime.now()` / `X.datetime.utcnow()` where X is the module
+        if isinstance(expr, nodes.Attribute) and expr.attrname == "datetime":
+            self.add_message(
+                "hass-avoid-datetime-now",
+                node=node,
+                args=(f"{expr.attrname}.{node.func.attrname}()", replacement),
+            )
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/plugins/hass_imports.py
+++ b/pylint/plugins/hass_imports.py
@@ -453,7 +453,7 @@ class HassImportsFormatChecker(BaseChecker):
             self.add_message(
                 "hass-avoid-datetime-now",
                 node=node,
-                args=(f"{expr.attrname}.{node.func.attrname}()", replacement),
+                args=(f"{expr.as_string()}.{node.func.attrname}()", replacement),
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -914,6 +914,8 @@ mark-parentheses = false
 "async_timeout".msg = "use asyncio.timeout instead"
 "pytz".msg = "use zoneinfo instead"
 "tests".msg = "You should not import tests"
+"datetime.datetime.now".msg = "use homeassistant.util.dt.now instead"
+"datetime.datetime.utcnow".msg = "use homeassistant.util.dt.utcnow instead"
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

> I recently reviewed a PR that permitted the use of `datetime.datetime.now()`, despite specific instructions in **`CLAUDE.md`**. It may be the case that a fix to `script/gen_copilot_instructions.py` is indicated.

This PR hardens the mechanisms used to prevent use of `datetime.datetime.now()` and `datetime.datetime.utcnow()` in favour of Home Assistant's `homeassistant.util.dt` equivalents, using establish mechanisms:

- **`AGENTS.md`** and **`.github/copilot-instructions.md`**: Added the anti-pattern to the ❌/✅ examples section so AI coding agents avoid generating this pattern, as per **`CLAUDE.md`**
- **`pyproject.toml`**: Added `datetime.datetime.now` and `datetime.datetime.utcnow` to ruff's `banned-api` (TID251) so the linter enforces this at CI time, similar to `pytz` → `zoneinfo`
- **`pylint/plugins/hass_imports.py`**: Added a new `W7428` pylint checker (`hass-avoid-datetime-now`) that catches `datetime.now()`, `datetime.utcnow()`, and the fully-qualified `datetime.datetime.now()` / `datetime.datetime.utcnow()` call forms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
