### PR TITLE
Raise issue on vera deprecated YAML

### DIFF
--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -18,9 +18,10 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 
 from .common import (
@@ -61,15 +62,51 @@ async def async_setup(hass: HomeAssistant, base_config: ConfigType) -> bool:
     if not (config := base_config.get(DOMAIN)):
         return True
 
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data=config,
-        )
-    )
+    hass.async_create_task(_async_setup(hass, config))
 
     return True
+
+
+async def _async_setup(hass: HomeAssistant, config: ConfigType) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=config,
+    )
+    if (
+        result.get("type") is FlowResultType.ABORT
+        and result.get("reason") != "already_configured"
+    ):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_yaml_import_issue_{result.get('reason')}",
+            breaks_in_ha_version="2026.10.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=f"deprecated_yaml_import_issue_{result.get('reason')}",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "Vera",
+            },
+        )
+        return
+
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        breaks_in_ha_version="2026.10.0",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Vera",
+        },
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
@@ -67,11 +68,30 @@ async def async_setup(hass: HomeAssistant, base_config: ConfigType) -> bool:
 
 
 async def _async_setup(hass: HomeAssistant, config: ConfigType) -> None:
-    await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
         data=config,
     )
+    if (
+        result.get("type") is FlowResultType.ABORT
+        and result.get("reason") != "already_configured"
+    ):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"deprecated_yaml_import_issue_{result.get('reason')}",
+            breaks_in_ha_version="2026.10.0",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=f"deprecated_yaml_import_issue_{result.get('reason')}",
+            translation_placeholders={
+                "domain": DOMAIN,
+                "integration_title": "Vera",
+            },
+        )
+        return
 
     ir.async_create_issue(
         hass,

--- a/homeassistant/components/vera/__init__.py
+++ b/homeassistant/components/vera/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
@@ -68,30 +67,11 @@ async def async_setup(hass: HomeAssistant, base_config: ConfigType) -> bool:
 
 
 async def _async_setup(hass: HomeAssistant, config: ConfigType) -> None:
-    result = await hass.config_entries.flow.async_init(
+    await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_IMPORT},
         data=config,
     )
-    if (
-        result.get("type") is FlowResultType.ABORT
-        and result.get("reason") != "already_configured"
-    ):
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            f"deprecated_yaml_import_issue_{result.get('reason')}",
-            breaks_in_ha_version="2026.10.0",
-            is_fixable=False,
-            issue_domain=DOMAIN,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key=f"deprecated_yaml_import_issue_{result.get('reason')}",
-            translation_placeholders={
-                "domain": DOMAIN,
-                "integration_title": "Vera",
-            },
-        )
-        return
 
     ir.async_create_issue(
         hass,

--- a/homeassistant/components/vera/strings.json
+++ b/homeassistant/components/vera/strings.json
@@ -17,6 +17,12 @@
       }
     }
   },
+  "issues": {
+    "deprecated_yaml_import_issue_cannot_connect": {
+      "description": "Configuring {integration_title} via YAML is deprecated and will be removed in a future release. While importing your configuration, a connection error occurred. Please correct your YAML configuration and restart Home Assistant, or remove the {domain} key from your configuration and configure the integration via the UI.",
+      "title": "The {integration_title} YAML configuration is being removed"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.vera.const import (
 from homeassistant.const import CONF_EXCLUDE, CONF_LIGHTS, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from tests.common import MockConfigEntry
 
@@ -66,7 +66,9 @@ async def test_async_step_user_success(hass: HomeAssistant) -> None:
     assert entries
 
 
-async def test_async_step_import_success(hass: HomeAssistant) -> None:
+async def test_async_step_import_success(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
     """Test import step success."""
     with patch("pyvera.VeraController") as vera_controller_class_mock:
         controller = MagicMock()
@@ -89,9 +91,18 @@ async def test_async_step_import_success(hass: HomeAssistant) -> None:
         }
         assert result["result"].unique_id == controller.serial_number
 
+        # Check that a deprecation repair issue was created
+        issue = issue_registry.async_get_issue(
+            "homeassistant", f"deprecated_yaml_{DOMAIN}"
+        )
+        assert issue is not None
+        assert issue.severity == "warning"
+
 
 async def test_async_step_import_success_with_legacy_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test import step success with legacy unique id."""
     entity_registry.async_get_or_create(
@@ -119,6 +130,13 @@ async def test_async_step_import_success_with_legacy_unique_id(
         }
         assert result["result"].unique_id == controller.serial_number
 
+        # Check that a deprecation repair issue was created
+        issue = issue_registry.async_get_issue(
+            "homeassistant", f"deprecated_yaml_{DOMAIN}"
+        )
+        assert issue is not None
+        assert issue.severity == "warning"
+
 
 async def test_async_step_finish_error(hass: HomeAssistant) -> None:
     """Test finish step with error."""
@@ -129,7 +147,7 @@ async def test_async_step_finish_error(hass: HomeAssistant) -> None:
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
+            context={"source": config_entries.SOURCE_USER},
             data={CONF_CONTROLLER: "http://127.0.0.1:123/"},
         )
 

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.vera.const import (
 from homeassistant.const import CONF_EXCLUDE, CONF_LIGHTS, CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -66,9 +66,7 @@ async def test_async_step_user_success(hass: HomeAssistant) -> None:
     assert entries
 
 
-async def test_async_step_import_success(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry
-) -> None:
+async def test_async_step_import_success(hass: HomeAssistant) -> None:
     """Test import step success."""
     with patch("pyvera.VeraController") as vera_controller_class_mock:
         controller = MagicMock()
@@ -91,18 +89,9 @@ async def test_async_step_import_success(
         }
         assert result["result"].unique_id == controller.serial_number
 
-        # Check that a deprecation repair issue was created
-        issue = issue_registry.async_get_issue(
-            "homeassistant", f"deprecated_yaml_{DOMAIN}"
-        )
-        assert issue is not None
-        assert issue.severity == "warning"
-
 
 async def test_async_step_import_success_with_legacy_unique_id(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    issue_registry: ir.IssueRegistry,
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test import step success with legacy unique id."""
     entity_registry.async_get_or_create(
@@ -129,13 +118,6 @@ async def test_async_step_import_success_with_legacy_unique_id(
             CONF_LEGACY_UNIQUE_ID: True,
         }
         assert result["result"].unique_id == controller.serial_number
-
-        # Check that a deprecation repair issue was created
-        issue = issue_registry.async_get_issue(
-            "homeassistant", f"deprecated_yaml_{DOMAIN}"
-        )
-        assert issue is not None
-        assert issue.severity == "warning"
 
 
 async def test_async_step_finish_error(hass: HomeAssistant) -> None:

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.components.vera import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 
 from .common import ComponentFactory, ConfigSource, new_simple_controller_config
 
@@ -53,6 +53,7 @@ async def test_init_from_file(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     vera_component_factory: ComponentFactory,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test function."""
     vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
@@ -75,6 +76,11 @@ async def test_init_from_file(
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1
     assert entry1.unique_id == "vera_first_serial_1"
+
+    # Check that a deprecation repair issue was created
+    issue = issue_registry.async_get_issue("homeassistant", f"deprecated_yaml_{DOMAIN}")
+    assert issue is not None
+    assert issue.severity == "warning"
 
 
 async def test_multiple_controllers_with_legacy_one(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The YAML configuration for vera is now deprecated. If you have
an existing YAML configuration, it has been imported into the UI automatically
and can be safely removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #72418 and #29880

As an alternative to #165659 if we feel that an issue is warranted despite it being already deprecated for 4 years

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
