### PR TITLE
Bump librehardwaremonitor-api to version 1.11.1

### DIFF
--- a/homeassistant/components/libre_hardware_monitor/manifest.json
+++ b/homeassistant/components/libre_hardware_monitor/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "silver",
-  "requirements": ["librehardwaremonitor-api==1.10.1"]
+  "requirements": ["librehardwaremonitor-api==1.11.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1419,7 +1419,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.10.1
+librehardwaremonitor-api==1.11.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1253,7 +1253,7 @@ libpyfoscamcgi==0.0.9
 libpyvivotek==0.6.1
 
 # homeassistant.components.libre_hardware_monitor
-librehardwaremonitor-api==1.10.1
+librehardwaremonitor-api==1.11.1
 
 # homeassistant.components.mikrotik
 librouteros==3.2.0

--- a/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
+++ b/tests/components/libre_hardware_monitor/fixtures/libre_hardware_monitor.json
@@ -1,5 +1,6 @@
 {
   "id": 0,
+  "Version": "0.9.7",
   "Text": "Sensor",
   "Min": "Min",
   "Value": "Value",

--- a/tests/components/libre_hardware_monitor/snapshots/test_diagnostics.ambr
+++ b/tests/components/libre_hardware_monitor/snapshots/test_diagnostics.ambr
@@ -317,6 +317,11 @@
           'value': '1.312',
         }),
       }),
+      'version': dict({
+        'major': 0,
+        'minor': 9,
+        'patch': 7,
+      }),
     }),
   })
 # ---

--- a/tests/components/libre_hardware_monitor/test_sensor.py
+++ b/tests/components/libre_hardware_monitor/test_sensor.py
@@ -14,7 +14,6 @@ from librehardwaremonitor_api import (
 from librehardwaremonitor_api.model import (
     DeviceId,
     DeviceName,
-    LibreHardwareMonitorData,
     LibreHardwareMonitorSensorData,
 )
 from librehardwaremonitor_api.sensor_type import SensorType
@@ -263,8 +262,8 @@ async def _mock_orphaned_device(
     previous_data = mock_lhm_client.get_data.return_value
     assert removed_device in previous_data.main_device_ids_and_names
 
-    mock_lhm_client.get_data.return_value = LibreHardwareMonitorData(
-        computer_name=mock_lhm_client.get_data.return_value.computer_name,
+    mock_lhm_client.get_data.return_value = replace(
+        mock_lhm_client.get_data.return_value,
         main_device_ids_and_names=MappingProxyType(
             {
                 device_id: name
@@ -279,7 +278,6 @@ async def _mock_orphaned_device(
                 if not sensor_id.startswith(removed_device)
             }
         ),
-        is_deprecated_version=False,
     )
 
     return device_registry.async_get_or_create(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `librehardwaremonitor-api` dependency to v1.11.1

1. Introduces a `version` field in the returned data, see https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/2240
2. Will make sure the integration doesn't break with LHM's next update, as there is a breaking API change with regards to the raw values the API provides: they are changed from strings to numbers (int, float). See https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/2254

Diff: https://github.com/Sab44/librehardwaremonitor-api/compare/v1.10.1...v1.11.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
