### PR TITLE
Support matching CC version ranges in Z-Wave discovery

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -43,6 +43,7 @@ from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_SETPOINT_PROPERTY,
 )
 from zwave_js_server.exceptions import UnknownValueData
+from zwave_js_server.model.endpoint import Endpoint
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import (
     ConfigurationValue,
@@ -68,6 +69,7 @@ from .discovery_data_template import (
 from .entity import NewZwaveDiscoveryInfo
 from .event import DISCOVERY_SCHEMAS as EVENT_SCHEMAS
 from .models import (
+    CommandClassVersionRange,
     FirmwareVersionRange,
     NewZWaveDiscoverySchema,
     ValueType,
@@ -128,6 +130,12 @@ class ZWaveDiscoverySchema:
     entity_registry_enabled_default: bool = True
     # [optional] the entity category for the discovered entity
     entity_category: EntityCategory | None = None
+    # [optional] the primary value's endpoint must support ALL of these CCs
+    # at a version within the specified range
+    required_cc_versions: dict[int, CommandClassVersionRange] | None = None
+    # [optional] the primary value's endpoint must NOT support ANY of these CCs
+    # at a version within the specified range
+    absent_cc_versions: dict[int, CommandClassVersionRange] | None = None
 
 
 DOOR_LOCK_CURRENT_MODE_SCHEMA = ZWaveValueDiscoverySchema(
@@ -1223,6 +1231,26 @@ DISCOVERY_SCHEMAS = [
 
 
 @callback
+def _check_cc_version_ranges(
+    node_endpoint: Endpoint,
+    cc_version_ranges: dict[int, CommandClassVersionRange],
+) -> bool:
+    """Return True if ALL CC version ranges are satisfied on the endpoint."""
+    for cc_id, version_range in cc_version_ranges.items():
+        cc_version = next(
+            (cc.version for cc in node_endpoint.command_classes if cc.id == cc_id),
+            None,
+        )
+        if cc_version is None:
+            return False
+        if version_range.min is not None and cc_version < version_range.min:
+            return False
+        if version_range.max is not None and cc_version > version_range.max:
+            return False
+    return True
+
+
+@callback
 def async_discover_node_values(
     node: ZwaveNode, device: DeviceEntry, discovered_value_ids: dict[str, set[str]]
 ) -> Generator[ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo]:
@@ -1332,6 +1360,24 @@ def async_discover_single_value(
             )
         ):
             continue
+
+        # check required_cc_versions
+        if schema.required_cc_versions is not None:
+            endpoint_idx = value.endpoint if value.endpoint is not None else 0
+            node_endpoint = value.node.endpoints.get(endpoint_idx)
+            if node_endpoint is None or not _check_cc_version_ranges(
+                node_endpoint, schema.required_cc_versions
+            ):
+                continue
+
+        # check absent_cc_versions
+        if schema.absent_cc_versions is not None:
+            endpoint_idx = value.endpoint if value.endpoint is not None else 0
+            node_endpoint = value.node.endpoints.get(endpoint_idx)
+            if node_endpoint is not None and _check_cc_version_ranges(
+                node_endpoint, schema.absent_cc_versions
+            ):
+                continue
 
         # check primary value
         if not check_value(value, schema.primary_value):

--- a/homeassistant/components/zwave_js/models.py
+++ b/homeassistant/components/zwave_js/models.py
@@ -86,6 +86,19 @@ class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
 
 
 @dataclass
+class CommandClassVersionRange:
+    """Command class version range."""
+
+    min: int | None = None
+    max: int | None = None
+
+    @classmethod
+    def any(cls) -> CommandClassVersionRange:
+        """Match any version (presence check only)."""
+        return cls()
+
+
+@dataclass
 class PlatformZwaveDiscoveryInfo:
     """Info discovered from (primary) ZWave Value to create entity."""
 
@@ -204,6 +217,12 @@ class NewZWaveDiscoverySchema:
     # [optional] bool to specify whether state is assumed
     # and events should be fired on value update
     assumed_state: bool = False
+    # [optional] the primary value's endpoint must support ALL of these CCs
+    # at a version within the specified range
+    required_cc_versions: dict[int, CommandClassVersionRange] | None = None
+    # [optional] the primary value's endpoint must NOT support ANY of these CCs
+    # at a version within the specified range
+    absent_cc_versions: dict[int, CommandClassVersionRange] | None = None
 
 
 @dataclass

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
+from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 
@@ -20,9 +21,11 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.components.zwave_js.discovery import (
+    CommandClassVersionRange,
     FirmwareVersionRange,
     ZWaveDiscoverySchema,
     ZWaveValueDiscoverySchema,
+    _check_cc_version_ranges,
 )
 from homeassistant.components.zwave_js.discovery_data_template import (
     DynamicCurrentTempClimateDataTemplate,
@@ -546,6 +549,178 @@ async def test_nabu_casa_zwa2(
     )
     assert state.attributes["friendly_name"] == "Home Assistant Connect ZWA-2 LED", (
         "The LED should have the correct friendly name"
+    )
+
+
+def test_command_class_version_range_any_version() -> None:
+    """Test CommandClassVersionRange.any() matches any version (presence check)."""
+    cc_id = CommandClass.SWITCH_MULTILEVEL
+
+    # CC present at any version passes
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 1),
+        {cc_id: CommandClassVersionRange.any()},
+    )
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 99),
+        {cc_id: CommandClassVersionRange.any()},
+    )
+
+    # CC absent fails
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, None),
+        {cc_id: CommandClassVersionRange.any()},
+    )
+
+
+def _make_mock_endpoint(cc_id: int, cc_version: int | None) -> MagicMock:
+    """Build a mock endpoint with a single command class entry."""
+    endpoint = MagicMock()
+    if cc_version is not None:
+        cc_info = MagicMock()
+        cc_info.id = cc_id
+        cc_info.version = cc_version
+        endpoint.command_classes = [cc_info]
+    else:
+        endpoint.command_classes = []
+    return endpoint
+
+
+def test_check_cc_version_ranges_required() -> None:
+    """Test _check_cc_version_ranges for required CC version matching."""
+    cc_id = CommandClass.SWITCH_MULTILEVEL
+
+    # Version within range (min=2, max=5) passes
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 3),
+        {cc_id: CommandClassVersionRange(min=2, max=5)},
+    )
+
+    # Version at min boundary passes
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 2),
+        {cc_id: CommandClassVersionRange(min=2, max=5)},
+    )
+
+    # Version at max boundary passes
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 5),
+        {cc_id: CommandClassVersionRange(min=2, max=5)},
+    )
+
+    # Version below min fails
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 1),
+        {cc_id: CommandClassVersionRange(min=2, max=5)},
+    )
+
+    # Version above max fails
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 6),
+        {cc_id: CommandClassVersionRange(min=2, max=5)},
+    )
+
+    # min-only (>=2): version 1 fails, version 2 passes, version 99 passes
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 1),
+        {cc_id: CommandClassVersionRange(min=2)},
+    )
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 2),
+        {cc_id: CommandClassVersionRange(min=2)},
+    )
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 99),
+        {cc_id: CommandClassVersionRange(min=2)},
+    )
+
+    # max-only (<=3): version 4 fails, version 3 passes, version 1 passes
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 4),
+        {cc_id: CommandClassVersionRange(max=3)},
+    )
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 3),
+        {cc_id: CommandClassVersionRange(max=3)},
+    )
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 1),
+        {cc_id: CommandClassVersionRange(max=3)},
+    )
+
+    # Exact match (min=4, max=4): version 4 passes, others fail
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 4),
+        {cc_id: CommandClassVersionRange(min=4, max=4)},
+    )
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 3),
+        {cc_id: CommandClassVersionRange(min=4, max=4)},
+    )
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 5),
+        {cc_id: CommandClassVersionRange(min=4, max=4)},
+    )
+
+    # CC not present in command_classes fails
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, None),
+        {cc_id: CommandClassVersionRange(min=2)},
+    )
+
+    # Multiple CCs: all must pass
+    cc_id2 = CommandClass.SWITCH_BINARY
+    endpoint = MagicMock()
+    cc_info1 = MagicMock()
+    cc_info1.id = cc_id
+    cc_info1.version = 3
+    cc_info2 = MagicMock()
+    cc_info2.id = cc_id2
+    cc_info2.version = 2
+    endpoint.command_classes = [cc_info1, cc_info2]
+
+    assert _check_cc_version_ranges(
+        endpoint,
+        {
+            cc_id: CommandClassVersionRange(min=2, max=4),
+            cc_id2: CommandClassVersionRange(min=1, max=3),
+        },
+    )
+
+    # Second CC version out of range → fails
+    assert not _check_cc_version_ranges(
+        endpoint,
+        {
+            cc_id: CommandClassVersionRange(min=2, max=4),
+            cc_id2: CommandClassVersionRange(min=3),  # cc_id2 version=2 < 3
+        },
+    )
+
+
+def test_check_cc_version_ranges_absent() -> None:
+    """Test absent_cc_versions logic via _check_cc_version_ranges.
+
+    For absent_cc_versions, the schema skips if _check_cc_version_ranges returns True
+    (meaning an absent condition IS satisfied — the CC is present and in the range).
+    """
+    cc_id = CommandClass.SWITCH_MULTILEVEL
+
+    # CC present and version in range → function returns True → schema would skip
+    assert _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 3),
+        {cc_id: CommandClassVersionRange(min=1)},
+    )
+
+    # CC present but version out of range → returns False → schema proceeds
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, 1),
+        {cc_id: CommandClassVersionRange(min=2)},
+    )
+
+    # CC absent entirely → returns False → schema proceeds
+    assert not _check_cc_version_ranges(
+        _make_mock_endpoint(cc_id, None),
+        {cc_id: CommandClassVersionRange(min=1)},
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Schemas can now specify which CC versions a device must (or must not) support, enabling different entities to be discovered depending on how a device implements a given CC.
For example, this allows us to distinguish between Multilevel Switch CC v4 based covers which report their target position, and Multilevel Switch CC v1-3 based covers which don't.

Examples:
```python
# Match SWITCH_MULTILEVEL versions 1-3
required_cc_versions={
    CommandClass.SWITCH_MULTILEVEL: CommandClassVersionRange(max=3),
}

# Match SWITCH_MULTILEVEL version 4
required_cc_versions={
    CommandClass.SWITCH_MULTILEVEL: CommandClassVersionRange(min=4),
}

# Match any version of SWITCH_MULTILEVEL
required_cc_versions={
    CommandClass.SWITCH_MULTILEVEL: CommandClassVersionRange.any(),
}

# Match only when a CC is not supported at all
absent_cc_versions={
    CommandClass.WINDOW_COVERING: CommandClassVersionRange.any(),
}

# Match only when a CC is not supported in version 5+
absent_cc_versions={
    CommandClass.WINDOW_COVERING: CommandClassVersionRange(min=5),
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: Allows us to properly solve what https://github.com/home-assistant/core/pull/165796 is partially solving
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
