### PR TITLE
Add set_volume toggle for external arc volume in LG webOS TV

### DIFF
--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -25,7 +25,13 @@ from homeassistant.helpers.service_info.ssdp import (
 )
 
 from . import WebOsTvConfigEntry
-from .const import CONF_SOURCES, CONF_USE_ABSOLUTE_VOLUME, DEFAULT_NAME, DOMAIN, WEBOSTV_EXCEPTIONS
+from .const import (
+    CONF_SOURCES,
+    CONF_USE_ABSOLUTE_VOLUME,
+    DEFAULT_NAME,
+    DOMAIN,
+    WEBOSTV_EXCEPTIONS,
+)
 from .helpers import get_sources
 
 DATA_SCHEMA = vol.Schema(

--- a/homeassistant/components/webostv/config_flow.py
+++ b/homeassistant/components/webostv/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
@@ -25,7 +25,7 @@ from homeassistant.helpers.service_info.ssdp import (
 )
 
 from . import WebOsTvConfigEntry
-from .const import CONF_SOURCES, DEFAULT_NAME, DOMAIN, WEBOSTV_EXCEPTIONS
+from .const import CONF_SOURCES, CONF_USE_ABSOLUTE_VOLUME, DEFAULT_NAME, DOMAIN, WEBOSTV_EXCEPTIONS
 from .helpers import get_sources
 
 DATA_SCHEMA = vol.Schema(
@@ -215,7 +215,10 @@ class OptionsFlowHandler(OptionsFlowWithReload):
         """Manage the options."""
         errors = {}
         if user_input is not None:
-            options_input = {CONF_SOURCES: user_input[CONF_SOURCES]}
+            options_input = {
+                CONF_SOURCES: user_input[CONF_SOURCES],
+                CONF_USE_ABSOLUTE_VOLUME: user_input[CONF_USE_ABSOLUTE_VOLUME],
+            }
             return self.async_create_entry(title="", data=options_input)
         # Get sources
         sources_list = []
@@ -238,6 +241,12 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                     CONF_SOURCES,
                     description={"suggested_value": sources},
                 ): cv.multi_select({source: source for source in sources_list}),
+                vol.Optional(
+                    CONF_USE_ABSOLUTE_VOLUME,
+                    default=self.config_entry.options.get(
+                        CONF_USE_ABSOLUTE_VOLUME, True
+                    ),
+                ): selector.BooleanSelector(),
             }
         )
 

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -17,6 +17,7 @@ ATTR_SOUND_OUTPUT = "sound_output"
 
 CONF_ON_ACTION = "turn_on_action"
 CONF_SOURCES = "sources"
+CONF_USE_ABSOLUTE_VOLUME = "use_absolute_volume"
 
 LIVE_TV_APP_ID = "com.webos.app.livetv"
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -34,6 +34,7 @@ from .const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
     CONF_SOURCES,
+    CONF_USE_ABSOLUTE_VOLUME,
     DOMAIN,
     LIVE_TV_APP_ID,
     WEBOSTV_EXCEPTIONS,
@@ -211,11 +212,9 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
             if tv_state.sound_output == "external_speaker":
                 supported = supported | SUPPORT_WEBOSTV_VOLUME
             elif tv_state.sound_output != "lineout":
-                supported = (
-                    supported
-                    | SUPPORT_WEBOSTV_VOLUME
-                    | MediaPlayerEntityFeature.VOLUME_SET
-                )
+                supported = supported | SUPPORT_WEBOSTV_VOLUME
+                if self._entry.options.get(CONF_USE_ABSOLUTE_VOLUME, True):
+                    supported = supported | MediaPlayerEntityFeature.VOLUME_SET
 
             self._supported_features = supported
 

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -82,10 +82,12 @@
     "step": {
       "init": {
         "data": {
-          "sources": "Sources list"
+          "sources": "Sources list",
+          "use_absolute_volume": "Enable absolute volume control"
         },
         "data_description": {
-          "sources": "List of sources to enable"
+          "sources": "List of sources to enable",
+          "use_absolute_volume": "Enable setting the exact volume level. Disable if your TV reports support for this but does not work correctly (common on some models using ARC)."
         },
         "description": "Select enabled sources",
         "title": "Options for LG webOS TV"

--- a/tests/components/webostv/test_config_flow.py
+++ b/tests/components/webostv/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components.webostv.const import (
     CONF_SOURCES,
+    CONF_USE_ABSOLUTE_VOLUME,
     DEFAULT_NAME,
     DOMAIN,
     LIVE_TV_APP_ID,
@@ -19,6 +20,8 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
+
+from tests.common import MockConfigEntry
 
 from . import setup_webostv
 from .const import (
@@ -447,3 +450,84 @@ async def test_reconfigure_wrong_device(hass: HomeAssistant, client) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_device"
+
+
+@pytest.mark.parametrize(
+    ("use_absolute_volume", "expected"),
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+async def test_options_flow_absolute_volume(
+    hass: HomeAssistant,
+    client,
+    use_absolute_volume: bool,
+    expected: bool,
+) -> None:
+    """Test use_absolute_volume option is saved correctly in options flow."""
+    entry = await setup_webostv(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SOURCES: [], CONF_USE_ABSOLUTE_VOLUME: use_absolute_volume},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_USE_ABSOLUTE_VOLUME] is expected
+
+
+async def test_options_flow_absolute_volume_default(
+    hass: HomeAssistant,
+    client,
+) -> None:
+    """Test use_absolute_volume defaults to True when not explicitly provided."""
+    entry = await setup_webostv(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Submit without CONF_USE_ABSOLUTE_VOLUME — schema default (True) should apply
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SOURCES: []},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_USE_ABSOLUTE_VOLUME] is True
+
+
+async def test_options_flow_absolute_volume_preserved(
+    hass: HomeAssistant,
+    client,
+) -> None:
+    """Test that an existing use_absolute_volume=False option is preserved across flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_CLIENT_SECRET: CLIENT_KEY},
+        options={CONF_USE_ABSOLUTE_VOLUME: False},
+        title=TV_NAME,
+        unique_id=FAKE_UUID,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SOURCES: [], CONF_USE_ABSOLUTE_VOLUME: False},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_USE_ABSOLUTE_VOLUME] is False

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.webostv.const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
+    CONF_USE_ABSOLUTE_VOLUME,
     DOMAIN,
     LIVE_TV_APP_ID,
     WebOsTvCommandError,
@@ -48,6 +49,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_CLIENT_SECRET,
+    CONF_HOST,
     ENTITY_MATCH_NONE,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
@@ -69,9 +71,9 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import setup_webostv
-from .const import CHANNEL_2, ENTITY_ID, TV_NAME
+from .const import CHANNEL_2, CLIENT_KEY, ENTITY_ID, FAKE_UUID, HOST, TV_NAME
 
-from tests.common import async_fire_time_changed, mock_restore_cache
+from tests.common import MockConfigEntry, async_fire_time_changed, mock_restore_cache
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
@@ -972,3 +974,80 @@ async def test_availability(
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.ON
     available_log = f"LG webOS TV entity {ENTITY_ID} is back online"
     assert available_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("sound_output", "use_absolute_volume", "expected_features"),
+    [
+        # use_absolute_volume=True (default): VOLUME_SET present for regular output
+        (
+            "speaker",
+            True,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET,
+        ),
+        # use_absolute_volume=False: VOLUME_SET absent even for regular output
+        (
+            "speaker",
+            False,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME,
+        ),
+        # use_absolute_volume=True: VOLUME_SET present for external_arc
+        (
+            "external_arc",
+            True,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET,
+        ),
+        # use_absolute_volume=False: VOLUME_SET absent for external_arc (the ARC bug case)
+        (
+            "external_arc",
+            False,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME,
+        ),
+        # external_speaker: option has no effect — always step/mute only, never VOLUME_SET
+        (
+            "external_speaker",
+            True,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME,
+        ),
+        (
+            "external_speaker",
+            False,
+            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME,
+        ),
+        # lineout: option has no effect — always no volume support
+        (
+            "lineout",
+            True,
+            SUPPORT_WEBOSTV,
+        ),
+        (
+            "lineout",
+            False,
+            SUPPORT_WEBOSTV,
+        ),
+    ],
+)
+async def test_supported_features_absolute_volume(
+    hass: HomeAssistant,
+    client: MockConfigEntry,
+    sound_output: str,
+    use_absolute_volume: bool,
+    expected_features: MediaPlayerEntityFeature,
+) -> None:
+    """Test VOLUME_SET feature is controlled by the use_absolute_volume option."""
+    client.tv_state.sound_output = sound_output
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: HOST, CONF_CLIENT_SECRET: CLIENT_KEY},
+        options={CONF_USE_ABSOLUTE_VOLUME: use_absolute_volume},
+        title=TV_NAME,
+        unique_id=FAKE_UUID,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await client.mock_state_update()
+
+    attrs = hass.states.get(ENTITY_ID).attributes
+    assert attrs[ATTR_SUPPORTED_FEATURES] == expected_features

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -983,7 +983,9 @@ async def test_availability(
         (
             "speaker",
             True,
-            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET,
+            SUPPORT_WEBOSTV
+            | SUPPORT_WEBOSTV_VOLUME
+            | MediaPlayerEntityFeature.VOLUME_SET,
         ),
         # use_absolute_volume=False: VOLUME_SET absent even for regular output
         (
@@ -995,7 +997,9 @@ async def test_availability(
         (
             "external_arc",
             True,
-            SUPPORT_WEBOSTV | SUPPORT_WEBOSTV_VOLUME | MediaPlayerEntityFeature.VOLUME_SET,
+            SUPPORT_WEBOSTV
+            | SUPPORT_WEBOSTV_VOLUME
+            | MediaPlayerEntityFeature.VOLUME_SET,
         ),
         # use_absolute_volume=False: VOLUME_SET absent for external_arc (the ARC bug case)
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a toggle in the webostv integration that allows users to switch between `media_player.set_volume` and `media_player.volume_up`/ `media_player.volume_down`, to fix volume commands being ignored on some LG TVs and allow users to use the volume commands that work in their TVs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The issue appeared after https://github.com/home-assistant/core/pull/136717 was merged since some TVs report they support `set_volume` but ignore the `set_volume` commands.

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/156874 (auto-closed, but many users who have commented on the issue, including myself are facing the issue)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Screenshots

Toggle on (the current state of the webostv integration, the volume set does not work on my TV):

<img width="288" height="360" alt="Settings_Toggle_On" src="https://github.com/user-attachments/assets/238d8c60-131c-461a-b428-e090e6ca68c2" /> <img width="290" height="654" alt="TV_Toggle_On" src="https://github.com/user-attachments/assets/611a035d-053c-42df-974e-5af2ffb22915" />

Toggle off (works on my TV):

<img width="290" height="360" alt="Settings_Toggle_Off" src="https://github.com/user-attachments/assets/eda0935a-1fa7-4d54-a9e3-372e30bc8e3a" /> <img width="288" height="652" alt="TV_Toggle_Off" src="https://github.com/user-attachments/assets/5b5866e9-cc38-4368-97c4-d19a531b36e7" />






