### PR TITLE
Prefer commanded value when determining legacy Z-Wave cover state

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -159,13 +159,13 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         if (current := self._current_position_value) is None or current.value is None:
             return
 
-        # Prefer the Z-Wave targetValue property when the device reports it.
-        # Legacy multilevel switches only report currentValue, so fall back to
-        # the target position we commanded when targetValue is not available.
+        # Prefer the target position we commanded, because legacy devices may
+        # leave a stale targetValue from a previous operation.  Fall back to
+        # the Z-Wave targetValue property only when no command is in flight.
         target_val = (
-            t.value
-            if (t := self._target_position_value) is not None and t.value is not None
-            else self._commanded_target_position
+            self._commanded_target_position
+            if self._commanded_target_position is not None
+            else (t.value if (t := self._target_position_value) is not None else None)
         )
 
         if target_val is not None and current.value == target_val:

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -171,6 +171,7 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         if target_val is not None and current.value == target_val:
             self._attr_is_opening = False
             self._attr_is_closing = False
+            self._commanded_target_position = None
 
     @property
     def current_cover_position(self) -> int | None:

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -1696,7 +1696,7 @@ async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
     assert state
     assert state.state == CoverState.CLOSED
 
-    # Set cover to fully open position via an unsolicited device report.
+    # Set cover to fully open position via an unsolicited device report,
     # while keeping targetValue unknown. This is the case when
     # the device was never controlled.
     node.receive_event(

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -1697,7 +1697,8 @@ async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
     assert state.state == CoverState.CLOSED
 
     # Set cover to fully open position via an unsolicited device report.
-    # This mirrors the log sequence: currentValue 0 => 99
+    # while keeping targetValue unknown. This is the case when
+    # the device was never controlled.
     node.receive_event(
         Event(
             type="value updated",
@@ -1844,5 +1845,145 @@ async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
     )
 
     # Cover must leave OPENING and report OPEN.
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPEN
+
+    # After controlling the device using set_value, targetValue gets populated
+    # in the Z-Wave JS value DB. Simulate a value updated event so the integration
+    # is in sync with Z-Wave JS.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "targetValue",
+                    "newValue": 99,
+                    "prevValue": None,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+
+    # Close cover again. The device will only send currentValue updates;
+    # targetValue stays stale at 99
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSING
+
+    # Intermediate currentValue-only updates.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": 50,
+                    "prevValue": 99,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSING
+
+    # Device reaches fully closed position (currentValue = 0).
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": 0,
+                    "prevValue": 50,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+
+    # Cover must be CLOSED, not stuck in CLOSING due to stale targetValue=99.
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED
+
+    # Now test the reverse: open the cover while targetValue is stale at 0.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "targetValue",
+                    "newValue": 0,
+                    "prevValue": 99,
+                    "propertyName": "targetValue",
+                },
+            },
+        )
+    )
+
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPENING
+
+    # Device reaches fully open position, targetValue stays stale at 0.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": 38,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": 99,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+
+    # Cover must be OPEN, not stuck in OPENING due to stale targetValue=0.
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state.state == CoverState.OPEN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#165003 was only a partial fix. It broke down when the device had previously been controlled, which resulted in a stale target value. Now we always prefer the commanded value over the target value, so the moving state is derived from the most recent controlling command before falling back to the target value.

This is by no means a perfect solution and misses edge cases like stopping the cover manually during a transition. But we'd need to distinguish between Multilevel Switch CC v1-3 devices and Multilevel Switch CC v4+ devices to do better - which the discovery scheme does not support right now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/165775
- This PR is related to issue: Followup to #165003
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
