### PR TITLE
Add keyboard text input services to Apple TV integration

### DIFF
--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -43,7 +43,6 @@ from .const import (
     SIGNAL_CONNECTED,
     SIGNAL_DISCONNECTED,
 )
-
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -47,7 +47,7 @@ from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 DEFAULT_NAME_TV = "Apple TV"
 DEFAULT_NAME_HP = "HomePod"

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -47,7 +47,7 @@ from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 DEFAULT_NAME_TV = "Apple TV"
 DEFAULT_NAME_HP = "HomePod"

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -30,9 +30,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CONF_CREDENTIALS,
@@ -43,7 +44,11 @@ from .const import (
     SIGNAL_DISCONNECTED,
 )
 
+from .services import async_setup_services
+
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 DEFAULT_NAME_TV = "Apple TV"
 DEFAULT_NAME_HP = "HomePod"
@@ -75,6 +80,12 @@ DEVICE_EXCEPTIONS = (
 
 
 type AppleTvConfigEntry = ConfigEntry[AppleTVManager]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Apple TV component."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> bool:

--- a/homeassistant/components/apple_tv/const.py
+++ b/homeassistant/components/apple_tv/const.py
@@ -9,3 +9,5 @@ CONF_START_OFF = "start_off"
 
 SIGNAL_CONNECTED = "apple_tv_connected"
 SIGNAL_DISCONNECTED = "apple_tv_disconnected"
+
+ATTR_TEXT = "text"

--- a/homeassistant/components/apple_tv/icons.json
+++ b/homeassistant/components/apple_tv/icons.json
@@ -1,4 +1,15 @@
 {
+  "services": {
+    "set_keyboard_text": {
+      "service": "mdi:keyboard"
+    },
+    "append_keyboard_text": {
+      "service": "mdi:keyboard"
+    },
+    "clear_keyboard_text": {
+      "service": "mdi:keyboard-off"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "keyboard_focused": {

--- a/homeassistant/components/apple_tv/icons.json
+++ b/homeassistant/components/apple_tv/icons.json
@@ -1,15 +1,4 @@
 {
-  "services": {
-    "set_keyboard_text": {
-      "service": "mdi:keyboard"
-    },
-    "append_keyboard_text": {
-      "service": "mdi:keyboard"
-    },
-    "clear_keyboard_text": {
-      "service": "mdi:keyboard-off"
-    }
-  },
   "entity": {
     "binary_sensor": {
       "keyboard_focused": {
@@ -18,6 +7,17 @@
           "off": "mdi:keyboard-off"
         }
       }
+    }
+  },
+  "services": {
+    "append_keyboard_text": {
+      "service": "mdi:keyboard"
+    },
+    "clear_keyboard_text": {
+      "service": "mdi:keyboard-off"
+    },
+    "set_keyboard_text": {
+      "service": "mdi:keyboard"
     }
   }
 }

--- a/homeassistant/components/apple_tv/services.py
+++ b/homeassistant/components/apple_tv/services.py
@@ -1,0 +1,131 @@
+"""Define services for the Apple TV integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import ATTR_TEXT, DOMAIN
+
+SERVICE_SET_KEYBOARD_TEXT = "set_keyboard_text"
+SERVICE_SET_KEYBOARD_TEXT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Required(ATTR_TEXT): cv.string,
+    }
+)
+
+SERVICE_APPEND_KEYBOARD_TEXT = "append_keyboard_text"
+SERVICE_APPEND_KEYBOARD_TEXT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+        vol.Required(ATTR_TEXT): cv.string,
+    }
+)
+
+SERVICE_CLEAR_KEYBOARD_TEXT = "clear_keyboard_text"
+SERVICE_CLEAR_KEYBOARD_TEXT_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
+    }
+)
+
+
+def _get_manager(call: ServiceCall):
+    """Get the AppleTVManager for a service call."""
+    from . import AppleTvConfigEntry
+
+    entry: AppleTvConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+    )
+    manager = entry.runtime_data
+    if manager.atv is None:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="not_connected",
+        )
+    return manager
+
+
+def _check_keyboard_focus(manager) -> None:
+    """Check that keyboard is focused on the device."""
+    from pyatv.const import KeyboardFocusState
+
+    try:
+        focus_state = manager.atv.keyboard.text_focus_state
+    except Exception as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="keyboard_not_available",
+        ) from err
+    if focus_state != KeyboardFocusState.Focused:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="keyboard_not_focused",
+        )
+
+
+async def _async_set_keyboard_text(call: ServiceCall) -> None:
+    """Set text in the keyboard input field on an Apple TV."""
+    manager = _get_manager(call)
+    _check_keyboard_focus(manager)
+    try:
+        await manager.atv.keyboard.text_set(call.data[ATTR_TEXT])
+    except Exception as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="keyboard_error",
+        ) from err
+
+
+async def _async_append_keyboard_text(call: ServiceCall) -> None:
+    """Append text to the keyboard input field on an Apple TV."""
+    manager = _get_manager(call)
+    _check_keyboard_focus(manager)
+    try:
+        await manager.atv.keyboard.text_append(call.data[ATTR_TEXT])
+    except Exception as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="keyboard_error",
+        ) from err
+
+
+async def _async_clear_keyboard_text(call: ServiceCall) -> None:
+    """Clear text in the keyboard input field on an Apple TV."""
+    manager = _get_manager(call)
+    _check_keyboard_focus(manager)
+    try:
+        await manager.atv.keyboard.text_clear()
+    except Exception as err:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="keyboard_error",
+        ) from err
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up the services for the Apple TV integration."""
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_KEYBOARD_TEXT,
+        _async_set_keyboard_text,
+        schema=SERVICE_SET_KEYBOARD_TEXT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_APPEND_KEYBOARD_TEXT,
+        _async_append_keyboard_text,
+        schema=SERVICE_APPEND_KEYBOARD_TEXT_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_KEYBOARD_TEXT,
+        _async_clear_keyboard_text,
+        schema=SERVICE_CLEAR_KEYBOARD_TEXT_SCHEMA,
+    )

--- a/homeassistant/components/apple_tv/services.py
+++ b/homeassistant/components/apple_tv/services.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from pyatv.const import KeyboardFocusState
 from pyatv.exceptions import NotSupportedError, ProtocolError
+from pyatv.interface import AppleTV as AppleTVInterface
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
@@ -14,9 +13,6 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import ATTR_TEXT, DOMAIN
-
-if TYPE_CHECKING:
-    from . import AppleTVManager
 
 SERVICE_SET_KEYBOARD_TEXT = "set_keyboard_text"
 SERVICE_SET_KEYBOARD_TEXT_SCHEMA = vol.Schema(
@@ -42,24 +38,24 @@ SERVICE_CLEAR_KEYBOARD_TEXT_SCHEMA = vol.Schema(
 )
 
 
-def _get_manager(call: ServiceCall) -> AppleTVManager:
-    """Get the AppleTVManager for a service call."""
+def _get_atv(call: ServiceCall) -> AppleTVInterface:
+    """Get the AppleTVInterface for a service call."""
     entry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
-    manager: AppleTVManager = entry.runtime_data
-    if manager.atv is None:
+    atv: AppleTVInterface | None = entry.runtime_data.atv
+    if atv is None:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="not_connected",
         )
-    return manager
+    return atv
 
 
-def _check_keyboard_focus(manager: AppleTVManager) -> None:
+def _check_keyboard_focus(atv: AppleTVInterface) -> None:
     """Check that keyboard is focused on the device."""
     try:
-        focus_state = manager.atv.keyboard.text_focus_state  # type: ignore[union-attr]
+        focus_state = atv.keyboard.text_focus_state
     except NotSupportedError as err:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -74,10 +70,10 @@ def _check_keyboard_focus(manager: AppleTVManager) -> None:
 
 async def _async_set_keyboard_text(call: ServiceCall) -> None:
     """Set text in the keyboard input field on an Apple TV."""
-    manager = _get_manager(call)
-    _check_keyboard_focus(manager)
+    atv = _get_atv(call)
+    _check_keyboard_focus(atv)
     try:
-        await manager.atv.keyboard.text_set(call.data[ATTR_TEXT])  # type: ignore[union-attr]
+        await atv.keyboard.text_set(call.data[ATTR_TEXT])
     except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
@@ -87,10 +83,10 @@ async def _async_set_keyboard_text(call: ServiceCall) -> None:
 
 async def _async_append_keyboard_text(call: ServiceCall) -> None:
     """Append text to the keyboard input field on an Apple TV."""
-    manager = _get_manager(call)
-    _check_keyboard_focus(manager)
+    atv = _get_atv(call)
+    _check_keyboard_focus(atv)
     try:
-        await manager.atv.keyboard.text_append(call.data[ATTR_TEXT])  # type: ignore[union-attr]
+        await atv.keyboard.text_append(call.data[ATTR_TEXT])
     except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
@@ -100,10 +96,10 @@ async def _async_append_keyboard_text(call: ServiceCall) -> None:
 
 async def _async_clear_keyboard_text(call: ServiceCall) -> None:
     """Clear text in the keyboard input field on an Apple TV."""
-    manager = _get_manager(call)
-    _check_keyboard_focus(manager)
+    atv = _get_atv(call)
+    _check_keyboard_focus(atv)
     try:
-        await manager.atv.keyboard.text_clear()  # type: ignore[union-attr]
+        await atv.keyboard.text_clear()
     except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/apple_tv/services.py
+++ b/homeassistant/components/apple_tv/services.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from pyatv.const import KeyboardFocusState
+from pyatv.exceptions import NotSupportedError, ProtocolError
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
@@ -10,6 +14,9 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 
 from .const import ATTR_TEXT, DOMAIN
+
+if TYPE_CHECKING:
+    from . import AppleTVManager
 
 SERVICE_SET_KEYBOARD_TEXT = "set_keyboard_text"
 SERVICE_SET_KEYBOARD_TEXT_SCHEMA = vol.Schema(
@@ -35,14 +42,12 @@ SERVICE_CLEAR_KEYBOARD_TEXT_SCHEMA = vol.Schema(
 )
 
 
-def _get_manager(call: ServiceCall):
+def _get_manager(call: ServiceCall) -> AppleTVManager:
     """Get the AppleTVManager for a service call."""
-    from . import AppleTvConfigEntry
-
-    entry: AppleTvConfigEntry = service.async_get_config_entry(
+    entry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
-    manager = entry.runtime_data
+    manager: AppleTVManager = entry.runtime_data
     if manager.atv is None:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
@@ -51,13 +56,11 @@ def _get_manager(call: ServiceCall):
     return manager
 
 
-def _check_keyboard_focus(manager) -> None:
+def _check_keyboard_focus(manager: AppleTVManager) -> None:
     """Check that keyboard is focused on the device."""
-    from pyatv.const import KeyboardFocusState
-
     try:
-        focus_state = manager.atv.keyboard.text_focus_state
-    except Exception as err:
+        focus_state = manager.atv.keyboard.text_focus_state  # type: ignore[union-attr]
+    except NotSupportedError as err:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="keyboard_not_available",
@@ -74,8 +77,8 @@ async def _async_set_keyboard_text(call: ServiceCall) -> None:
     manager = _get_manager(call)
     _check_keyboard_focus(manager)
     try:
-        await manager.atv.keyboard.text_set(call.data[ATTR_TEXT])
-    except Exception as err:
+        await manager.atv.keyboard.text_set(call.data[ATTR_TEXT])  # type: ignore[union-attr]
+    except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="keyboard_error",
@@ -87,8 +90,8 @@ async def _async_append_keyboard_text(call: ServiceCall) -> None:
     manager = _get_manager(call)
     _check_keyboard_focus(manager)
     try:
-        await manager.atv.keyboard.text_append(call.data[ATTR_TEXT])
-    except Exception as err:
+        await manager.atv.keyboard.text_append(call.data[ATTR_TEXT])  # type: ignore[union-attr]
+    except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="keyboard_error",
@@ -100,8 +103,8 @@ async def _async_clear_keyboard_text(call: ServiceCall) -> None:
     manager = _get_manager(call)
     _check_keyboard_focus(manager)
     try:
-        await manager.atv.keyboard.text_clear()
-    except Exception as err:
+        await manager.atv.keyboard.text_clear()  # type: ignore[union-attr]
+    except ProtocolError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="keyboard_error",

--- a/homeassistant/components/apple_tv/services.yaml
+++ b/homeassistant/components/apple_tv/services.yaml
@@ -1,0 +1,31 @@
+set_keyboard_text:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: apple_tv
+    text:
+      required: true
+      selector:
+        text:
+
+append_keyboard_text:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: apple_tv
+    text:
+      required: true
+      selector:
+        text:
+
+clear_keyboard_text:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: apple_tv

--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -1,58 +1,4 @@
 {
-  "exceptions": {
-    "not_connected": {
-      "message": "Apple TV is not connected"
-    },
-    "keyboard_not_available": {
-      "message": "Keyboard input is not supported by this device"
-    },
-    "keyboard_not_focused": {
-      "message": "No text input field is currently focused on the Apple TV"
-    },
-    "keyboard_error": {
-      "message": "An error occurred while sending text to the Apple TV"
-    }
-  },
-  "services": {
-    "set_keyboard_text": {
-      "name": "Set keyboard text",
-      "description": "Sets the text in the currently focused text input field on an Apple TV.",
-      "fields": {
-        "config_entry_id": {
-          "name": "[%key:common::config_flow::data::config_entry%]",
-          "description": "The Apple TV to send text to."
-        },
-        "text": {
-          "name": "Text",
-          "description": "The text to set."
-        }
-      }
-    },
-    "append_keyboard_text": {
-      "name": "Append keyboard text",
-      "description": "Appends text to the currently focused text input field on an Apple TV.",
-      "fields": {
-        "config_entry_id": {
-          "name": "[%key:common::config_flow::data::config_entry%]",
-          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]"
-        },
-        "text": {
-          "name": "[%key:component::apple_tv::services::set_keyboard_text::fields::text::name%]",
-          "description": "The text to append."
-        }
-      }
-    },
-    "clear_keyboard_text": {
-      "name": "Clear keyboard text",
-      "description": "Clears the text in the currently focused text input field on an Apple TV.",
-      "fields": {
-        "config_entry_id": {
-          "name": "[%key:common::config_flow::data::config_entry%]",
-          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]"
-        }
-      }
-    }
-  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -123,6 +69,20 @@
       }
     }
   },
+  "exceptions": {
+    "keyboard_error": {
+      "message": "An error occurred while sending text to the Apple TV"
+    },
+    "keyboard_not_available": {
+      "message": "Keyboard input is not supported by this device"
+    },
+    "keyboard_not_focused": {
+      "message": "No text input field is currently focused on the Apple TV"
+    },
+    "not_connected": {
+      "message": "Apple TV is not connected"
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -131,6 +91,46 @@
         },
         "description": "Configure general device settings"
       }
+    }
+  },
+  "services": {
+    "append_keyboard_text": {
+      "description": "Appends text to the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]",
+          "name": "[%key:common::config_flow::data::config_entry%]"
+        },
+        "text": {
+          "description": "The text to append.",
+          "name": "[%key:component::apple_tv::services::set_keyboard_text::fields::text::name%]"
+        }
+      },
+      "name": "Append keyboard text"
+    },
+    "clear_keyboard_text": {
+      "description": "Clears the text in the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]",
+          "name": "[%key:common::config_flow::data::config_entry%]"
+        }
+      },
+      "name": "Clear keyboard text"
+    },
+    "set_keyboard_text": {
+      "description": "Sets the text in the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Apple TV to send text to.",
+          "name": "[%key:common::config_flow::data::config_entry%]"
+        },
+        "text": {
+          "description": "The text to set.",
+          "name": "Text"
+        }
+      },
+      "name": "Set keyboard text"
     }
   }
 }

--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -1,4 +1,58 @@
 {
+  "exceptions": {
+    "not_connected": {
+      "message": "Apple TV is not connected"
+    },
+    "keyboard_not_available": {
+      "message": "Keyboard input is not supported by this device"
+    },
+    "keyboard_not_focused": {
+      "message": "No text input field is currently focused on the Apple TV"
+    },
+    "keyboard_error": {
+      "message": "An error occurred while sending text to the Apple TV"
+    }
+  },
+  "services": {
+    "set_keyboard_text": {
+      "name": "Set keyboard text",
+      "description": "Sets the text in the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "name": "[%key:common::config_flow::data::config_entry%]",
+          "description": "The Apple TV to send text to."
+        },
+        "text": {
+          "name": "Text",
+          "description": "The text to set."
+        }
+      }
+    },
+    "append_keyboard_text": {
+      "name": "Append keyboard text",
+      "description": "Appends text to the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "name": "[%key:common::config_flow::data::config_entry%]",
+          "description": "The Apple TV to send text to."
+        },
+        "text": {
+          "name": "Text",
+          "description": "The text to append."
+        }
+      }
+    },
+    "clear_keyboard_text": {
+      "name": "Clear keyboard text",
+      "description": "Clears the text in the currently focused text input field on an Apple TV.",
+      "fields": {
+        "config_entry_id": {
+          "name": "[%key:common::config_flow::data::config_entry%]",
+          "description": "The Apple TV to clear text on."
+        }
+      }
+    }
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -99,7 +99,7 @@
       "fields": {
         "config_entry_id": {
           "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]",
-          "name": "[%key:common::config_flow::data::config_entry%]"
+          "name": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::name%]"
         },
         "text": {
           "description": "The text to append.",
@@ -113,7 +113,7 @@
       "fields": {
         "config_entry_id": {
           "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]",
-          "name": "[%key:common::config_flow::data::config_entry%]"
+          "name": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::name%]"
         }
       },
       "name": "Clear keyboard text"
@@ -123,7 +123,7 @@
       "fields": {
         "config_entry_id": {
           "description": "The Apple TV to send text to.",
-          "name": "[%key:common::config_flow::data::config_entry%]"
+          "name": "Apple TV"
         },
         "text": {
           "description": "The text to set.",

--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -34,10 +34,10 @@
       "fields": {
         "config_entry_id": {
           "name": "[%key:common::config_flow::data::config_entry%]",
-          "description": "The Apple TV to send text to."
+          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]"
         },
         "text": {
-          "name": "Text",
+          "name": "[%key:component::apple_tv::services::set_keyboard_text::fields::text::name%]",
           "description": "The text to append."
         }
       }
@@ -48,7 +48,7 @@
       "fields": {
         "config_entry_id": {
           "name": "[%key:common::config_flow::data::config_entry%]",
-          "description": "The Apple TV to clear text on."
+          "description": "[%key:component::apple_tv::services::set_keyboard_text::fields::config_entry_id::description%]"
         }
       }
     }

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -17,9 +17,9 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_atv() -> MagicMock:
+def mock_atv() -> AsyncMock:
     """Create a mock Apple TV interface with keyboard support."""
-    atv = MagicMock()
+    atv = AsyncMock()
     atv.keyboard = AsyncMock()
     atv.keyboard.text_focus_state = KeyboardFocusState.Focused
     atv.device_info.model = DeviceModel.Gen4K
@@ -33,7 +33,7 @@ def mock_atv() -> MagicMock:
 async def mock_config_entry(
     hass: HomeAssistant,
     mock_async_zeroconf: MagicMock,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> MockConfigEntry:
     """Set up Apple TV integration with mocked pyatv."""
     entry = MockConfigEntry(
@@ -64,7 +64,7 @@ async def mock_config_entry(
 async def test_set_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test setting keyboard text."""
     await hass.services.async_call(
@@ -79,7 +79,7 @@ async def test_set_keyboard_text(
 async def test_append_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test appending keyboard text."""
     await hass.services.async_call(
@@ -97,7 +97,7 @@ async def test_append_keyboard_text(
 async def test_clear_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test clearing keyboard text."""
     await hass.services.async_call(
@@ -112,7 +112,7 @@ async def test_clear_keyboard_text(
 async def test_set_keyboard_text_not_connected(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test error when device is not connected."""
     mock_config_entry.runtime_data.atv = None
@@ -128,7 +128,7 @@ async def test_set_keyboard_text_not_connected(
 async def test_set_keyboard_text_not_focused(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test error when keyboard is not focused."""
     mock_atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
@@ -144,7 +144,7 @@ async def test_set_keyboard_text_not_focused(
 async def test_set_keyboard_text_not_supported(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test error when keyboard is not supported by device."""
     with (
@@ -153,6 +153,7 @@ async def test_set_keyboard_text_not_supported(
             "text_focus_state",
             new_callable=PropertyMock,
             side_effect=NotSupportedError("text_focus_state is not supported"),
+            create=True,
         ),
         pytest.raises(ServiceValidationError),
     ):
@@ -167,7 +168,7 @@ async def test_set_keyboard_text_not_supported(
 async def test_set_keyboard_text_protocol_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_atv: MagicMock,
+    mock_atv: AsyncMock,
 ) -> None:
     """Test error when text_set raises a protocol error."""
     mock_atv.keyboard.text_set.side_effect = ProtocolError("send failed")

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -1,14 +1,19 @@
 """Tests for Apple TV keyboard services."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from pyatv.const import KeyboardFocusState
+from pyatv.exceptions import NotSupportedError, ProtocolError
 import pytest
 
 from homeassistant.components.apple_tv.const import ATTR_TEXT, DOMAIN
+from homeassistant.components.apple_tv.services import async_setup_services
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -22,77 +27,72 @@ def mock_manager() -> MagicMock:
 
 
 @pytest.fixture
-async def mock_config_entry(
-    hass: HomeAssistant, mock_manager: MagicMock
-) -> str:
-    """Set up a mock config entry and return its entry_id."""
-    from homeassistant.config_entries import ConfigEntry
-
-    entry = ConfigEntry(
-        data={},
-        disabled_by=None,
+def mock_config_entry(hass: HomeAssistant, mock_manager: MagicMock) -> MockConfigEntry:
+    """Set up a mock config entry."""
+    entry = MockConfigEntry(
         domain=DOMAIN,
-        minor_version=1,
-        options={},
-        source="user",
         title="Living Room",
         unique_id="test_unique_id",
-        version=1,
     )
+    entry.add_to_hass(hass)
+    entry.mock_state(hass, ConfigEntryState.LOADED)
     entry.runtime_data = mock_manager
-    entry._async_set_state(hass, ConfigEntry.State.LOADED, None)
-    hass.config_entries._entries[entry.entry_id] = entry
-    hass.config_entries._domain_index.setdefault(DOMAIN, []).append(entry.entry_id)
-
-    # Register services
-    from homeassistant.components.apple_tv.services import async_setup_services
-
     async_setup_services(hass)
-
-    return entry.entry_id
+    return entry
 
 
 async def test_set_keyboard_text(
-    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
 ) -> None:
     """Test setting keyboard text."""
     await hass.services.async_call(
         DOMAIN,
         "set_keyboard_text",
-        {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "Star Wars"},
+        {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "Star Wars"},
         blocking=True,
     )
     mock_manager.atv.keyboard.text_set.assert_called_once_with("Star Wars")
 
 
 async def test_append_keyboard_text(
-    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
 ) -> None:
     """Test appending keyboard text."""
     await hass.services.async_call(
         DOMAIN,
         "append_keyboard_text",
-        {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: " Episode IV"},
+        {
+            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+            ATTR_TEXT: " Episode IV",
+        },
         blocking=True,
     )
     mock_manager.atv.keyboard.text_append.assert_called_once_with(" Episode IV")
 
 
 async def test_clear_keyboard_text(
-    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
 ) -> None:
     """Test clearing keyboard text."""
     await hass.services.async_call(
         DOMAIN,
         "clear_keyboard_text",
-        {ATTR_CONFIG_ENTRY_ID: mock_config_entry},
+        {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id},
         blocking=True,
     )
     mock_manager.atv.keyboard.text_clear.assert_called_once()
 
 
 async def test_set_keyboard_text_not_connected(
-    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
 ) -> None:
     """Test error when device is not connected."""
     mock_manager.atv = None
@@ -100,13 +100,15 @@ async def test_set_keyboard_text_not_connected(
         await hass.services.async_call(
             DOMAIN,
             "set_keyboard_text",
-            {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "test"},
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "test"},
             blocking=True,
         )
 
 
 async def test_set_keyboard_text_not_focused(
-    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
 ) -> None:
     """Test error when keyboard is not focused."""
     mock_manager.atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
@@ -114,6 +116,42 @@ async def test_set_keyboard_text_not_focused(
         await hass.services.async_call(
             DOMAIN,
             "set_keyboard_text",
-            {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "test"},
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "test"},
+            blocking=True,
+        )
+
+
+async def test_set_keyboard_text_not_supported(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
+) -> None:
+    """Test error when keyboard is not supported by device."""
+    type(mock_manager.atv.keyboard).text_focus_state = property(
+        lambda self: (_ for _ in ()).throw(
+            NotSupportedError("text_focus_state is not supported")
+        )
+    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_keyboard_text",
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "test"},
+            blocking=True,
+        )
+
+
+async def test_set_keyboard_text_protocol_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_manager: MagicMock,
+) -> None:
+    """Test error when text_set raises a protocol error."""
+    mock_manager.atv.keyboard.text_set.side_effect = ProtocolError("send failed")
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_keyboard_text",
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "test"},
             blocking=True,
         )

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -147,12 +147,15 @@ async def test_set_keyboard_text_not_supported(
     mock_atv: MagicMock,
 ) -> None:
     """Test error when keyboard is not supported by device."""
-    with patch.object(
-        type(mock_atv.keyboard),
-        "text_focus_state",
-        new_callable=PropertyMock,
-        side_effect=NotSupportedError("text_focus_state is not supported"),
-    ), pytest.raises(ServiceValidationError):
+    with (
+        patch.object(
+            type(mock_atv.keyboard),
+            "text_focus_state",
+            new_callable=PropertyMock,
+            side_effect=NotSupportedError("text_focus_state is not supported"),
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
         await hass.services.async_call(
             DOMAIN,
             "set_keyboard_text",

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -2,49 +2,69 @@
 
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from pyatv.const import KeyboardFocusState
+from pyatv.const import DeviceModel, KeyboardFocusState, Protocol
 from pyatv.exceptions import NotSupportedError, ProtocolError
 import pytest
 
 from homeassistant.components.apple_tv.const import ATTR_TEXT, DOMAIN
-from homeassistant.components.apple_tv.services import async_setup_services
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_ADDRESS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from .common import create_conf, mrp_service
 
 from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_manager() -> MagicMock:
-    """Create a mock AppleTVManager."""
-    manager = MagicMock()
-    manager.atv = MagicMock()
-    manager.atv.keyboard = AsyncMock()
-    manager.atv.keyboard.text_focus_state = KeyboardFocusState.Focused
-    return manager
+def mock_atv() -> MagicMock:
+    """Create a mock Apple TV interface with keyboard support."""
+    atv = MagicMock()
+    atv.keyboard = AsyncMock()
+    atv.keyboard.text_focus_state = KeyboardFocusState.Focused
+    atv.device_info.model = DeviceModel.Gen4K
+    atv.device_info.raw_model = "AppleTV6,2"
+    atv.device_info.version = "15.0"
+    atv.device_info.mac = "AA:BB:CC:DD:EE:FF"
+    return atv
 
 
 @pytest.fixture
-def mock_config_entry(hass: HomeAssistant, mock_manager: MagicMock) -> MockConfigEntry:
-    """Set up a mock config entry."""
+async def mock_config_entry(
+    hass: HomeAssistant,
+    mock_async_zeroconf: MagicMock,
+    mock_atv: MagicMock,
+) -> MockConfigEntry:
+    """Set up Apple TV integration with mocked pyatv."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Living Room",
-        unique_id="test_unique_id",
+        unique_id="mrpid",
+        data={
+            CONF_ADDRESS: "127.0.0.1",
+            CONF_NAME: "Living Room",
+            "credentials": {str(Protocol.MRP.value): "mrp_creds"},
+            "identifiers": ["mrpid"],
+        },
     )
     entry.add_to_hass(hass)
-    entry.mock_state(hass, ConfigEntryState.LOADED)
-    entry.runtime_data = mock_manager
-    async_setup_services(hass)
+
+    scan_result = create_conf("127.0.0.1", "Living Room", mrp_service())
+
+    with (
+        patch("homeassistant.components.apple_tv.scan", return_value=[scan_result]),
+        patch("homeassistant.components.apple_tv.connect", return_value=mock_atv),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
     return entry
 
 
 async def test_set_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test setting keyboard text."""
     await hass.services.async_call(
@@ -53,13 +73,13 @@ async def test_set_keyboard_text(
         {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id, ATTR_TEXT: "Star Wars"},
         blocking=True,
     )
-    mock_manager.atv.keyboard.text_set.assert_called_once_with("Star Wars")
+    mock_atv.keyboard.text_set.assert_called_once_with("Star Wars")
 
 
 async def test_append_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test appending keyboard text."""
     await hass.services.async_call(
@@ -71,13 +91,13 @@ async def test_append_keyboard_text(
         },
         blocking=True,
     )
-    mock_manager.atv.keyboard.text_append.assert_called_once_with(" Episode IV")
+    mock_atv.keyboard.text_append.assert_called_once_with(" Episode IV")
 
 
 async def test_clear_keyboard_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test clearing keyboard text."""
     await hass.services.async_call(
@@ -86,16 +106,16 @@ async def test_clear_keyboard_text(
         {ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id},
         blocking=True,
     )
-    mock_manager.atv.keyboard.text_clear.assert_called_once()
+    mock_atv.keyboard.text_clear.assert_called_once()
 
 
 async def test_set_keyboard_text_not_connected(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test error when device is not connected."""
-    mock_manager.atv = None
+    mock_config_entry.runtime_data.atv = None
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,
@@ -108,10 +128,10 @@ async def test_set_keyboard_text_not_connected(
 async def test_set_keyboard_text_not_focused(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test error when keyboard is not focused."""
-    mock_manager.atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
+    mock_atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
     with pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             DOMAIN,
@@ -124,11 +144,11 @@ async def test_set_keyboard_text_not_focused(
 async def test_set_keyboard_text_not_supported(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test error when keyboard is not supported by device."""
     with patch.object(
-        type(mock_manager.atv.keyboard),
+        type(mock_atv.keyboard),
         "text_focus_state",
         new_callable=PropertyMock,
         side_effect=NotSupportedError("text_focus_state is not supported"),
@@ -144,10 +164,10 @@ async def test_set_keyboard_text_not_supported(
 async def test_set_keyboard_text_protocol_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_manager: MagicMock,
+    mock_atv: MagicMock,
 ) -> None:
     """Test error when text_set raises a protocol error."""
-    mock_manager.atv.keyboard.text_set.side_effect = ProtocolError("send failed")
+    mock_atv.keyboard.text_set.side_effect = ProtocolError("send failed")
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             DOMAIN,

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -1,0 +1,119 @@
+"""Tests for Apple TV keyboard services."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pyatv.const import KeyboardFocusState
+import pytest
+
+from homeassistant.components.apple_tv.const import ATTR_TEXT, DOMAIN
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+
+@pytest.fixture
+def mock_manager() -> MagicMock:
+    """Create a mock AppleTVManager."""
+    manager = MagicMock()
+    manager.atv = MagicMock()
+    manager.atv.keyboard = AsyncMock()
+    manager.atv.keyboard.text_focus_state = KeyboardFocusState.Focused
+    return manager
+
+
+@pytest.fixture
+async def mock_config_entry(
+    hass: HomeAssistant, mock_manager: MagicMock
+) -> str:
+    """Set up a mock config entry and return its entry_id."""
+    from homeassistant.config_entries import ConfigEntry
+
+    entry = ConfigEntry(
+        data={},
+        disabled_by=None,
+        domain=DOMAIN,
+        minor_version=1,
+        options={},
+        source="user",
+        title="Living Room",
+        unique_id="test_unique_id",
+        version=1,
+    )
+    entry.runtime_data = mock_manager
+    entry._async_set_state(hass, ConfigEntry.State.LOADED, None)
+    hass.config_entries._entries[entry.entry_id] = entry
+    hass.config_entries._domain_index.setdefault(DOMAIN, []).append(entry.entry_id)
+
+    # Register services
+    from homeassistant.components.apple_tv.services import async_setup_services
+
+    async_setup_services(hass)
+
+    return entry.entry_id
+
+
+async def test_set_keyboard_text(
+    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+) -> None:
+    """Test setting keyboard text."""
+    await hass.services.async_call(
+        DOMAIN,
+        "set_keyboard_text",
+        {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "Star Wars"},
+        blocking=True,
+    )
+    mock_manager.atv.keyboard.text_set.assert_called_once_with("Star Wars")
+
+
+async def test_append_keyboard_text(
+    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+) -> None:
+    """Test appending keyboard text."""
+    await hass.services.async_call(
+        DOMAIN,
+        "append_keyboard_text",
+        {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: " Episode IV"},
+        blocking=True,
+    )
+    mock_manager.atv.keyboard.text_append.assert_called_once_with(" Episode IV")
+
+
+async def test_clear_keyboard_text(
+    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+) -> None:
+    """Test clearing keyboard text."""
+    await hass.services.async_call(
+        DOMAIN,
+        "clear_keyboard_text",
+        {ATTR_CONFIG_ENTRY_ID: mock_config_entry},
+        blocking=True,
+    )
+    mock_manager.atv.keyboard.text_clear.assert_called_once()
+
+
+async def test_set_keyboard_text_not_connected(
+    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+) -> None:
+    """Test error when device is not connected."""
+    mock_manager.atv = None
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_keyboard_text",
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "test"},
+            blocking=True,
+        )
+
+
+async def test_set_keyboard_text_not_focused(
+    hass: HomeAssistant, mock_config_entry: str, mock_manager: MagicMock
+) -> None:
+    """Test error when keyboard is not focused."""
+    mock_manager.atv.keyboard.text_focus_state = KeyboardFocusState.Unfocused
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_keyboard_text",
+            {ATTR_CONFIG_ENTRY_ID: mock_config_entry, ATTR_TEXT: "test"},
+            blocking=True,
+        )

--- a/tests/components/apple_tv/test_services.py
+++ b/tests/components/apple_tv/test_services.py
@@ -1,6 +1,6 @@
 """Tests for Apple TV keyboard services."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from pyatv.const import KeyboardFocusState
 from pyatv.exceptions import NotSupportedError, ProtocolError
@@ -127,12 +127,12 @@ async def test_set_keyboard_text_not_supported(
     mock_manager: MagicMock,
 ) -> None:
     """Test error when keyboard is not supported by device."""
-    type(mock_manager.atv.keyboard).text_focus_state = property(
-        lambda self: (_ for _ in ()).throw(
-            NotSupportedError("text_focus_state is not supported")
-        )
-    )
-    with pytest.raises(ServiceValidationError):
+    with patch.object(
+        type(mock_manager.atv.keyboard),
+        "text_focus_state",
+        new_callable=PropertyMock,
+        side_effect=NotSupportedError("text_focus_state is not supported"),
+    ), pytest.raises(ServiceValidationError):
         await hass.services.async_call(
             DOMAIN,
             "set_keyboard_text",


### PR DESCRIPTION
## Proposed change

Adds three new services to the Apple TV integration that expose pyatv's `Keyboard` interface for text input:

- `apple_tv.set_keyboard_text` — Sets text in the currently focused text input field
- `apple_tv.append_keyboard_text` — Appends text to the currently focused text input field
- `apple_tv.clear_keyboard_text` — Clears the currently focused text input field

### Credit

This work builds on the original implementation by @toscano in #152398. Their PR introduced the concept and initial code. This PR picks up that stalled work and addresses all maintainer feedback from @joostlek:
- Service handlers in a dedicated `services.py` file (Mealie/Overseerr pattern)
- Uses `config_entry_id` targeting instead of `entity_id`
- Follows the [action-setup quality scale rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/action-setup)
- Rebased on current `dev` (no merge conflicts)

The keyboard focus binary sensor (#152397, also by @toscano) is already merged — this PR adds the corresponding service actions.

All three services validate that:
- The device is connected (`HomeAssistantError` if not)
- The keyboard interface is supported (`ServiceValidationError` with `NotSupportedError`)
- A text input field is currently focused (`ServiceValidationError` if unfocused)

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: #152398
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr