### PR TITLE
Do not use moving states for Multilevel Switch CC v1-3 Z-Wave covers

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -9,6 +9,7 @@ from zwave_js_server.const import (
     SET_VALUE_SUCCESS,
     TARGET_STATE_PROPERTY,
     TARGET_VALUE_PROPERTY,
+    CommandClass,
     SetValueStatus,
 )
 from zwave_js_server.const.command_class.barrier_operator import BarrierState
@@ -87,9 +88,8 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
     _current_position_value: ZwaveValue | None = None
     _target_position_value: ZwaveValue | None = None
     _stop_position_value: ZwaveValue | None = None
-    # Keep track of the target position for legacy devices
-    # that don't include the targetValue in their reports.
-    _commanded_target_position: int | None = None
+    # Remember whether the moving state can be tracked reliably for this device.
+    _moving_state_disabled: bool = False
 
     def _set_position_values(
         self,
@@ -159,16 +159,11 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
         if (current := self._current_position_value) is None or current.value is None:
             return
 
-        # Prefer the Z-Wave targetValue property when the device reports it.
-        # Legacy multilevel switches only report currentValue, so fall back to
-        # the target position we commanded when targetValue is not available.
-        target_val = (
-            t.value
-            if (t := self._target_position_value) is not None and t.value is not None
-            else self._commanded_target_position
-        )
-
-        if target_val is not None and current.value == target_val:
+        if (
+            (t := self._target_position_value) is not None
+            and t.value is not None
+            and current.value == t.value
+        ):
             self._attr_is_opening = False
             self._attr_is_closing = False
 
@@ -192,9 +187,10 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             self._target_position_value, target_position
         )
         if (
+            self._moving_state_disabled
             # If the command is unsupervised, or the device reported that it started
             # working, we can assume the cover is moving in the desired direction.
-            result is None
+            or result is None
             or result.status
             not in (SetValueStatus.WORKING, SetValueStatus.SUCCESS_UNSUPERVISED)
             # If we don't know the current position, we don't know which direction
@@ -212,8 +208,6 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             self._attr_is_closing = True
         else:
             return
-
-        self._commanded_target_position = target_position
 
         self.async_write_ha_state()
 
@@ -361,6 +355,17 @@ class ZWaveMultilevelSwitchCover(CoverPositionMixin):
                 or self.get_zwave_value(COVER_ON_PROPERTY)
             ),
         )
+
+        # Multilevel Switch CC v3 and earlier don't report targetValue,
+        # so we cannot determine when the cover stops moving,
+        # especially when the device is controlled physically.
+        # OPENING/CLOSING states must not be used for these devices,
+        # because they will become stale/incorrect.
+        if (
+            self.info.primary_value.command_class == CommandClass.SWITCH_MULTILEVEL
+            and self.info.primary_value.cc_version < 4
+        ):
+            self._moving_state_disabled = True
 
         # Entity class attributes
         self._attr_device_class = CoverDeviceClass.WINDOW

--- a/tests/components/zwave_js/fixtures/chain_actuator_zws12_state.json
+++ b/tests/components/zwave_js/fixtures/chain_actuator_zws12_state.json
@@ -59,6 +59,7 @@
       "endpoint": 0,
       "property": "targetValue",
       "propertyName": "targetValue",
+      "ccVersion": 4,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -74,6 +75,7 @@
       "endpoint": 0,
       "property": "duration",
       "propertyName": "duration",
+      "ccVersion": 4,
       "metadata": {
         "type": "duration",
         "readable": true,
@@ -87,6 +89,7 @@
       "endpoint": 0,
       "property": "currentValue",
       "propertyName": "currentValue",
+      "ccVersion": 4,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -103,6 +106,7 @@
       "endpoint": 0,
       "property": "Open",
       "propertyName": "Open",
+      "ccVersion": 4,
       "metadata": {
         "type": "boolean",
         "readable": true,
@@ -117,6 +121,7 @@
       "endpoint": 0,
       "property": "Close",
       "propertyName": "Close",
+      "ccVersion": 4,
       "metadata": {
         "type": "boolean",
         "readable": true,
@@ -131,6 +136,7 @@
       "endpoint": 0,
       "property": "currentValue",
       "propertyName": "currentValue",
+      "ccVersion": 1,
       "metadata": {
         "type": "boolean",
         "readable": true,
@@ -145,6 +151,7 @@
       "endpoint": 0,
       "property": "targetValue",
       "propertyName": "targetValue",
+      "ccVersion": 1,
       "metadata": {
         "type": "boolean",
         "readable": true,
@@ -158,6 +165,7 @@
       "endpoint": 0,
       "property": "manufacturerId",
       "propertyName": "manufacturerId",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -174,6 +182,7 @@
       "endpoint": 0,
       "property": "productType",
       "propertyName": "productType",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -190,6 +199,7 @@
       "endpoint": 0,
       "property": "productId",
       "propertyName": "productId",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -206,6 +216,7 @@
       "endpoint": 0,
       "property": "libraryType",
       "propertyName": "libraryType",
+      "ccVersion": 1,
       "metadata": {
         "type": "any",
         "readable": true,
@@ -220,6 +231,7 @@
       "endpoint": 0,
       "property": "protocolVersion",
       "propertyName": "protocolVersion",
+      "ccVersion": 1,
       "metadata": {
         "type": "any",
         "readable": true,
@@ -234,6 +246,7 @@
       "endpoint": 0,
       "property": "firmwareVersions",
       "propertyName": "firmwareVersions",
+      "ccVersion": 1,
       "metadata": {
         "type": "any",
         "readable": true,
@@ -248,6 +261,7 @@
       "endpoint": 0,
       "property": "hardwareVersion",
       "propertyName": "hardwareVersion",
+      "ccVersion": 1,
       "metadata": {
         "type": "any",
         "readable": true,
@@ -261,6 +275,7 @@
       "endpoint": 0,
       "property": 13,
       "propertyName": "Last saved position",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -283,6 +298,7 @@
       "endpoint": 0,
       "property": 15,
       "propertyName": "Close after time",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -305,6 +321,7 @@
       "endpoint": 0,
       "property": 7,
       "propertyName": "Motor speed I",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -326,6 +343,7 @@
       "endpoint": 0,
       "property": 8,
       "propertyName": "1 Motor speed II (rain sensor)",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -347,6 +365,7 @@
       "endpoint": 0,
       "property": 12,
       "propertyName": "Callibrate",
+      "ccVersion": 1,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -370,6 +389,7 @@
       "propertyKey": "Sensor status",
       "propertyName": "Water Alarm",
       "propertyKeyName": "Sensor status",
+      "ccVersion": 8,
       "metadata": {
         "type": "number",
         "readable": true,
@@ -390,6 +410,7 @@
       "propertyKey": "Over-load status",
       "propertyName": "Power Management",
       "propertyKeyName": "Over-load status",
+      "ccVersion": 8,
       "metadata": {
         "type": "number",
         "readable": true,

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any
 from unittest.mock import MagicMock
@@ -1678,128 +1679,49 @@ async def test_multilevel_switch_cover_moving_state_none_result(
     assert state.state == CoverState.CLOSED
 
 
-async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
+async def test_multilevel_switch_cover_v3_no_moving_state_supervised(
     hass: HomeAssistant,
     client: MagicMock,
-    chain_actuator_zws12: Node,
+    chain_actuator_zws12_state: dict[str, Any],
     integration: MockConfigEntry,
 ) -> None:
-    """Test cover transitions to CLOSED/OPEN without targetValue updates.
+    """Test v3 Multilevel Switch cover never sets OPENING/CLOSING even with Supervision."""
+    node_state = copy.deepcopy(chain_actuator_zws12_state)
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.SWITCH_MULTILEVEL:
+            value["ccVersion"] = 3
+    client.driver.controller.receive_event(
+        Event(
+            type="node added",
+            data={
+                "source": "controller",
+                "event": "node added",
+                "node": node_state,
+                "result": {},
+            },
+        )
+    )
+    await hass.async_block_till_done()
+    node = client.driver.controller.nodes[node_state["nodeId"]]
 
-    Regression test for issue #164915: covers with no supervision where the
-    device only sends currentValue updates (no targetValue updates) should
-    still properly transition from CLOSING/OPENING to CLOSED/OPEN once the
-    current position reaches the fully closed or fully open position.
-    """
-    node = chain_actuator_zws12
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state
     assert state.state == CoverState.CLOSED
 
-    # Set cover to fully open position via an unsolicited device report.
-    # This mirrors the log sequence: currentValue 0 => 99
-    node.receive_event(
-        Event(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": node.node_id,
-                "args": {
-                    "commandClassName": "Multilevel Switch",
-                    "commandClass": 38,
-                    "endpoint": 0,
-                    "property": "currentValue",
-                    "newValue": 99,
-                    "prevValue": 0,
-                    "propertyName": "currentValue",
-                },
-            },
-        )
-    )
-
-    state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.OPEN
-
-    # Simulate SUCCESS_UNSUPERVISED (no Supervision CC on device).
+    # WORKING result (Supervision CC) must NOT optimistically set OPENING
     client.async_send_command.return_value = {
-        "result": {"status": SetValueStatus.SUCCESS_UNSUPERVISED}
+        "result": {"status": SetValueStatus.WORKING}
     }
-
-    # Close cover – should optimistically enter CLOSING.
-    await hass.services.async_call(
-        COVER_DOMAIN,
-        SERVICE_CLOSE_COVER,
-        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
-        blocking=True,
-    )
-
-    state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.CLOSING
-
-    # Simulate intermediate report from device (currentValue only, no targetValue).
-    # Log sequence: currentValue 99 => 78
-    node.receive_event(
-        Event(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": node.node_id,
-                "args": {
-                    "commandClassName": "Multilevel Switch",
-                    "commandClass": 38,
-                    "endpoint": 0,
-                    "property": "currentValue",
-                    "newValue": 78,
-                    "prevValue": 99,
-                    "propertyName": "currentValue",
-                },
-            },
-        )
-    )
-
-    state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.CLOSING
-
-    # Simulate device reaching the fully closed position.
-    # Log sequence: currentValue 78 => 0
-    node.receive_event(
-        Event(
-            type="value updated",
-            data={
-                "source": "node",
-                "event": "value updated",
-                "nodeId": node.node_id,
-                "args": {
-                    "commandClassName": "Multilevel Switch",
-                    "commandClass": 38,
-                    "endpoint": 0,
-                    "property": "currentValue",
-                    "newValue": 0,
-                    "prevValue": 78,
-                    "propertyName": "currentValue",
-                },
-            },
-        )
-    )
-
-    # Cover must leave CLOSING and report CLOSED.
-    state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.CLOSED
-
-    # Now test the opening direction with the same conditions.
-    # Log sequence: currentValue 0 => 18 => 99
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
         {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
         blocking=True,
     )
-
     state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.OPENING
+    assert state.state == CoverState.CLOSED
 
+    # Position updates still work correctly.
     node.receive_event(
         Event(
             type="value updated",
@@ -1809,19 +1731,28 @@ async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
                 "nodeId": node.node_id,
                 "args": {
                     "commandClassName": "Multilevel Switch",
-                    "commandClass": 38,
+                    "commandClass": CommandClass.SWITCH_MULTILEVEL,
                     "endpoint": 0,
                     "property": "currentValue",
-                    "newValue": 18,
+                    "newValue": 99,
                     "prevValue": 0,
                     "propertyName": "currentValue",
                 },
             },
         )
     )
-
     state = hass.states.get(WINDOW_COVER_ENTITY)
-    assert state.state == CoverState.OPENING
+    assert state.state == CoverState.OPEN
+
+    # WORKING result must NOT optimistically set CLOSING
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPEN
 
     node.receive_event(
         Event(
@@ -1832,17 +1763,136 @@ async def test_multilevel_switch_cover_unsupervised_no_target_value_update(
                 "nodeId": node.node_id,
                 "args": {
                     "commandClassName": "Multilevel Switch",
-                    "commandClass": 38,
+                    "commandClass": CommandClass.SWITCH_MULTILEVEL,
                     "endpoint": 0,
                     "property": "currentValue",
-                    "newValue": 99,
-                    "prevValue": 18,
+                    "newValue": 0,
+                    "prevValue": 99,
                     "propertyName": "currentValue",
                 },
             },
         )
     )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED
 
-    # Cover must leave OPENING and report OPEN.
+    # SUCCESS result must NOT set OPENING
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.SUCCESS}
+    }
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED
+
+
+async def test_multilevel_switch_cover_v3_no_moving_state_unsupervised(
+    hass: HomeAssistant,
+    client: MagicMock,
+    chain_actuator_zws12_state: dict[str, Any],
+    integration: MockConfigEntry,
+) -> None:
+    """Test v3 Multilevel Switch cover never sets OPENING/CLOSING without Supervision."""
+    node_state = copy.deepcopy(chain_actuator_zws12_state)
+    for value in node_state["values"]:
+        if value["commandClass"] == CommandClass.SWITCH_MULTILEVEL:
+            value["ccVersion"] = 3
+    client.driver.controller.receive_event(
+        Event(
+            type="node added",
+            data={
+                "source": "controller",
+                "event": "node added",
+                "node": node_state,
+                "result": {},
+            },
+        )
+    )
+    await hass.async_block_till_done()
+    node = client.driver.controller.nodes[node_state["nodeId"]]
+
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+    # SUCCESS_UNSUPERVISED must NOT set OPENING
+    client.async_send_command.return_value = {
+        "result": {"status": SetValueStatus.SUCCESS_UNSUPERVISED}
+    }
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_OPEN_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED
+
+    # Position updates still work correctly.
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": CommandClass.SWITCH_MULTILEVEL,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": 99,
+                    "prevValue": 0,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state.state == CoverState.OPEN
+
+    # SUCCESS_UNSUPERVISED must NOT set CLOSING
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_CLOSE_COVER,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY},
+        blocking=True,
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.OPEN
+
+    node.receive_event(
+        Event(
+            type="value updated",
+            data={
+                "source": "node",
+                "event": "value updated",
+                "nodeId": node.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Switch",
+                    "commandClass": CommandClass.SWITCH_MULTILEVEL,
+                    "endpoint": 0,
+                    "property": "currentValue",
+                    "newValue": 0,
+                    "prevValue": 99,
+                    "propertyName": "currentValue",
+                },
+            },
+        )
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED
+
+    # SUCCESS_UNSUPERVISED set_position must NOT set OPENING
+    await hass.services.async_call(
+        COVER_DOMAIN,
+        SERVICE_SET_COVER_POSITION,
+        {ATTR_ENTITY_ID: WINDOW_COVER_ENTITY, ATTR_POSITION: 50},
+        blocking=True,
+    )
+    state = hass.states.get(WINDOW_COVER_ENTITY)
+    assert state.state == CoverState.CLOSED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://github.com/home-assistant/core/issues/163163 introduced moving state tracking for Z-Wave covers.

https://github.com/home-assistant/core/pull/165003 tried to extend this to legacy (v1-3) Multilevel Switch based covers by keeping track of the last commanded value and comparing against that but missed a crucial issue: Controlling such a cover sets targetValue, which is then stale and preferred over the last commanded value.
Additionally, physically controlling such a device only updates the current value, which makes both targetValue and the last commanded value stale, leading to incorrect moving states.

This PR changes the approach to decide based on the Multilevel Switch CC version whether we can reliably track the moving state. For v4+ we continue updating the moving state, for v1-3 we no longer do.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
	- fixes https://github.com/home-assistant/core/issues/165775
	- fixes https://github.com/home-assistant/core/issues/165726
- This PR is related to issue:
	- closes https://github.com/home-assistant/core/pull/165796
	- closes https://github.com/home-assistant/core/pull/165845
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
