### PR TITLE
Fix wemo tests for Python 3.14.3

### DIFF
--- a/homeassistant/components/wemo/coordinator.py
+++ b/homeassistant/components/wemo/coordinator.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, fields
 from datetime import timedelta
 from functools import partial
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pywemo import Insight, LongPressMixin, WeMoDevice
 from pywemo.exceptions import ActionException, PyWeMoException
@@ -145,9 +145,10 @@ class DeviceCoordinator(DataUpdateCoordinator[None]):
         if self._shutdown_requested:
             return
         await super().async_shutdown()
-        if TYPE_CHECKING:
-            # mypy doesn't known that the device_id is set in async_setup.
-            assert self.device_id is not None
+        if self.device_id is None:
+            # async_refresh failed in async_register_device before async_setup
+            # was called, so this coordinator was never fully registered.
+            return
         del _async_coordinators(self.hass)[self.device_id]
         assert self.options  # Always set by async_register_device.
         if self.options.enable_subscription:

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -146,6 +146,12 @@ async def test_avaliable_after_update(
         {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
         blocking=True,
     )
+    # _wemo_call_wrapper schedules async_update_listeners via hass.add_job
+    # from the executor thread, which goes through two levels of call_soon
+    # before the entity state is written.
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
     assert hass.states.get(wemo_entity.entity_id).state == STATE_UNAVAILABLE
 
     pywemo_registry.callbacks[pywemo_device.name](pywemo_device, "", "")

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -73,6 +73,11 @@ async def test_turn_on_brightness(
         {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_BRIGHTNESS: 204},
         blocking=True,
     )
+    # _wemo_call_wrapper schedules async_update_listeners via hass.add_job
+    # from the executor thread, which goes through two levels of call_soon
+    # before the entity state is written.
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     pywemo_device.set_brightness.assert_called_once_with(80)
     states = hass.states.get(wemo_entity.entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In response to #162263, this PR fixes the 5 failing `wemo` tests:
```
FAILED tests/components/wemo/test_light_bridge.py::test_available_after_update - AssertionError: assert 'off' == 'unavailable'
FAILED tests/components/wemo/test_init.py::test_static_with_upnp_failure - KeyError: None
FAILED tests/components/wemo/test_light_dimmer.py::test_available_after_update - AssertionError: assert 'off' == 'unavailable'
FAILED tests/components/wemo/test_light_dimmer.py::test_turn_on_brightness - AssertionError: assert 'off' == 'on'
FAILED tests/components/wemo/test_switch.py::test_available_after_update - AssertionError: assert 'off' == 'unavailable'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
