### PR TITLE
Fix Abort exception caught by wrong handler in backup encrypt/decrypt

### DIFF
--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -246,6 +246,8 @@ def decrypt_backup(
         except (DecryptError, SecureTarError, tarfile.TarError) as err:
             LOGGER.warning("Error decrypting backup: %s", err)
             error = err
+        except Abort:
+            raise
         except Exception as err:  # noqa: BLE001
             LOGGER.exception("Unexpected error when decrypting backup: %s", err)
             error = err
@@ -332,8 +334,10 @@ def encrypt_backup(
         except (EncryptError, SecureTarError, tarfile.TarError) as err:
             LOGGER.warning("Error encrypting backup: %s", err)
             error = err
+        except Abort:
+            raise
         except Exception as err:  # noqa: BLE001
-            LOGGER.exception("Unexpected error when decrypting backup: %s", err)
+            LOGGER.exception("Unexpected error when encrypting backup: %s", err)
             error = err
         else:
             # Pad the output stream to the requested minimum size


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

When a backup encrypt/decrypt operation is aborted (e.g. the consumer cancels the stream), the `Abort` exception raised by `AsyncIteratorWriter.write()` is caught by the broad `except Exception` clause instead of propagating to the intended outer `except Abort` handler. This causes spurious "Unexpected error when decrypting backup" log messages with full tracebacks for what is actually a normal abort flow.

This PR adds `except Abort: raise` before `except Exception` in both `encrypt_backup` and `decrypt_backup` so that `Abort` reaches the correct handler.

Also fixes a copy-paste error in `encrypt_backup` where the log message incorrectly said "decrypting" instead of "encrypting".

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #165769
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
