### PR TITLE
Allow retry on invalid encryption key in victron_ble config flow

### DIFF
--- a/homeassistant/components/victron_ble/config_flow.py
+++ b/homeassistant/components/victron_ble/config_flow.py
@@ -66,6 +66,7 @@ class VictronBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         discovery_info = self._discovered_devices_info[self._discovered_device]
         title = discovery_info.name
 
+        errors: dict[str, str] = {}
         if user_input is not None:
             # see if we can create a device with the access token
             device = VictronBluetoothDeviceData(user_input[CONF_ACCESS_TOKEN])
@@ -76,12 +77,13 @@ class VictronBLEConfigFlow(ConfigFlow, domain=DOMAIN):
                     title=title,
                     data=user_input,
                 )
-            return self.async_abort(reason="invalid_access_token")
+            errors["base"] = "invalid_access_token"
 
         return self.async_show_form(
             step_id="access_token",
             data_schema=STEP_ACCESS_TOKEN_DATA_SCHEMA,
             description_placeholders={"title": title},
+            errors=errors,
         )
 
     async def async_step_user(

--- a/homeassistant/components/victron_ble/config_flow.py
+++ b/homeassistant/components/victron_ble/config_flow.py
@@ -70,14 +70,9 @@ class VictronBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # see if we can create a device with the access token
             device = VictronBluetoothDeviceData(user_input[CONF_ACCESS_TOKEN])
-            try:
-                key_valid = device.validate_advertisement_key(
-                    discovery_info.manufacturer_data[VICTRON_IDENTIFIER]
-                )
-            except (ValueError, IndexError):
-                _LOGGER.debug("Error validating advertisement key", exc_info=True)
-                key_valid = False
-            if key_valid:
+            if device.validate_advertisement_key(
+                discovery_info.manufacturer_data[VICTRON_IDENTIFIER]
+            ):
                 return self.async_create_entry(
                     title=title,
                     data=user_input,

--- a/homeassistant/components/victron_ble/config_flow.py
+++ b/homeassistant/components/victron_ble/config_flow.py
@@ -70,9 +70,14 @@ class VictronBLEConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # see if we can create a device with the access token
             device = VictronBluetoothDeviceData(user_input[CONF_ACCESS_TOKEN])
-            if device.validate_advertisement_key(
-                discovery_info.manufacturer_data[VICTRON_IDENTIFIER]
-            ):
+            try:
+                key_valid = device.validate_advertisement_key(
+                    discovery_info.manufacturer_data[VICTRON_IDENTIFIER]
+                )
+            except (ValueError, IndexError):
+                _LOGGER.debug("Error validating advertisement key", exc_info=True)
+                key_valid = False
+            if key_valid:
                 return self.async_create_entry(
                     title=title,
                     data=user_input,

--- a/homeassistant/components/victron_ble/strings.json
+++ b/homeassistant/components/victron_ble/strings.json
@@ -8,8 +8,10 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "invalid_access_token": "Invalid encryption key for instant readout",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+    },
+    "error": {
+      "invalid_access_token": "Invalid encryption key for instant readout"
     },
     "flow_title": "{title}",
     "step": {

--- a/tests/components/victron_ble/test_config_flow.py
+++ b/tests/components/victron_ble/test_config_flow.py
@@ -56,6 +56,36 @@ async def test_async_step_bluetooth_valid_device(
     assert set(flow_result.data.keys()) == {CONF_ACCESS_TOKEN}
 
 
+async def test_async_step_bluetooth_invalid_key_retry(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test wrong key via bluetooth discovery shows error and allows retry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_BLUETOOTH},
+        data=VICTRON_VEBUS_SERVICE_INFO,
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "access_token"
+
+    # enter wrong key
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_ACCESS_TOKEN: VICTRON_TEST_WRONG_TOKEN},
+    )
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "access_token"
+    assert result.get("errors") == {"base": "invalid_access_token"}
+
+    # retry with correct key
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_ACCESS_TOKEN: VICTRON_VEBUS_TOKEN},
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == VICTRON_VEBUS_SERVICE_INFO.name
+
+
 @pytest.mark.parametrize(
     ("source", "service_info", "expected_reason"),
     [
@@ -94,7 +124,9 @@ async def test_abort_scenarios(
 
 
 async def test_async_step_user_with_devices_found(
-    hass: HomeAssistant, mock_discovered_service_info: AsyncMock
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovered_service_info: AsyncMock,
 ) -> None:
     """Test setup from service info cache with devices found."""
     result = await hass.config_entries.flow.async_init(
@@ -111,12 +143,21 @@ async def test_async_step_user_with_devices_found(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "access_token"
 
-    # test invalid access token (valid already tested above)
+    # test invalid access token shows error and allows retry
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_ACCESS_TOKEN: VICTRON_TEST_WRONG_TOKEN}
     )
-    assert result.get("type") is FlowResultType.ABORT
-    assert result.get("reason") == "invalid_access_token"
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "access_token"
+    assert result.get("errors") == {"base": "invalid_access_token"}
+
+    # test retry with valid access token succeeds
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_ACCESS_TOKEN: VICTRON_VEBUS_TOKEN},
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == VICTRON_VEBUS_SERVICE_INFO.name
 
 
 async def test_async_step_user_device_added_between_steps(


### PR DESCRIPTION
## Proposed change
Previously, entering a wrong encryption key during setup would abort the config flow entirely, preventing the device from being re-discovered. Now the form is re-displayed with an error message, allowing the user to re-enter the correct key.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162120
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
