### PR TITLE
Use external library wrapper in Tuya cover

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -6,16 +6,18 @@ from dataclasses import dataclass
 from typing import Any
 
 from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import (
-    DPCodeBooleanWrapper,
-    DPCodeEnumWrapper,
-    DPCodeIntegerWrapper,
+from tuya_device_handlers.device_wrapper.cover import (
+    ControlBackModePercentageMappingWrapper,
+    CoverClosedEnumWrapper,
+    CoverInstructionBooleanWrapper,
+    CoverInstructionEnumWrapper,
+    CoverInstructionSpecialEnumWrapper,
 )
-from tuya_device_handlers.type_information import (
-    EnumTypeInformation,
-    IntegerTypeInformation,
+from tuya_device_handlers.device_wrapper.extended import (
+    DPCodeInvertedBooleanWrapper,
+    DPCodeInvertedPercentageWrapper,
+    DPCodePercentageWrapper,
 )
-from tuya_device_handlers.utils import RemapHelper
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.cover import (
@@ -35,123 +37,17 @@ from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 
 
-class _DPCodePercentageMappingWrapper(DPCodeIntegerWrapper[int]):
-    """Wrapper for DPCode position values mapping to 0-100 range."""
-
-    def __init__(self, dpcode: str, type_information: IntegerTypeInformation) -> None:
-        """Init DPCodeIntegerWrapper."""
-        super().__init__(dpcode, type_information)
-        self._remap_helper = RemapHelper.from_type_information(type_information, 0, 100)
-
-    def _position_reversed(self, device: CustomerDevice) -> bool:
-        """Check if the position and direction should be reversed."""
-        return False
-
-    def read_device_status(self, device: CustomerDevice) -> int | None:
-        if (value := device.status.get(self.dpcode)) is None:
-            return None
-
-        return round(
-            self._remap_helper.remap_value_to(
-                value, reverse=self._position_reversed(device)
-            )
-        )
-
-    def _convert_value_to_raw_value(self, device: CustomerDevice, value: Any) -> Any:
-        return round(
-            self._remap_helper.remap_value_from(
-                value, reverse=self._position_reversed(device)
-            )
-        )
-
-
-class _InvertedPercentageMappingWrapper(_DPCodePercentageMappingWrapper):
-    """Wrapper for DPCode position values mapping to 0-100 range."""
-
-    def _position_reversed(self, device: CustomerDevice) -> bool:
-        """Check if the position and direction should be reversed."""
-        return True
-
-
-class _ControlBackModePercentageMappingWrapper(_DPCodePercentageMappingWrapper):
-    """Wrapper for DPCode position values with control_back_mode support."""
-
-    def _position_reversed(self, device: CustomerDevice) -> bool:
-        """Check if the position and direction should be reversed."""
-        return device.status.get(DPCode.CONTROL_BACK_MODE) != "back"
-
-
-class _InstructionBooleanWrapper(DPCodeBooleanWrapper):
-    """Wrapper for boolean-based open/close instructions."""
-
-    options = ["open", "close"]
-    _ACTION_MAPPINGS = {"open": True, "close": False}
-
-    def _convert_value_to_raw_value(self, device: CustomerDevice, value: str) -> bool:
-        return self._ACTION_MAPPINGS[value]
-
-
-class _InstructionEnumWrapper(DPCodeEnumWrapper):
-    """Wrapper for enum-based open/close/stop instructions."""
-
-    _ACTION_MAPPINGS = {"open": "open", "close": "close", "stop": "stop"}
-
-    def __init__(self, dpcode: str, type_information: EnumTypeInformation) -> None:
-        super().__init__(dpcode, type_information)
-        self.options = [
-            ha_action
-            for ha_action, tuya_action in self._ACTION_MAPPINGS.items()
-            if tuya_action in type_information.range
-        ]
-
-    def _convert_value_to_raw_value(self, device: CustomerDevice, value: str) -> str:
-        return self._ACTION_MAPPINGS[value]
-
-
-class _SpecialInstructionEnumWrapper(_InstructionEnumWrapper):
-    """Wrapper for enum-based instructions with special values (FZ/ZZ/STOP)."""
-
-    _ACTION_MAPPINGS = {"open": "FZ", "close": "ZZ", "stop": "STOP"}
-
-
-class _IsClosedInvertedWrapper(DPCodeBooleanWrapper):
-    """Boolean wrapper for checking if cover is closed (inverted)."""
-
-    def read_device_status(self, device: CustomerDevice) -> bool | None:
-        if (value := self._read_dpcode_value(device)) is None:
-            return None
-        return not value
-
-
-class _IsClosedEnumWrapper(DPCodeEnumWrapper[bool]):
-    """Enum wrapper for checking if state is closed."""
-
-    _MAPPINGS = {
-        "close": True,
-        "fully_close": True,
-        "open": False,
-        "fully_open": False,
-    }
-
-    def read_device_status(self, device: CustomerDevice) -> bool | None:
-        if (value := self._read_dpcode_value(device)) is None:
-            return None
-        return self._MAPPINGS.get(value)
-
-
 @dataclass(frozen=True)
 class TuyaCoverEntityDescription(CoverEntityDescription):
     """Describe a Tuya cover entity."""
 
     current_state: DPCode | tuple[DPCode, ...] | None = None
-    current_state_wrapper: type[_IsClosedInvertedWrapper | _IsClosedEnumWrapper] = (
-        _IsClosedEnumWrapper
-    )
+    current_state_wrapper: type[
+        DPCodeInvertedBooleanWrapper | CoverClosedEnumWrapper
+    ] = CoverClosedEnumWrapper
     current_position: DPCode | tuple[DPCode, ...] | None = None
-    instruction_wrapper: type[_InstructionEnumWrapper] = _InstructionEnumWrapper
-    position_wrapper: type[_DPCodePercentageMappingWrapper] = (
-        _InvertedPercentageMappingWrapper
-    )
+    instruction_wrapper: type[CoverInstructionEnumWrapper] = CoverInstructionEnumWrapper
+    position_wrapper: type[DPCodePercentageWrapper] = DPCodeInvertedPercentageWrapper
     set_position: DPCode | None = None
 
 
@@ -162,7 +58,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_key="indexed_door",
             translation_placeholders={"index": "1"},
             current_state=DPCode.DOORCONTACT_STATE,
-            current_state_wrapper=_IsClosedInvertedWrapper,
+            current_state_wrapper=DPCodeInvertedBooleanWrapper,
             device_class=CoverDeviceClass.GARAGE,
         ),
         TuyaCoverEntityDescription(
@@ -170,7 +66,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_key="indexed_door",
             translation_placeholders={"index": "2"},
             current_state=DPCode.DOORCONTACT_STATE_2,
-            current_state_wrapper=_IsClosedInvertedWrapper,
+            current_state_wrapper=DPCodeInvertedBooleanWrapper,
             device_class=CoverDeviceClass.GARAGE,
         ),
         TuyaCoverEntityDescription(
@@ -178,7 +74,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_key="indexed_door",
             translation_placeholders={"index": "3"},
             current_state=DPCode.DOORCONTACT_STATE_3,
-            current_state_wrapper=_IsClosedInvertedWrapper,
+            current_state_wrapper=DPCodeInvertedBooleanWrapper,
             device_class=CoverDeviceClass.GARAGE,
         ),
     ),
@@ -213,7 +109,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             current_position=DPCode.POSITION,
             set_position=DPCode.POSITION,
             device_class=CoverDeviceClass.CURTAIN,
-            instruction_wrapper=_SpecialInstructionEnumWrapper,
+            instruction_wrapper=CoverInstructionSpecialEnumWrapper,
         ),
         # switch_1 is an undocumented code that behaves identically to control
         # It is used by the Kogan Smart Blinds Driver
@@ -230,7 +126,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             key=DPCode.CONTROL,
             translation_key="curtain",
             current_position=DPCode.PERCENT_CONTROL,
-            position_wrapper=_ControlBackModePercentageMappingWrapper,
+            position_wrapper=ControlBackModePercentageMappingWrapper,
             set_position=DPCode.PERCENT_CONTROL,
             device_class=CoverDeviceClass.CURTAIN,
         ),
@@ -239,7 +135,7 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
             translation_key="indexed_curtain",
             translation_placeholders={"index": "2"},
             current_position=DPCode.PERCENT_CONTROL_2,
-            position_wrapper=_ControlBackModePercentageMappingWrapper,
+            position_wrapper=ControlBackModePercentageMappingWrapper,
             set_position=DPCode.PERCENT_CONTROL_2,
             device_class=CoverDeviceClass.CURTAIN,
         ),
@@ -266,7 +162,7 @@ def _get_instruction_wrapper(
         return enum_wrapper
 
     # Fallback to a boolean wrapper if available
-    return _InstructionBooleanWrapper.find_dpcode(
+    return CoverInstructionBooleanWrapper.find_dpcode(
         device, description.key, prefer_function=True
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace:
- `_DPCodePercentageMappingWrapper` with `DPCodePercentageWrapper`
- `_InvertedPercentageMappingWrapper` with `DPCodeInvertedPercentageWrapper`
- `_ControlBackModePercentageMappingWrapper` with `ControlBackModePercentageMappingWrapper`
- `_InstructionBooleanWrapper` with `CoverInstructionBooleanWrapper`
- `_InstructionEnumWrapper` with `CoverInstructionEnumWrapper`
- `_SpecialInstructionEnumWrapper` with `CoverInstructionSpecialEnumWrapper`
- `_IsClosedInvertedWrapper` with `DPCodeInvertedBooleanWrapper`
- `_IsClosedEnumWrapper` with `CoverClosedEnumWrapper`

Follow-up to #165462

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
