### PR TITLE
Load lovelace resource collection eagerly during setup

### DIFF
--- a/homeassistant/components/lovelace/resources.py
+++ b/homeassistant/components/lovelace/resources.py
@@ -62,13 +62,31 @@ class ResourceStorageCollection(collection.DictStorageCollection):
         )
         self.ll_config = ll_config
 
-    async def async_get_info(self) -> dict[str, int]:
-        """Return the resources info for YAML mode."""
+    async def _async_ensure_loaded(self) -> None:
+        """Ensure the collection has been loaded from storage."""
         if not self.loaded:
             await self.async_load()
             self.loaded = True
 
+    async def async_get_info(self) -> dict[str, int]:
+        """Return the resources info for YAML mode."""
+        await self._async_ensure_loaded()
         return {"resources": len(self.async_items() or [])}
+
+    async def async_create_item(self, data: dict) -> dict:
+        """Create a new item."""
+        await self._async_ensure_loaded()
+        return await super().async_create_item(data)
+
+    async def async_update_item(self, item_id: str, updates: dict) -> dict:
+        """Update item."""
+        await self._async_ensure_loaded()
+        return await super().async_update_item(item_id, updates)
+
+    async def async_delete_item(self, item_id: str) -> None:
+        """Delete item."""
+        await self._async_ensure_loaded()
+        await super().async_delete_item(item_id)
 
     async def _async_load_data(self) -> collection.SerializedStorageCollection | None:
         """Load the data."""
@@ -118,10 +136,6 @@ class ResourceStorageCollection(collection.DictStorageCollection):
 
     async def _update_data(self, item: dict, update_data: dict) -> dict:
         """Return a new updated data object."""
-        if not self.loaded:
-            await self.async_load()
-            self.loaded = True
-
         update_data = self.UPDATE_SCHEMA(update_data)
         if CONF_RESOURCE_TYPE_WS in update_data:
             update_data[CONF_TYPE] = update_data.pop(CONF_RESOURCE_TYPE_WS)

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -8,6 +8,7 @@ import uuid
 import pytest
 
 from homeassistant.components.lovelace import dashboard, resources
+from homeassistant.components.lovelace.const import LOVELACE_DATA
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -276,6 +277,41 @@ async def test_storage_resources_import_invalid(
         "resources"
         in hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT]["data"]["config"]
     )
+
+
+async def test_storage_resources_create_preserves_existing(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test async_create_item lazy-loads before writing.
+
+    Custom integrations may call async_create_item() during startup before the
+    frontend triggers a resource listing. Without a lazy-load guard, the
+    collection is empty and async_create_item() overwrites all existing
+    resources on disk.
+    """
+    resource_config = [{**item, "id": uuid.uuid4().hex} for item in RESOURCE_EXAMPLES]
+    hass_storage[resources.RESOURCE_STORAGE_KEY] = {
+        "key": resources.RESOURCE_STORAGE_KEY,
+        "version": 1,
+        "data": {"items": resource_config},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+
+    resource_collection = hass.data[LOVELACE_DATA].resources
+
+    # Directly call async_create_item before any websocket listing
+    await resource_collection.async_create_item(
+        {"res_type": "module", "url": "/local/new.js"}
+    )
+
+    # Existing resources must still be present
+    items = resource_collection.async_items()
+    assert len(items) == len(resource_config) + 1
+    urls = [item["url"] for item in items]
+    for original in resource_config:
+        assert original["url"] in urls
+    assert "/local/new.js" in urls
 
 
 @pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])


### PR DESCRIPTION
## Proposed change

`ResourceStorageCollection` is created during `lovelace.async_setup()` but never loaded from disk at that point. Loading is deferred (lazy) and the guard only exists in `async_get_info()`, `_update_data()`, and `websocket_lovelace_resources_impl()`.

The inherited `async_create_item()`, `async_update_item()`, and `async_delete_item()` have no lazy-load guard, so any code calling them before the frontend triggers a resource listing operates on an empty collection. A subsequent `async_create_item()` then saves only the newly created item, **overwriting `.storage/lovelace_resources` and destroying all existing Lovelace resources**.

This change adds lazy-load guards to `async_create_item()`, `async_update_item()`, and `async_delete_item()` via a shared `_async_ensure_loaded()` helper, avoiding extra I/O during startup. The redundant guard in `_update_data()` is removed since `async_update_item()` now ensures loading before reaching it.

Fixes #165767

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Custom integrations that register Lovelace resources via `hass.data["lovelace"].resources.async_create_item()` during startup (before the frontend triggers a resource listing) would silently destroy all existing resources
- This was reported by multiple users at https://github.com/kvanbiesen/bmw-cardata-ha/discussions/316

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented out code in this PR
- [x] Tests have been added to verify that the new code works