### PR TITLE
Fix backblaze_b2 tests for Python 3.14.3

### DIFF
--- a/tests/components/backblaze_b2/test_repairs.py
+++ b/tests/components/backblaze_b2/test_repairs.py
@@ -45,7 +45,8 @@ async def test_repair_issue_creation(
     expected_issues: int,
 ) -> None:
     """Test repair issue creation for different exception types."""
-    with patch.object(hass, "async_add_executor_job", side_effect=exception):
+    mock_entry.runtime_data.api.account_info.get_allowed.side_effect = exception
+    with patch.object(mock_entry, "async_start_reauth"):
         await async_check_for_repair_issues(hass, mock_entry)
 
     issues = ir.async_get(hass).issues

--- a/tests/components/backblaze_b2/test_repairs.py
+++ b/tests/components/backblaze_b2/test_repairs.py
@@ -29,10 +29,24 @@ def mock_entry():
     return entry
 
 
+async def test_unauthorized_triggers_reauth(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+) -> None:
+    """Test that Unauthorized exception triggers reauth flow."""
+    mock_entry.runtime_data.api.account_info.get_allowed.side_effect = Unauthorized(
+        "test", "auth_failed"
+    )
+    with patch.object(mock_entry, "async_start_reauth") as mock_reauth:
+        await async_check_for_repair_issues(hass, mock_entry)
+
+    mock_reauth.assert_called_once_with(hass)
+    assert len(ir.async_get(hass).issues) == 0
+
+
 @pytest.mark.parametrize(
     ("exception", "expected_issues"),
     [
-        (Unauthorized("test", "auth_failed"), 0),  # Handled by reauth flow
         (RestrictedBucket("test"), 1),  # Creates repair issue
         (NonExistentBucket("test"), 1),  # Creates repair issue
         (B2Error("test"), 0),  # Just logs, no issue
@@ -46,11 +60,11 @@ async def test_repair_issue_creation(
 ) -> None:
     """Test repair issue creation for different exception types."""
     mock_entry.runtime_data.api.account_info.get_allowed.side_effect = exception
-    with patch.object(mock_entry, "async_start_reauth"):
+    with patch.object(mock_entry, "async_start_reauth") as mock_reauth:
         await async_check_for_repair_issues(hass, mock_entry)
 
-    issues = ir.async_get(hass).issues
-    assert len(issues) == expected_issues
+    mock_reauth.assert_not_called()
+    assert len(ir.async_get(hass).issues) == expected_issues
 
 
 async def test_async_create_fix_flow(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Blackblaze B2 integration fails tests with Python 3.13.3. Not sure how this wasn't an issue before, but when testing for the Unauthorized exception in `test_repair_issue_creation`, it will actually start a reauth flow which uses `async_add_executor_job` internally as far as I can tell. I now changed the test to only patch the api.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
