### PR TITLE
Fix TypeError in SmartThings climate for Samsung VRF/SAC units when optional mode or DRLC status is None

### DIFF
--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -611,8 +611,10 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
                 Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE,
                 Attribute.SUPPORTED_AC_OPTIONAL_MODE,
             )
-            modes = []
-            for mode in (supported_modes or []):
+            if supported_modes is None:
+                return None
+            modes: list[str] = []
+            for mode in supported_modes:
                 if (ha_mode := PRESET_MODE_TO_HA.get(mode)) is not None:
                     modes.append(ha_mode)
                 else:
@@ -622,6 +624,11 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
                     )
             return modes
         return None
+
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Return a list of available preset modes."""
+        return self._determine_preset_modes()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set optional AC modes."""

--- a/homeassistant/components/smartthings/climate.py
+++ b/homeassistant/components/smartthings/climate.py
@@ -516,7 +516,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         )
         res = {}
         for key in ("duration", "start", "override", "drlcLevel"):
-            if key in drlc_status:
+            if drlc_status and key in drlc_status:
                 dict_key = {"drlcLevel": "drlc_status_level"}.get(
                     key, f"drlc_status_{key}"
                 )
@@ -612,7 +612,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
                 Attribute.SUPPORTED_AC_OPTIONAL_MODE,
             )
             modes = []
-            for mode in supported_modes:
+            for mode in (supported_modes or []):
                 if (ha_mode := PRESET_MODE_TO_HA.get(mode)) is not None:
                     modes.append(ha_mode)
                 else:

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -482,6 +482,49 @@ async def test_ac_set_preset_mode(
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
+async def test_ac_supported_optional_modes_none(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup when supported optional mode list is None."""
+    set_attribute_value(
+        devices,
+        Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE,
+        Attribute.SUPPORTED_AC_OPTIONAL_MODE,
+        None,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("climate.ac_office_granit") is not None
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
+async def test_ac_drlc_status_none(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup when demand response load control status is None."""
+    set_attribute_value(
+        devices,
+        Capability.DEMAND_RESPONSE_LOAD_CONTROL,
+        Attribute.DEMAND_RESPONSE_LOAD_CONTROL_STATUS,
+        None,
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("climate.ac_office_granit")
+    assert state is not None
+    assert "drlc_status_duration" not in state.attributes
+    assert "drlc_status_start" not in state.attributes
+    assert "drlc_status_override" not in state.attributes
+    assert "drlc_status_level" not in state.attributes
+
+
+@pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])
 async def test_ac_state_update(
     hass: HomeAssistant,
     devices: AsyncMock,


### PR DESCRIPTION
## Proposed change
Fixes TypeError crashes when setting up SmartThings climate entities for Samsung VRF/SAC air conditioners, including devices such as MIM-H04N WiFi kit with DA-SAC-INDOOR sub-devices.

Two capabilities can be reported as supported before state has been populated:
- custom.airConditionerOptionalMode
- demandResponseLoadControl

In this initial state, both values may be None. The climate code previously assumed concrete values and could raise TypeError:

```
Error while setting up smartthings platform for climate: 'NoneType' object is not iterable

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 455, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/usr/src/homeassistant/homeassistant/components/smartthings/climate.py", line 158, in async_setup_entry
    SmartThingsAirConditioner(entry_data.client, device)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/smartthings/climate.py", line 402, in __init__
    self._attr_preset_modes = self._determine_preset_modes()
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/components/smartthings/climate.py", line 615, in _determine_preset_modes
    for mode in supported_modes:
                ^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

And:

```
Error adding entity climate.ar_direito for domain climate with platform smartthings

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 680, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 998, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1395, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1018, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1163, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1074, in __async_calculate_state
    if extra_state_attributes := self.extra_state_attributes:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/smartthings/climate.py", line 519, in extra_state_attributes
    if key in drlc_status:
       ^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not a container or iterable
```

This PR adds two defensive guards:
- Preset mode discovery now iterates over supported modes or an empty list when None is reported.
- DRLC extra attributes now verify DRLC status is present before key access.

Behavior is unchanged when valid values are present, and startup no longer crashes when these values are temporarily None.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: 
- This PR is related to issue: same as #105156
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
