### PR TITLE
Improve subentry error handling for Telegram bot

### DIFF
--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -119,8 +119,8 @@ async def async_discover_authorization_server(
         _LOGGER.info("Authorization Server Metadata not found, using default paths")
         return OAuthConfig(
             authorization_server=AuthorizationServer(
-                authorize_url=str(parsed_url.with_path("/authorize")),
-                token_url=str(parsed_url.with_path("/token")),
+                authorize_url=str(parsed_url.with_path("/auth/authorize")),
+                token_url=str(parsed_url.with_path("/auth/token")),
             )
         )
 

--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -119,8 +119,8 @@ async def async_discover_authorization_server(
         _LOGGER.info("Authorization Server Metadata not found, using default paths")
         return OAuthConfig(
             authorization_server=AuthorizationServer(
-                authorize_url=str(parsed_url.with_path("/auth/authorize")),
-                token_url=str(parsed_url.with_path("/auth/token")),
+                authorize_url=str(parsed_url.with_path("/authorize")),
+                token_url=str(parsed_url.with_path("/token")),
             )
         )
 

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -616,13 +616,8 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
                 description_placeholders["error_message"] = str(err)
 
             if not errors:
-                title = (
-                    f"{chat_info.effective_name} ({chat_id})"
-                    if chat_info.effective_name
-                    else str(chat_id)
-                )
                 return self.async_create_entry(
-                    title=title,
+                    title=chat_info.effective_name or str(chat_id),
                     data={CONF_CHAT_ID: chat_id},
                     unique_id=str(chat_id),
                 )

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -153,6 +153,7 @@ STEP_WEBHOOKS_DATA_SCHEMA: vol.Schema = vol.Schema(
         vol.Required(CONF_TRUSTED_NETWORKS): vol.Coerce(str),
     }
 )
+SUBENTRY_SCHEMA: vol.Schema = vol.Schema({vol.Required(CONF_CHAT_ID): vol.Coerce(int)})
 OPTIONS_SCHEMA: vol.Schema = vol.Schema(
     {
         vol.Required(
@@ -598,24 +599,35 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
             )
 
         errors: dict[str, str] = {}
+        description_placeholders = DESCRIPTION_PLACEHOLDERS.copy()
 
         if user_input is not None:
             config_entry: TelegramBotConfigEntry = self._get_entry()
             bot = config_entry.runtime_data.bot
 
+            # validate chat id
             chat_id: int = user_input[CONF_CHAT_ID]
-            chat_name = await _async_get_chat_name(bot, chat_id)
-            if chat_name:
+            try:
+                chat_info: ChatFullInfo = await bot.get_chat(chat_id)
+            except BadRequest:
+                errors["base"] = "chat_not_found"
+            except TelegramError as err:
+                errors["base"] = "telegram_error"
+                description_placeholders["error_message"] = str(err)
+
+            if not errors:
+                title = (
+                    f"{chat_info.effective_name} ({chat_id})"
+                    if chat_info.effective_name
+                    else str(chat_id)
+                )
                 return self.async_create_entry(
-                    title=f"{chat_name} ({chat_id})",
+                    title=title,
                     data={CONF_CHAT_ID: chat_id},
                     unique_id=str(chat_id),
                 )
 
-            errors["base"] = "chat_not_found"
-
         service: TelegramNotificationService = self._get_entry().runtime_data
-        description_placeholders = DESCRIPTION_PLACEHOLDERS.copy()
         description_placeholders["bot_username"] = f"@{service.bot.username}"
         description_placeholders["bot_url"] = f"https://t.me/{service.bot.username}"
 
@@ -639,7 +651,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                vol.Schema({vol.Required(CONF_CHAT_ID): vol.Coerce(int)}),
+                SUBENTRY_SCHEMA,
                 suggested_values,
             ),
             description_placeholders=description_placeholders,
@@ -677,11 +689,3 @@ async def _get_most_recent_chat(
             )
 
     return None
-
-
-async def _async_get_chat_name(bot: Bot, chat_id: int) -> str:
-    try:
-        chat_info: ChatFullInfo = await bot.get_chat(chat_id)
-        return chat_info.effective_name or str(chat_id)
-    except BadRequest:
-        return ""

--- a/homeassistant/components/telegram_bot/config_flow.py
+++ b/homeassistant/components/telegram_bot/config_flow.py
@@ -613,7 +613,7 @@ class AllowedChatIdsSubEntryFlowHandler(ConfigSubentryFlow):
                 errors["base"] = "chat_not_found"
             except TelegramError as err:
                 errors["base"] = "telegram_error"
-                description_placeholders["error_message"] = str(err)
+                description_placeholders[ERROR_MESSAGE] = str(err)
 
             if not errors:
                 return self.async_create_entry(

--- a/homeassistant/components/telegram_bot/strings.json
+++ b/homeassistant/components/telegram_bot/strings.json
@@ -92,7 +92,8 @@
       },
       "entry_type": "Allowed chat ID",
       "error": {
-        "chat_not_found": "Chat not found"
+        "chat_not_found": "Chat not found",
+        "telegram_error": "[%key:component::telegram_bot::config::error::telegram_error%]"
       },
       "initiate_flow": {
         "user": "Add allowed chat ID"

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -557,7 +557,7 @@ async def test_subentry_flow(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert subentry.subentry_type == SUBENTRY_TYPE_ALLOWED_CHAT_IDS
-    assert subentry.title == "mock title (987654321)"
+    assert subentry.title == "mock title"
     assert subentry.unique_id == "987654321"
     assert subentry.data == {CONF_CHAT_ID: 987654321}
 

--- a/tests/components/telegram_bot/test_config_flow.py
+++ b/tests/components/telegram_bot/test_config_flow.py
@@ -596,6 +596,22 @@ async def test_subentry_flow_chat_error(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    # test: network error
+
+    with patch("homeassistant.components.telegram_bot.bot.Bot.get_chat") as mock_bot:
+        mock_bot.side_effect = NetworkError("mock network error")
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            user_input={CONF_CHAT_ID: 1234567890},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "telegram_error"
+    assert result["description_placeholders"]["error_message"] == "mock network error"
+
     # test: chat not found
 
     with patch("homeassistant.components.telegram_bot.bot.Bot.get_chat") as mock_bot:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. Handled exceptions in subentry flow.
2. Removed chat_id from subentry title to make it more user friendly. (Previously, users can only use chat_ids in actions. Now that we have support for notify entities, chat_ids are not required anymore)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
