### PR TITLE
Bump pylutron to 0.4.0 and support multi-state LEDs

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -20,6 +20,7 @@ PLATFORMS = [
     Platform.FAN,
     Platform.LIGHT,
     Platform.SCENE,
+    Platform.SELECT,
     Platform.SWITCH,
 ]
 
@@ -79,83 +80,15 @@ async def async_setup_entry(
     for area in lutron_client.areas:
         _LOGGER.debug("Working on area %s", area.name)
         for output in area.outputs:
-            platform = None
-            _LOGGER.debug("Working on output %s", output.type)
-            if output.type == "SYSTEM_SHADE":
-                entry_data.covers.append((area.name, output))
-                platform = Platform.COVER
-            elif output.type == "CEILING_FAN_TYPE":
-                entry_data.fans.append((area.name, output))
-                platform = Platform.FAN
-            elif output.is_dimmable:
-                entry_data.lights.append((area.name, output))
-                platform = Platform.LIGHT
-            else:
-                entry_data.switches.append((area.name, output))
-                platform = Platform.SWITCH
-
-            _async_check_entity_unique_id(
-                hass,
-                entity_registry,
-                platform,
-                output.uuid,
-                output.legacy_uuid,
-                entry_data.client.guid,
-            )
-            _async_check_device_identifiers(
-                hass,
-                device_registry,
-                output.uuid,
-                output.legacy_uuid,
-                entry_data.client.guid,
+            _async_setup_output(
+                hass, entry_data, output, area.name, entity_registry, device_registry
             )
 
         for keypad in area.keypads:
-            _async_check_keypad_identifiers(
-                hass,
-                device_registry,
-                keypad.id,
-                keypad.uuid,
-                keypad.legacy_uuid,
-                entry_data.client.guid,
+            _async_setup_keypad(
+                hass, entry_data, keypad, area.name, entity_registry, device_registry
             )
-            for button in keypad.buttons:
-                # If the button has a function assigned to it, add it as a scene
-                if button.name != "Unknown Button" and button.button_type in (
-                    "SingleAction",
-                    "Toggle",
-                    "SingleSceneRaiseLower",
-                    "MasterRaiseLower",
-                    "AdvancedToggle",
-                ):
-                    # Associate an LED with a button if there is one
-                    led = next(
-                        (led for led in keypad.leds if led.number == button.number),
-                        None,
-                    )
-                    entry_data.scenes.append((area.name, keypad, button, led))
 
-                    platform = Platform.SCENE
-                    _async_check_entity_unique_id(
-                        hass,
-                        entity_registry,
-                        platform,
-                        button.uuid,
-                        button.legacy_uuid,
-                        entry_data.client.guid,
-                    )
-                    if led is not None:
-                        platform = Platform.SWITCH
-                        _async_check_entity_unique_id(
-                            hass,
-                            entity_registry,
-                            platform,
-                            led.uuid,
-                            led.legacy_uuid,
-                            entry_data.client.guid,
-                        )
-                if button.button_type:
-                    entry_data.buttons.append((area.name, keypad, button))
         if area.occupancy_group is not None:
             entry_data.binary_sensors.append((area.name, area.occupancy_group))
             platform = Platform.BINARY_SENSOR
@@ -187,6 +120,102 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+def _async_setup_output(
+    hass: HomeAssistant,
+    entry_data: LutronData,
+    output: Output,
+    area_name: str,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Set up a Lutron output."""
+    platform = None
+    _LOGGER.debug("Working on output %s", output.type)
+    if output.type == "SYSTEM_SHADE":
+        entry_data.covers.append((area_name, output))
+        platform = Platform.COVER
+    elif output.type == "CEILING_FAN_TYPE":
+        entry_data.fans.append((area_name, output))
+        platform = Platform.FAN
+    elif output.is_dimmable:
+        entry_data.lights.append((area_name, output))
+        platform = Platform.LIGHT
+    else:
+        entry_data.switches.append((area_name, output))
+        platform = Platform.SWITCH
+
+    _async_check_entity_unique_id(
+        hass,
+        entity_registry,
+        platform,
+        output.uuid,
+        output.legacy_uuid,
+        entry_data.client.guid,
+    )
+    _async_check_device_identifiers(
+        hass,
+        device_registry,
+        output.uuid,
+        output.legacy_uuid,
+        entry_data.client.guid,
+    )
+
+
+def _async_setup_keypad(
+    hass: HomeAssistant,
+    entry_data: LutronData,
+    keypad: Keypad,
+    area_name: str,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Set up a Lutron keypad."""
+    _async_check_keypad_identifiers(
+        hass,
+        device_registry,
+        keypad.id,
+        keypad.uuid,
+        keypad.legacy_uuid,
+        entry_data.client.guid,
+    )
+    for button in keypad.buttons:
+        # If the button has a function assigned to it, add it as a scene
+        if button.name != "Unknown Button" and button.button_type in (
+            "SingleAction",
+            "Toggle",
+            "SingleSceneRaiseLower",
+            "MasterRaiseLower",
+            "AdvancedToggle",
+        ):
+            # Associate an LED with a button if there is one
+            led = next(
+                (led for led in keypad.leds if led.number == button.number),
+                None,
+            )
+            entry_data.scenes.append((area_name, keypad, button, led))
+
+            _async_check_entity_unique_id(
+                hass,
+                entity_registry,
+                Platform.SCENE,
+                button.uuid,
+                button.legacy_uuid,
+                entry_data.client.guid,
+            )
+            if led is not None:
+                for platform in (Platform.SWITCH, Platform.SELECT):
+                    _async_check_entity_unique_id(
+                        hass,
+                        entity_registry,
+                        platform,
+                        led.uuid,
+                        led.legacy_uuid,
+                        entry_data.client.guid,
+                    )
+        if button.button_type:
+            entry_data.buttons.append((area_name, keypad, button))
 
 
 def _async_check_entity_unique_id(

--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pylutron"],
-  "requirements": ["pylutron==0.3.0"],
+  "requirements": ["pylutron==0.4.0"],
   "single_config_entry": true
 }

--- a/homeassistant/components/lutron/select.py
+++ b/homeassistant/components/lutron/select.py
@@ -1,0 +1,75 @@
+"""Support for Lutron selects."""
+
+from __future__ import annotations
+
+from pylutron import Button, Keypad, Led, Lutron
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import LutronConfigEntry
+from .entity import LutronKeypad
+
+_LED_STATE_MAP = {
+    Led.LED_OFF: "Off",
+    Led.LED_ON: "On",
+    Led.LED_SLOW_FLASH: "Slow Flash",
+    Led.LED_FAST_FLASH: "Fast Flash",
+}
+
+_LED_NAME_MAP = {v: k for k, v in _LED_STATE_MAP.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LutronConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Lutron select platform."""
+    entry_data = config_entry.runtime_data
+    entities: list[SelectEntity] = []
+
+    # Add the indicator LEDs for scenes (keypad buttons)
+    for area_name, keypad, scene, led in entry_data.scenes:
+        if led is not None:
+            entities.append(
+                LutronLedSelect(area_name, keypad, scene, led, entry_data.client)
+            )
+    async_add_entities(entities, True)
+
+
+class LutronLedSelect(LutronKeypad, SelectEntity):
+    """Representation of a Lutron Keypad LED."""
+
+    _lutron_device: Led
+    _attr_options = list(_LED_NAME_MAP.keys())
+
+    def __init__(
+        self,
+        area_name: str,
+        keypad: Keypad,
+        scene_device: Button,
+        led_device: Led,
+        controller: Lutron,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(area_name, led_device, controller, keypad)
+        self._keypad_name = keypad.name
+        self._attr_name = f"{scene_device.name} LED"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return _LED_STATE_MAP.get(self._lutron_device.last_state)
+
+    def select_option(self, option: str) -> None:
+        """Change the selected option."""
+        self._lutron_device.state = _LED_NAME_MAP[option]
+
+    def _request_state(self) -> None:
+        """Request the state from the device."""
+        _ = self._lutron_device.state
+
+    def _update_attrs(self) -> None:
+        """Update the state attributes."""

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -34,6 +34,12 @@
       }
     }
   },
+  "issues": {
+    "deprecated_led_switch": {
+      "description": "The switch entity for Lutron Keypad LEDs is deprecated and will be removed in Home Assistant 2026.9.0.\n\nPlease update your automations and dashboards to use the new `select` entity for Keypad LEDs, which supports multiple states like flashing, and remove the switch entity.",
+      "title": "Lutron Keypad LED Switch is deprecated"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 from pylutron import Button, Keypad, Led, Lutron, Output
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import LutronConfigEntry
+from .const import DOMAIN
 from .entity import LutronDevice, LutronKeypad
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -33,9 +38,29 @@ async def async_setup_entry(
         entities.append(LutronSwitch(area_name, device, entry_data.client))
 
     # Add the indicator LEDs for scenes (keypad buttons)
+    led_switches = []
     for area_name, keypad, scene, led in entry_data.scenes:
         if led is not None:
-            entities.append(LutronLed(area_name, keypad, scene, led, entry_data.client))
+            led_switches.append(
+                LutronLed(area_name, keypad, scene, led, entry_data.client)
+            )
+
+    if led_switches:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_led_switch",
+            breaks_in_ha_version="2026.9.0",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="deprecated_led_switch",
+        )
+        _LOGGER.warning(
+            "The Lutron Keypad LED switch entity is deprecated and will be removed in "
+            "Home Assistant 2026.9.0. Please use the new select entity instead"
+        )
+        entities.extend(led_switches)
+
     async_add_entities(entities, True)
 
 
@@ -71,6 +96,7 @@ class LutronLed(LutronKeypad, SwitchEntity):
     """Representation of a Lutron Keypad LED."""
 
     _lutron_device: Led
+    _attr_entity_registry_visible_default = False
 
     def __init__(
         self,
@@ -87,11 +113,11 @@ class LutronLed(LutronKeypad, SwitchEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the LED on."""
-        self._lutron_device.state = True
+        self._lutron_device.state = Led.LED_ON
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the LED off."""
-        self._lutron_device.state = False
+        self._lutron_device.state = Led.LED_OFF
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -108,4 +134,4 @@ class LutronLed(LutronKeypad, SwitchEntity):
 
     def _update_attrs(self) -> None:
         """Update the state attributes."""
-        self._attr_is_on = self._lutron_device.last_state
+        self._attr_is_on = self._lutron_device.last_state != Led.LED_OFF

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2251,7 +2251,7 @@ pylitterbot==2025.1.0
 pylutron-caseta==0.27.0
 
 # homeassistant.components.lutron
-pylutron==0.3.0
+pylutron==0.4.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1925,7 +1925,7 @@ pylitterbot==2025.1.0
 pylutron-caseta==0.27.0
 
 # homeassistant.components.lutron
-pylutron==0.3.0
+pylutron==0.4.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/tests/components/lutron/snapshots/test_switch.ambr
+++ b/tests/components/lutron/snapshots/test_switch.ambr
@@ -14,7 +14,7 @@
     'entity_category': None,
     'entity_id': 'switch.test_keypad_test_button',
     'has_entity_name': True,
-    'hidden_by': None,
+    'hidden_by': <RegistryEntryHider.INTEGRATION: 'integration'>,
     'icon': None,
     'id': <ANY>,
     'labels': set({

--- a/tests/components/lutron/test_select.py
+++ b/tests/components/lutron/test_select.py
@@ -1,0 +1,70 @@
+"""Tests for the Lutron select platform."""
+
+from unittest.mock import MagicMock
+
+from pylutron import Led
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_led_select_setup(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the setup of Lutron LED select entities."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, "lutron", {})
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("select.test_keypad_test_button_led")
+    assert entry.unique_id == "12345678901_led_uuid"
+
+    state = hass.states.get("select.test_keypad_test_button_led")
+    assert state is not None
+    assert state.state == "Off"
+    assert state.attributes["options"] == ["Off", "On", "Slow Flash", "Fast Flash"]
+
+
+async def test_led_select_option(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test selecting an option for a Lutron LED select entity."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, "lutron", {})
+    await hass.async_block_till_done()
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
+    # Set up the mock to act like a real object for 'state'
+    type(led).state = Led.LED_OFF
+
+    # Select "On"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: "select.test_keypad_test_button_led", ATTR_OPTION: "On"},
+        blocking=True,
+    )
+    assert led.state == Led.LED_ON
+
+    # Select "Slow Flash"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.test_keypad_test_button_led",
+            ATTR_OPTION: "Slow Flash",
+        },
+        blocking=True,
+    )
+    assert led.state == Led.LED_SLOW_FLASH

--- a/tests/components/lutron/test_switch.py
+++ b/tests/components/lutron/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from pylutron import Led
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -13,7 +14,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -30,6 +31,7 @@ async def test_switch_setup(
     mock_lutron: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test switch setup."""
@@ -47,6 +49,12 @@ async def test_switch_setup(
     await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+    # Verify a repair issue was created
+    issue = issue_registry.async_get_issue("lutron", "deprecated_led_switch")
+    assert issue is not None
+    assert issue.translation_key == "deprecated_led_switch"
+    assert issue.severity == ir.IssueSeverity.WARNING
 
 
 async def test_switch_turn_on_off(
@@ -84,19 +92,26 @@ async def test_switch_turn_on_off(
 
 
 async def test_led_turn_on_off(
-    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test LED turn on and off."""
     mock_config_entry.add_to_hass(hass)
 
     led = mock_lutron.areas[0].keypads[0].leds[0]
-    led.state = 0
-    led.last_state = 0
+    led.state = Led.LED_OFF
+    led.last_state = Led.LED_OFF
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     entity_id = "switch.test_keypad_test_button"
+
+    # Verify hidden by default
+    entry = entity_registry.async_get(entity_id)
+    assert entry.hidden_by == er.RegistryEntryHider.INTEGRATION
 
     # Turn on
     await hass.services.async_call(
@@ -105,7 +120,7 @@ async def test_led_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert led.state == 1
+    assert led.state == Led.LED_ON
 
     # Turn off
     await hass.services.async_call(
@@ -114,4 +129,4 @@ async def test_led_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert led.state == 0
+    assert led.state == Led.LED_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update to pylytron 0.4.0: https://github.com/thecynic/pylutron/releases/tag/0.4.0
Full Changelog: https://github.com/thecynic/pylutron/compare/0.3.0...0.4.0

pylutron 0.4.0 changes the behaviors of LEDs to a multi-state entity.  This PR deprecates the switch entity for Lutron LEDs and introduces a Select entity to support multi-state LEDs.  Repair notifications and future deprecation changes have been put in place.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/44120
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
