### PR TITLE
Use return value from target_entities directly in condition tests

### DIFF
--- a/tests/components/alarm_control_panel/test_condition.py
+++ b/tests/components/alarm_control_panel/test_condition.py
@@ -25,9 +25,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_alarm_control_panels(hass: HomeAssistant) -> list[str]:
+async def target_alarm_control_panels(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple alarm_control_panel entities associated with different targets."""
-    return (await target_entities(hass, "alarm_control_panel"))["included"]
+    return await target_entities(hass, "alarm_control_panel")
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ async def test_alarm_control_panel_conditions_gated_by_labs_flag(
 )
 async def test_alarm_control_panel_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_alarm_control_panels: list[str],
+    target_alarm_control_panels: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -129,10 +129,10 @@ async def test_alarm_control_panel_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the alarm_control_panel state condition with the 'any' behavior."""
-    other_entity_ids = set(target_alarm_control_panels) - {entity_id}
+    other_entity_ids = set(target_alarm_control_panels["included"]) - {entity_id}
 
     # Set all alarm_control_panels, including the tested alarm_control_panel, to the initial state
-    for eid in target_alarm_control_panels:
+    for eid in target_alarm_control_panels["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -227,7 +227,7 @@ async def test_alarm_control_panel_state_condition_behavior_any(
 )
 async def test_alarm_control_panel_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_alarm_control_panels: list[str],
+    target_alarm_control_panels: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -236,10 +236,10 @@ async def test_alarm_control_panel_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the alarm_control_panel state condition with the 'all' behavior."""
-    other_entity_ids = set(target_alarm_control_panels) - {entity_id}
+    other_entity_ids = set(target_alarm_control_panels["included"]) - {entity_id}
 
     # Set all alarm_control_panels, including the tested alarm_control_panel, to the initial state
-    for eid in target_alarm_control_panels:
+    for eid in target_alarm_control_panels["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/assist_satellite/test_condition.py
+++ b/tests/components/assist_satellite/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_assist_satellites(hass: HomeAssistant) -> list[str]:
+async def target_assist_satellites(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple assist satellite entities associated with different targets."""
-    return (await target_entities(hass, "assist_satellite"))["included"]
+    return await target_entities(hass, "assist_satellite")
 
 
 @pytest.mark.parametrize(
@@ -74,7 +74,7 @@ async def test_assist_satellite_conditions_gated_by_labs_flag(
 )
 async def test_assist_satellite_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_assist_satellites: list[str],
+    target_assist_satellites: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -83,10 +83,10 @@ async def test_assist_satellite_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the assist satellite state condition with the 'any' behavior."""
-    other_entity_ids = set(target_assist_satellites) - {entity_id}
+    other_entity_ids = set(target_assist_satellites["included"]) - {entity_id}
 
     # Set all assist satellites, including the tested one, to the initial state
-    for eid in target_assist_satellites:
+    for eid in target_assist_satellites["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -142,7 +142,7 @@ async def test_assist_satellite_state_condition_behavior_any(
 )
 async def test_assist_satellite_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_assist_satellites: list[str],
+    target_assist_satellites: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -151,10 +151,10 @@ async def test_assist_satellite_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the assist satellite state condition with the 'all' behavior."""
-    other_entity_ids = set(target_assist_satellites) - {entity_id}
+    other_entity_ids = set(target_assist_satellites["included"]) - {entity_id}
 
     # Set all assist satellites, including the tested one, to the initial state
-    for eid in target_assist_satellites:
+    for eid in target_assist_satellites["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/climate/test_condition.py
+++ b/tests/components/climate/test_condition.py
@@ -25,9 +25,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_climates(hass: HomeAssistant) -> list[str]:
+async def target_climates(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple climate entities associated with different targets."""
-    return (await target_entities(hass, "climate"))["included"]
+    return await target_entities(hass, "climate")
 
 
 @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ async def test_climate_conditions_gated_by_labs_flag(
 )
 async def test_climate_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_climates: list[str],
+    target_climates: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -85,10 +85,10 @@ async def test_climate_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the climate state condition with the 'any' behavior."""
-    other_entity_ids = set(target_climates) - {entity_id}
+    other_entity_ids = set(target_climates["included"]) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
-    for eid in target_climates:
+    for eid in target_climates["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -141,7 +141,7 @@ async def test_climate_state_condition_behavior_any(
 )
 async def test_climate_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_climates: list[str],
+    target_climates: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -150,10 +150,10 @@ async def test_climate_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the climate state condition with the 'all' behavior."""
-    other_entity_ids = set(target_climates) - {entity_id}
+    other_entity_ids = set(target_climates["included"]) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
-    for eid in target_climates:
+    for eid in target_climates["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -205,7 +205,7 @@ async def test_climate_state_condition_behavior_all(
 )
 async def test_climate_attribute_condition_behavior_any(
     hass: HomeAssistant,
-    target_climates: list[str],
+    target_climates: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -214,10 +214,10 @@ async def test_climate_attribute_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the climate attribute condition with the 'any' behavior."""
-    other_entity_ids = set(target_climates) - {entity_id}
+    other_entity_ids = set(target_climates["included"]) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
-    for eid in target_climates:
+    for eid in target_climates["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -268,7 +268,7 @@ async def test_climate_attribute_condition_behavior_any(
 )
 async def test_climate_attribute_condition_behavior_all(
     hass: HomeAssistant,
-    target_climates: list[str],
+    target_climates: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -277,10 +277,10 @@ async def test_climate_attribute_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the climate attribute condition with the 'all' behavior."""
-    other_entity_ids = set(target_climates) - {entity_id}
+    other_entity_ids = set(target_climates["included"]) - {entity_id}
 
     # Set all climates, including the tested climate, to the initial state
-    for eid in target_climates:
+    for eid in target_climates["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/device_tracker/test_condition.py
+++ b/tests/components/device_tracker/test_condition.py
@@ -20,9 +20,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_device_trackers(hass: HomeAssistant) -> list[str]:
+async def target_device_trackers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple device tracker entities associated with different targets."""
-    return (await target_entities(hass, "device_tracker"))["included"]
+    return await target_entities(hass, "device_tracker")
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ async def test_device_tracker_conditions_gated_by_labs_flag(
 )
 async def test_device_tracker_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_device_trackers: list[str],
+    target_device_trackers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -70,10 +70,10 @@ async def test_device_tracker_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the device tracker state condition with the 'any' behavior."""
-    other_entity_ids = set(target_device_trackers) - {entity_id}
+    other_entity_ids = set(target_device_trackers["included"]) - {entity_id}
 
     # Set all device trackers, including the tested one, to the initial state
-    for eid in target_device_trackers:
+    for eid in target_device_trackers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -119,7 +119,7 @@ async def test_device_tracker_state_condition_behavior_any(
 )
 async def test_device_tracker_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_device_trackers: list[str],
+    target_device_trackers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -128,10 +128,10 @@ async def test_device_tracker_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the device tracker state condition with the 'all' behavior."""
-    other_entity_ids = set(target_device_trackers) - {entity_id}
+    other_entity_ids = set(target_device_trackers["included"]) - {entity_id}
 
     # Set all device trackers, including the tested one, to the initial state
-    for eid in target_device_trackers:
+    for eid in target_device_trackers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/fan/test_condition.py
+++ b/tests/components/fan/test_condition.py
@@ -20,19 +20,19 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_fans(hass: HomeAssistant) -> list[str]:
+async def target_fans(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple fan entities associated with different targets."""
-    return (await target_entities(hass, "fan"))["included"]
+    return await target_entities(hass, "fan")
 
 
 @pytest.fixture
-async def target_switches(hass: HomeAssistant) -> list[str]:
+async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple switch entities associated with different targets.
 
     Note: The switches are used to ensure that only fan entities are considered
     in the condition evaluation and not other toggle entities.
     """
-    return (await target_entities(hass, "switch"))["included"]
+    return await target_entities(hass, "switch")
 
 
 @pytest.mark.parametrize(
@@ -71,8 +71,8 @@ async def test_fan_conditions_gated_by_labs_flag(
 )
 async def test_fan_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_fans: list[str],
-    target_switches: list[str],
+    target_fans: dict[str, list[str]],
+    target_switches: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -81,10 +81,10 @@ async def test_fan_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the fan state condition with the 'any' behavior."""
-    other_entity_ids = set(target_fans) - {entity_id}
+    other_entity_ids = set(target_fans["included"]) - {entity_id}
 
     # Set all fans, including the tested fan, to the initial state
-    for eid in target_fans:
+    for eid in target_fans["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -97,7 +97,7 @@ async def test_fan_state_condition_behavior_any(
 
     # Set state for switches to ensure that they don't impact the condition
     for state in states:
-        for eid in target_switches:
+        for eid in target_switches["included"]:
             set_or_remove_state(hass, eid, state["included"])
             await hass.async_block_till_done()
             assert condition(hass) is False
@@ -137,7 +137,7 @@ async def test_fan_state_condition_behavior_any(
 )
 async def test_fan_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_fans: list[str],
+    target_fans: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -150,10 +150,10 @@ async def test_fan_state_condition_behavior_all(
     hass.states.async_set("switch.label_switch_1", STATE_OFF)
     hass.states.async_set("switch.label_switch_2", STATE_ON)
 
-    other_entity_ids = set(target_fans) - {entity_id}
+    other_entity_ids = set(target_fans["included"]) - {entity_id}
 
     # Set all fans, including the tested fan, to the initial state
-    for eid in target_fans:
+    for eid in target_fans["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/humidifier/test_condition.py
+++ b/tests/components/humidifier/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_humidifiers(hass: HomeAssistant) -> list[str]:
+async def target_humidifiers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple humidifier entities associated with different targets."""
-    return (await target_entities(hass, "humidifier"))["included"]
+    return await target_entities(hass, "humidifier")
 
 
 @pytest.mark.parametrize(
@@ -64,7 +64,7 @@ async def test_humidifier_conditions_gated_by_labs_flag(
 )
 async def test_humidifier_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_humidifiers: list[str],
+    target_humidifiers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -73,10 +73,10 @@ async def test_humidifier_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the humidifier state condition with the 'any' behavior."""
-    other_entity_ids = set(target_humidifiers) - {entity_id}
+    other_entity_ids = set(target_humidifiers["included"]) - {entity_id}
 
     # Set all humidifiers, including the tested humidifier, to the initial state
-    for eid in target_humidifiers:
+    for eid in target_humidifiers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -122,7 +122,7 @@ async def test_humidifier_state_condition_behavior_any(
 )
 async def test_humidifier_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_humidifiers: list[str],
+    target_humidifiers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -131,10 +131,10 @@ async def test_humidifier_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the humidifier state condition with the 'all' behavior."""
-    other_entity_ids = set(target_humidifiers) - {entity_id}
+    other_entity_ids = set(target_humidifiers["included"]) - {entity_id}
 
     # Set all humidifiers, including the tested humidifier, to the initial state
-    for eid in target_humidifiers:
+    for eid in target_humidifiers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -181,7 +181,7 @@ async def test_humidifier_state_condition_behavior_all(
 )
 async def test_humidifier_attribute_condition_behavior_any(
     hass: HomeAssistant,
-    target_humidifiers: list[str],
+    target_humidifiers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -190,10 +190,10 @@ async def test_humidifier_attribute_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the humidifier attribute condition with the 'any' behavior."""
-    other_entity_ids = set(target_humidifiers) - {entity_id}
+    other_entity_ids = set(target_humidifiers["included"]) - {entity_id}
 
     # Set all humidifiers, including the tested humidifier, to the initial state
-    for eid in target_humidifiers:
+    for eid in target_humidifiers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -239,7 +239,7 @@ async def test_humidifier_attribute_condition_behavior_any(
 )
 async def test_humidifier_attribute_condition_behavior_all(
     hass: HomeAssistant,
-    target_humidifiers: list[str],
+    target_humidifiers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -248,10 +248,10 @@ async def test_humidifier_attribute_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the humidifier attribute condition with the 'all' behavior."""
-    other_entity_ids = set(target_humidifiers) - {entity_id}
+    other_entity_ids = set(target_humidifiers["included"]) - {entity_id}
 
     # Set all humidifiers, including the tested humidifier, to the initial state
-    for eid in target_humidifiers:
+    for eid in target_humidifiers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/lawn_mower/test_condition.py
+++ b/tests/components/lawn_mower/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_lawn_mowers(hass: HomeAssistant) -> list[str]:
+async def target_lawn_mowers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lawn mower entities associated with different targets."""
-    return (await target_entities(hass, "lawn_mower"))["included"]
+    return await target_entities(hass, "lawn_mower")
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ async def test_lawn_mower_conditions_gated_by_labs_flag(
 )
 async def test_lawn_mower_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_lawn_mowers: list[str],
+    target_lawn_mowers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -89,10 +89,10 @@ async def test_lawn_mower_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the lawn mower state condition with the 'any' behavior."""
-    other_entity_ids = set(target_lawn_mowers) - {entity_id}
+    other_entity_ids = set(target_lawn_mowers["included"]) - {entity_id}
 
     # Set all lawn mowers, including the tested lawn mower, to the initial state
-    for eid in target_lawn_mowers:
+    for eid in target_lawn_mowers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -153,7 +153,7 @@ async def test_lawn_mower_state_condition_behavior_any(
 )
 async def test_lawn_mower_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_lawn_mowers: list[str],
+    target_lawn_mowers: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -162,10 +162,10 @@ async def test_lawn_mower_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the lawn mower state condition with the 'all' behavior."""
-    other_entity_ids = set(target_lawn_mowers) - {entity_id}
+    other_entity_ids = set(target_lawn_mowers["included"]) - {entity_id}
 
     # Set all lawn mowers, including the tested lawn mower, to the initial state
-    for eid in target_lawn_mowers:
+    for eid in target_lawn_mowers["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/light/test_condition.py
+++ b/tests/components/light/test_condition.py
@@ -20,19 +20,19 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_lights(hass: HomeAssistant) -> list[str]:
+async def target_lights(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple light entities associated with different targets."""
-    return (await target_entities(hass, "light"))["included"]
+    return await target_entities(hass, "light")
 
 
 @pytest.fixture
-async def target_switches(hass: HomeAssistant) -> list[str]:
+async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple switch entities associated with different targets.
 
     Note: The switches are used to ensure that only light entities are considered
     in the condition evaluation and not other toggle entities.
     """
-    return (await target_entities(hass, "switch"))["included"]
+    return await target_entities(hass, "switch")
 
 
 @pytest.mark.parametrize(
@@ -71,8 +71,8 @@ async def test_light_conditions_gated_by_labs_flag(
 )
 async def test_light_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_lights: list[str],
-    target_switches: list[str],
+    target_lights: dict[str, list[str]],
+    target_switches: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -81,10 +81,10 @@ async def test_light_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the light state condition with the 'any' behavior."""
-    other_entity_ids = set(target_lights) - {entity_id}
+    other_entity_ids = set(target_lights["included"]) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state
-    for eid in target_lights:
+    for eid in target_lights["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -97,7 +97,7 @@ async def test_light_state_condition_behavior_any(
 
     # Set state for switches to ensure that they don't impact the condition
     for state in states:
-        for eid in target_switches:
+        for eid in target_switches["included"]:
             set_or_remove_state(hass, eid, state["included"])
             await hass.async_block_till_done()
             assert condition(hass) is False
@@ -137,7 +137,7 @@ async def test_light_state_condition_behavior_any(
 )
 async def test_light_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_lights: list[str],
+    target_lights: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -150,10 +150,10 @@ async def test_light_state_condition_behavior_all(
     hass.states.async_set("switch.label_switch_1", STATE_OFF)
     hass.states.async_set("switch.label_switch_2", STATE_ON)
 
-    other_entity_ids = set(target_lights) - {entity_id}
+    other_entity_ids = set(target_lights["included"]) - {entity_id}
 
     # Set all lights, including the tested light, to the initial state
-    for eid in target_lights:
+    for eid in target_lights["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/lock/test_condition.py
+++ b/tests/components/lock/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_locks(hass: HomeAssistant) -> list[str]:
+async def target_locks(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lock entities associated with different targets."""
-    return (await target_entities(hass, "lock"))["included"]
+    return await target_entities(hass, "lock")
 
 
 @pytest.mark.parametrize(
@@ -74,7 +74,7 @@ async def test_lock_conditions_gated_by_labs_flag(
 )
 async def test_lock_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_locks: list[str],
+    target_locks: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -83,10 +83,10 @@ async def test_lock_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the lock state condition with the 'any' behavior."""
-    other_entity_ids = set(target_locks) - {entity_id}
+    other_entity_ids = set(target_locks["included"]) - {entity_id}
 
     # Set all locks, including the tested lock, to the initial state
-    for eid in target_locks:
+    for eid in target_locks["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -142,7 +142,7 @@ async def test_lock_state_condition_behavior_any(
 )
 async def test_lock_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_locks: list[str],
+    target_locks: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -151,10 +151,10 @@ async def test_lock_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the lock state condition with the 'all' behavior."""
-    other_entity_ids = set(target_locks) - {entity_id}
+    other_entity_ids = set(target_locks["included"]) - {entity_id}
 
     # Set all locks, including the tested lock, to the initial state
-    for eid in target_locks:
+    for eid in target_locks["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/media_player/test_condition.py
+++ b/tests/components/media_player/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_media_players(hass: HomeAssistant) -> list[str]:
+async def target_media_players(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple media player entities associated with different targets."""
-    return (await target_entities(hass, "media_player"))["included"]
+    return await target_entities(hass, "media_player")
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ async def test_media_player_conditions_gated_by_labs_flag(
 )
 async def test_media_player_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_media_players: list[str],
+    target_media_players: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -101,10 +101,10 @@ async def test_media_player_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the media player state condition with the 'any' behavior."""
-    other_entity_ids = set(target_media_players) - {entity_id}
+    other_entity_ids = set(target_media_players["included"]) - {entity_id}
 
     # Set all media players, including the tested media player, to the initial state
-    for eid in target_media_players:
+    for eid in target_media_players["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -177,7 +177,7 @@ async def test_media_player_state_condition_behavior_any(
 )
 async def test_media_player_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_media_players: list[str],
+    target_media_players: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -186,10 +186,10 @@ async def test_media_player_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the media player state condition with the 'all' behavior."""
-    other_entity_ids = set(target_media_players) - {entity_id}
+    other_entity_ids = set(target_media_players["included"]) - {entity_id}
 
     # Set all media players, including the tested media player, to the initial state
-    for eid in target_media_players:
+    for eid in target_media_players["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/person/test_condition.py
+++ b/tests/components/person/test_condition.py
@@ -20,9 +20,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_persons(hass: HomeAssistant) -> list[str]:
+async def target_persons(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple person entities associated with different targets."""
-    return (await target_entities(hass, "person"))["included"]
+    return await target_entities(hass, "person")
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ async def test_person_conditions_gated_by_labs_flag(
 )
 async def test_person_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_persons: list[str],
+    target_persons: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -70,10 +70,10 @@ async def test_person_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the person state condition with the 'any' behavior."""
-    other_entity_ids = set(target_persons) - {entity_id}
+    other_entity_ids = set(target_persons["included"]) - {entity_id}
 
     # Set all persons, including the tested person, to the initial state
-    for eid in target_persons:
+    for eid in target_persons["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -119,7 +119,7 @@ async def test_person_state_condition_behavior_any(
 )
 async def test_person_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_persons: list[str],
+    target_persons: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -128,10 +128,10 @@ async def test_person_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the person state condition with the 'all' behavior."""
-    other_entity_ids = set(target_persons) - {entity_id}
+    other_entity_ids = set(target_persons["included"]) - {entity_id}
 
     # Set all persons, including the tested person, to the initial state
-    for eid in target_persons:
+    for eid in target_persons["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/siren/test_condition.py
+++ b/tests/components/siren/test_condition.py
@@ -20,19 +20,19 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_sirens(hass: HomeAssistant) -> list[str]:
+async def target_sirens(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple siren entities associated with different targets."""
-    return (await target_entities(hass, "siren"))["included"]
+    return await target_entities(hass, "siren")
 
 
 @pytest.fixture
-async def target_switches(hass: HomeAssistant) -> list[str]:
+async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple switch entities associated with different targets.
 
     Note: The switches are used to ensure that only siren entities are considered
     in the condition evaluation and not other toggle entities.
     """
-    return (await target_entities(hass, "switch"))["included"]
+    return await target_entities(hass, "switch")
 
 
 @pytest.mark.parametrize(
@@ -71,8 +71,8 @@ async def test_siren_conditions_gated_by_labs_flag(
 )
 async def test_siren_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_sirens: list[str],
-    target_switches: list[str],
+    target_sirens: dict[str, list[str]],
+    target_switches: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -81,10 +81,10 @@ async def test_siren_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the siren state condition with the 'any' behavior."""
-    other_entity_ids = set(target_sirens) - {entity_id}
+    other_entity_ids = set(target_sirens["included"]) - {entity_id}
 
     # Set all sirens, including the tested siren, to the initial state
-    for eid in target_sirens:
+    for eid in target_sirens["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -97,7 +97,7 @@ async def test_siren_state_condition_behavior_any(
 
     # Set state for switches to ensure that they don't impact the condition
     for state in states:
-        for eid in target_switches:
+        for eid in target_switches["included"]:
             set_or_remove_state(hass, eid, state["included"])
             await hass.async_block_till_done()
             assert condition(hass) is False
@@ -137,7 +137,7 @@ async def test_siren_state_condition_behavior_any(
 )
 async def test_siren_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_sirens: list[str],
+    target_sirens: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -149,10 +149,10 @@ async def test_siren_state_condition_behavior_all(
     # Set state for two switches to ensure that they don't impact the condition
     hass.states.async_set("switch.label_switch_1", STATE_OFF)
     hass.states.async_set("switch.label_switch_2", STATE_ON)
-    other_entity_ids = set(target_sirens) - {entity_id}
+    other_entity_ids = set(target_sirens["included"]) - {entity_id}
 
     # Set all sirens, including the tested siren, to the initial state
-    for eid in target_sirens:
+    for eid in target_sirens["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/switch/test_condition.py
+++ b/tests/components/switch/test_condition.py
@@ -20,19 +20,19 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_lights(hass: HomeAssistant) -> list[str]:
+async def target_lights(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple light entities associated with different targets.
 
     Note: The lights are used to ensure that only switch entities are considered
     in the condition evaluation and not other toggle entities.
     """
-    return (await target_entities(hass, "light"))["included"]
+    return await target_entities(hass, "light")
 
 
 @pytest.fixture
-async def target_switches(hass: HomeAssistant) -> list[str]:
+async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple switch entities associated with different targets."""
-    return (await target_entities(hass, "switch"))["included"]
+    return await target_entities(hass, "switch")
 
 
 @pytest.mark.parametrize(
@@ -71,8 +71,8 @@ async def test_switch_conditions_gated_by_labs_flag(
 )
 async def test_switch_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_lights: list[str],
-    target_switches: list[str],
+    target_lights: dict[str, list[str]],
+    target_switches: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -81,10 +81,10 @@ async def test_switch_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the switch state condition with the 'any' behavior."""
-    other_entity_ids = set(target_switches) - {entity_id}
+    other_entity_ids = set(target_switches["included"]) - {entity_id}
 
     # Set all switches, including the tested switch, to the initial state
-    for eid in target_switches:
+    for eid in target_switches["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -97,7 +97,7 @@ async def test_switch_state_condition_behavior_any(
 
     # Set state for lights to ensure that they don't impact the condition
     for state in states:
-        for eid in target_lights:
+        for eid in target_lights["included"]:
             set_or_remove_state(hass, eid, state["included"])
             await hass.async_block_till_done()
             assert condition(hass) is False
@@ -137,7 +137,7 @@ async def test_switch_state_condition_behavior_any(
 )
 async def test_switch_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_switches: list[str],
+    target_switches: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -150,10 +150,10 @@ async def test_switch_state_condition_behavior_all(
     hass.states.async_set("switch.label_switch_1", STATE_OFF)
     hass.states.async_set("switch.label_switch_2", STATE_ON)
 
-    other_entity_ids = set(target_switches) - {entity_id}
+    other_entity_ids = set(target_switches["included"]) - {entity_id}
 
     # Set all switches, including the tested switch, to the initial state
-    for eid in target_switches:
+    for eid in target_switches["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 

--- a/tests/components/vacuum/test_condition.py
+++ b/tests/components/vacuum/test_condition.py
@@ -21,9 +21,9 @@ from tests.components.common import (
 
 
 @pytest.fixture
-async def target_vacuums(hass: HomeAssistant) -> list[str]:
+async def target_vacuums(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple vacuum entities associated with different targets."""
-    return (await target_entities(hass, "vacuum"))["included"]
+    return await target_entities(hass, "vacuum")
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ async def test_vacuum_conditions_gated_by_labs_flag(
 )
 async def test_vacuum_state_condition_behavior_any(
     hass: HomeAssistant,
-    target_vacuums: list[str],
+    target_vacuums: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -89,10 +89,10 @@ async def test_vacuum_state_condition_behavior_any(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the vacuum state condition with the 'any' behavior."""
-    other_entity_ids = set(target_vacuums) - {entity_id}
+    other_entity_ids = set(target_vacuums["included"]) - {entity_id}
 
     # Set all vacuums, including the tested vacuum, to the initial state
-    for eid in target_vacuums:
+    for eid in target_vacuums["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 
@@ -153,7 +153,7 @@ async def test_vacuum_state_condition_behavior_any(
 )
 async def test_vacuum_state_condition_behavior_all(
     hass: HomeAssistant,
-    target_vacuums: list[str],
+    target_vacuums: dict[str, list[str]],
     condition_target_config: dict,
     entity_id: str,
     entities_in_target: int,
@@ -162,10 +162,10 @@ async def test_vacuum_state_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the vacuum state condition with the 'all' behavior."""
-    other_entity_ids = set(target_vacuums) - {entity_id}
+    other_entity_ids = set(target_vacuums["included"]) - {entity_id}
 
     # Set all vacuums, including the tested vacuum, to the initial state
-    for eid in target_vacuums:
+    for eid in target_vacuums["included"]:
         set_or_remove_state(hass, eid, states[0]["included"])
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use return value from target_entities directly in all condition tests

This is in preparation of deduplicating test bodies

Note: This is the same change as in https://github.com/home-assistant/core/pull/165761 but for condition tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
