### PR TITLE
Add support for Tuya wg2 alarm panel (Duosmart C30)

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -33,7 +33,13 @@ ALARM: dict[DeviceCategory, tuple[AlarmControlPanelEntityDescription, ...]] = {
             key=DPCode.MASTER_MODE,
             name="Alarm",
         ),
-    )
+    ),
+    DeviceCategory.WG2: (
+        AlarmControlPanelEntityDescription(
+            key=DPCode.MASTER_MODE,
+            name="Alarm",
+        ),
+    ),
 }
 
 

--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -317,6 +317,11 @@ BINARY_SENSORS: dict[DeviceCategory, tuple[TuyaBinarySensorEntityDescription, ..
             entity_category=EntityCategory.DIAGNOSTIC,
             on_value="alarm",
         ),
+        TuyaBinarySensorEntityDescription(
+            key=DPCode.CHARGE_STATE,
+            device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        ),
     ),
     DeviceCategory.WK: (
         TuyaBinarySensorEntityDescription(

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -867,6 +867,7 @@ class DPCode(StrEnum):
     SWITCH_7 = "switch_7"  # Switch 7
     SWITCH_8 = "switch_8"  # Switch 8
     SWITCH_ALARM_LIGHT = "switch_alarm_light"
+    SWITCH_ALARM_PROPEL = "switch_alarm_propel"
     SWITCH_ALARM_SOUND = "switch_alarm_sound"
     SWITCH_BACKLIGHT = "switch_backlight"  # Backlight switch
     SWITCH_CHARGE = "switch_charge"
@@ -874,6 +875,7 @@ class DPCode(StrEnum):
     SWITCH_DISTURB = "switch_disturb"
     SWITCH_FAN = "switch_fan"
     SWITCH_HORIZONTAL = "switch_horizontal"  # Horizontal swing flap switch
+    SWITCH_KB_SOUND = "switch_kb_sound"  # Keyboard beep switch
     SWITCH_LED = "switch_led"  # Switch
     SWITCH_LED_1 = "switch_led_1"
     SWITCH_LED_2 = "switch_led_2"

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -383,6 +383,28 @@ NUMBERS: dict[DeviceCategory, tuple[NumberEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    DeviceCategory.WG2: (
+        NumberEntityDescription(
+            key=DPCode.DELAY_SET,
+            # This setting is called "Arm Delay" in the official Tuya app
+            translation_key="arm_delay",
+            device_class=NumberDeviceClass.DURATION,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.ALARM_DELAY_TIME,
+            translation_key="alarm_delay",
+            device_class=NumberDeviceClass.DURATION,
+            entity_category=EntityCategory.CONFIG,
+        ),
+        NumberEntityDescription(
+            key=DPCode.ALARM_TIME,
+            # This setting is called "Siren Duration" in the official Tuya app
+            translation_key="siren_duration",
+            device_class=NumberDeviceClass.DURATION,
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
     DeviceCategory.WK: (
         NumberEntityDescription(
             key=DPCode.TEMP_CORRECTION,

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1233,6 +1233,7 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         *BATTERY_SENSORS,
     ),
+    DeviceCategory.WG2: (*BATTERY_SENSORS,),
     DeviceCategory.WK: (*BATTERY_SENSORS,),
     DeviceCategory.WKCZ: (
         TuyaSensorEntityDescription(

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -915,6 +915,9 @@
       }
     },
     "switch": {
+      "alarm_push": {
+        "name": "Alarm push"
+      },
       "anion": {
         "name": "Anion"
       },
@@ -974,6 +977,9 @@
       },
       "ionizer": {
         "name": "Ionizer"
+      },
+      "keyboard_tone": {
+        "name": "Keyboard tone"
       },
       "motion_alarm": {
         "name": "Motion alarm"

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -790,6 +790,16 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             translation_key="mute",
             entity_category=EntityCategory.CONFIG,
         ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_KB_SOUND,
+            translation_key="keyboard_tone",
+            entity_category=EntityCategory.CONFIG,
+        ),
+        SwitchEntityDescription(
+            key=DPCode.SWITCH_ALARM_PROPEL,
+            translation_key="alarm_push",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ),
     DeviceCategory.WK: (
         SwitchEntityDescription(

--- a/tests/components/tuya/fixtures/wg2_pkhw2vbphv4csrir.json
+++ b/tests/components/tuya/fixtures/wg2_pkhw2vbphv4csrir.json
@@ -1,0 +1,135 @@
+{
+  "name": "C30",
+  "category": "wg2",
+  "product_id": "pkhw2vbphv4csrir",
+  "product_name": "C30",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2024-12-02T20:08:56+00:00",
+  "create_time": "2024-12-02T20:08:56+00:00",
+  "update_time": "2024-12-02T20:08:56+00:00",
+  "function": {
+    "master_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["disarmed", "arm", "home", "sos"]
+      }
+    },
+    "delay_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 256,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "alarm_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 1,
+        "max": 21,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_kb_sound": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "switch_alarm_propel": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "alarm_delay_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 256,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status_range": {
+    "master_mode": {
+      "type": "Enum",
+      "value": {
+        "range": ["disarmed", "arm", "home", "sos"]
+      }
+    },
+    "delay_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 256,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "alarm_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "min",
+        "min": 1,
+        "max": 21,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "switch_kb_sound": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "charge_state": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "battery_percentage": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "alarm_msg": {
+      "type": "Raw",
+      "value": {}
+    },
+    "switch_alarm_propel": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "alarm_delay_time": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 256,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "master_mode": "disarmed",
+    "delay_set": 15,
+    "alarm_time": 3,
+    "switch_kb_sound": true,
+    "charge_state": false,
+    "battery_percentage": 85,
+    "alarm_msg": "**REDACTED**",
+    "switch_alarm_propel": true,
+    "alarm_delay_time": 20
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
@@ -1,4 +1,57 @@
 # serializer version: 1
+# name: test_platform_setup_and_discovery[alarm_control_panel.c30-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'alarm_control_panel',
+    'entity_category': None,
+    'entity_id': 'alarm_control_panel.c30',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <AlarmControlPanelEntityFeature: 11>,
+    'translation_key': None,
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwmaster_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[alarm_control_panel.c30-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'changed_by': None,
+      'code_arm_required': False,
+      'code_format': None,
+      'friendly_name': 'C30',
+      'supported_features': <AlarmControlPanelEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'alarm_control_panel.c30',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disarmed',
+  })
+# ---
 # name: test_platform_setup_and_discovery[alarm_control_panel.multifunction_alarm-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_binary_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_binary_sensor.ambr
@@ -99,6 +99,56 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[binary_sensor.c30_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.c30_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwcharge_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[binary_sensor.c30_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery_charging',
+      'friendly_name': 'C30 Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.c30_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[binary_sensor.cat_feeder_feeding-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_number.ambr
+++ b/tests/components/tuya/snapshots/test_number.ambr
@@ -177,6 +177,186 @@
     'state': '-0.8',
   })
 # ---
+# name: test_platform_setup_and_discovery[number.c30_alarm_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 256.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.c30_alarm_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Alarm delay',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Alarm delay',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_delay',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwalarm_delay_time',
+    'unit_of_measurement': 's',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.c30_alarm_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'C30 Alarm delay',
+      'max': 256.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': 's',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.c30_alarm_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.c30_arm_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 256.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.c30_arm_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Arm delay',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Arm delay',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'arm_delay',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwdelay_set',
+    'unit_of_measurement': 's',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.c30_arm_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'C30 Arm delay',
+      'max': 256.0,
+      'min': 0.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': 's',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.c30_arm_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.c30_siren_duration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'max': 21.0,
+      'min': 1.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.c30_siren_duration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Siren duration',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Siren duration',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'siren_duration',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwalarm_time',
+    'unit_of_measurement': 'min',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.c30_siren_duration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'C30 Siren duration',
+      'max': 21.0,
+      'min': 1.0,
+      'mode': <NumberMode.AUTO: 'auto'>,
+      'step': 1.0,
+      'unit_of_measurement': 'min',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.c30_siren_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[number.c9_volume-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -3875,6 +3875,60 @@
     'state': '0.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.c30_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.c30_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwbattery_percentage',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.c30_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'C30 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.c30_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '85.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.c9_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -1784,6 +1784,104 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.c30_alarm_push-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.c30_alarm_push',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Alarm push',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Alarm push',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_push',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwswitch_alarm_propel',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.c30_alarm_push-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'C30 Alarm push',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.c30_alarm_push',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.c30_keyboard_tone-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.c30_keyboard_tone',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Keyboard tone',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Keyboard tone',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'keyboard_tone',
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwswitch_kb_sound',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.c30_keyboard_tone-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'C30 Keyboard tone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.c30_keyboard_tone',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.c9_flip-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({

--- a/tests/components/tuya/test_alarm_control_panel.py
+++ b/tests/components/tuya/test_alarm_control_panel.py
@@ -43,8 +43,11 @@ async def test_platform_setup_and_discovery(
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 @pytest.mark.parametrize(
-    "mock_device_code",
-    ["mal_gyitctrjj1kefxp2"],
+    ("mock_device_code", "entity_id"),
+    [
+        ("mal_gyitctrjj1kefxp2", "alarm_control_panel.multifunction_alarm"),
+        ("wg2_pkhw2vbphv4csrir", "alarm_control_panel.c30"),
+    ],
 )
 @pytest.mark.parametrize(
     ("service", "command"),
@@ -62,9 +65,9 @@ async def test_service(
     mock_device: CustomerDevice,
     service: str,
     command: dict[str, Any],
+    entity_id: str,
 ) -> None:
     """Test service."""
-    entity_id = "alarm_control_panel.multifunction_alarm"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
     state = hass.states.get(entity_id)
@@ -82,8 +85,11 @@ async def test_service(
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 @pytest.mark.parametrize(
-    "mock_device_code",
-    ["mal_gyitctrjj1kefxp2"],
+    ("mock_device_code", "entity_id"),
+    [
+        ("mal_gyitctrjj1kefxp2", "alarm_control_panel.multifunction_alarm"),
+        ("wg2_pkhw2vbphv4csrir", "alarm_control_panel.c30"),
+    ],
 )
 @pytest.mark.parametrize(
     ("status_updates", "expected_state"),
@@ -131,9 +137,9 @@ async def test_state(
     mock_device: CustomerDevice,
     status_updates: dict[str, Any],
     expected_state: str,
+    entity_id: str,
 ) -> None:
     """Test state."""
-    entity_id = "alarm_control_panel.multifunction_alarm"
     mock_device.status.update(status_updates)
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 


### PR DESCRIPTION
### Proposed change

The wg2 device category is documented in the Tuya platform as "Gateway control", but it is also used by standalone alarm panels such as my Duosmart C30 (product_id: pkhw2vbphv4csrir). I realized that my C30 device (and potentially many other similar devices) was showing up as unsupported with no entities created.

This PR adds entity mappings for wg2 devices across multiple platforms:

- Alarm control panel: master_mode DP (arm -> armed away, disarmed -> disarmed, home -> armed home, sos -> triggered)
- Sensor: battery percentage
- Binary sensor: charging state
- Number: arm delay (delay_set), alarm delay (alarm_delay_time), siren duration (alarm_time)
- Switch: keyboard tone (switch_kb_sound), alarm push notifications (switch_alarm_propel)

Two new DPCode entries are also added: SWITCH_ALARM_PROPEL and SWITCH_KB_SOUND.

The change was tested on a physical Duosmart C30 running via Home Assistant Green (HA 2026.3.1).

### Type of change

- New feature (which adds functionality to an existing integration)

### Additional information

- This PR fixes or closes issue: No
- This PR is related to issue: No
- Link to documentation pull request: N/A

### Checklist

- [x]  I understand the code I am submitting and can explain how it works.
- [x]  The code change is tested and works locally.
- [x]  Local tests pass. Your PR cannot be merged unless tests pass
- [x]  There is no commented out code in this PR.
- [x]  I have followed the development checklist
- [x]  I have followed the perfect PR recommendations
- [x]  The code has been formatted using Ruff (ruff format homeassistant tests)
- [x]  Tests have been added to verify that the new code works.
- [x]  Any generated code has been carefully reviewed for correctness and compliance with project standards.