### PR TITLE
Bump Pysmlight to 0.3.0

### DIFF
--- a/homeassistant/components/smlight/manifest.json
+++ b/homeassistant/components/smlight/manifest.json
@@ -12,7 +12,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "silver",
-  "requirements": ["pysmlight==0.2.16"],
+  "requirements": ["pysmlight==0.3.0"],
   "zeroconf": [
     {
       "type": "_slzb-06._tcp.local."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2488,7 +2488,7 @@ pysmhi==1.1.0
 pysml==0.1.5
 
 # homeassistant.components.smlight
-pysmlight==0.2.16
+pysmlight==0.3.0
 
 # homeassistant.components.snmp
 pysnmp==7.1.22

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2120,7 +2120,7 @@ pysmhi==1.1.0
 pysml==0.1.5
 
 # homeassistant.components.smlight
-pysmlight==0.2.16
+pysmlight==0.3.0
 
 # homeassistant.components.snmp
 pysnmp==7.1.22

--- a/tests/components/smlight/snapshots/test_diagnostics.ambr
+++ b/tests/components/smlight/snapshots/test_diagnostics.ambr
@@ -3,11 +3,14 @@
   dict({
     'info': dict({
       'MAC': 'AA:BB:CC:DD:EE:FF',
+      'addons': dict({
+      }),
       'coord_mode': 0,
       'device_ip': '192.168.1.161',
       'fs_total': 3456,
       'fw_channel': 'dev',
       'hostname': 'SLZB-06p7',
+      'hw_version': None,
       'legacy_api': 0,
       'model': 'SLZB-06p7',
       'radios': list([
@@ -30,6 +33,7 @@
       ]),
       'ram_total': 296,
       'sw_version': 'v2.3.6',
+      'u_device': False,
       'wifi_mode': 0,
       'zb_channel': 0,
       'zb_flash_size': 704,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
New feature release that provides new API to control peripherals on SMLIGHT SLZB-Ultima devices. This will allow to add new platform support for RGB LED Strip, IR Remote and Buzzer on these devices. It is otherwise backwards compatible with all other devices.

https://github.com/smlight-tech/pysmlight/releases/tag/v0.3.0
Full Changelog: https://github.com/smlight-tech/pysmlight/compare/v0.2.16...v0.3.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X]Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X]] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X]Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
