### PR TITLE
Demo valve registry entry and device

### DIFF
--- a/homeassistant/components/demo/valve.py
+++ b/homeassistant/components/demo/valve.py
@@ -9,8 +9,11 @@ from typing import Any
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature, ValveState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_utc_time_change
+
+from . import DOMAIN
 
 OPEN_CLOSE_DELAY = 2  # Used to give a realistic open/close experience in frontend
 
@@ -47,6 +50,10 @@ class DemoValve(ValveEntity):
         """Initialize the valve."""
         self._attr_unique_id = unique_id
         self._attr_name = name
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            name=name,
+        )
         if moveable:
             self._attr_supported_features = (
                 ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE

--- a/homeassistant/components/demo/valve.py
+++ b/homeassistant/components/demo/valve.py
@@ -37,6 +37,8 @@ async def async_setup_entry(
 class DemoValve(ValveEntity):
     """Representation of a Demo valve."""
 
+    _attr_has_entity_name = True
+    _attr_name = None
     _attr_should_poll = False
 
     def __init__(
@@ -49,7 +51,6 @@ class DemoValve(ValveEntity):
     ) -> None:
         """Initialize the valve."""
         self._attr_unique_id = unique_id
-        self._attr_name = name
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, unique_id)},
             name=name,

--- a/homeassistant/components/demo/valve.py
+++ b/homeassistant/components/demo/valve.py
@@ -23,10 +23,10 @@ async def async_setup_entry(
     """Set up the Demo config entry."""
     async_add_entities(
         [
-            DemoValve("Front Garden", ValveState.OPEN),
-            DemoValve("Orchard", ValveState.CLOSED),
-            DemoValve("Back Garden", ValveState.CLOSED, position=70),
-            DemoValve("Trees", ValveState.CLOSED, position=30),
+            DemoValve("valve_1", "Front Garden", ValveState.OPEN),
+            DemoValve("valve_2", "Orchard", ValveState.CLOSED),
+            DemoValve("valve_3", "Back Garden", ValveState.CLOSED, position=70),
+            DemoValve("valve_4", "Trees", ValveState.CLOSED, position=30),
         ]
     )
 
@@ -38,12 +38,14 @@ class DemoValve(ValveEntity):
 
     def __init__(
         self,
+        unique_id: str,
         name: str,
         state: str,
         moveable: bool = True,
         position: int | None = None,
     ) -> None:
         """Initialize the valve."""
+        self._attr_unique_id = unique_id
         self._attr_name = name
         if moveable:
             self._attr_supported_features = (

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -19,10 +19,9 @@ from homeassistant.components.valve import (
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import async_capture_events, async_fire_time_changed
+from tests.common import MockConfigEntry, async_capture_events, async_fire_time_changed
 
 FRONT_GARDEN = "valve.front_garden"
 ORCHARD = "valve.orchard"
@@ -41,11 +40,12 @@ def valve_only() -> Generator[None]:
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass: HomeAssistant, valve_only: None):
-    """Set up demo component."""
-    assert await async_setup_component(
-        hass, VALVE_DOMAIN, {VALVE_DOMAIN: {"platform": DOMAIN}}
-    )
+async def setup_comp(hass: HomeAssistant, valve_only: None) -> None:
+    """Set up demo component from config entry."""
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
 

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -18,7 +18,6 @@ from homeassistant.components.valve import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, async_capture_events, async_fire_time_changed
@@ -157,22 +156,3 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(state_changes) == 0
-
-
-async def test_valves_are_in_entity_registry(hass: HomeAssistant) -> None:
-    """Test demo valves create entity and device registry entries."""
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
-    back_garden = entity_registry.async_get(BACK_GARDEN)
-    trees = entity_registry.async_get(TREES)
-
-    assert back_garden is not None
-    assert back_garden.unique_id == "valve_3"
-    assert back_garden.device_id is not None
-    assert device_registry.async_get(back_garden.device_id) is not None
-
-    assert trees is not None
-    assert trees.unique_id == "valve_4"
-    assert trees.device_id is not None
-    assert device_registry.async_get(trees.device_id) is not None

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -1,5 +1,6 @@
 """The tests for the Demo valve platform."""
 
+from collections.abc import Generator
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -17,6 +18,7 @@ from homeassistant.components.valve import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -25,10 +27,11 @@ from tests.common import async_capture_events, async_fire_time_changed
 FRONT_GARDEN = "valve.front_garden"
 ORCHARD = "valve.orchard"
 BACK_GARDEN = "valve.back_garden"
+TREES = "valve.trees"
 
 
 @pytest.fixture
-async def valve_only() -> None:
+def valve_only() -> Generator[None]:
     """Enable only the valve platform."""
     with patch(
         "homeassistant.components.demo.COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM",
@@ -50,6 +53,7 @@ async def setup_comp(hass: HomeAssistant, valve_only: None):
 async def test_closing(hass: HomeAssistant) -> None:
     """Test the closing of a valve."""
     state = hass.states.get(FRONT_GARDEN)
+    assert state is not None
     assert state.state == ValveState.OPEN
     await hass.async_block_till_done()
 
@@ -63,9 +67,11 @@ async def test_closing(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert state_changes[0].data["entity_id"] == FRONT_GARDEN
+    assert state_changes[0].data["new_state"] is not None
     assert state_changes[0].data["new_state"].state == ValveState.CLOSING
 
     assert state_changes[1].data["entity_id"] == FRONT_GARDEN
+    assert state_changes[1].data["new_state"] is not None
     assert state_changes[1].data["new_state"].state == ValveState.CLOSED
 
 
@@ -73,6 +79,7 @@ async def test_closing(hass: HomeAssistant) -> None:
 async def test_opening(hass: HomeAssistant) -> None:
     """Test the opening of a valve."""
     state = hass.states.get(ORCHARD)
+    assert state is not None
     assert state.state == ValveState.CLOSED
     await hass.async_block_till_done()
 
@@ -83,15 +90,18 @@ async def test_opening(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert state_changes[0].data["entity_id"] == ORCHARD
+    assert state_changes[0].data["new_state"] is not None
     assert state_changes[0].data["new_state"].state == ValveState.OPENING
 
     assert state_changes[1].data["entity_id"] == ORCHARD
+    assert state_changes[1].data["new_state"] is not None
     assert state_changes[1].data["new_state"].state == ValveState.OPEN
 
 
 async def test_set_valve_position(hass: HomeAssistant) -> None:
     """Test moving the valve to a specific position."""
     state = hass.states.get(BACK_GARDEN)
+    assert state is not None
     assert state.attributes[ATTR_CURRENT_POSITION] == 70
 
     # close to 10%
@@ -102,6 +112,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
         blocking=True,
     )
     state = hass.states.get(BACK_GARDEN)
+    assert state is not None
     assert state.state == ValveState.CLOSING
 
     for _ in range(6):
@@ -110,6 +121,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(BACK_GARDEN)
+    assert state is not None
     assert state.attributes[ATTR_CURRENT_POSITION] == 10
     assert state.state == ValveState.OPEN
 
@@ -121,6 +133,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
         blocking=True,
     )
     state = hass.states.get(BACK_GARDEN)
+    assert state is not None
     assert state.state == ValveState.OPENING
 
     for _ in range(7):
@@ -129,6 +142,7 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     state = hass.states.get(BACK_GARDEN)
+    assert state is not None
     assert state.attributes[ATTR_CURRENT_POSITION] == 80
     assert state.state == ValveState.OPEN
 
@@ -143,3 +157,16 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(state_changes) == 0
+
+
+async def test_valves_are_in_entity_registry(hass: HomeAssistant) -> None:
+    """Test demo valves create entity registry entries."""
+    entity_registry = er.async_get(hass)
+
+    back_garden = entity_registry.async_get(BACK_GARDEN)
+    trees = entity_registry.async_get(TREES)
+
+    assert back_garden is not None
+    assert back_garden.unique_id == "valve_3"
+    assert trees is not None
+    assert trees.unique_id == "valve_4"

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -18,7 +18,7 @@ from homeassistant.components.valve import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -160,7 +160,8 @@ async def test_set_valve_position(hass: HomeAssistant) -> None:
 
 
 async def test_valves_are_in_entity_registry(hass: HomeAssistant) -> None:
-    """Test demo valves create entity registry entries."""
+    """Test demo valves create entity and device registry entries."""
+    device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
     back_garden = entity_registry.async_get(BACK_GARDEN)
@@ -168,5 +169,10 @@ async def test_valves_are_in_entity_registry(hass: HomeAssistant) -> None:
 
     assert back_garden is not None
     assert back_garden.unique_id == "valve_3"
+    assert back_garden.device_id is not None
+    assert device_registry.async_get(back_garden.device_id) is not None
+
     assert trees is not None
     assert trees.unique_id == "valve_4"
+    assert trees.device_id is not None
+    assert device_registry.async_get(trees.device_id) is not None

--- a/tests/components/demo/test_valve.py
+++ b/tests/components/demo/test_valve.py
@@ -25,7 +25,6 @@ from tests.common import MockConfigEntry, async_capture_events, async_fire_time_
 FRONT_GARDEN = "valve.front_garden"
 ORCHARD = "valve.orchard"
 BACK_GARDEN = "valve.back_garden"
-TREES = "valve.trees"
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Gives demo valves a registry entry and device.

Used in testing for https://github.com/home-assistant/frontend/pull/30190 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
