### PR TITLE
Bump pylutron to 0.4.0 and maintain switch compatibility

### DIFF
--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pylutron"],
-  "requirements": ["pylutron==0.3.0"],
+  "requirements": ["pylutron==0.4.0"],
   "single_config_entry": true
 }

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -87,11 +87,11 @@ class LutronLed(LutronKeypad, SwitchEntity):
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the LED on."""
-        self._lutron_device.state = True
+        self._lutron_device.state = Led.LED_ON
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the LED off."""
-        self._lutron_device.state = False
+        self._lutron_device.state = Led.LED_OFF
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
@@ -108,4 +108,4 @@ class LutronLed(LutronKeypad, SwitchEntity):
 
     def _update_attrs(self) -> None:
         """Update the state attributes."""
-        self._attr_is_on = self._lutron_device.last_state
+        self._attr_is_on = self._lutron_device.last_state != Led.LED_OFF

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2251,7 +2251,7 @@ pylitterbot==2025.1.0
 pylutron-caseta==0.27.0
 
 # homeassistant.components.lutron
-pylutron==0.3.0
+pylutron==0.4.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1925,7 +1925,7 @@ pylitterbot==2025.1.0
 pylutron-caseta==0.27.0
 
 # homeassistant.components.lutron
-pylutron==0.3.0
+pylutron==0.4.0
 
 # homeassistant.components.mailgun
 pymailgunner==1.4

--- a/tests/components/lutron/test_switch.py
+++ b/tests/components/lutron/test_switch.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from pylutron import Led
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -105,7 +106,7 @@ async def test_led_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert led.state == 1
+    assert led.state == Led.LED_ON
 
     # Turn off
     await hass.services.async_call(
@@ -114,4 +115,22 @@ async def test_led_turn_on_off(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert led.state == 0
+    assert led.state == Led.LED_OFF
+
+
+async def test_led_slow_flash(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test LED in slow flash state."""
+    mock_config_entry.add_to_hass(hass)
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
+    led.last_state = Led.LED_SLOW_FLASH
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "switch.test_keypad_test_button"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"

--- a/tests/components/lutron/test_switch.py
+++ b/tests/components/lutron/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_ON,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -118,14 +119,18 @@ async def test_led_turn_on_off(
     assert led.state == Led.LED_OFF
 
 
-async def test_led_slow_flash(
-    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+@pytest.mark.parametrize("led_state", [Led.LED_SLOW_FLASH, Led.LED_FAST_FLASH])
+async def test_led_flash_states(
+    hass: HomeAssistant,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    led_state: int,
 ) -> None:
-    """Test LED in slow flash state."""
+    """Test LED in flash states."""
     mock_config_entry.add_to_hass(hass)
 
     led = mock_lutron.areas[0].keypads[0].leds[0]
-    led.last_state = Led.LED_SLOW_FLASH
+    led.last_state = led_state
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -133,4 +138,4 @@ async def test_led_slow_flash(
     entity_id = "switch.test_keypad_test_button"
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "on"
+    assert state.state == STATE_ON


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update to pylytron 0.4.0: https://github.com/thecynic/pylutron/releases/tag/0.4.0
Full Changelog: https://github.com/thecynic/pylutron/compare/0.3.0...0.4.0

pylutron 0.4.0 changed the API for LEDs to handle additional states: Slow Flash and Fast Flash.  This PR maintains existing behavior by assuming that any non-off state == on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
