### PR TITLE
Add alarm control panel support for Tuya WG2 alarm panel (Duosmart C30)

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -35,7 +35,13 @@ ALARM: dict[DeviceCategory, tuple[AlarmControlPanelEntityDescription, ...]] = {
             key=DPCode.MASTER_MODE,
             name="Alarm",
         ),
-    )
+    ),
+    DeviceCategory.WG2: (
+        AlarmControlPanelEntityDescription(
+            key=DPCode.MASTER_MODE,
+            name="Alarm",
+        ),
+    ),
 }
 
 _TUYA_TO_HA_STATE_MAPPINGS = {

--- a/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
@@ -1,8 +1,9 @@
 # serializer version: 1
 # name: test_platform_setup_and_discovery[alarm_control_panel.c30-entry]
   EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
+    'aliases': list([
+      None,
+    ]),
     'area_id': None,
     'capabilities': None,
     'config_entry_id': <ANY>,

--- a/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
+++ b/tests/components/tuya/snapshots/test_alarm_control_panel.ambr
@@ -1,4 +1,57 @@
 # serializer version: 1
+# name: test_platform_setup_and_discovery[alarm_control_panel.c30-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'alarm_control_panel',
+    'entity_category': None,
+    'entity_id': 'alarm_control_panel.c30',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <AlarmControlPanelEntityFeature: 11>,
+    'translation_key': None,
+    'unique_id': 'tuya.rirsc4vhpbv2whkp2gwmaster_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[alarm_control_panel.c30-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'changed_by': None,
+      'code_arm_required': False,
+      'code_format': None,
+      'friendly_name': 'C30',
+      'supported_features': <AlarmControlPanelEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'alarm_control_panel.c30',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'disarmed',
+  })
+# ---
 # name: test_platform_setup_and_discovery[alarm_control_panel.multifunction_alarm-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -7150,7 +7150,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tuya',
-    'model': 'C30 (unsupported)',
+    'model': 'C30',
     'model_id': 'pkhw2vbphv4csrir',
     'name': 'C30',
     'name_by_user': None,

--- a/tests/components/tuya/test_alarm_control_panel.py
+++ b/tests/components/tuya/test_alarm_control_panel.py
@@ -43,8 +43,11 @@ async def test_platform_setup_and_discovery(
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 @pytest.mark.parametrize(
-    "mock_device_code",
-    ["mal_gyitctrjj1kefxp2"],
+    ("mock_device_code", "entity_id"),
+    [
+        ("mal_gyitctrjj1kefxp2", "alarm_control_panel.multifunction_alarm"),
+        ("wg2_pkhw2vbphv4csrir", "alarm_control_panel.c30"),
+    ],
 )
 @pytest.mark.parametrize(
     ("service", "command"),
@@ -62,9 +65,9 @@ async def test_service(
     mock_device: CustomerDevice,
     service: str,
     command: dict[str, Any],
+    entity_id: str,
 ) -> None:
     """Test service."""
-    entity_id = "alarm_control_panel.multifunction_alarm"
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 
     state = hass.states.get(entity_id)
@@ -82,8 +85,11 @@ async def test_service(
 
 @patch("homeassistant.components.tuya.PLATFORMS", [Platform.ALARM_CONTROL_PANEL])
 @pytest.mark.parametrize(
-    "mock_device_code",
-    ["mal_gyitctrjj1kefxp2"],
+    ("mock_device_code", "entity_id"),
+    [
+        ("mal_gyitctrjj1kefxp2", "alarm_control_panel.multifunction_alarm"),
+        ("wg2_pkhw2vbphv4csrir", "alarm_control_panel.c30"),
+    ],
 )
 @pytest.mark.parametrize(
     ("status_updates", "expected_state"),
@@ -131,9 +137,9 @@ async def test_state(
     mock_device: CustomerDevice,
     status_updates: dict[str, Any],
     expected_state: str,
+    entity_id: str,
 ) -> None:
     """Test state."""
-    entity_id = "alarm_control_panel.multifunction_alarm"
     mock_device.status.update(status_updates)
     await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
 


### PR DESCRIPTION
## Proposed change

Adds `MASTER_MODE` alarm control panel entity to `DeviceCategory.WG2`, for the Duosmart C30 alarm panel. Expands `test_service` and `test_state` to run against both the MAL and WG2 fixtures.

Split from #165648 as requested by @epenet.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: #165648 (closed, split into per-platform PRs)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr