### PR TITLE
Add state_class inheritance to min_max sensor

### DIFF
--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -28,12 +28,17 @@ from homeassistant.const import (
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.entity import get_device_class
+from homeassistant.helpers.entity import get_capability, get_device_class
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
@@ -210,7 +215,6 @@ class MinMaxSensor(SensorEntity):
 
     _attr_icon = ICON
     _attr_should_poll = False
-    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,
@@ -263,6 +267,7 @@ class MinMaxSensor(SensorEntity):
             self._async_min_max_sensor_state_listener(state_event, update_state=False)
 
         self._update_device_class()
+        self._update_state_class()
         self._calc_values()
 
     @property
@@ -374,6 +379,51 @@ class MinMaxSensor(SensorEntity):
             dc is not None and dc == device_classes[0] for dc in device_classes
         ):
             self._attr_device_class = device_classes[0]
+
+    @callback
+    def _update_state_class(self) -> None:
+        """Update state_class based on source entities.
+
+        If all source entities have the same state_class, inherit it.
+        If source entities have a different state_class, raise an issue.
+        """
+        state_classes: list[SensorStateClass] = []
+        source_entities: list[str] = []
+
+        if not self._entity_ids:
+            return
+
+        for entity_id in self._entity_ids:
+            try:
+                state_class = get_capability(self.hass, entity_id, "state_class")
+                if state_class:
+                    state_classes.append(SensorStateClass(state_class))
+                    source_entities.append(entity_id)
+            except HomeAssistantError, ValueError:
+                # If we can't get device class for any entity, don't set it
+                return
+
+        # Only inherit state_class if all entities have the same non-None state_class
+        if state_classes and all(sc == state_classes[0] for sc in state_classes):
+            async_delete_issue(
+                self.hass, DOMAIN, f"{self.entity_id}_state_classes_not_matching"
+            )
+            self._attr_state_class = state_classes[0]
+        else:
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                f"{self.entity_id}_state_classes_not_matching",
+                is_fixable=False,
+                is_persistent=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="state_classes_not_matching",
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                    "source_entities": ", ".join(source_entities),
+                    "state_classes": ", ".join(state_classes),
+                },
+            )
 
     @callback
     def _calc_values(self) -> None:

--- a/homeassistant/components/min_max/strings.json
+++ b/homeassistant/components/min_max/strings.json
@@ -16,6 +16,12 @@
       }
     }
   },
+  "issues": {
+    "state_classes_not_matching": {
+      "description": "State classes `{state_classes}` on source entities `{source_entities}` need to be identical for min/max sensor `{entity_id}`.\n\nPlease correct the state classes on the source entities and reload the min/max sensor to fix this issue.",
+      "title": "State classes are not correct"
+    }
+  },
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!-- not a breaking change -->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Change #157602 (2026.3.0) added `device_class` inheritance to the `min_max` sensor, but the `state_class` was not considered, leading to warnings when the `device_class` is e.g. `monetary`, `energy`. This PR adds logic to `min_max` to also inherit the `state_class`, and create an issue when the entities have different state classes.

Notes:
* Much of the work in this change, including the new issue, is inspired by the `group` integration, however while working on this I noticed other differences in how the sensors are initialized and added to hass and how conflicting attributes are identified. I'd be happy to continue harmonizing these in follow-on PRs.
* The translation string for the new repair is inspired by a corresponding string in the `group` integration, however the text is slightly different. Future PRs could add issues for inconsistent `device_class`, `unit_of_measurement`, etc. values or make the strings common (however the issue would appear to the user as reported by something other than "Group" and "Min/Max", and the icons would be generic).
* I'd be OK with splitting the repair management (`async_create_issue`/`async_delete_issue`) to a separate PR if this one should be backported for 2026.3.x and the added strings interfere with that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: #165276 
- This PR is related to issue: 
- Link to documentation pull request: n/a
- Link to developer documentation pull request: n/a 
- Link to frontend pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
