### PR TITLE
Refactor wemo integration to use async service action handlers

### DIFF
--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -70,16 +70,12 @@ class WemoEntity(CoordinatorEntity[DeviceCoordinator]):
         Handles errors from the device and ensures all entities sharing the
         same coordinator are aware of updates to the device state.
         """
-
-        def _call() -> None:
-            try:
-                action()
-            except ActionException as err:
-                _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
-                self.coordinator.last_exception = err
-                self.coordinator.last_update_success = False
-
-        await self.hass.async_add_executor_job(_call)
+        try:
+            await self.hass.async_add_executor_job(action)
+        except ActionException as err:
+            _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
+            self.coordinator.last_exception = err
+            self.coordinator.last_update_success = False
         self.coordinator.async_update_listeners()
 
 

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -76,7 +76,8 @@ class WemoEntity(CoordinatorEntity[DeviceCoordinator]):
             _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
             self.coordinator.last_exception = err
             self.coordinator.last_update_success = False
-        self.coordinator.async_update_listeners()
+        finally:
+            self.coordinator.async_update_listeners()
 
 
 class WemoBinaryStateEntity(WemoEntity):

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
-import contextlib
+from collections.abc import Callable
 import logging
+from typing import Any
 
 from pywemo.exceptions import ActionException
 
@@ -64,23 +64,23 @@ class WemoEntity(CoordinatorEntity[DeviceCoordinator]):
         """Return the device info."""
         return self._device_info
 
-    @contextlib.contextmanager
-    def _wemo_call_wrapper(self, message: str) -> Generator[None]:
-        """Wrap calls to the device that change its state.
+    async def _async_wemo_call(self, message: str, action: Callable[[], Any]) -> None:
+        """Run a wemo device action in the executor and update listeners.
 
-        1. Takes care of making available=False when communications with the
-           device fails.
-        2. Ensures all entities sharing the same coordinator are aware of
-           updates to the device state.
+        Handles errors from the device and ensures all entities sharing the
+        same coordinator are aware of updates to the device state.
         """
-        try:
-            yield
-        except ActionException as err:
-            _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
-            self.coordinator.last_exception = err
-            self.coordinator.last_update_success = False  # Used for self.available.
-        finally:
-            self.hass.add_job(self.coordinator.async_update_listeners)
+
+        def _call() -> None:
+            try:
+                action()
+            except ActionException as err:
+                _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
+                self.coordinator.last_exception = err
+                self.coordinator.last_update_success = False
+
+        await self.hass.async_add_executor_job(_call)
+        self.coordinator.async_update_listeners()
 
 
 class WemoBinaryStateEntity(WemoEntity):

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -65,7 +65,7 @@ class WemoEntity(CoordinatorEntity[DeviceCoordinator]):
         return self._device_info
 
     async def _async_wemo_call(self, message: str, action: Callable[[], Any]) -> None:
-        """Run a wemo device action in the executor and update listeners.
+        """Run a WeMo device action in the executor and update listeners.
 
         Handles errors from the device and ensures all entities sharing the
         same coordinator are aware of updates to the device state.

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import functools as ft
 import math
 from typing import Any
 
@@ -60,14 +61,16 @@ async def async_setup_entry(
 
     platform = entity_platform.async_get_current_platform()
 
-    # This will call WemoHumidifier.set_humidity(target_humidity=VALUE)
+    # This will call WemoHumidifier.async_set_humidity(target_humidity=VALUE)
     platform.async_register_entity_service(
-        SERVICE_SET_HUMIDITY, SET_HUMIDITY_SCHEMA, WemoHumidifier.set_humidity.__name__
+        SERVICE_SET_HUMIDITY,
+        SET_HUMIDITY_SCHEMA,
+        WemoHumidifier.async_set_humidity.__name__,
     )
 
-    # This will call WemoHumidifier.reset_filter_life()
+    # This will call WemoHumidifier.async_reset_filter_life()
     platform.async_register_entity_service(
-        SERVICE_RESET_FILTER_LIFE, None, WemoHumidifier.reset_filter_life.__name__
+        SERVICE_RESET_FILTER_LIFE, None, WemoHumidifier.async_reset_filter_life.__name__
     )
 
 
@@ -124,25 +127,26 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
             self._last_fan_on_mode = self.wemo.fan_mode
         super()._handle_coordinator_update()
 
-    def turn_on(
+    async def async_turn_on(
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Turn the fan on."""
-        self._set_percentage(percentage)
+        await self._async_set_percentage(percentage)
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        with self._wemo_call_wrapper("turn off"):
-            self.wemo.set_state(FanMode.Off)
+        await self._async_wemo_call(
+            "turn off", ft.partial(self.wemo.set_state, FanMode.Off)
+        )
 
-    def set_percentage(self, percentage: int) -> None:
+    async def async_set_percentage(self, percentage: int) -> None:
         """Set the fan_mode of the Humidifier."""
-        self._set_percentage(percentage)
+        await self._async_set_percentage(percentage)
 
-    def _set_percentage(self, percentage: int | None) -> None:
+    async def _async_set_percentage(self, percentage: int | None) -> None:
         if percentage is None:
             named_speed = self._last_fan_on_mode
         elif percentage == 0:
@@ -152,10 +156,11 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
                 math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
             )
 
-        with self._wemo_call_wrapper("set speed"):
-            self.wemo.set_state(named_speed)
+        await self._async_wemo_call(
+            "set speed", ft.partial(self.wemo.set_state, named_speed)
+        )
 
-    def set_humidity(self, target_humidity: float) -> None:
+    async def async_set_humidity(self, target_humidity: float) -> None:
         """Set the target humidity level for the Humidifier."""
         if target_humidity < 50:
             pywemo_humidity = DesiredHumidity.FortyFivePercent
@@ -168,10 +173,10 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         elif target_humidity >= 100:
             pywemo_humidity = DesiredHumidity.OneHundredPercent
 
-        with self._wemo_call_wrapper("set humidity"):
-            self.wemo.set_humidity(pywemo_humidity)
+        await self._async_wemo_call(
+            "set humidity", ft.partial(self.wemo.set_humidity, pywemo_humidity)
+        )
 
-    def reset_filter_life(self) -> None:
+    async def async_reset_filter_life(self) -> None:
         """Reset the filter life to 100%."""
-        with self._wemo_call_wrapper("reset filter life"):
-            self.wemo.reset_filter_life()
+        await self._async_wemo_call("reset filter life", self.wemo.reset_filter_life)

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -137,7 +137,7 @@ class WemoHumidifier(WemoBinaryStateEntity, FanEntity):
         await self._async_set_percentage(percentage)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+        """Turn the fan off."""
         await self._async_wemo_call(
             "turn off", ft.partial(self.wemo.set_state, FanMode.Off)
         )

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools as ft
 from typing import Any, cast
 
 from pywemo import Bridge, BridgeLight, Dimmer
@@ -166,7 +167,7 @@ class WemoLight(WemoEntity, LightEntity):
         """Return true if device is on."""
         return self.light.state.get("onoff", WEMO_OFF) != WEMO_OFF
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
         xy_color = None
 
@@ -184,7 +185,7 @@ class WemoLight(WemoEntity, LightEntity):
             "force_update": False,
         }
 
-        with self._wemo_call_wrapper("turn on"):
+        def _turn_on() -> None:
             if xy_color is not None:
                 self.light.set_color(xy_color, transition=transition_time)
 
@@ -195,12 +196,14 @@ class WemoLight(WemoEntity, LightEntity):
 
             self.light.turn_on(**turn_on_kwargs)
 
-    def turn_off(self, **kwargs: Any) -> None:
+        await self._async_wemo_call("turn on", _turn_on)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition_time = int(kwargs.get(ATTR_TRANSITION, 0))
-
-        with self._wemo_call_wrapper("turn off"):
-            self.light.turn_off(transition=transition_time)
+        await self._async_wemo_call(
+            "turn off", ft.partial(self.light.turn_off, transition=transition_time)
+        )
 
 
 class WemoDimmer(WemoBinaryStateEntity, LightEntity):
@@ -216,20 +219,19 @@ class WemoDimmer(WemoBinaryStateEntity, LightEntity):
         wemo_brightness: int = self.wemo.get_brightness()
         return int((wemo_brightness * 255) / 100)
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the dimmer on."""
         # Wemo dimmer switches use a range of [0, 100] to control
         # brightness. Level 255 might mean to set it to previous value
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
             brightness = int((brightness / 255) * 100)
-            with self._wemo_call_wrapper("set brightness"):
-                self.wemo.set_brightness(brightness)
+            await self._async_wemo_call(
+                "set brightness", ft.partial(self.wemo.set_brightness, brightness)
+            )
         else:
-            with self._wemo_call_wrapper("turn on"):
-                self.wemo.on()
+            await self._async_wemo_call("turn on", self.wemo.on)
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the dimmer off."""
-        with self._wemo_call_wrapper("turn off"):
-            self.wemo.off()
+        await self._async_wemo_call("turn off", self.wemo.off)

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -119,12 +119,10 @@ class WemoSwitch(WemoBinaryStateEntity, SwitchEntity):
             return "mdi:coffee"
         return None
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        with self._wemo_call_wrapper("turn on"):
-            self.wemo.on()
+        await self._async_wemo_call("turn on", self.wemo.on)
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        with self._wemo_call_wrapper("turn off"):
-            self.wemo.off()
+        await self._async_wemo_call("turn off", self.wemo.off)

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -146,11 +146,6 @@ async def test_avaliable_after_update(
         {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
         blocking=True,
     )
-    # _wemo_call_wrapper schedules async_update_listeners via hass.add_job
-    # from the executor thread, which goes through two levels of call_soon
-    # before the entity state is written.
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     assert hass.states.get(wemo_entity.entity_id).state == STATE_UNAVAILABLE
 

--- a/tests/components/wemo/test_light_dimmer.py
+++ b/tests/components/wemo/test_light_dimmer.py
@@ -73,11 +73,6 @@ async def test_turn_on_brightness(
         {ATTR_ENTITY_ID: [wemo_entity.entity_id], ATTR_BRIGHTNESS: 204},
         blocking=True,
     )
-    # _wemo_call_wrapper schedules async_update_listeners via hass.add_job
-    # from the executor thread, which goes through two levels of call_soon
-    # before the entity state is written.
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     pywemo_device.set_brightness.assert_called_once_with(80)
     states = hass.states.get(wemo_entity.entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#165768 was a rather ugly fix for the Python 3.14.3 breakage. Instead of resorting to two `await hass.async_block_till_done()` calls, in this PR we revert this change and refactor the wemo integration to use async service handlers (async_turn_on, async_turn_off, etc.) instead of sync ones. This keeps the main context on the event loop and only switches to an executor for the sync pywemo device calls.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
