### PR TITLE
Validate set_system_mode params in code instead of by schema for Evohome

### DIFF
--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -361,8 +361,8 @@ class EvoController(EvoClimateEntity):
     async def async_tcs_svc_request(self, service: str, data: dict[str, Any]) -> None:
         """Process a service request (system mode) for a controller.
 
-        Data validation is not required, it will have been done upstream via a service
-        schema.
+        Data validation is not required here; it is performed upstream by the service
+        handler (service schema plus runtime checks).
         """
 
         if service == EvoService.RESET_SYSTEM:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -361,7 +361,8 @@ class EvoController(EvoClimateEntity):
     async def async_tcs_svc_request(self, service: str, data: dict[str, Any]) -> None:
         """Process a service request (system mode) for a controller.
 
-        Data validation is not required, it will have been done upstream.
+        Data validation is not required, it will have been done upstream via a service
+        schema.
         """
 
         if service == EvoService.RESET_SYSTEM:

--- a/homeassistant/components/evohome/climate.py
+++ b/homeassistant/components/evohome/climate.py
@@ -388,9 +388,16 @@ class EvoController(EvoClimateEntity):
     ) -> None:
         """Set a Controller to any of its native operating modes."""
         until = dt_util.as_utc(until) if until else None
-        await self.coordinator.call_client_api(
-            self._evo_device.set_mode(mode, until=until)
-        )
+        try:
+            await self.coordinator.call_client_api(
+                self._evo_device.set_mode(mode, until=until)
+            )
+        except evo.InvalidSystemModeError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_system_mode",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -139,6 +139,9 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             result = await client_api
 
+        except ec2.InvalidSystemModeError:
+            raise
+
         except ec2.ApiRequestFailedError as err:
             self.logger.error(err)
             return None

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -26,10 +26,7 @@ from evohomeasync2.schemas.typedefs import EvoLocStatusResponseT, EvoTcsConfigRe
 
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-
-from .const import DOMAIN
 
 
 class EvoDataUpdateCoordinator(DataUpdateCoordinator):
@@ -141,13 +138,6 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
 
         try:
             result = await client_api
-
-        except ec2.InvalidSystemModeError as err:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="invalid_system_mode",
-                translation_placeholders={"error": str(err)},
-            ) from err
 
         except ec2.ApiRequestFailedError as err:
             self.logger.error(err)

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -150,11 +150,8 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
             ) from err
 
         except ec2.ApiRequestFailedError as err:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="api_call_failed",
-                translation_placeholders={"error": str(err)},
-            ) from err
+            self.logger.error(err)
+            return None
 
         if request_refresh:  # wait a moment for system to quiesce before updating state
             await self.async_request_refresh()  # hass.async_create_task() won't help

--- a/homeassistant/components/evohome/coordinator.py
+++ b/homeassistant/components/evohome/coordinator.py
@@ -26,7 +26,10 @@ from evohomeasync2.schemas.typedefs import EvoLocStatusResponseT, EvoTcsConfigRe
 
 from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
 
 
 class EvoDataUpdateCoordinator(DataUpdateCoordinator):
@@ -139,9 +142,19 @@ class EvoDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             result = await client_api
 
+        except ec2.InvalidSystemModeError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_system_mode",
+                translation_placeholders={"error": str(err)},
+            ) from err
+
         except ec2.ApiRequestFailedError as err:
-            self.logger.error(err)
-            return None
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="api_call_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         if request_refresh:  # wait a moment for system to quiesce before updating state
             await self.async_request_refresh()  # hass.async_create_task() won't help

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Final
 
-from evohomeasync2.schemas.const import SystemMode as EvoSystemMode
+import evohomeasync2 as ec2
+from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
+from evohomeasync2.schemas.const import (
+    S2_DURATION,
+    S2_PERIOD,
+    SystemMode as EvoSystemMode,
+)
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.const import ATTR_MODE
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import verify_domain_control
@@ -64,6 +71,42 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
     )
 
 
+def _validate_set_system_mode_params(call: ServiceCall, tcs: ec2.ControlSystem) -> None:
+    """Validate that a set_system_mode service call is properly formed."""
+
+    mode = call.data[ATTR_MODE]
+    evo_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
+
+    if (mode_info := evo_modes.get(mode)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_not_supported",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+    if not mode_info[SZ_CAN_BE_TEMPORARY]:
+        if ATTR_DURATION in call.data or ATTR_PERIOD in call.data:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="mode_cant_be_temporary",
+                translation_placeholders={ATTR_MODE: mode},
+            )
+
+    elif mode_info[SZ_TIMING_MODE] == S2_DURATION and ATTR_PERIOD in call.data:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_cant_have_period",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+    elif mode_info[SZ_TIMING_MODE] == S2_PERIOD and ATTR_DURATION in call.data:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="mode_cant_have_duration",
+            translation_placeholders={ATTR_MODE: mode},
+        )
+
+
 @callback
 def setup_service_functions(
     hass: HomeAssistant, coordinator: EvoDataUpdateCoordinator
@@ -82,7 +125,10 @@ def setup_service_functions(
 
     @verify_domain_control(DOMAIN)
     async def set_system_mode(call: ServiceCall) -> None:
-        """Set the system mode."""
+        """Set the system mode or reset the system."""
+
+        if call.service == EvoService.SET_SYSTEM_MODE:  # no validation for RESET_SYSTEM
+            _validate_set_system_mode_params(call, coordinator.tcs)
 
         payload = {
             "unique_id": coordinator.tcs.id,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,8 +23,18 @@ from homeassistant.helpers.service import verify_domain_control
 from .const import ATTR_DURATION, ATTR_PERIOD, ATTR_SETPOINT, DOMAIN, EvoService
 from .coordinator import EvoDataUpdateCoordinator
 
-# system mode schemas are built dynamically when the services are registered
-# because supported modes can vary for edge-case systems
+# System service schemas (registered as domain services)
+SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
+    vol.Required(ATTR_MODE): vol.In(EvoSystemMode),
+    vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
+    ),
+    vol.Exclusive(ATTR_PERIOD, "temporary"): vol.All(
+        cv.time_period,
+        vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
+    ),
+}
 
 # Zone service schemas (registered as entity services)
 SET_ZONE_OVERRIDE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -7,11 +7,7 @@ from typing import Any, Final
 
 import evohomeasync2 as ec2
 from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
-from evohomeasync2.schemas.const import (
-    S2_DURATION,
-    S2_PERIOD,
-    SystemMode as EvoSystemMode,
-)
+from evohomeasync2.schemas.const import S2_DURATION, S2_PERIOD
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -27,7 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(ATTR_MODE): vol.In(EvoSystemMode),
+    vol.Required(ATTR_MODE): str,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,7 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    vol.Required(ATTR_MODE): str,  # avoid vol.In(SystemMode)
+    vol.Required(ATTR_MODE): cv.string,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,
         vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -5,12 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Final
 
-from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
-from evohomeasync2.schemas.const import (
-    S2_DURATION as SZ_DURATION,
-    S2_PERIOD as SZ_PERIOD,
-    SystemMode as EvoSystemMode,
-)
+from evohomeasync2.schemas.const import SystemMode as EvoSystemMode
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -101,54 +96,11 @@ def setup_service_functions(
     hass.services.async_register(DOMAIN, EvoService.REFRESH_SYSTEM, force_refresh)
     hass.services.async_register(DOMAIN, EvoService.RESET_SYSTEM, set_system_mode)
 
-    # Enumerate which operating modes are supported by this system
-    modes = list(coordinator.tcs.allowed_system_modes)
-
-    system_mode_schemas = []
-    modes = [m for m in modes if m[SZ_SYSTEM_MODE] != EvoSystemMode.AUTO_WITH_RESET]
-
-    # Permanent-only modes will use this schema
-    perm_modes = [m[SZ_SYSTEM_MODE] for m in modes if not m[SZ_CAN_BE_TEMPORARY]]
-    if perm_modes:  # any of: "Auto", "HeatingOff": permanent only
-        schema = vol.Schema({vol.Required(ATTR_MODE): vol.In(perm_modes)})
-        system_mode_schemas.append(schema)
-
-    modes = [m for m in modes if m[SZ_CAN_BE_TEMPORARY]]
-
-    # These modes are set for a number of hours (or indefinitely): use this schema
-    temp_modes = [m[SZ_SYSTEM_MODE] for m in modes if m[SZ_TIMING_MODE] == SZ_DURATION]
-    if temp_modes:  # any of: "AutoWithEco", permanent or for 0-24 hours
-        schema = vol.Schema(
-            {
-                vol.Required(ATTR_MODE): vol.In(temp_modes),
-                vol.Optional(ATTR_DURATION): vol.All(
-                    cv.time_period,
-                    vol.Range(min=timedelta(hours=0), max=timedelta(hours=24)),
-                ),
-            }
-        )
-        system_mode_schemas.append(schema)
-
-    # These modes are set for a number of days (or indefinitely): use this schema
-    temp_modes = [m[SZ_SYSTEM_MODE] for m in modes if m[SZ_TIMING_MODE] == SZ_PERIOD]
-    if temp_modes:  # any of: "Away", "Custom", "DayOff", permanent or for 1-99 days
-        schema = vol.Schema(
-            {
-                vol.Required(ATTR_MODE): vol.In(temp_modes),
-                vol.Optional(ATTR_PERIOD): vol.All(
-                    cv.time_period,
-                    vol.Range(min=timedelta(days=1), max=timedelta(days=99)),
-                ),
-            }
-        )
-        system_mode_schemas.append(schema)
-
-    if system_mode_schemas:
-        hass.services.async_register(
-            DOMAIN,
-            EvoService.SET_SYSTEM_MODE,
-            set_system_mode,
-            schema=vol.Schema(vol.Any(*system_mode_schemas)),
-        )
+    hass.services.async_register(
+        DOMAIN,
+        EvoService.SET_SYSTEM_MODE,
+        set_system_mode,
+        schema=vol.Schema(SET_SYSTEM_MODE_SCHEMA),
+    )
 
     _register_zone_entity_services(hass)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,7 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
-    # using cv.string here, so can throw ServiceValidationError instead of vol.Invalid
+    # unsupported modes are rejected at runtime with ServiceValidationError
     vol.Required(ATTR_MODE): cv.string,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -107,12 +107,7 @@ def _validate_set_system_mode_params(call: ServiceCall, tcs: ec2.ControlSystem) 
 def setup_service_functions(
     hass: HomeAssistant, coordinator: EvoDataUpdateCoordinator
 ) -> None:
-    """Set up the service handlers for the system/zone operating modes.
-
-    Not all Honeywell TCC-compatible systems support all operating modes. In addition,
-    each mode will require any of four distinct service schemas. This has to be
-    enumerated before registering the appropriate handlers.
-    """
+    """Set up the service handlers for Evohome systems."""
 
     @verify_domain_control(DOMAIN)
     async def force_refresh(call: ServiceCall) -> None:
@@ -121,7 +116,7 @@ def setup_service_functions(
 
     @verify_domain_control(DOMAIN)
     async def set_system_mode(call: ServiceCall) -> None:
-        """Set the system mode or reset the system."""
+        """Set the Evohome system mode or reset the system."""
 
         if call.service == EvoService.SET_SYSTEM_MODE:  # no validation for RESET_SYSTEM
             _validate_set_system_mode_params(call, coordinator.tcs)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -23,6 +23,7 @@ from .coordinator import EvoDataUpdateCoordinator
 
 # System service schemas (registered as domain services)
 SET_SYSTEM_MODE_SCHEMA: Final[dict[str | vol.Marker, Any]] = {
+    # using cv.string here, so can throw ServiceValidationError instead of vol.Invalid
     vol.Required(ATTR_MODE): cv.string,  # avoid vol.In(SystemMode)
     vol.Exclusive(ATTR_DURATION, "temporary"): vol.All(
         cv.time_period,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, Final
 
-import evohomeasync2 as ec2
+from evohomeasync2 import ControlSystem
 from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
 from evohomeasync2.schemas.const import S2_DURATION, S2_PERIOD
 import voluptuous as vol
@@ -67,7 +67,7 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
     )
 
 
-def _validate_set_system_mode_params(call: ServiceCall, tcs: ec2.ControlSystem) -> None:
+def _validate_set_system_mode_params(call: ServiceCall, tcs: ControlSystem) -> None:
     """Validate that a set_system_mode service call is properly formed."""
 
     mode = call.data[ATTR_MODE]

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -73,6 +73,10 @@ def _validate_set_system_mode_params(call: ServiceCall, tcs: ControlSystem) -> N
     mode = call.data[ATTR_MODE]
     evo_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
 
+    # Validation occurs here, instead of in the library, because it uses a slightly
+    # different schema (until instead of duration/period) for the method invoked
+    # via this service call
+
     if (mode_info := evo_modes.get(mode)) is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -118,7 +122,11 @@ def setup_service_functions(
     async def set_system_mode(call: ServiceCall) -> None:
         """Set the Evohome system mode or reset the system."""
 
-        if call.service == EvoService.SET_SYSTEM_MODE:  # no validation for RESET_SYSTEM
+        # No validation for RESET_SYSTEM here (other than the schema), as the library
+        # method invoked via that service call may be able to emulate the reset even if
+        # the system doesn't support auto_with_reset natively
+
+        if call.service == EvoService.SET_SYSTEM_MODE:
             _validate_set_system_mode_params(call, coordinator.tcs)
 
         payload = {

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -122,9 +122,9 @@ def setup_service_functions(
     async def set_system_mode(call: ServiceCall) -> None:
         """Set the Evohome system mode or reset the system."""
 
-        # No validation for RESET_SYSTEM here (other than the schema), as the library
-        # method invoked via that service call may be able to emulate the reset even if
-        # the system doesn't support auto_with_reset natively
+        # No additional validation for RESET_SYSTEM here, as the library method invoked
+        # via that service call may be able to emulate the reset even if the system
+        # doesn't support auto_with_reset natively
 
         if call.service == EvoService.SET_SYSTEM_MODE:
             _validate_set_system_mode_params(call, coordinator.tcs)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -130,7 +130,7 @@ def setup_service_functions(
 
         # No additional validation for RESET_SYSTEM here, as the library method invoked
         # via that service call may be able to emulate the reset even if the system
-        # doesn't support auto_with_reset natively
+        # doesn't support AutoWithReset natively
 
         if call.service == EvoService.SET_SYSTEM_MODE:
             _validate_set_system_mode_params(coordinator.tcs, call.data)

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -85,7 +85,7 @@ def _validate_set_system_mode_params(tcs: ControlSystem, data: dict[str, Any]) -
             translation_placeholders={ATTR_MODE: mode},
         )
 
-    # volutpuous schema ensures that duration and period are not both present
+    # voluptuous schema ensures that duration and period are not both present
 
     if not mode_info[SZ_CAN_BE_TEMPORARY]:
         if ATTR_DURATION in data or ATTR_PERIOD in data:

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -68,10 +68,10 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
     )
 
 
-def _validate_set_system_mode_params(call: ServiceCall, tcs: ControlSystem) -> None:
+def _validate_set_system_mode_params(tcs: ControlSystem, data: dict[str, Any]) -> None:
     """Validate that a set_system_mode service call is properly formed."""
 
-    mode = call.data[ATTR_MODE]
+    mode = data[ATTR_MODE]
     evo_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
 
     # Validation occurs here, instead of in the library, because it uses a slightly
@@ -86,21 +86,21 @@ def _validate_set_system_mode_params(call: ServiceCall, tcs: ControlSystem) -> N
         )
 
     if not mode_info[SZ_CAN_BE_TEMPORARY]:
-        if ATTR_DURATION in call.data or ATTR_PERIOD in call.data:
+        if ATTR_DURATION in data or ATTR_PERIOD in data:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="mode_cant_be_temporary",
                 translation_placeholders={ATTR_MODE: mode},
             )
 
-    elif mode_info[SZ_TIMING_MODE] == S2_DURATION and ATTR_PERIOD in call.data:
+    elif mode_info[SZ_TIMING_MODE] == S2_DURATION and ATTR_PERIOD in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_period",
             translation_placeholders={ATTR_MODE: mode},
         )
 
-    elif mode_info[SZ_TIMING_MODE] == S2_PERIOD and ATTR_DURATION in call.data:
+    elif mode_info[SZ_TIMING_MODE] == S2_PERIOD and ATTR_DURATION in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_duration",
@@ -128,7 +128,7 @@ def setup_service_functions(
         # doesn't support auto_with_reset natively
 
         if call.service == EvoService.SET_SYSTEM_MODE:
-            _validate_set_system_mode_params(call, coordinator.tcs)
+            _validate_set_system_mode_params(coordinator.tcs, call.data)
 
         payload = {
             "unique_id": coordinator.tcs.id,

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -142,8 +142,6 @@ def setup_service_functions(
         }
         async_dispatcher_send(hass, DOMAIN, payload)
 
-    assert coordinator.tcs is not None  # mypy
-
     hass.services.async_register(DOMAIN, EvoService.REFRESH_SYSTEM, force_refresh)
     hass.services.async_register(DOMAIN, EvoService.RESET_SYSTEM, set_system_mode)
 

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -72,18 +72,20 @@ def _validate_set_system_mode_params(tcs: ControlSystem, data: dict[str, Any]) -
     """Validate that a set_system_mode service call is properly formed."""
 
     mode = data[ATTR_MODE]
-    evo_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
+    tcs_modes = {m[SZ_SYSTEM_MODE]: m for m in tcs.allowed_system_modes}
 
     # Validation occurs here, instead of in the library, because it uses a slightly
     # different schema (until instead of duration/period) for the method invoked
     # via this service call
 
-    if (mode_info := evo_modes.get(mode)) is None:
+    if (mode_info := tcs_modes.get(mode)) is None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_not_supported",
             translation_placeholders={ATTR_MODE: mode},
         )
+
+    # volutpuous schema ensures that duration and period are not both present
 
     if not mode_info[SZ_CAN_BE_TEMPORARY]:
         if ATTR_DURATION in data or ATTR_PERIOD in data:
@@ -92,15 +94,18 @@ def _validate_set_system_mode_params(tcs: ControlSystem, data: dict[str, Any]) -
                 translation_key="mode_cant_be_temporary",
                 translation_placeholders={ATTR_MODE: mode},
             )
+        return
 
-    elif mode_info[SZ_TIMING_MODE] == S2_DURATION and ATTR_PERIOD in data:
+    timing_mode = mode_info.get(SZ_TIMING_MODE)  # will not be None, as can_be_temporary
+
+    if timing_mode == S2_DURATION and ATTR_PERIOD in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_period",
             translation_placeholders={ATTR_MODE: mode},
         )
 
-    elif mode_info[SZ_TIMING_MODE] == S2_PERIOD and ATTR_DURATION in data:
+    if timing_mode == S2_PERIOD and ATTR_DURATION in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_duration",

--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -7,7 +7,10 @@ from typing import Any, Final
 
 from evohomeasync2 import ControlSystem
 from evohomeasync2.const import SZ_CAN_BE_TEMPORARY, SZ_SYSTEM_MODE, SZ_TIMING_MODE
-from evohomeasync2.schemas.const import S2_DURATION, S2_PERIOD
+from evohomeasync2.schemas.const import (
+    S2_DURATION as SZ_DURATION,
+    S2_PERIOD as SZ_PERIOD,
+)
 import voluptuous as vol
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
@@ -98,14 +101,14 @@ def _validate_set_system_mode_params(tcs: ControlSystem, data: dict[str, Any]) -
 
     timing_mode = mode_info.get(SZ_TIMING_MODE)  # will not be None, as can_be_temporary
 
-    if timing_mode == S2_DURATION and ATTR_PERIOD in data:
+    if timing_mode == SZ_DURATION and ATTR_PERIOD in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_period",
             translation_placeholders={ATTR_MODE: mode},
         )
 
-    if timing_mode == S2_PERIOD and ATTR_DURATION in data:
+    if timing_mode == SZ_PERIOD and ATTR_DURATION in data:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="mode_cant_have_duration",

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -13,7 +13,9 @@ set_system_mode:
             - "Away"
             - "Custom"
             - "DayOff"
+            - "Heat"
             - "HeatingOff"
+            - "Off"
     period:
       example: '{"days": 28}'
       selector:

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -16,6 +16,7 @@ set_system_mode:
             - "Heat"
             - "HeatingOff"
             - "Off"
+          custom_value: true
     period:
       example: '{"days": 28}'
       selector:

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -14,7 +14,6 @@ set_system_mode:
             - "Custom"
             - "DayOff"
             - "HeatingOff"
-          custom_value: true
     period:
       example: '{"days": 28}'
       selector:

--- a/homeassistant/components/evohome/services.yaml
+++ b/homeassistant/components/evohome/services.yaml
@@ -13,9 +13,7 @@ set_system_mode:
             - "Away"
             - "Custom"
             - "DayOff"
-            - "Heat"
             - "HeatingOff"
-            - "Off"
           custom_value: true
     period:
       example: '{"days": 28}'

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -1,5 +1,17 @@
 {
   "exceptions": {
+    "mode_cant_be_temporary": {
+      "message": "The mode `{mode}` does not support `duration` or `period`"
+    },
+    "mode_cant_have_duration": {
+      "message": "The mode `{mode}` does not support `duration`; use `period` instead"
+    },
+    "mode_cant_have_period": {
+      "message": "The mode `{mode}` does not support `period`; use `duration` instead"
+    },
+    "mode_not_supported": {
+      "message": "The mode `{mode}` is not supported by this controller"
+    },
     "zone_only_service": {
       "message": "Only zones support the `{service}` action"
     }

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -1,5 +1,11 @@
 {
   "exceptions": {
+    "api_call_failed": {
+      "message": "The Evohome API call failed: {error}"
+    },
+    "invalid_system_mode": {
+      "message": "The requested system mode is not supported: {error}"
+    },
     "mode_cant_be_temporary": {
       "message": "The mode `{mode}` does not support `duration` or `period`"
     },

--- a/homeassistant/components/evohome/strings.json
+++ b/homeassistant/components/evohome/strings.json
@@ -1,8 +1,5 @@
 {
   "exceptions": {
-    "api_call_failed": {
-      "message": "The Evohome API call failed: {error}"
-    },
     "invalid_system_mode": {
       "message": "The requested system mode is not supported: {error}"
     },

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
+from evohomeasync2 import exceptions as evo_exc
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -28,7 +29,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .conftest import setup_evohome
 from .const import TEST_INSTALLS
@@ -187,6 +188,58 @@ async def test_ctl_turn_off(
         results.append(mock_fcn.await_args.args)  # type: ignore[union-attr]
 
     assert results == snapshot
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_ctl_invalid_system_mode(
+    hass: HomeAssistant,
+    ctl_id: str,
+) -> None:
+    """Test translated exception when the requested system mode is invalid."""
+
+    with (
+        patch(
+            "evohomeasync2.control_system.ControlSystem.set_mode",
+            side_effect=evo_exc.InvalidSystemModeError("Unsupported mode: xxx"),
+        ),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: ctl_id,
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "invalid_system_mode"
+
+
+@pytest.mark.parametrize("install", ["default"])
+async def test_ctl_api_request_failed(
+    hass: HomeAssistant,
+    ctl_id: str,
+) -> None:
+    """Test translated exception when the client API request fails."""
+
+    with (
+        patch(
+            "evohomeasync2.control_system.ControlSystem.set_mode",
+            side_effect=evo_exc.ApiRequestFailedError("Request failed", status=500),
+        ),
+        pytest.raises(ServiceValidationError) as exc_info,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {
+                ATTR_ENTITY_ID: ctl_id,
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "api_call_failed"
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)

--- a/tests/components/evohome/test_climate.py
+++ b/tests/components/evohome/test_climate.py
@@ -216,32 +216,6 @@ async def test_ctl_invalid_system_mode(
     assert exc_info.value.translation_key == "invalid_system_mode"
 
 
-@pytest.mark.parametrize("install", ["default"])
-async def test_ctl_api_request_failed(
-    hass: HomeAssistant,
-    ctl_id: str,
-) -> None:
-    """Test translated exception when the client API request fails."""
-
-    with (
-        patch(
-            "evohomeasync2.control_system.ControlSystem.set_mode",
-            side_effect=evo_exc.ApiRequestFailedError("Request failed", status=500),
-        ),
-        pytest.raises(ServiceValidationError) as exc_info,
-    ):
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_TURN_OFF,
-            {
-                ATTR_ENTITY_ID: ctl_id,
-            },
-            blocking=True,
-        )
-
-    assert exc_info.value.translation_key == "api_call_failed"
-
-
 @pytest.mark.parametrize("install", TEST_INSTALLS)
 async def test_ctl_turn_on(
     hass: HomeAssistant,

--- a/tests/components/evohome/test_init.py
+++ b/tests/components/evohome/test_init.py
@@ -7,7 +7,7 @@ import logging
 from unittest.mock import Mock, patch
 
 import aiohttp
-from evohomeasync2 import EvohomeClient, exceptions as exc
+from evohomeasync2 import EvohomeClient, exceptions as evo_exc
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -90,7 +90,7 @@ LOG_SETUP_FAILED = (
 EXC_BAD_CONNECTION = aiohttp.ClientConnectionError(
     "Connection error",
 )
-EXC_BAD_CREDENTIALS = exc.AuthenticationFailedError(
+EXC_BAD_CREDENTIALS = evo_exc.AuthenticationFailedError(
     "Authenticator response is invalid: {'error': 'invalid_grant'}",
     status=HTTPStatus.BAD_REQUEST,
 )

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -44,9 +44,9 @@ async def test_refresh_system(
 
 
 @pytest.mark.parametrize("install", TEST_INSTALLS)  # some don't support AutoWithReset
+@pytest.mark.usefixtures("evohome")
 async def test_reset_system(
     hass: HomeAssistant,
-    ctl_id: str,
 ) -> None:
     """Test Evohome's reset_system service (for a temperature control system)."""
 

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -43,7 +43,7 @@ async def test_refresh_system(
         mock_fcn.assert_awaited_once_with()
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)  # not all TCSs support AutoWithReset
+@pytest.mark.parametrize("install", TEST_INSTALLS)  # some dont support AutoWithReset
 async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -43,7 +43,7 @@ async def test_refresh_system(
         mock_fcn.assert_awaited_once_with()
 
 
-@pytest.mark.parametrize("install", TEST_INSTALLS)  # some dont support AutoWithReset
+@pytest.mark.parametrize("install", TEST_INSTALLS)  # some don't support AutoWithReset
 async def test_reset_system(
     hass: HomeAssistant,
     ctl_id: str,

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -270,3 +270,52 @@ async def test_zone_services_with_ctl_id(
 
     assert exc_info.value.translation_key == "zone_only_service"
     assert exc_info.value.translation_placeholders == {"service": service}
+
+
+_SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
+    (
+        {"mode": "NotARealMode"},
+        "mode_not_supported",
+    ),
+    (
+        {"mode": "Auto", "duration": {"hours": 1}},
+        "mode_cant_be_temporary",
+    ),
+    (
+        {"mode": "AutoWithEco", "period": {"days": 1}},
+        "mode_cant_have_period",
+    ),
+    (
+        {"mode": "DayOff", "duration": {"hours": 1}},
+        "mode_cant_have_duration",
+    ),
+]
+
+
+@pytest.mark.parametrize("install", ["default"])
+@pytest.mark.parametrize(
+    ("service_data", "expected_translation_key"),
+    _SET_SYSTEM_MODE_VALIDATOR_PARAMS,
+    ids=[k for _, k in _SET_SYSTEM_MODE_VALIDATOR_PARAMS],
+)
+async def test_set_system_mode_validator(
+    hass: HomeAssistant,
+    evohome: EvohomeClient,
+    service_data: dict[str, Any],
+    expected_translation_key: str,
+) -> None:
+    """Test ServiceValidationError for all controller system mode validation cases."""
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_SYSTEM_MODE,
+            service_data,
+            target={},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == expected_translation_key
+    assert exc_info.value.translation_placeholders == {
+        ATTR_MODE: service_data[ATTR_MODE]
+    }

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -274,19 +274,19 @@ async def test_zone_services_with_ctl_id(
 
 _SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
     (
-        {"mode": "NotARealMode"},
+        {ATTR_MODE: "NotARealMode"},
         "mode_not_supported",
     ),
     (
-        {"mode": "Auto", "duration": {"hours": 1}},
+        {ATTR_MODE: "Auto", ATTR_DURATION: {"hours": 1}},
         "mode_cant_be_temporary",
     ),
     (
-        {"mode": "AutoWithEco", "period": {"days": 1}},
+        {ATTR_MODE: "AutoWithEco", ATTR_PERIOD: {"days": 1}},
         "mode_cant_have_period",
     ),
     (
-        {"mode": "DayOff", "duration": {"hours": 1}},
+        {ATTR_MODE: "DayOff", ATTR_DURATION: {"hours": 1}},
         "mode_cant_have_duration",
     ),
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move most of the validation of the `set_system_mode` service call parameters from a voluptuous schema to code.
 - permits use of `ServiceValidationError` instead of `vol.Invalid`

> This PR prepares this integration for config flow; specifically for multiple systems per user login.

Most evohome-compatible systems support the same system modes (although older systems do not support `AutoWithReset`). However, a minority of systems support a subset, or a distinct set of such modes.

Therefore, the evohome integration builds the service schemas dynamically when the integration is first loaded.

But evohome will soon support multiple systems (rather than simply the first system it finds), and each could have a different set of modes.

Thus, validation of the `set_system_mode` service call parameters is being moved; from a voluptuous schema, into code. Currently, this is done in **services.py**, but when controller service calls become entity-level services, a method in the corresponding entity class, `EvoController`, will invokes these checks.

A subsequent PR will migrate these services from domain- to entity-level service calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
