### PR TITLE
Schlage: Use the lock's connected status as an additional available signal

### DIFF
--- a/homeassistant/components/schlage/entity.py
+++ b/homeassistant/components/schlage/entity.py
@@ -42,4 +42,8 @@ class SchlageEntity(CoordinatorEntity[SchlageDataUpdateCoordinator]):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        return super().available and self.device_id in self.coordinator.data.locks
+        return (
+            super().available
+            and self.device_id in self.coordinator.data.locks
+            and self._lock.connected
+        )

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -60,6 +60,11 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
         self._attr_is_jammed = self._lock.is_jammed
         self._attr_changed_by = self._lock.last_changed_by()
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._lock.connected
+
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         await self.hass.async_add_executor_job(self._lock.lock)

--- a/homeassistant/components/schlage/lock.py
+++ b/homeassistant/components/schlage/lock.py
@@ -60,11 +60,6 @@ class SchlageLockEntity(SchlageEntity, LockEntity):
         self._attr_is_jammed = self._lock.is_jammed
         self._attr_changed_by = self._lock.last_changed_by()
 
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        return super().available and self._lock.connected
-
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the device."""
         await self.hass.async_add_executor_job(self._lock.lock)

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Schlage tests."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.components.schlage.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import Awaitable
 
 from . import MockSchlageConfigEntry
 
@@ -32,20 +33,32 @@ def mock_config_entry() -> MockSchlageConfigEntry:
 
 @pytest.fixture
 async def mock_added_config_entry(
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+) -> MockSchlageConfigEntry:
+    """Mock ConfigEntry that's been added to HA."""
+    return await mock_add_config_entry()
+
+
+@pytest.fixture
+async def mock_add_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockSchlageConfigEntry,
     mock_pyschlage_auth: Mock,
     mock_schlage: Mock,
     mock_lock: Mock,
-) -> MockSchlageConfigEntry:
+) -> Callable[[], Awaitable[MockSchlageConfigEntry]]:
     """Mock ConfigEntry that's been added to HA."""
-    mock_schlage.locks.return_value = [mock_lock]
-    mock_schlage.users.return_value = []
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    assert DOMAIN in hass.config_entries.async_domains()
-    return mock_config_entry
+
+    async def callback() -> MockSchlageConfigEntry:
+        mock_schlage.locks.return_value = [mock_lock]
+        mock_schlage.users.return_value = []
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert DOMAIN in hass.config_entries.async_domains()
+        return mock_config_entry
+
+    return callback
 
 
 @pytest.fixture
@@ -58,14 +71,14 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_schlage() -> Mock:
+def mock_schlage() -> Generator[Mock]:
     """Mock pyschlage.Schlage."""
     with patch("pyschlage.Schlage", autospec=True) as mock_schlage:
         yield mock_schlage.return_value
 
 
 @pytest.fixture
-def mock_pyschlage_auth() -> Mock:
+def mock_pyschlage_auth() -> Generator[Mock]:
     """Mock pyschlage.Auth."""
     with patch("pyschlage.Auth", autospec=True) as mock_auth:
         mock_auth.return_value.user_id = "abc123"

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -34,7 +34,7 @@ def mock_config_entry() -> MockSchlageConfigEntry:
 async def mock_added_config_entry(
     mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> MockSchlageConfigEntry:
-    """Return a callback that adds and sets up a mock ConfigEntry in HA when awaited."""
+    """Return a mock ConfigEntry that has been added to and set up in Home Assistant."""
     return await mock_add_config_entry()
 
 

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -1,6 +1,6 @@
 """Common fixtures for the Schlage tests."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from typing import Any
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
@@ -10,7 +10,6 @@ import pytest
 from homeassistant.components.schlage.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import Awaitable
 
 from . import MockSchlageConfigEntry
 
@@ -35,7 +34,7 @@ def mock_config_entry() -> MockSchlageConfigEntry:
 async def mock_added_config_entry(
     mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> MockSchlageConfigEntry:
-    """Mock ConfigEntry that's been added to HA."""
+    """Return a callback that adds and sets up a mock ConfigEntry in HA when awaited."""
     return await mock_add_config_entry()
 
 

--- a/tests/components/schlage/snapshots/test_binary_sensor.ambr
+++ b/tests/components/schlage/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_binary_sensor_attributes[binary_sensor.vault_door_keypad_disabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.vault_door_keypad_disabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Keypad disabled',
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'keypad_disabled',
+    'unique_id': 'test_keypad_disabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_attributes[binary_sensor.vault_door_keypad_disabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Vault Door Keypad disabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vault_door_keypad_disabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/schlage/snapshots/test_lock.ambr
+++ b/tests/components/schlage/snapshots/test_lock.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_lock_attributes[lock.vault_door-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'lock',
+    'entity_category': None,
+    'entity_id': 'lock.vault_door',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_lock_attributes[lock.vault_door-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'changed_by': 'thumbturn',
+      'friendly_name': 'Vault Door',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vault_door',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---

--- a/tests/components/schlage/snapshots/test_select.ambr
+++ b/tests/components/schlage/snapshots/test_select.ambr
@@ -1,0 +1,70 @@
+# serializer version: 1
+# name: test_select_attributes[select.vault_door_auto_lock_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0',
+        '5',
+        '15',
+        '30',
+        '60',
+        '120',
+        '240',
+        '300',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.vault_door_auto_lock_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Auto-lock time',
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'auto_lock_time',
+    'unique_id': 'test_auto_lock_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_attributes[select.vault_door_auto_lock_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Vault Door Auto-lock time',
+      'options': list([
+        '0',
+        '5',
+        '15',
+        '30',
+        '60',
+        '120',
+        '240',
+        '300',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.vault_door_auto_lock_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15',
+  })
+# ---

--- a/tests/components/schlage/snapshots/test_sensor.ambr
+++ b/tests/components/schlage/snapshots/test_sensor.ambr
@@ -1,0 +1,54 @@
+# serializer version: 1
+# name: test_sensor_attributes[sensor.vault_door_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.vault_door_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test_battery_level',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_attributes[sensor.vault_door_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Vault Door Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vault_door_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20',
+  })
+# ---

--- a/tests/components/schlage/snapshots/test_switch.ambr
+++ b/tests/components/schlage/snapshots/test_switch.ambr
@@ -1,0 +1,99 @@
+# serializer version: 1
+# name: test_switch_attributes[switch.vault_door_1_touch_locking-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.vault_door_1_touch_locking',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': '1-Touch Locking',
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_and_leave',
+    'unique_id': 'test_lock_and_leve',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_attributes[switch.vault_door_1_touch_locking-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'switch',
+      'friendly_name': 'Vault Door 1-Touch Locking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vault_door_1_touch_locking',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_attributes[switch.vault_door_keypress_beep-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.vault_door_keypress_beep',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'Keypress Beep',
+    'platform': 'schlage',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'beeper',
+    'unique_id': 'test_beeper',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_attributes[switch.vault_door_keypress_beep-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'switch',
+      'friendly_name': 'Vault Door Keypress Beep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vault_door_keypress_beep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/schlage/test_binary_sensor.py
+++ b/tests/components/schlage/test_binary_sensor.py
@@ -1,65 +1,64 @@
 """Test Schlage binary_sensor."""
 
-from datetime import timedelta
-from unittest.mock import Mock
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 from pyschlage.exceptions import UnknownError
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_ON, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from . import MockSchlageConfigEntry
 
-from tests.common import async_fire_time_changed
+from tests.common import snapshot_platform
+
+
+async def test_binary_sensor_attributes(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test binary sensor attributes."""
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.BINARY_SENSOR]):
+        config_entry = await mock_add_config_entry()
+        await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 async def test_keypad_disabled_binary_sensor(
     hass: HomeAssistant,
-    mock_schlage: Mock,
     mock_lock: Mock,
-    mock_added_config_entry: MockSchlageConfigEntry,
-    freezer: FrozenDateTimeFactory,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> None:
     """Test the keypad_disabled binary_sensor."""
     mock_lock.keypad_disabled.reset_mock()
     mock_lock.keypad_disabled.return_value = True
-
-    # Make the coordinator refresh data.
-    freezer.tick(timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
-    assert keypad is not None
-    assert keypad.state == STATE_ON
-    assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
-
-    mock_lock.keypad_disabled.assert_called_once_with([])
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await mock_add_config_entry()
+        keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
+        assert keypad is not None
+        assert keypad.state == STATE_ON
+        assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
+        mock_lock.keypad_disabled.assert_called_once_with([])
 
 
 async def test_keypad_disabled_binary_sensor_use_previous_logs_on_failure(
     hass: HomeAssistant,
-    mock_schlage: Mock,
     mock_lock: Mock,
-    mock_added_config_entry: MockSchlageConfigEntry,
-    freezer: FrozenDateTimeFactory,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> None:
     """Test the keypad_disabled binary_sensor."""
     mock_lock.keypad_disabled.reset_mock()
     mock_lock.keypad_disabled.return_value = True
     mock_lock.logs.reset_mock()
     mock_lock.logs.side_effect = UnknownError("Cannot load logs")
-
-    # Make the coordinator refresh data.
-    freezer.tick(timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
-    assert keypad is not None
-    assert keypad.state == STATE_ON
-    assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
-
-    mock_lock.keypad_disabled.assert_called_once_with([])
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.BINARY_SENSOR]):
+        await mock_add_config_entry()
+        keypad = hass.states.get("binary_sensor.vault_door_keypad_disabled")
+        assert keypad is not None
+        assert keypad.state == STATE_ON
+        assert keypad.attributes["device_class"] == BinarySensorDeviceClass.PROBLEM
+        mock_lock.keypad_disabled.assert_called_once_with([])

--- a/tests/components/schlage/test_binary_sensor.py
+++ b/tests/components/schlage/test_binary_sensor.py
@@ -45,12 +45,12 @@ async def test_keypad_disabled_binary_sensor(
         mock_lock.keypad_disabled.assert_called_once_with([])
 
 
-async def test_keypad_disabled_binary_sensor_use_previous_logs_on_failure(
+async def test_keypad_disabled_binary_sensor_logs_failure(
     hass: HomeAssistant,
     mock_lock: Mock,
     mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> None:
-    """Test the keypad_disabled binary_sensor."""
+    """Test the keypad_disabled binary_sensor when loading logs fails."""
     mock_lock.keypad_disabled.reset_mock()
     mock_lock.keypad_disabled.return_value = True
     mock_lock.logs.reset_mock()

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -64,7 +64,7 @@ async def test_lock_disconnected(
     mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
     mock_lock: Mock,
 ) -> None:
-    """Test lock jammed state."""
+    """Test lock disconnected/unavailable state."""
     mock_lock.connected = False
     with patch("homeassistant.components.schlage.PLATFORMS", [Platform.LOCK]):
         await mock_add_config_entry()

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -3,10 +3,10 @@
 from collections.abc import Awaitable, Callable
 from unittest.mock import Mock, patch
 
-from syrupy.assertion import SnapshotAssertion
 from pyschlage.code import AccessCode
 from pyschlage.exceptions import Error as SchlageError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState

--- a/tests/components/schlage/test_lock.py
+++ b/tests/components/schlage/test_lock.py
@@ -1,9 +1,9 @@
 """Test schlage lock."""
 
-from datetime import timedelta
-from unittest.mock import Mock
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock, patch
 
-from freezegun.api import FrozenDateTimeFactory
+from syrupy.assertion import SnapshotAssertion
 from pyschlage.code import AccessCode
 from pyschlage.exceptions import Error as SchlageError
 import pytest
@@ -16,37 +16,61 @@ from homeassistant.components.schlage.const import (
     SERVICE_DELETE_CODE,
     SERVICE_GET_CODES,
 )
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+    STATE_UNAVAILABLE,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import entity_registry as er
 
 from . import MockSchlageConfigEntry
 
-from tests.common import async_fire_time_changed
+from tests.common import snapshot_platform
 
 
 async def test_lock_attributes(
     hass: HomeAssistant,
-    mock_added_config_entry: MockSchlageConfigEntry,
-    mock_schlage: Mock,
-    mock_lock: Mock,
-    freezer: FrozenDateTimeFactory,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test lock attributes."""
-    lock = hass.states.get("lock.vault_door")
-    assert lock is not None
-    assert lock.state == LockState.UNLOCKED
-    assert lock.attributes["changed_by"] == "thumbturn"
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.LOCK]):
+        config_entry = await mock_add_config_entry()
+        await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
+
+async def test_lock_jammed(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    mock_lock: Mock,
+) -> None:
+    """Test lock jammed state."""
     mock_lock.is_locked = False
     mock_lock.is_jammed = True
-    # Make the coordinator refresh data.
-    freezer.tick(timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    lock = hass.states.get("lock.vault_door")
-    assert lock is not None
-    assert lock.state == LockState.JAMMED
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.LOCK]):
+        await mock_add_config_entry()
+        lock = hass.states.get("lock.vault_door")
+        assert lock is not None
+        assert lock.state == LockState.JAMMED
+
+
+async def test_lock_disconnected(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    mock_lock: Mock,
+) -> None:
+    """Test lock jammed state."""
+    mock_lock.connected = False
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.LOCK]):
+        await mock_add_config_entry()
+        lock = hass.states.get("lock.vault_door")
+        assert lock is not None
+        assert lock.state == STATE_UNAVAILABLE
 
 
 async def test_lock_services(
@@ -79,22 +103,16 @@ async def test_lock_services(
 async def test_changed_by(
     hass: HomeAssistant,
     mock_lock: Mock,
-    mock_added_config_entry: MockSchlageConfigEntry,
-    freezer: FrozenDateTimeFactory,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> None:
     """Test population of the changed_by attribute."""
     mock_lock.last_changed_by.reset_mock()
     mock_lock.last_changed_by.return_value = "access code - foo"
-
-    # Make the coordinator refresh data.
-    freezer.tick(timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-    mock_lock.last_changed_by.assert_called_with()
-
-    lock_device = hass.states.get("lock.vault_door")
-    assert lock_device is not None
-    assert lock_device.attributes.get("changed_by") == "access code - foo"
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.LOCK]):
+        await mock_add_config_entry()
+        lock = hass.states.get("lock.vault_door")
+        assert lock is not None
+        assert lock.attributes.get("changed_by") == "access code - foo"
 
 
 async def test_add_code_service(

--- a/tests/components/schlage/test_select.py
+++ b/tests/components/schlage/test_select.py
@@ -1,6 +1,7 @@
 """Test Schlage select."""
 
-from unittest.mock import Mock
+from collections.abc import Awaitable, Callable
+from unittest.mock import Mock, patch
 
 from pyschlage.lock import AUTO_LOCK_TIMES
 
@@ -12,30 +13,46 @@ from homeassistant.components.select import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.translation import LOCALE_EN, async_get_translations
 
 from . import MockSchlageConfigEntry
+
+from tests.common import SnapshotAssertion, snapshot_platform
+
+
+async def test_select_attributes(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test select attributes."""
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.SELECT]):
+        config_entry = await mock_add_config_entry()
+        await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 async def test_select(
     hass: HomeAssistant,
     mock_lock: Mock,
-    mock_added_config_entry: MockSchlageConfigEntry,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
 ) -> None:
     """Test the auto-lock time select entity."""
-    entity_id = "select.vault_door_auto_lock_time"
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.SELECT]):
+        await mock_add_config_entry()
 
-    select = hass.states.get(entity_id)
-    assert select is not None
-    assert select.state == "15"
+        select = hass.states.get("select.vault_door_auto_lock_time")
+        assert select is not None
+        assert select.state == "15"
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "30"},
-        blocking=True,
-    )
-    mock_lock.set_auto_lock_time.assert_called_once_with(30)
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: select.entity_id, ATTR_OPTION: "30"},
+            blocking=True,
+        )
+        mock_lock.set_auto_lock_time.assert_called_once_with(30)
 
 
 async def test_auto_lock_time_translations(hass: HomeAssistant) -> None:

--- a/tests/components/schlage/test_sensor.py
+++ b/tests/components/schlage/test_sensor.py
@@ -1,18 +1,24 @@
 """Test schlage sensor."""
 
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.const import PERCENTAGE
+from collections.abc import Awaitable, Callable
+from unittest.mock import patch
+
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from . import MockSchlageConfigEntry
 
+from tests.common import SnapshotAssertion, snapshot_platform
 
-async def test_battery_sensor(
-    hass: HomeAssistant, mock_added_config_entry: MockSchlageConfigEntry
+
+async def test_sensor_attributes(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
 ) -> None:
-    """Test the battery sensor."""
-    battery_sensor = hass.states.get("sensor.vault_door_battery")
-    assert battery_sensor is not None
-    assert battery_sensor.state == "20"
-    assert battery_sensor.attributes["unit_of_measurement"] == PERCENTAGE
-    assert battery_sensor.attributes["device_class"] == SensorDeviceClass.BATTERY
+    """Test sensor attributes."""
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await mock_add_config_entry()
+        await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/schlage/test_switch.py
+++ b/tests/components/schlage/test_switch.py
@@ -1,12 +1,33 @@
 """Test schlage switch."""
 
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from . import MockSchlageConfigEntry
+
+from tests.common import SnapshotAssertion, patch, snapshot_platform
+
+
+async def test_switch_attributes(
+    hass: HomeAssistant,
+    mock_add_config_entry: Callable[[], Awaitable[MockSchlageConfigEntry]],
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test switch attributes."""
+    with patch("homeassistant.components.schlage.PLATFORMS", [Platform.SWITCH]):
+        config_entry = await mock_add_config_entry()
+        await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
 async def test_beeper_services(


### PR DESCRIPTION
## Proposed change
Use the `connected` state from the API as an additional signal for whether the lock is available.

As suggested in #165366

Also clean up the test a bit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165366
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
