### PR TITLE
Remove shell=True from command_line notify (CWE-78)

### DIFF
--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import shlex
 import subprocess
 from typing import Any
 
@@ -49,12 +50,11 @@ class CommandLineNotificationService(BaseNotificationService):
 
         LOGGER.debug("Running with message: %s", message)
 
-        with subprocess.Popen(  # noqa: S602 # shell by design
-            command,
+        with subprocess.Popen(
+            shlex.split(command),
             universal_newlines=True,
             stdin=subprocess.PIPE,
             close_fds=False,  # required for posix_spawn
-            shell=True,
         ) as proc:
             try:
                 proc.communicate(input=message, timeout=self._timeout)

--- a/homeassistant/components/command_line/notify.py
+++ b/homeassistant/components/command_line/notify.py
@@ -50,8 +50,18 @@ class CommandLineNotificationService(BaseNotificationService):
 
         LOGGER.debug("Running with message: %s", message)
 
+        try:
+            argv = shlex.split(command)
+        except ValueError as err:
+            _LOGGER.error("Error parsing command %s: %s", command, err)
+            return
+
+        if not argv:
+            _LOGGER.error("Empty command provided for notification")
+            return
+
         with subprocess.Popen(
-            shlex.split(command),
+            argv,
             universal_newlines=True,
             stdin=subprocess.PIPE,
             close_fds=False,  # required for posix_spawn


### PR DESCRIPTION
Replace Popen(command, ..., shell=True) with Popen(shlex.split(command), ...) to eliminate OS command injection risk (CWE-78, Ruff S602). This follows the same pattern used in the shell_command integration.
