### PR TITLE
Add initial quality scale for intellifire

### DIFF
--- a/homeassistant/components/intellifire/quality_scale.yaml
+++ b/homeassistant/components/intellifire/quality_scale.yaml
@@ -1,0 +1,66 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not register any custom service actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: No service actions are provided by this integration.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: This integration does not register any custom service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters: todo
+  docs-installation-parameters: todo
+  entity-unavailable: todo
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow: done
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery: done
+  discovery-update-info: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/intellifire/quality_scale.yaml
+++ b/homeassistant/components/intellifire/quality_scale.yaml
@@ -46,11 +46,11 @@ rules:
   docs-examples: todo
   docs-known-limitations: todo
   docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
+  docs-supported-functions: done
+  docs-troubleshooting: done
   docs-use-cases: todo
   dynamic-devices: todo
-  entity-category: todo
+  entity-category: done
   entity-device-class: todo
   entity-disabled-by-default: todo
   entity-translations: todo

--- a/homeassistant/components/intellifire/quality_scale.yaml
+++ b/homeassistant/components/intellifire/quality_scale.yaml
@@ -12,9 +12,15 @@ rules:
   docs-actions:
     status: exempt
     comment: No service actions are provided by this integration.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
   entity-event-setup: done
   entity-unique-id: done
   has-entity-name: done

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -463,7 +463,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "inkbird",
     "insteon",
     "integration",
-    "intellifire",
     "intesishome",
     "ios",
     "iotawatt",


### PR DESCRIPTION
## Proposed change

Add initial quality scale for intellifire


### Bronze rule evidence

| Rule | | Evidence |
|---|:---:|---|
| `action-setup` | exempt | No `hass.services.async_register` or `async_register_entity_service` calls |
| `appropriate-polling` | ✅ | [`coordinator.py#L39`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/coordinator.py#L39) `update_interval=timedelta(seconds=15)`; library auto-poll disabled at [`__init__.py#L147`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/__init__.py#L147) |
| `brands` | ✅ | [home-assistant/brands](https://github.com/home-assistant/brands/tree/master/core_integrations/intellifire) |
| `common-modules` | ✅ | [`coordinator.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/coordinator.py), [`const.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/const.py), [`entity.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/entity.py) |
| `config-flow` | ✅ | [`config_flow.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py) — `async_step_user`, `async_step_dhcp`, `async_step_reauth`, `OptionsFlow`; `data_description` at [`strings.json#L18-L21`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/strings.json#L18-L21) |
| `config-flow-test-coverage` | ✅ | [`test_config_flow.py`](https://github.com/home-assistant/core/blob/dev/tests/components/intellifire/test_config_flow.py) — single/multi-fireplace, bad credentials, abort, DHCP, reauth, all five options-flow error branches |
| `dependency-transparency` | ✅ | [`manifest.json#L15`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/manifest.json#L15) — `intellifire4py==4.4.0` pinned |
| `docs-actions` | exempt | No service actions registered |
| `docs-high-level-description` | ✅ | https://www.home-assistant.io/integrations/intellifire |
| `docs-installation-instructions` | ✅ | https://www.home-assistant.io/integrations/intellifire |
| `docs-removal-instructions` | ✅ | https://www.home-assistant.io/integrations/intellifire |
| `entity-event-setup` | ✅ | [`entity.py#L11`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/entity.py#L11) — all entities extend `CoordinatorEntity`; subscription lifecycle managed internally |
| `entity-unique-id` | ✅ | [`entity.py#L25`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/entity.py#L25) — `_attr_unique_id = f"{description.key}_{coordinator.fireplace.serial}"` |
| `has-entity-name` | ✅ | [`entity.py#L15`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/entity.py#L15) — `_attr_has_entity_name = True` on shared base class |
| `runtime-data` | ✅ | [`__init__.py#L165`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/__init__.py#L165) — `entry.runtime_data = data_update_coordinator`; no `hass.data[DOMAIN]` usage |
| `test-before-configure` | ✅ | [`config_flow.py#L125-L133`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L125-L133) — login before entry creation; DHCP polls device at [`L260-L263`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L260-L263) |
| `test-before-setup` | ✅ | [`__init__.py#L141`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/__init__.py#L141) `ConfigEntryAuthFailed`; [`L154-L157`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/__init__.py#L154-L157) `ConfigEntryNotReady` on `TimeoutError` |
| `unique-config-entry` | ✅ | [`config_flow.py#L168-L169`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L168-L169) — `async_set_unique_id(serial)` + `_abort_if_unique_id_configured`; DHCP guards at [`L259`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L259) |

### Silver rule evidence (done items)

| Rule | | Evidence |
|---|:---:|---|
| `action-exceptions` | exempt | No service actions registered |
| `config-entry-unloading` | ✅ | [`__init__.py#L216-L220`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/__init__.py#L216-L220) — `async_unload_entry` delegates to `async_unload_platforms` |
| `integration-owner` | ✅ | [`manifest.json#L4`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/manifest.json#L4) — `"codeowners": ["@jeeftor"]` |
| `reauthentication-flow` | ✅ | [`config_flow.py#L235-L247`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L235-L247) — `async_step_reauth` + `async_update_reload_and_abort` at [`L227-L230`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L227-L230) |

### Gold rule evidence (done items)

| Rule | | Evidence |
|---|:---:|---|
| `devices` | ✅ | [`coordinator.py#L58-L66`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/coordinator.py#L58-L66) — `device_info` property; all entities set `_attr_device_info` at [`entity.py#L29`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/entity.py#L29) |
| `discovery` | ✅ | [`manifest.json#L6-L10`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/manifest.json#L6-L10) — `dhcp` hostname pattern; [`config_flow.py#L249-L271`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/config_flow.py#L249-L271) — `async_step_dhcp` |
| `entity-category` | ✅ | [`sensor.py#L75-L153`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/sensor.py#L75-L153) — `EntityCategory.DIAGNOSTIC` on read_mode, control_mode, downtime, uptime, connection_quality, ecm_latency, ipv4_address; [`binary_sensor.py#L58-L146`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/intellifire/binary_sensor.py#L58-L146) — `EntityCategory.DIAGNOSTIC` on all error and connectivity sensors |
| `docs-supported-functions` | ✅ | https://www.home-assistant.io/integrations/intellifire — lists all controllable entities (flame, pilot, fan, thermostat, light, flame height) and all sensor/binary sensor entities |
| `docs-troubleshooting` | ✅ | https://www.home-assistant.io/integrations/intellifire — troubleshooting section covers debug logging config, soft reset via iftapi.net, and power cycle procedure |



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
