### PR TITLE
vicare: Remove heating type config, defaulting to auto-detection

### DIFF
--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -27,9 +27,26 @@ from .const import (
     VICARE_TOKEN_FILENAME,
 )
 from .types import ViCareConfigEntry, ViCareData, ViCareDevice
-from .utils import get_device, get_device_serial, login
+from .utils import get_device_serial, login
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: ViCareConfigEntry
+) -> bool:
+    """Migrate old entry."""
+    if config_entry.version > 2:
+        return False
+
+    if config_entry.version == 1:
+        _LOGGER.debug("Migrating ViCare config entry from version 1 to 2")
+        data = {**config_entry.data}
+        data.pop("heating_type", None)
+        hass.config_entries.async_update_entry(config_entry, data=data, version=2)
+        _LOGGER.debug("Migration to version 2 successful")
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bool:
@@ -74,7 +91,7 @@ def setup_vicare_api(hass: HomeAssistant, entry: ViCareConfigEntry) -> PyViCare:
         )
 
     devices = [
-        ViCareDevice(config=device_config, api=get_device(device_config))
+        ViCareDevice(config=device_config, api=device_config.asAutoDetectDevice())
         for device_config in device_config_list
         if bool(device_config.isOnline())
     ]

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -74,7 +74,7 @@ def setup_vicare_api(hass: HomeAssistant, entry: ViCareConfigEntry) -> PyViCare:
         )
 
     devices = [
-        ViCareDevice(config=device_config, api=get_device(entry, device_config))
+        ViCareDevice(config=device_config, api=get_device(device_config))
         for device_config in device_config_list
         if bool(device_config.isOnline())
     ]

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -36,15 +36,17 @@ async def async_migrate_entry(
     hass: HomeAssistant, config_entry: ViCareConfigEntry
 ) -> bool:
     """Migrate old entry."""
-    if config_entry.version > 2:
+    if config_entry.version > 1:
         return False
 
-    if config_entry.version == 1:
-        _LOGGER.debug("Migrating ViCare config entry from version 1 to 2")
+    if config_entry.version == 1 and config_entry.minor_version < 2:
+        _LOGGER.debug("Migrating ViCare config entry from version 1.1 to 1.2")
         data = {**config_entry.data}
         data.pop("heating_type", None)
-        hass.config_entries.async_update_entry(config_entry, data=data, version=2)
-        _LOGGER.debug("Migration to version 2 successful")
+        hass.config_entries.async_update_entry(
+            config_entry, data=data, minor_version=2
+        )
+        _LOGGER.debug("Migration to version 1.2 successful")
 
     return True
 

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -43,9 +43,7 @@ async def async_migrate_entry(
         _LOGGER.debug("Migrating ViCare config entry from version 1.1 to 1.2")
         data = {**config_entry.data}
         data.pop("heating_type", None)
-        hass.config_entries.async_update_entry(
-            config_entry, data=data, minor_version=2
-        )
+        hass.config_entries.async_update_entry(config_entry, data=data, minor_version=2)
         _LOGGER.debug("Migration to version 1.2 successful")
 
     return True

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -18,14 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import (
-    CONF_HEATING_TYPE,
-    DEFAULT_HEATING_TYPE,
-    DOMAIN,
-    VICARE_NAME,
-    VIESSMANN_DEVELOPER_PORTAL,
-    HeatingType,
-)
+from .const import DOMAIN, VICARE_NAME, VIESSMANN_DEVELOPER_PORTAL
 from .utils import login
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,9 +33,6 @@ REAUTH_SCHEMA = vol.Schema(
 USER_SCHEMA = REAUTH_SCHEMA.extend(
     {
         vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_HEATING_TYPE, default=DEFAULT_HEATING_TYPE.value): vol.In(
-            [e.value for e in HeatingType]
-        ),
     }
 )
 

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -40,7 +40,7 @@ USER_SCHEMA = REAUTH_SCHEMA.extend(
 class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ViCare."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/vicare/config_flow.py
+++ b/homeassistant/components/vicare/config_flow.py
@@ -40,7 +40,8 @@ USER_SCHEMA = REAUTH_SCHEMA.extend(
 class ViCareConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for ViCare."""
 
-    VERSION = 2
+    VERSION = 1
+    MINOR_VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/vicare/const.py
+++ b/homeassistant/components/vicare/const.py
@@ -1,7 +1,5 @@
 """Constants for the ViCare integration."""
 
-import enum
-
 from homeassistant.const import Platform
 
 DOMAIN = "vicare"
@@ -31,7 +29,6 @@ VICARE_TOKEN_FILENAME = "vicare_token.save"
 VIESSMANN_DEVELOPER_PORTAL = "https://app.developer.viessmann-climatesolutions.com"
 
 CONF_CIRCUIT = "circuit"
-CONF_HEATING_TYPE = "heating_type"
 
 DEFAULT_CACHE_DURATION = 60
 
@@ -43,28 +40,3 @@ VICARE_KWH = "kilowattHour"
 VICARE_PERCENT = "percent"
 VICARE_W = "watt"
 VICARE_WH = "wattHour"
-
-
-class HeatingType(enum.Enum):
-    """Possible options for heating type."""
-
-    auto = "auto"
-    gas = "gas"
-    oil = "oil"
-    pellets = "pellets"
-    heatpump = "heatpump"
-    fuelcell = "fuelcell"
-    hybrid = "hybrid"
-
-
-DEFAULT_HEATING_TYPE = HeatingType.auto
-
-HEATING_TYPE_TO_CREATOR_METHOD = {
-    HeatingType.auto: "asAutoDetectDevice",
-    HeatingType.gas: "asGazBoiler",
-    HeatingType.fuelcell: "asFuelCell",
-    HeatingType.heatpump: "asHeatPump",
-    HeatingType.oil: "asOilBoiler",
-    HeatingType.pellets: "asPelletsBoiler",
-    HeatingType.hybrid: "asHybridDevice",
-}

--- a/homeassistant/components/vicare/strings.json
+++ b/homeassistant/components/vicare/strings.json
@@ -24,13 +24,11 @@
       "user": {
         "data": {
           "client_id": "Client ID",
-          "heating_type": "Heating type",
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::email%]"
         },
         "data_description": {
           "client_id": "The ID of the API client created in the [Viessmann developer portal]({viessmann_developer_portal}).",
-          "heating_type": "Allows to overrule the device auto detection.",
           "password": "The password to log in to your ViCare account.",
           "username": "The email address to log in to your ViCare account."
         },

--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from PyViCare.PyViCare import PyViCare
 from PyViCare.PyViCareDevice import Device as PyViCareDevice
-from PyViCare.PyViCareDeviceConfig import PyViCareDeviceConfig
 from PyViCare.PyViCareHeatingDevice import (
     HeatingDeviceWithComponent as PyViCareHeatingDeviceComponent,
 )
@@ -45,11 +44,6 @@ def login(
         hass.config.path(STORAGE_DIR, VICARE_TOKEN_FILENAME),
     )
     return vicare_api
-
-
-def get_device(device_config: PyViCareDeviceConfig) -> PyViCareDevice:
-    """Get device for device config."""
-    return device_config.asAutoDetectDevice()
 
 
 def get_device_serial(device: PyViCareDevice) -> str | None:

--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -25,14 +25,7 @@ from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import (
-    CONF_HEATING_TYPE,
-    DEFAULT_CACHE_DURATION,
-    HEATING_TYPE_TO_CREATOR_METHOD,
-    VICARE_TOKEN_FILENAME,
-    HeatingType,
-)
-from .types import ViCareConfigEntry
+from .const import DEFAULT_CACHE_DURATION, VICARE_TOKEN_FILENAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,14 +47,9 @@ def login(
     return vicare_api
 
 
-def get_device(
-    entry: ViCareConfigEntry, device_config: PyViCareDeviceConfig
-) -> PyViCareDevice:
+def get_device(device_config: PyViCareDeviceConfig) -> PyViCareDevice:
     """Get device for device config."""
-    return getattr(
-        device_config,
-        HEATING_TYPE_TO_CREATOR_METHOD[HeatingType(entry.data[CONF_HEATING_TYPE])],
-    )()
+    return device_config.asAutoDetectDevice()
 
 
 def get_device_serial(device: PyViCareDevice) -> str | None:

--- a/tests/components/vicare/__init__.py
+++ b/tests/components/vicare/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.components.vicare.const import CONF_HEATING_TYPE
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
@@ -16,7 +15,6 @@ ENTRY_CONFIG: Final[dict[str, str]] = {
     CONF_USERNAME: "foo@bar.com",
     CONF_PASSWORD: "1234",
     CONF_CLIENT_ID: "5678",
-    CONF_HEATING_TYPE: "auto",
 }
 
 MOCK_MAC = "B874241B7B9"

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -76,7 +76,7 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id="ViCare",
         entry_id="1234",
         data=ENTRY_CONFIG,
-        version=2,
+        minor_version=2,
     )
 
 

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -76,6 +76,7 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id="ViCare",
         entry_id="1234",
         data=ENTRY_CONFIG,
+        version=2,
     )
 
 

--- a/tests/components/vicare/snapshots/test_config_flow.ambr
+++ b/tests/components/vicare/snapshots/test_config_flow.ambr
@@ -2,7 +2,6 @@
 # name: test_form_dhcp
   dict({
     'client_id': '5678',
-    'heating_type': 'auto',
     'password': '1234',
     'username': 'foo@bar.com',
   })
@@ -10,7 +9,6 @@
 # name: test_user_create_entry
   dict({
     'client_id': '5678',
-    'heating_type': 'auto',
     'password': '1234',
     'username': 'foo@bar.com',
   })

--- a/tests/components/vicare/snapshots/test_diagnostics.ambr
+++ b/tests/components/vicare/snapshots/test_diagnostics.ambr
@@ -4732,7 +4732,7 @@
       }),
       'domain': 'vicare',
       'entry_id': '1234',
-      'minor_version': 1,
+      'minor_version': 2,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -4742,7 +4742,7 @@
       ]),
       'title': 'Mock Title',
       'unique_id': 'ViCare',
-      'version': 2,
+      'version': 1,
     }),
   })
 # ---

--- a/tests/components/vicare/snapshots/test_diagnostics.ambr
+++ b/tests/components/vicare/snapshots/test_diagnostics.ambr
@@ -4742,7 +4742,7 @@
       ]),
       'title': 'Mock Title',
       'unique_id': 'ViCare',
-      'version': 1,
+      'version': 2,
     }),
   })
 # ---

--- a/tests/components/vicare/snapshots/test_diagnostics.ambr
+++ b/tests/components/vicare/snapshots/test_diagnostics.ambr
@@ -4724,7 +4724,6 @@
     'entry': dict({
       'data': dict({
         'client_id': '**REDACTED**',
-        'heating_type': 'auto',
         'password': '**REDACTED**',
         'username': '**REDACTED**',
       }),

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -7,10 +7,50 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import MODULE
+from . import ENTRY_CONFIG, MODULE
 from .conftest import Fixture, MockPyViCare
 
 from tests.common import MockConfigEntry
+
+
+async def test_migrate_entry_v1_to_v2(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test migration of config entry from v1 to v2 removes heating_type."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ViCare",
+        data={**ENTRY_CONFIG, "heating_type": "auto"},
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 2
+    assert "heating_type" not in config_entry.data
+
+
+async def test_migrate_entry_v1_to_v2_no_heating_type(
+    hass: HomeAssistant,
+    mock_setup_entry: None,
+) -> None:
+    """Test migration of config entry from v1 to v2 when heating_type is absent."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ViCare",
+        data=ENTRY_CONFIG,
+        version=1,
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.version == 2
+    assert "heating_type" not in config_entry.data
 
 
 # Device migration test can be removed in 2025.4.0

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -13,43 +13,47 @@ from .conftest import Fixture, MockPyViCare
 from tests.common import MockConfigEntry
 
 
-async def test_migrate_entry_v1_to_v2(
+async def test_migrate_entry_v1_1_to_v1_2(
     hass: HomeAssistant,
     mock_setup_entry: None,
 ) -> None:
-    """Test migration of config entry from v1 to v2 removes heating_type."""
+    """Test migration of config entry from v1.1 to v1.2 removes heating_type."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="ViCare",
         data={**ENTRY_CONFIG, "heating_type": "auto"},
         version=1,
+        minor_version=1,
     )
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.version == 2
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 2
     assert "heating_type" not in config_entry.data
 
 
-async def test_migrate_entry_v1_to_v2_no_heating_type(
+async def test_migrate_entry_v1_1_to_v1_2_no_heating_type(
     hass: HomeAssistant,
     mock_setup_entry: None,
 ) -> None:
-    """Test migration of config entry from v1 to v2 when heating_type is absent."""
+    """Test migration of config entry from v1.1 to v1.2 when heating_type is absent."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="ViCare",
         data=ENTRY_CONFIG,
         version=1,
+        minor_version=1,
     )
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.version == 2
+    assert config_entry.version == 1
+    assert config_entry.minor_version == 2
     assert "heating_type" not in config_entry.data
 
 


### PR DESCRIPTION
## Proposed change

Remove the heating type selection from the ViCare config flow and always use auto-detection (`asAutoDetectDevice()`).

The heating type option was a legacy workaround for early PyViCare versions where auto-detection was unreliable. Modern PyViCare auto-detects device types reliably based on API roles, making the manual override unnecessary.

This simplifies the setup flow and removes dead code (the `HeatingType` enum, `HEATING_TYPE_TO_CREATOR_METHOD` mapping, and related constants).

Existing config entries that still have `heating_type` stored are unaffected — the value is simply ignored.

Requested by @CFenner in #165621.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr