### PR TITLE
Bump py-unifi-access to 1.1.0

### DIFF
--- a/homeassistant/components/unifi_access/manifest.json
+++ b/homeassistant/components/unifi_access/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["unifi_access_api"],
   "quality_scale": "bronze",
-  "requirements": ["py-unifi-access==1.0.0"]
+  "requirements": ["py-unifi-access==1.1.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1883,7 +1883,7 @@ py-sucks==0.9.11
 py-synologydsm-api==2.7.3
 
 # homeassistant.components.unifi_access
-py-unifi-access==1.0.0
+py-unifi-access==1.1.0
 
 # homeassistant.components.atome
 pyAtome==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1632,7 +1632,7 @@ py-sucks==0.9.11
 py-synologydsm-api==2.7.3
 
 # homeassistant.components.unifi_access
-py-unifi-access==1.0.0
+py-unifi-access==1.1.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.2


### PR DESCRIPTION
## Proposed change

Bump the UniFi Access integration dependency from `py-unifi-access==1.0.0` to `py-unifi-access==1.1.0`.

This updates the integration to the latest published version of the UniFi Access client library without changing the integration code itself. The generated requirement lock files are updated accordingly.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

### Dependency diff

- `py-unifi-access` `1.0.0` → `1.1.0`
https://github.com/imhotep/py-unifi-access/compare/1.0.0...1.1.0

PyPI release pages:
- `1.0.0`: https://pypi.org/project/py-unifi-access/1.0.0/
- `1.1.0`: https://pypi.org/project/py-unifi-access/1.1.0/

Repository / changelog source:
- https://github.com/imhotep/py-unifi-access

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
