### PR TITLE
Rework patching and handling of client runner in arcam

### DIFF
--- a/homeassistant/components/arcam_fmj/__init__.py
+++ b/homeassistant/components/arcam_fmj/__init__.py
@@ -2,8 +2,8 @@
 
 import asyncio
 from asyncio import timeout
+from contextlib import AsyncExitStack
 import logging
-from typing import Any
 
 from arcam.fmj import ConnectionFailed
 from arcam.fmj.client import Client
@@ -54,36 +54,31 @@ async def _run_client(
     client = runtime_data.client
     coordinators = runtime_data.coordinators
 
-    def _listen(_: Any) -> None:
-        for coordinator in coordinators.values():
-            coordinator.async_notify_data_updated()
-
     while True:
         try:
-            async with timeout(interval):
-                await client.start()
+            async with AsyncExitStack() as stack:
+                async with timeout(interval):
+                    await client.start()
+                stack.push_async_callback(client.stop)
 
-            _LOGGER.debug("Client connected %s", client.host)
+                _LOGGER.debug("Client connected %s", client.host)
 
-            try:
-                for coordinator in coordinators.values():
-                    await coordinator.state.start()
-
-                with client.listen(_listen):
+                try:
                     for coordinator in coordinators.values():
-                        coordinator.async_notify_connected()
-                    await client.process()
-            finally:
-                await client.stop()
+                        await stack.enter_async_context(
+                            coordinator.async_monitor_client()
+                        )
 
-                _LOGGER.debug("Client disconnected %s", client.host)
-                for coordinator in coordinators.values():
-                    coordinator.async_notify_disconnected()
+                    await client.process()
+                finally:
+                    _LOGGER.debug("Client disconnected %s", client.host)
 
         except ConnectionFailed:
-            await asyncio.sleep(interval)
+            pass
         except TimeoutError:
             continue
         except Exception:
             _LOGGER.exception("Unexpected exception, aborting arcam client")
             return
+
+        await asyncio.sleep(interval)

--- a/homeassistant/components/arcam_fmj/coordinator.py
+++ b/homeassistant/components/arcam_fmj/coordinator.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 import logging
 
 from arcam.fmj import ConnectionFailed
-from arcam.fmj.client import Client
+from arcam.fmj.client import AmxDuetResponse, Client, ResponsePacket
 from arcam.fmj.state import State
 
 from homeassistant.config_entries import ConfigEntry
@@ -51,7 +53,7 @@ class ArcamFmjCoordinator(DataUpdateCoordinator[None]):
         )
         self.client = client
         self.state = State(client, zone)
-        self.last_update_success = False
+        self.update_in_progress = False
 
         name = config_entry.title
         unique_id = config_entry.unique_id or config_entry.entry_id
@@ -74,24 +76,34 @@ class ArcamFmjCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Fetch data for manual refresh."""
         try:
+            self.update_in_progress = True
             await self.state.update()
         except ConnectionFailed as err:
             raise UpdateFailed(
                 f"Connection failed during update for zone {self.state.zn}"
             ) from err
+        finally:
+            self.update_in_progress = False
 
     @callback
-    def async_notify_data_updated(self) -> None:
-        """Notify that new data has been received from the device."""
-        self.async_set_updated_data(None)
+    def _async_notify_packet(self, packet: ResponsePacket | AmxDuetResponse) -> None:
+        """Packet callback to detect changes to state."""
+        if (
+            not isinstance(packet, ResponsePacket)
+            or packet.zn != self.state.zn
+            or self.update_in_progress
+        ):
+            return
 
-    @callback
-    def async_notify_connected(self) -> None:
-        """Handle client connected."""
-        self.hass.async_create_task(self.async_refresh())
-
-    @callback
-    def async_notify_disconnected(self) -> None:
-        """Handle client disconnected."""
-        self.last_update_success = False
         self.async_update_listeners()
+
+    @asynccontextmanager
+    async def async_monitor_client(self) -> AsyncGenerator[None]:
+        """Monitor a client and state for changes while connected."""
+        async with self.state:
+            self.hass.async_create_task(self.async_refresh())
+            try:
+                with self.client.listen(self._async_notify_packet):
+                    yield
+            finally:
+                self.hass.async_create_task(self.async_refresh())

--- a/homeassistant/components/arcam_fmj/entity.py
+++ b/homeassistant/components/arcam_fmj/entity.py
@@ -26,3 +26,8 @@ class ArcamFmjEntity(CoordinatorEntity[ArcamFmjCoordinator]):
         if description is not None:
             self._attr_unique_id = f"{self._attr_unique_id}-{description.key}"
             self.entity_description = description
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self.coordinator.client.connected

--- a/tests/components/arcam_fmj/conftest.py
+++ b/tests/components/arcam_fmj/conftest.py
@@ -1,15 +1,17 @@
 """Tests for the arcam_fmj component."""
 
-from collections.abc import AsyncGenerator
-from unittest.mock import Mock, patch
+from asyncio import CancelledError, Queue
+from collections.abc import AsyncGenerator, Generator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, Mock, patch
 
-from arcam.fmj.client import Client
+from arcam.fmj.client import Client, ResponsePacket
 from arcam.fmj.state import State
 import pytest
 
 from homeassistant.components.arcam_fmj.const import DEFAULT_NAME
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -28,12 +30,50 @@ MOCK_CONFIG_ENTRY = {CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT}
 
 
 @pytest.fixture(name="client")
-def client_fixture() -> Mock:
+def client_fixture() -> Generator[Mock]:
     """Get a mocked client."""
     client = Mock(Client)
     client.host = MOCK_HOST
     client.port = MOCK_PORT
-    return client
+
+    queue = Queue[BaseException | None]()
+    listeners = set()
+
+    async def _start():
+        client.connected = True
+
+    async def _process():
+        result = await queue.get()
+        client.connected = False
+        if isinstance(result, BaseException):
+            raise result
+
+    @contextmanager
+    def _listen(listener):
+        listeners.add(listener)
+        yield client
+        listeners.remove(listener)
+
+    @callback
+    def _notify_data_updated(zn=1):
+        packet = Mock(ResponsePacket)
+        packet.zn = zn
+        for listener in listeners:
+            listener(packet)
+
+    @callback
+    def _notify_connection(exception: Exception | None = None):
+        queue.put_nowait(exception)
+
+    client.start.side_effect = _start
+    client.process.side_effect = _process
+    client.listen.side_effect = _listen
+    client.notify_data_updated = _notify_data_updated
+    client.notify_connection = _notify_connection
+
+    yield client
+
+    queue.put_nowait(CancelledError())
 
 
 @pytest.fixture(name="state_1")
@@ -52,6 +92,8 @@ def state_1_fixture(client: Mock) -> State:
     state.get_mute.return_value = None
     state.get_decode_modes.return_value = []
     state.get_decode_mode.return_value = None
+    state.__aenter__ = AsyncMock()
+    state.__aexit__ = AsyncMock()
     return state
 
 
@@ -71,6 +113,8 @@ def state_2_fixture(client: Mock) -> State:
     state.get_mute.return_value = None
     state.get_decode_modes.return_value = []
     state.get_decode_mode.return_value = None
+    state.__aenter__ = AsyncMock()
+    state.__aexit__ = AsyncMock()
     return state
 
 
@@ -104,18 +148,6 @@ async def player_setup_fixture(
             return state_2
         raise ValueError(f"Unknown player zone: {zone}")
 
-    async def _mock_run_client(hass: HomeAssistant, runtime_data, interval):
-        coordinators = runtime_data.coordinators
-
-        def _notify_data_updated() -> None:
-            for coordinator in coordinators.values():
-                coordinator.async_notify_data_updated()
-
-        client.notify_data_updated = _notify_data_updated
-
-        for coordinator in coordinators.values():
-            coordinator.async_notify_connected()
-
     await async_setup_component(hass, "homeassistant", {})
 
     with (
@@ -123,10 +155,6 @@ async def player_setup_fixture(
         patch(
             "homeassistant.components.arcam_fmj.coordinator.State",
             side_effect=state_mock,
-        ),
-        patch(
-            "homeassistant.components.arcam_fmj._run_client",
-            side_effect=_mock_run_client,
         ),
     ):
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/arcam_fmj/test_media_player.py
+++ b/tests/components/arcam_fmj/test_media_player.py
@@ -33,7 +33,7 @@ from homeassistant.components.media_player import (
     SERVICE_VOLUME_UP,
     MediaType,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant, State as CoreState
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -60,6 +60,21 @@ async def test_setup(
 ) -> None:
     """Test setup creates expected entities."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("player_setup")
+async def test_disconnect(hass: HomeAssistant, client: Mock) -> None:
+    """Test a disconnection is detected."""
+    data = hass.states.get(MOCK_ENTITY_ID)
+    assert data
+    assert data.state != STATE_UNAVAILABLE
+
+    client.notify_connection(ConnectionFailed())
+    await hass.async_block_till_done()
+
+    data = hass.states.get(MOCK_ENTITY_ID)
+    assert data
+    assert data.state == STATE_UNAVAILABLE
 
 
 async def update(hass: HomeAssistant, client: Mock, entity_id: str) -> CoreState:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Rework client runner in arcam to ensure we:
  - Stop client listener, 
  - Ensure a sleep between connection attempts
- Rework state listener to ensure we only re-trigger coordinator update on timer since changes are async and does not need a full update cycle
- Add tests for disconnection of clients
- Rework tests to avoid patching internal client runner


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
