### PR TITLE
Lutron Keypad LEDs as Select entities

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -29,6 +29,7 @@ PLATFORMS = [
     Platform.FAN,
     Platform.LIGHT,
     Platform.SCENE,
+    Platform.SELECT,
     Platform.SWITCH,
 ]
 
@@ -215,14 +216,15 @@ def _setup_keypad(
                 entry_data.client.guid,
             )
             if led is not None:
-                _async_check_entity_unique_id(
-                    hass,
-                    entity_registry,
-                    Platform.SWITCH,
-                    led.uuid,
-                    led.legacy_uuid,
-                    entry_data.client.guid,
-                )
+                for platform in (Platform.SWITCH, Platform.SELECT):
+                    _async_check_entity_unique_id(
+                        hass,
+                        entity_registry,
+                        platform,
+                        led.uuid,
+                        led.legacy_uuid,
+                        entry_data.client.guid,
+                    )
         if button.button_type:
             entry_data.buttons.append((area_name, keypad, button))
 

--- a/homeassistant/components/lutron/select.py
+++ b/homeassistant/components/lutron/select.py
@@ -1,0 +1,76 @@
+"""Support for Lutron selects."""
+
+from __future__ import annotations
+
+from pylutron import Button, Keypad, Led, Lutron
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import LutronConfigEntry
+from .entity import LutronKeypad
+
+_LED_STATE_TO_OPTION = {
+    Led.LED_OFF: "off",
+    Led.LED_ON: "on",
+    Led.LED_SLOW_FLASH: "slow_flash",
+    Led.LED_FAST_FLASH: "fast_flash",
+}
+
+_LED_OPTION_TO_STATE = {v: k for k, v in _LED_STATE_TO_OPTION.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: LutronConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Lutron select platform."""
+    entry_data = config_entry.runtime_data
+
+    # Add the indicator LEDs for scenes (keypad buttons)
+    async_add_entities(
+        [
+            LutronLedSelect(area_name, keypad, scene, led, entry_data.client)
+            for area_name, keypad, scene, led in entry_data.scenes
+            if led is not None
+        ],
+        True,
+    )
+
+
+class LutronLedSelect(LutronKeypad, SelectEntity):
+    """Representation of a Lutron Keypad LED."""
+
+    _lutron_device: Led
+    _attr_options = list(_LED_STATE_TO_OPTION.values())
+    _attr_translation_key = "led_state"
+
+    def __init__(
+        self,
+        area_name: str,
+        keypad: Keypad,
+        scene_device: Button,
+        led_device: Led,
+        controller: Lutron,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(area_name, led_device, controller, keypad)
+        self._keypad_name = keypad.name
+        self._attr_name = f"{scene_device.name} LED"
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return _LED_STATE_TO_OPTION.get(self._lutron_device.last_state)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.hass.async_add_executor_job(
+            setattr, self._lutron_device, "state", _LED_OPTION_TO_STATE[option]
+        )
+
+    def _request_state(self) -> None:
+        """Request the state from the device."""
+        _ = self._lutron_device.state

--- a/homeassistant/components/lutron/select.py
+++ b/homeassistant/components/lutron/select.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
-
 from pylutron import Button, Keypad, Led, Lutron
 
 from homeassistant.components.select import SelectEntity
@@ -60,7 +57,6 @@ class LutronLedSelect(LutronKeypad, SelectEntity):
     ) -> None:
         """Initialize the select entity."""
         super().__init__(area_name, led_device, controller, keypad)
-        self._keypad_name = keypad.name
         self._attr_name = f"{scene_device.name} LED"
 
     @property
@@ -68,20 +64,9 @@ class LutronLedSelect(LutronKeypad, SelectEntity):
         """Return the selected entity option to represent the entity state."""
         return _LED_STATE_TO_OPTION.get(self._lutron_device.last_state)
 
-    async def async_select_option(self, option: str) -> None:
+    def select_option(self, option: str) -> None:
         """Change the selected option."""
-        await self.hass.async_add_executor_job(
-            setattr, self._lutron_device, "state", _LED_OPTION_TO_STATE[option]
-        )
-
-    @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return the state attributes."""
-        return {
-            "keypad": self._keypad_name,
-            "scene": self._attr_name,
-            "led": self._lutron_device.name,
-        }
+        self._lutron_device.state = _LED_OPTION_TO_STATE[option]
 
     def _request_state(self) -> None:
         """Request the state from the device."""

--- a/homeassistant/components/lutron/select.py
+++ b/homeassistant/components/lutron/select.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 from pylutron import Button, Keypad, Led, Lutron
 
 from homeassistant.components.select import SelectEntity
@@ -70,6 +73,15 @@ class LutronLedSelect(LutronKeypad, SelectEntity):
         await self.hass.async_add_executor_job(
             setattr, self._lutron_device, "state", _LED_OPTION_TO_STATE[option]
         )
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return the state attributes."""
+        return {
+            "keypad": self._keypad_name,
+            "scene": self._attr_name,
+            "led": self._lutron_device.name,
+        }
 
     def _request_state(self) -> None:
         """Request the state from the device."""

--- a/homeassistant/components/lutron/strings.json
+++ b/homeassistant/components/lutron/strings.json
@@ -32,6 +32,16 @@
           }
         }
       }
+    },
+    "select": {
+      "led_state": {
+        "state": {
+          "fast_flash": "Fast flash",
+          "off": "[%key:common::state::off%]",
+          "on": "[%key:common::state::on%]",
+          "slow_flash": "Slow flash"
+        }
+      }
     }
   },
   "options": {

--- a/tests/components/lutron/snapshots/test_select.ambr
+++ b/tests/components/lutron/snapshots/test_select.ambr
@@ -1,0 +1,64 @@
+# serializer version: 1
+# name: test_led_select_setup[select.test_keypad_test_button_led-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'off',
+        'on',
+        'slow_flash',
+        'fast_flash',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.test_keypad_test_button_led',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Test Button LED',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Test Button LED',
+    'platform': 'lutron',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'led_state',
+    'unique_id': '12345678901_led_uuid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_led_select_setup[select.test_keypad_test_button_led-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Keypad Test Button LED',
+      'options': list([
+        'off',
+        'on',
+        'slow_flash',
+        'fast_flash',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.test_keypad_test_button_led',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/lutron/snapshots/test_select.ambr
+++ b/tests/components/lutron/snapshots/test_select.ambr
@@ -47,15 +47,12 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Keypad Test Button LED',
-      'keypad': 'Test Keypad',
-      'led': 'Test LED',
       'options': list([
         'off',
         'on',
         'slow_flash',
         'fast_flash',
       ]),
-      'scene': 'Test Button LED',
     }),
     'context': <ANY>,
     'entity_id': 'select.test_keypad_test_button_led',

--- a/tests/components/lutron/snapshots/test_select.ambr
+++ b/tests/components/lutron/snapshots/test_select.ambr
@@ -47,12 +47,15 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Keypad Test Button LED',
+      'keypad': 'Test Keypad',
+      'led': 'Test LED',
       'options': list([
         'off',
         'on',
         'slow_flash',
         'fast_flash',
       ]),
+      'scene': 'Test Button LED',
     }),
     'context': <ANY>,
     'entity_id': 'select.test_keypad_test_button_led',

--- a/tests/components/lutron/test_select.py
+++ b/tests/components/lutron/test_select.py
@@ -1,0 +1,135 @@
+"""Tests for the Lutron select platform."""
+
+from unittest.mock import MagicMock, patch
+
+from pylutron import Led
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def setup_platforms():
+    """Patch PLATFORMS for all tests in this file."""
+    with patch("homeassistant.components.lutron.PLATFORMS", [Platform.SELECT]):
+        yield
+
+
+async def test_led_select_setup(
+    hass: HomeAssistant,
+    mock_lutron: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the setup of Lutron LED select entities."""
+    mock_config_entry.add_to_hass(hass)
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
+    led.last_state = Led.LED_OFF
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_led_select_option(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test selecting an option for a Lutron LED select entity."""
+    mock_config_entry.add_to_hass(hass)
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
+    led.state = Led.LED_OFF
+    led.last_state = Led.LED_OFF
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "select.test_keypad_test_button_led"
+
+    # Select "on"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "on"},
+        blocking=True,
+    )
+    assert led.state == Led.LED_ON
+    # Update last_state to simulate optimistic update from library
+    led.last_state = Led.LED_ON
+    # Trigger update to refresh HA state
+    await async_update_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+
+    # Select "slow_flash"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "slow_flash"},
+        blocking=True,
+    )
+    assert led.state == Led.LED_SLOW_FLASH
+    led.last_state = Led.LED_SLOW_FLASH
+    await async_update_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "slow_flash"
+
+    # Select "fast_flash"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "fast_flash"},
+        blocking=True,
+    )
+    assert led.state == Led.LED_FAST_FLASH
+    led.last_state = Led.LED_FAST_FLASH
+    await async_update_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "fast_flash"
+
+    # Select "off"
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: "off"},
+        blocking=True,
+    )
+    assert led.state == Led.LED_OFF
+    led.last_state = Led.LED_OFF
+    await async_update_entity(hass, entity_id)
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "off"
+
+
+async def test_led_select_unknown_state(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test handling of unknown LED state from pylutron."""
+    mock_config_entry.add_to_hass(hass)
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
+    led.last_state = 99  # Unknown state
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.test_keypad_test_button_led")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/lutron/test_select.py
+++ b/tests/components/lutron/test_select.py
@@ -13,7 +13,6 @@ from homeassistant.components.select import (
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_OPTION, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import async_update_entity
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -51,8 +50,6 @@ async def test_led_select_option(
     mock_config_entry.add_to_hass(hass)
 
     led = mock_lutron.areas[0].keypads[0].leds[0]
-    led.state = Led.LED_OFF
-    led.last_state = Led.LED_OFF
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -67,13 +64,6 @@ async def test_led_select_option(
         blocking=True,
     )
     assert led.state == Led.LED_ON
-    # Update last_state to simulate optimistic update from library
-    led.last_state = Led.LED_ON
-    # Trigger update to refresh HA state
-    await async_update_entity(hass, entity_id)
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == "on"
 
     # Select "slow_flash"
     await hass.services.async_call(
@@ -83,11 +73,6 @@ async def test_led_select_option(
         blocking=True,
     )
     assert led.state == Led.LED_SLOW_FLASH
-    led.last_state = Led.LED_SLOW_FLASH
-    await async_update_entity(hass, entity_id)
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == "slow_flash"
 
     # Select "fast_flash"
     await hass.services.async_call(
@@ -97,11 +82,6 @@ async def test_led_select_option(
         blocking=True,
     )
     assert led.state == Led.LED_FAST_FLASH
-    led.last_state = Led.LED_FAST_FLASH
-    await async_update_entity(hass, entity_id)
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == "fast_flash"
 
     # Select "off"
     await hass.services.async_call(
@@ -111,11 +91,30 @@ async def test_led_select_option(
         blocking=True,
     )
     assert led.state == Led.LED_OFF
+
+
+async def test_led_select_update(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test LED state update from library."""
+    mock_config_entry.add_to_hass(hass)
+
+    led = mock_lutron.areas[0].keypads[0].leds[0]
     led.last_state = Led.LED_OFF
-    await async_update_entity(hass, entity_id)
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == "off"
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "select.test_keypad_test_button_led"
+    assert hass.states.get(entity_id).state == "off"
+
+    # Simulate update from library
+    led.last_state = Led.LED_SLOW_FLASH
+    callback = led.subscribe.call_args[0][0]
+    callback(led, None, None, {})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "slow_flash"
 
 
 async def test_led_select_unknown_state(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Lutron seeTouch and similar keypad LEDs can actually support 4 states: on, off, slow-flash, and fast-flash.  These are currently modeled as switches.  This PR adds support for the multiple states using select entities.  Legacy switch entities will be scheduled for deprecation in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44168
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
