### PR TITLE
risco: improve local reconnect/unload robustness

### DIFF
--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -99,7 +99,10 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
                 _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
                 return
 
-        _LOGGER.error("Error in Risco library", exc_info=error)
+        _LOGGER.error(
+            "Error in Risco library",
+            exc_info=(type(error), error, error.__traceback__),
+        )
         if isinstance(error, ConnectionResetError) and not hass.is_stopping:
             _LOGGER.debug("Disconnected from panel. Reloading integration")
             hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -93,7 +93,10 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         return False
 
     async def _error(error: Exception) -> None:
-        if isinstance(error, OperationError) and str(error) == "Timeout in command: CLOCK":
+        if (
+            isinstance(error, OperationError)
+            and str(error) == "Timeout in command: CLOCK"
+        ):
             _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
             return
 

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -93,12 +93,11 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         return False
 
     async def _error(error: Exception) -> None:
-        if (
-            isinstance(error, OperationError)
-            and str(error) == "Timeout in command: CLOCK"
-        ):
-            _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
-            return
+        if isinstance(error, OperationError):
+            message = str(error)
+            if "Timeout in command: CLOCK" in message:
+                _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
+                return
 
         _LOGGER.error("Error in Risco library", exc_info=error)
         if isinstance(error, ConnectionResetError) and not hass.is_stopping:
@@ -182,7 +181,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 await local_data.system.disconnect()
             except Exception:  # noqa: BLE001
-                _LOGGER.warning("Failed to disconnect from local Risco panel")
+                _LOGGER.warning(
+                    "Failed to disconnect from local Risco panel", exc_info=True
+                )
 
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import logging
 
-from pyrisco import CannotConnectError, RiscoCloud, RiscoLocal, UnauthorizedError
+from pyrisco import (
+    CannotConnectError,
+    OperationError,
+    RiscoCloud,
+    RiscoLocal,
+    UnauthorizedError,
+)
 from pyrisco.common import Partition, System, Zone
 
 from homeassistant.config_entries import ConfigEntry
@@ -25,6 +31,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
+    CONF_COMMUNICATION_DELAY,
     CONF_CONCURRENCY,
     DATA_COORDINATOR,
     DEFAULT_CONCURRENCY,
@@ -70,7 +77,11 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     data = entry.data
     concurrency = entry.options.get(CONF_CONCURRENCY, DEFAULT_CONCURRENCY)
     risco = RiscoLocal(
-        data[CONF_HOST], data[CONF_PORT], data[CONF_PIN], concurrency=concurrency
+        data[CONF_HOST],
+        data[CONF_PORT],
+        data[CONF_PIN],
+        communication_delay=data.get(CONF_COMMUNICATION_DELAY, 0),
+        concurrency=concurrency,
     )
 
     try:
@@ -82,6 +93,10 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
         return False
 
     async def _error(error: Exception) -> None:
+        if isinstance(error, OperationError) and str(error) == "Timeout in command: CLOCK":
+            _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
+            return
+
         _LOGGER.error("Error in Risco library", exc_info=error)
         if isinstance(error, ConnectionResetError) and not hass.is_stopping:
             _LOGGER.debug("Disconnected from panel. Reloading integration")
@@ -161,7 +176,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         if is_local(entry):
             local_data: LocalData = hass.data[DOMAIN][entry.entry_id]
-            await local_data.system.disconnect()
+            try:
+                await local_data.system.disconnect()
+            except Exception:  # noqa: BLE001
+                _LOGGER.warning("Failed to disconnect from local Risco panel")
 
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -53,6 +53,8 @@ PLATFORMS = [
     Platform.SWITCH,
 ]
 _LOGGER = logging.getLogger(__name__)
+# pyrisco exposes timeout context as message text for this case.
+CLOCK_TIMEOUT_ERROR_FRAGMENT = "Timeout in command: CLOCK"
 
 
 def is_local(entry: ConfigEntry) -> bool:
@@ -95,7 +97,7 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
     async def _error(error: Exception) -> None:
         if isinstance(error, OperationError):
             message = str(error)
-            if "Timeout in command: CLOCK" in message:
+            if CLOCK_TIMEOUT_ERROR_FRAGMENT in message:
                 _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
                 return
 

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -99,6 +99,13 @@ async def _async_setup_local_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
             message = str(error)
             if CLOCK_TIMEOUT_ERROR_FRAGMENT in message:
                 _LOGGER.warning("Risco keep-alive timeout, waiting for reconnection")
+                if not hass.is_stopping:
+                    _LOGGER.debug(
+                        "Reloading integration after Risco keep-alive timeout"
+                    )
+                    hass.async_create_task(
+                        hass.config_entries.async_reload(entry.entry_id)
+                    )
                 return
 
         _LOGGER.error(

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -1,10 +1,14 @@
 """Tests for the Risco integration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from homeassistant.components.risco.const import CONF_COMMUNICATION_DELAY, DOMAIN, TYPE_LOCAL
+from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture
@@ -37,5 +41,44 @@ async def test_unload_handles_disconnect_error(
     with patch(
         "homeassistant.components.risco.RiscoLocal.disconnect",
         side_effect=RuntimeError("disconnect failed"),
-    ):
+    ) as disconnect_mock:
         assert await hass.config_entries.async_unload(setup_risco_local.entry_id)
+        disconnect_mock.assert_awaited_once()
+
+
+async def test_local_setup_uses_stored_communication_delay(
+    hass: HomeAssistant,
+) -> None:
+    """Test local setup passes stored communication delay to the client."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_TYPE: TYPE_LOCAL,
+            CONF_HOST: "test-host",
+            CONF_PORT: 5004,
+            CONF_PIN: "1234",
+            CONF_COMMUNICATION_DELAY: 2,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.risco.RiscoLocal", autospec=True) as risco_local,
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        risco_local.return_value.connect = AsyncMock()
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        risco_local.assert_called_once_with(
+            "test-host",
+            5004,
+            "1234",
+            communication_delay=2,
+            concurrency=4,
+        )

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -1,7 +1,9 @@
 """Tests for the Risco integration."""
 
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from pyrisco import OperationError
 import pytest
 
 from homeassistant.components.risco.const import (
@@ -16,14 +18,17 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def mock_error_handler():
+def mock_error_handler() -> MagicMock:
     """Create a mock for add_error_handler."""
     with patch("homeassistant.components.risco.RiscoLocal.add_error_handler") as mock:
         yield mock
 
 
 async def test_connection_reset(
-    hass: HomeAssistant, two_zone_local, mock_error_handler, setup_risco_local
+    hass: HomeAssistant,
+    two_zone_local: dict[int, Any],
+    mock_error_handler: MagicMock,
+    setup_risco_local: MockConfigEntry,
 ) -> None:
     """Test config entry reload on connection reset."""
 
@@ -39,7 +44,9 @@ async def test_connection_reset(
 
 
 async def test_unload_handles_disconnect_error(
-    hass: HomeAssistant, two_zone_local, setup_risco_local
+    hass: HomeAssistant,
+    two_zone_local: dict[int, Any],
+    setup_risco_local: MockConfigEntry,
 ) -> None:
     """Test unload succeeds when local disconnect errors out."""
     with patch(
@@ -88,3 +95,26 @@ async def test_local_setup_uses_stored_communication_delay(
             communication_delay=2,
             concurrency=4,
         )
+
+
+async def test_clock_operation_error_is_downgraded(
+    hass: HomeAssistant,
+    two_zone_local: dict[int, Any],
+    mock_error_handler: MagicMock,
+    setup_risco_local: MockConfigEntry,
+) -> None:
+    """Test CLOCK keep-alive operation errors do not trigger reload/error."""
+    callback = mock_error_handler.call_args.args[0]
+    assert callback is not None
+
+    with (
+        patch.object(hass.config_entries, "async_reload") as reload_mock,
+        patch("homeassistant.components.risco._LOGGER") as logger_mock,
+    ):
+        await callback(OperationError("Timeout in command: CLOCK"))
+
+    reload_mock.assert_not_awaited()
+    logger_mock.error.assert_not_called()
+    logger_mock.warning.assert_called_once_with(
+        "Risco keep-alive timeout, waiting for reconnection"
+    )

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -28,3 +28,14 @@ async def test_connection_reset(
 
         await callback(ConnectionResetError())
         reload_mock.assert_awaited_once()
+
+
+async def test_unload_handles_disconnect_error(
+    hass: HomeAssistant, two_zone_local, setup_risco_local
+) -> None:
+    """Test unload succeeds when local disconnect errors out."""
+    with patch(
+        "homeassistant.components.risco.RiscoLocal.disconnect",
+        side_effect=RuntimeError("disconnect failed"),
+    ):
+        assert await hass.config_entries.async_unload(setup_risco_local.entry_id)

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -103,7 +103,7 @@ async def test_clock_operation_error_is_downgraded(
     mock_error_handler: MagicMock,
     setup_risco_local: MockConfigEntry,
 ) -> None:
-    """Test CLOCK keep-alive operation errors do not trigger reload/error."""
+    """Test CLOCK keep-alive operation errors warn and trigger reload."""
     callback = mock_error_handler.call_args.args[0]
     assert callback is not None
 
@@ -113,7 +113,7 @@ async def test_clock_operation_error_is_downgraded(
     ):
         await callback(OperationError("Timeout in command: CLOCK"))
 
-    reload_mock.assert_not_awaited()
+    reload_mock.assert_awaited_once_with(setup_risco_local.entry_id)
     logger_mock.error.assert_not_called()
     logger_mock.warning.assert_called_once_with(
         "Risco keep-alive timeout, waiting for reconnection"

--- a/tests/components/risco/test_init.py
+++ b/tests/components/risco/test_init.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.risco.const import CONF_COMMUNICATION_DELAY, DOMAIN, TYPE_LOCAL
+from homeassistant.components.risco.const import (
+    CONF_COMMUNICATION_DELAY,
+    DOMAIN,
+    TYPE_LOCAL,
+)
 from homeassistant.const import CONF_HOST, CONF_PIN, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
 
@@ -63,7 +67,9 @@ async def test_local_setup_uses_stored_communication_delay(
     config_entry.add_to_hass(hass)
 
     with (
-        patch("homeassistant.components.risco.RiscoLocal", autospec=True) as risco_local,
+        patch(
+            "homeassistant.components.risco.RiscoLocal", autospec=True
+        ) as risco_local,
         patch.object(
             hass.config_entries,
             "async_forward_entry_setups",


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

This PR improves resilience for the local Risco integration under unstable connections.

Changes included:
- Pass configured communication delay into local runtime client setup.
- Handle repetitive local keep-alive CLOCK timeout noise as warning-level reconnect noise.
- Keep reload behavior for actual connection-reset paths.
- Prevent unload failure if local disconnect raises.
- Improve error logging traceback handling in callback error paths.
- Add regression tests for:
  - unload behavior when disconnect raises,
  - local setup passing communication delay,
  - CLOCK timeout handling path.

Rationale for CLOCK timeout handling:
- In affected setups, CLOCK keep-alive timeout can repeat frequently while reconnect is already in progress.
- Triggering additional reload actions for this specific transient timeout can create noisy overlapping unload/reload cycles.
- This change keeps logs actionable while preserving reload behavior for real disconnect/reset conditions.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.