### PR TITLE
Fix victron_ble charger error sensor always showing unknown

### DIFF
--- a/homeassistant/components/victron_ble/sensor.py
+++ b/homeassistant/components/victron_ble/sensor.py
@@ -148,7 +148,10 @@ def error_to_state(value: float | str | None) -> str | None:
         "network_c": "network",
         "network_d": "network",
     }
-    return value_map.get(value)
+    mapped = value_map.get(value)
+    if mapped is not None:
+        return mapped
+    return value if isinstance(value, str) and value in CHARGER_ERROR_OPTIONS else None
 
 
 DEVICE_STATE_OPTIONS = [

--- a/tests/components/victron_ble/snapshots/test_sensor.ambr
+++ b/tests/components/victron_ble/snapshots/test_sensor.ambr
@@ -287,7 +287,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'no_error',
   })
 # ---
 # name: test_sensors[ac_charger][sensor.smart_charger_output_phase_1_current-entry]
@@ -2817,7 +2817,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'no_error',
   })
 # ---
 # name: test_sensors[solar_charger][sensor.solar_charger_external_device_load-entry]

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -4,6 +4,8 @@ from home_assistant_bluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.victron_ble.const import DOMAIN
+from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -24,6 +26,21 @@ from .fixtures import (
 
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.bluetooth import inject_bluetooth_service_info
+
+VICTRON_IDENTIFIER = 0x02E1
+
+# Crafted solar charger advertisements with specific charger_error values.
+# These are real encrypted payloads using VICTRON_SOLAR_CHARGER_TOKEN.
+SOLAR_CHARGER_ERROR_PAYLOADS = {
+    # ChargerError.NO_ERROR -> state "no_error"
+    "no_error": "100242a0016207adceb37b605d7e0ee21b24df5c0404040410951e81ea42b0492e356ad5ed8f7eb7",
+    # ChargerError.INTERNAL_SUPPLY_A -> mapped to state "internal_supply"
+    "internal_supply": "100242a0016207adce787b605d7e0ee21b24df5c0404040410951e81ea42b0492e356ad5ed8f7eb7",
+    # ChargerError.VOLTAGE_HIGH -> state "voltage_high"
+    "voltage_high": "100242a0016207adceb17b605d7e0ee21b24df5c0404040410951e81ea42b0492e356ad5ed8f7eb7",
+    # ChargerError.NETWORK_A -> mapped to state "network"
+    "network": "100242a0016207adcef77b605d7e0ee21b24df5c0404040410951e81ea42b0492e356ad5ed8f7eb7",
+}
 
 
 @pytest.mark.usefixtures("enable_bluetooth")
@@ -72,3 +89,48 @@ async def test_sensors(
 
     # Use snapshot testing to verify all entity states and registry entries
     await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
+@pytest.mark.parametrize(
+    ("payload_hex", "expected_state"),
+    [
+        (SOLAR_CHARGER_ERROR_PAYLOADS["no_error"], "no_error"),
+        (SOLAR_CHARGER_ERROR_PAYLOADS["internal_supply"], "internal_supply"),
+        (SOLAR_CHARGER_ERROR_PAYLOADS["voltage_high"], "voltage_high"),
+        (SOLAR_CHARGER_ERROR_PAYLOADS["network"], "network"),
+    ],
+    ids=["no_error", "internal_supply_variant", "voltage_high", "network_variant"],
+)
+async def test_charger_error_state(
+    hass: HomeAssistant,
+    payload_hex: str,
+    expected_state: str,
+) -> None:
+    """Test that charger error values are correctly mapped to sensor states."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_ACCESS_TOKEN: VICTRON_SOLAR_CHARGER_TOKEN},
+        unique_id=VICTRON_SOLAR_CHARGER_SERVICE_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    service_info = BluetoothServiceInfo(
+        name="Solar Charger",
+        address=VICTRON_SOLAR_CHARGER_SERVICE_INFO.address,
+        rssi=-60,
+        manufacturer_data={VICTRON_IDENTIFIER: bytes.fromhex(payload_hex)},
+        service_data={},
+        service_uuids=[],
+        source="local",
+    )
+
+    inject_bluetooth_service_info(hass, service_info)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.solar_charger_charger_error")
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/components/victron_ble/test_sensor.py
+++ b/tests/components/victron_ble/test_sensor.py
@@ -4,7 +4,7 @@ from home_assistant_bluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.victron_ble.const import DOMAIN
+from homeassistant.components.victron_ble.const import DOMAIN, VICTRON_IDENTIFIER
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -26,8 +26,6 @@ from .fixtures import (
 
 from tests.common import MockConfigEntry, snapshot_platform
 from tests.components.bluetooth import inject_bluetooth_service_info
-
-VICTRON_IDENTIFIER = 0x02E1
 
 # Crafted solar charger advertisements with specific charger_error values.
 # These are real encrypted payloads using VICTRON_SOLAR_CHARGER_TOKEN.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `error_to_state()` converter in the Victron BLE integration only maps variant-suffixed error codes (like `internal_supply_a` → `internal_supply`) but returns `None` for values that are already valid options (like `no_error`). This causes the `charger_error` enum sensor to always show as `unknown`, even when the device reports a valid error state such as `no_error`.

The fix falls back to returning the value itself when it is a recognized option in `CHARGER_ERROR_OPTIONS`, with a type check to satisfy mypy.

This was identified during review of #165473: https://github.com/home-assistant/core/pull/165473#discussion_r2940692990

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: https://github.com/home-assistant/core/pull/165473#discussion_r2940692990
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr