### PR TITLE
Fix last reset handling in Tessie

### DIFF
--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -9,6 +9,7 @@ from itertools import chain
 from typing import cast
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -81,7 +82,7 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
     ),
     TessieSensorEntityDescription(
         key="charge_state_charge_energy_added",
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,
         suggested_display_precision=1,
@@ -479,6 +480,17 @@ ENERGY_HISTORY_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = tuple(
 
 PARALLEL_UPDATES = 0
 
+CHARGE_ENERGY_RESET_KEYS = frozenset({"charge_state_charge_energy_added"})
+CHARGE_ENERGY_RESET_THRESHOLD = 1.0  # kWh
+
+
+def _is_charge_energy_reset(previous_value: float | None, new_value: float) -> bool:
+    """Return if a charge energy value indicates a reset."""
+    return previous_value is not None and (
+        (new_value == 0 and previous_value != 0)
+        or new_value < previous_value - CHARGE_ENERGY_RESET_THRESHOLD
+    )
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -533,10 +545,11 @@ async def async_setup_entry(
     )
 
 
-class TessieVehicleSensorEntity(TessieEntity, SensorEntity):
+class TessieVehicleSensorEntity(TessieEntity, RestoreSensor):
     """Base class for Tessie sensor entities."""
 
     entity_description: TessieSensorEntityDescription
+    _previous_native_value: float | None = None
 
     def __init__(
         self,
@@ -546,6 +559,26 @@ class TessieVehicleSensorEntity(TessieEntity, SensorEntity):
         """Initialize the sensor."""
         self.entity_description = description
         super().__init__(vehicle, description.key)
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        await super().async_added_to_hass()
+        if (
+            self.entity_description.key in CHARGE_ENERGY_RESET_KEYS
+            and (last_state := await self.async_get_last_state()) is not None
+            and (last_reset := last_state.attributes.get("last_reset")) is not None
+        ):
+            self._attr_last_reset = dt_util.parse_datetime(str(last_reset))
+
+    def _async_update_attrs(self) -> None:
+        """Update the attributes of the sensor."""
+        if self.entity_description.key in CHARGE_ENERGY_RESET_KEYS:
+            raw_value = self.get()
+            if isinstance(raw_value, float | int):
+                new_value = float(raw_value)
+                if _is_charge_energy_reset(self._previous_native_value, new_value):
+                    self._attr_last_reset = dt_util.utcnow()
+                self._previous_native_value = new_value
 
     @property
     def native_value(self) -> StateType | datetime:

--- a/tests/components/tessie/snapshots/test_sensor.ambr
+++ b/tests/components/tessie/snapshots/test_sensor.ambr
@@ -2449,7 +2449,7 @@
     }),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -2489,7 +2489,7 @@
     'attributes': ReadOnlyDict({
       'device_class': 'energy',
       'friendly_name': 'Test Charge energy added',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -1,5 +1,9 @@
 """Test the Tessie sensor platform."""
 
+from copy import deepcopy
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -8,7 +12,9 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import TEST_VEHICLE_STATE_ONLINE, assert_entities, setup_platform
+
+from tests.common import async_fire_time_changed
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -25,3 +31,114 @@ async def test_sensors(
     entry = await setup_platform(hass, [Platform.SENSOR])
 
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
+
+
+async def test_charge_energy_reset(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_get_state: AsyncMock,
+) -> None:
+    """Test reset detection for charge energy sensor."""
+
+    freezer.move_to("2024-01-01 00:00:00+00:00")
+
+    # Initial fixture has charge_energy_added = 18.47
+    await setup_platform(hass, [Platform.SENSOR])
+    entity_id = "sensor.test_charge_energy_added"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "18.47"
+    assert state.attributes.get("last_reset") is None
+
+    # Small correction should NOT trigger reset
+    correction_data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
+    correction_data["charge_state"]["charge_energy_added"] = 18.0
+    mock_get_state.return_value = correction_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "18.0"
+    assert state.attributes.get("last_reset") is None
+
+    # Drop to 0 should trigger reset
+    freezer.move_to("2024-01-01 01:00:00+00:00")
+    reset_data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
+    reset_data["charge_state"]["charge_energy_added"] = 0
+    mock_get_state.return_value = reset_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "0"
+    assert state.attributes.get("last_reset") is not None
+    last_reset = state.attributes["last_reset"]
+
+    # Additional 0 updates should not move last_reset forward
+    freezer.move_to("2024-01-01 01:30:00+00:00")
+    mock_get_state.return_value = reset_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "0"
+    assert state.attributes["last_reset"] == last_reset
+
+    # Large drop (> 1 kWh) should trigger reset
+    increase_data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
+    increase_data["charge_state"]["charge_energy_added"] = 20.0
+    mock_get_state.return_value = increase_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    freezer.move_to("2024-01-01 02:00:00+00:00")
+    drop_data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
+    drop_data["charge_state"]["charge_energy_added"] = 5.0
+    mock_get_state.return_value = drop_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "5.0"
+    assert state.attributes.get("last_reset") is not None
+
+
+async def test_charge_energy_restore_last_reset(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_get_state: AsyncMock,
+) -> None:
+    """Test that last_reset is restored after a reload."""
+
+    freezer.move_to("2024-01-01 00:00:00+00:00")
+
+    # Initial fixture has charge_energy_added = 18.47
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    entity_id = "sensor.test_charge_energy_added"
+
+    # Trigger a reset by dropping to 0
+    freezer.move_to("2024-01-01 01:00:00+00:00")
+    reset_data = deepcopy(TEST_VEHICLE_STATE_ONLINE)
+    reset_data["charge_state"]["charge_energy_added"] = 0
+    mock_get_state.return_value = reset_data
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    last_reset = state.attributes["last_reset"]
+    assert last_reset is not None
+
+    # Reload the entry
+    mock_get_state.return_value = TEST_VEHICLE_STATE_ONLINE
+    with patch("homeassistant.components.tessie.PLATFORMS", [Platform.SENSOR]):
+        assert await hass.config_entries.async_reload(entry.entry_id)
+
+    # last_reset should be restored
+    state = hass.states.get(entity_id)
+    assert state.attributes["last_reset"] == last_reset


### PR DESCRIPTION
## Proposed change
This PR extracts the Tessie-only changes from `origin/t_total` onto `upstream/dev` so they can be reviewed upstream independently. It includes updates in the Tessie integration and corresponding test/snapshot updates, focused on last-reset-related behavior.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- This PR supersedes: https://github.com/home-assistant/core/pull/162528

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
