### PR TITLE
trigger Activity update only on significant changes in roborock state/attr

### DIFF
--- a/homeassistant/components/roborock/significant_change.py
+++ b/homeassistant/components/roborock/significant_change.py
@@ -28,14 +28,12 @@ def async_check_significant_change(
     **kwargs: Any,
 ) -> bool | None:
     """Test if state significantly changed."""
-    old_attrs_s = set({
-        k: v
-        for k, v in old_attrs.items() if k in SIGNIFICANT_ATTRIBUTES
-    }.items())
-    new_attrs_s = set({
-        k: v
-        for k, v in new_attrs.items() if k in SIGNIFICANT_ATTRIBUTES
-    }.items())
+    old_attrs_s = set(
+        {k: v for k, v in old_attrs.items() if k in SIGNIFICANT_ATTRIBUTES}.items()
+    )
+    new_attrs_s = set(
+        {k: v for k, v in new_attrs.items() if k in SIGNIFICANT_ATTRIBUTES}.items()
+    )
     changed_attrs: set[str] = {item[0] for item in old_attrs_s ^ new_attrs_s}
 
     if old_state != new_state:

--- a/homeassistant/components/roborock/significant_change.py
+++ b/homeassistant/components/roborock/significant_change.py
@@ -1,0 +1,65 @@
+"""Helper to test significant Roborock state changes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.vacuum import ATTR_FAN_SPEED
+from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.significant_change import (
+    check_absolute_change,
+    check_valid_float,
+)
+
+SIGNIFICANT_ATTRIBUTES: set[str] = {
+    ATTR_BATTERY_LEVEL,
+    ATTR_FAN_SPEED,
+}
+
+
+@callback
+def async_check_significant_change(
+    hass: HomeAssistant,
+    old_state: str,
+    old_attrs: dict,
+    new_state: str,
+    new_attrs: dict,
+    **kwargs: Any,
+) -> bool | None:
+    """Test if state significantly changed."""
+    old_attrs_s = set({
+        k: v
+        for k, v in old_attrs.items() if k in SIGNIFICANT_ATTRIBUTES
+    }.items())
+    new_attrs_s = set({
+        k: v
+        for k, v in new_attrs.items() if k in SIGNIFICANT_ATTRIBUTES
+    }.items())
+    changed_attrs: set[str] = {item[0] for item in old_attrs_s ^ new_attrs_s}
+
+    if old_state != new_state:
+        if old_attrs_s == new_attrs_s:
+            # This is a map-only update and is not worth logging.
+            return False
+        return True
+
+    for attr_name in changed_attrs:
+        if attr_name != ATTR_BATTERY_LEVEL:
+            return True
+
+        old_attr_value = old_attrs.get(attr_name)
+        new_attr_value = new_attrs.get(attr_name)
+        if new_attr_value is None or not check_valid_float(new_attr_value):
+            # New attribute value is invalid, ignore it
+            continue
+
+        if old_attr_value is None or not check_valid_float(old_attr_value):
+            # Old attribute value was invalid, we should report again
+            return True
+
+        if check_absolute_change(old_attr_value, new_attr_value, 1.0):
+            return True
+
+    # no significant attribute change detected
+    return False

--- a/homeassistant/components/roborock/significant_change.py
+++ b/homeassistant/components/roborock/significant_change.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.vacuum import ATTR_FAN_SPEED
+from homeassistant.components.vacuum import ATTR_FAN_SPEED, VacuumActivity
 from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.significant_change import (
@@ -15,6 +15,15 @@ from homeassistant.helpers.significant_change import (
 SIGNIFICANT_ATTRIBUTES: set[str] = {
     ATTR_BATTERY_LEVEL,
     ATTR_FAN_SPEED,
+}
+
+VACUUM_STATES: set[str] = {
+    VacuumActivity.CLEANING,
+    VacuumActivity.DOCKED,
+    VacuumActivity.ERROR,
+    VacuumActivity.IDLE,
+    VacuumActivity.PAUSED,
+    VacuumActivity.RETURNING,
 }
 
 
@@ -37,8 +46,10 @@ def async_check_significant_change(
     changed_attrs: set[str] = {item[0] for item in old_attrs_s ^ new_attrs_s}
 
     if old_state != new_state:
-        if old_attrs_s == new_attrs_s:
+        if new_state not in VACUUM_STATES:
             # This is a map-only update and is not worth logging.
+            return False
+        if old_attrs_s == new_attrs_s:
             return False
         return True
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There is a significant_change callback in the generic vacuum component, but the 'state' of roborock is referenced by a timestamp. This timestamp is constantly updated when the map refreshes, so states are constantly logged to the activity logger. The new custom significant_change code reorders the checks to make sure that the state changed and attributes are different.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #161039 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
