### PR TITLE
Stop manually assigning an entity_id in waterfurnace sensors

### DIFF
--- a/homeassistant/components/waterfurnace/sensor.py
+++ b/homeassistant/components/waterfurnace/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from homeassistant.components.sensor import (
-    ENTITY_ID_FORMAT,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -19,7 +18,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import slugify
 
 from . import DOMAIN, WaterFurnaceConfigEntry
 from .coordinator import WaterFurnaceCoordinator
@@ -178,10 +176,6 @@ class WaterFurnaceSensor(CoordinatorEntity[WaterFurnaceCoordinator], SensorEntit
         super().__init__(coordinator)
         self.entity_description = description
 
-        # This ensures that the sensors are isolated per waterfurnace unit
-        self.entity_id = ENTITY_ID_FORMAT.format(
-            f"wf_{slugify(coordinator.unit)}_{slugify(description.key)}"
-        )
         self._attr_unique_id = f"{coordinator.unit}_{description.key}"
 
         device_info = DeviceInfo(

--- a/tests/components/waterfurnace/snapshots/test_sensor.ambr
+++ b/tests/components/waterfurnace/snapshots/test_sensor.ambr
@@ -1,105 +1,5 @@
 # serializer version: 1
-# name: test_sensors[sensor.wf_test_gwid_12345_actualcompressorspeed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_actualcompressorspeed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Compressor speed',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_actualcompressorspeed',
-    'supported_features': 0,
-    'translation_key': 'actual_compressor_speed',
-    'unique_id': 'TEST_GWID_12345_actualcompressorspeed',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_actualcompressorspeed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Test ABC Type Compressor speed',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_actualcompressorspeed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1200',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_airflowcurrentspeed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_airflowcurrentspeed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Fan speed',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_airflowcurrentspeed',
-    'supported_features': 0,
-    'translation_key': 'airflow_current_speed',
-    'unique_id': 'TEST_GWID_12345_airflowcurrentspeed',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_airflowcurrentspeed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Test ABC Type Fan speed',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_airflowcurrentspeed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '850',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_auxpower-entry]
+# name: test_sensors[sensor.test_abc_type_active_setpoint-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -115,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_auxpower',
+    'entity_id': 'sensor.test_abc_type_active_setpoint',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -123,521 +23,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': None,
-    'original_name': 'Aux power',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_auxpower',
-    'supported_features': 0,
-    'translation_key': 'aux_power',
-    'unique_id': 'TEST_GWID_12345_auxpower',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_auxpower-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Test ABC Type Aux power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_auxpower',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_compressorpower-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_compressorpower',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': None,
-    'original_name': 'Compressor power',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_compressorpower',
-    'supported_features': 0,
-    'translation_key': 'compressor_power',
-    'unique_id': 'TEST_GWID_12345_compressorpower',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_compressorpower-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Test ABC Type Compressor power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_compressorpower',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '800',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_enteringwatertemp-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_enteringwatertemp',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Loop temperature',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_enteringwatertemp',
-    'supported_features': 0,
-    'translation_key': 'entering_water_temp',
-    'unique_id': 'TEST_GWID_12345_enteringwatertemp',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_enteringwatertemp-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'temperature',
-      'friendly_name': 'Test ABC Type Loop temperature',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_enteringwatertemp',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '6.0',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_fanpower-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_fanpower',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': None,
-    'original_name': 'Fan power',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_fanpower',
-    'supported_features': 0,
-    'translation_key': 'fan_power',
-    'unique_id': 'TEST_GWID_12345_fanpower',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_fanpower-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Test ABC Type Fan power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_fanpower',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '150',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_leavingairtemp-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_leavingairtemp',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Leaving air temperature',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_leavingairtemp',
-    'supported_features': 0,
-    'translation_key': 'leaving_air_temp',
-    'unique_id': 'TEST_GWID_12345_leavingairtemp',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_leavingairtemp-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'temperature',
-      'friendly_name': 'Test ABC Type Leaving air temperature',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_leavingairtemp',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '43.6111111111111',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_leavingwatertemp-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_leavingwatertemp',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Leaving water temperature',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_leavingwatertemp',
-    'supported_features': 0,
-    'translation_key': 'leaving_water_temp',
-    'unique_id': 'TEST_GWID_12345_leavingwatertemp',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_leavingwatertemp-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'temperature',
-      'friendly_name': 'Test ABC Type Leaving water temperature',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_leavingwatertemp',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_looppumppower-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_looppumppower',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': None,
-    'original_name': 'Loop pump power',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_looppumppower',
-    'supported_features': 0,
-    'translation_key': 'loop_pump_power',
-    'unique_id': 'TEST_GWID_12345_looppumppower',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_looppumppower-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Test ABC Type Loop pump power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_looppumppower',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '50',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_mode-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_mode',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Furnace mode',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_mode',
-    'supported_features': 0,
-    'translation_key': 'mode',
-    'unique_id': 'TEST_GWID_12345_mode',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_mode-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Test ABC Type Furnace mode',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_mode',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'Heating 2',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_totalunitpower-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_totalunitpower',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
-    'original_icon': None,
-    'original_name': 'Total power',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_totalunitpower',
-    'supported_features': 0,
-    'translation_key': 'total_unit_power',
-    'unique_id': 'TEST_GWID_12345_totalunitpower',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_totalunitpower-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Test ABC Type Total power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_totalunitpower',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1500',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatactivesetpoint-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatactivesetpoint',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Active setpoint',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -648,14 +34,14 @@
     'original_name': 'Active setpoint',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatactivesetpoint',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tstat_active_setpoint',
     'unique_id': 'TEST_GWID_12345_tstatactivesetpoint',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatactivesetpoint-state]
+# name: test_sensors[sensor.test_abc_type_active_setpoint-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -664,14 +50,14 @@
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatactivesetpoint',
+    'entity_id': 'sensor.test_abc_type_active_setpoint',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '22.2222222222222',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatcoolingsetpoint-entry]
+# name: test_sensors[sensor.test_abc_type_aux_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -687,7 +73,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatcoolingsetpoint',
+    'entity_id': 'sensor.test_abc_type_aux_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -695,7 +81,173 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Aux power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Aux power',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'aux_power',
+    'unique_id': 'TEST_GWID_12345_auxpower',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_aux_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test ABC Type Aux power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_aux_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_compressor_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_compressor_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Compressor power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Compressor power',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'compressor_power',
+    'unique_id': 'TEST_GWID_12345_compressorpower',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_compressor_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test ABC Type Compressor power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_compressor_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '800',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_compressor_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_compressor_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Compressor speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Compressor speed',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'actual_compressor_speed',
+    'unique_id': 'TEST_GWID_12345_actualcompressorspeed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_compressor_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test ABC Type Compressor speed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_compressor_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1200',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_cooling_setpoint-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_cooling_setpoint',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cooling setpoint',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -706,14 +258,14 @@
     'original_name': 'Cooling setpoint',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatcoolingsetpoint',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tstat_cooling_setpoint',
     'unique_id': 'TEST_GWID_12345_tstatcoolingsetpoint',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatcoolingsetpoint-state]
+# name: test_sensors[sensor.test_abc_type_cooling_setpoint-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -722,14 +274,14 @@
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatcoolingsetpoint',
+    'entity_id': 'sensor.test_abc_type_cooling_setpoint',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatdehumidsetpoint-entry]
+# name: test_sensors[sensor.test_abc_type_dehumidification_setpoint-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -745,7 +297,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatdehumidsetpoint',
+    'entity_id': 'sensor.test_abc_type_dehumidification_setpoint',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -753,7 +305,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Dehumidification setpoint',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
@@ -761,14 +313,14 @@
     'original_name': 'Dehumidification setpoint',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatdehumidsetpoint',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tstat_dehumid_setpoint',
     'unique_id': 'TEST_GWID_12345_tstatdehumidsetpoint',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatdehumidsetpoint-state]
+# name: test_sensors[sensor.test_abc_type_dehumidification_setpoint-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'humidity',
@@ -777,14 +329,14 @@
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatdehumidsetpoint',
+    'entity_id': 'sensor.test_abc_type_dehumidification_setpoint',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatheatingsetpoint-entry]
+# name: test_sensors[sensor.test_abc_type_fan_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -800,7 +352,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatheatingsetpoint',
+    'entity_id': 'sensor.test_abc_type_fan_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -808,7 +360,165 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Fan power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Fan power',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'fan_power',
+    'unique_id': 'TEST_GWID_12345_fanpower',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_fan_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test ABC Type Fan power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_fan_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '150',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_fan_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_fan_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Fan speed',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Fan speed',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'airflow_current_speed',
+    'unique_id': 'TEST_GWID_12345_airflowcurrentspeed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_fan_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test ABC Type Fan speed',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_fan_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '850',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_furnace_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_furnace_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Furnace mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Furnace mode',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mode',
+    'unique_id': 'TEST_GWID_12345_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_furnace_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test ABC Type Furnace mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_furnace_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Heating 2',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_heating_setpoint-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_heating_setpoint',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Heating setpoint',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -819,14 +529,14 @@
     'original_name': 'Heating setpoint',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatheatingsetpoint',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'tstat_heating_setpoint',
     'unique_id': 'TEST_GWID_12345_tstatheatingsetpoint',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatheatingsetpoint-state]
+# name: test_sensors[sensor.test_abc_type_heating_setpoint-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -835,14 +545,14 @@
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatheatingsetpoint',
+    'entity_id': 'sensor.test_abc_type_heating_setpoint',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstathumidsetpoint-entry]
+# name: test_sensors[sensor.test_abc_type_humidity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -858,7 +568,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstathumidsetpoint',
+    'entity_id': 'sensor.test_abc_type_humidity',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -866,62 +576,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
-    'original_icon': None,
-    'original_name': 'Humidity setpoint',
-    'platform': 'waterfurnace',
-    'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstathumidsetpoint',
-    'supported_features': 0,
-    'translation_key': 'tstat_humid_setpoint',
-    'unique_id': 'TEST_GWID_12345_tstathumidsetpoint',
-    'unit_of_measurement': '%',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstathumidsetpoint-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'humidity',
-      'friendly_name': 'Test ABC Type Humidity setpoint',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstathumidsetpoint',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '45',
-  })
-# ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatrelativehumidity-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatrelativehumidity',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Humidity',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
@@ -929,14 +584,14 @@
     'original_name': 'Humidity',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatrelativehumidity',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
     'unique_id': 'TEST_GWID_12345_tstatrelativehumidity',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatrelativehumidity-state]
+# name: test_sensors[sensor.test_abc_type_humidity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'humidity',
@@ -945,14 +600,14 @@
       'unit_of_measurement': '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatrelativehumidity',
+    'entity_id': 'sensor.test_abc_type_humidity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '43',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatroomtemp-entry]
+# name: test_sensors[sensor.test_abc_type_humidity_setpoint-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -968,7 +623,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatroomtemp',
+    'entity_id': 'sensor.test_abc_type_humidity_setpoint',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -976,7 +631,294 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Humidity setpoint',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity setpoint',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'tstat_humid_setpoint',
+    'unique_id': 'TEST_GWID_12345_tstathumidsetpoint',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_humidity_setpoint-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'Test ABC Type Humidity setpoint',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_humidity_setpoint',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '45',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_leaving_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_leaving_air_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Leaving air temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Leaving air temperature',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaving_air_temp',
+    'unique_id': 'TEST_GWID_12345_leavingairtemp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_leaving_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Test ABC Type Leaving air temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_leaving_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '43.6111111111111',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_leaving_water_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_leaving_water_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Leaving water temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Leaving water temperature',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'leaving_water_temp',
+    'unique_id': 'TEST_GWID_12345_leavingwatertemp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_leaving_water_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Test ABC Type Leaving water temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_leaving_water_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_loop_pump_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_loop_pump_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loop pump power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Loop pump power',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'loop_pump_power',
+    'unique_id': 'TEST_GWID_12345_looppumppower',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_loop_pump_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test ABC Type Loop pump power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_loop_pump_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_loop_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_loop_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Loop temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Loop temperature',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'entering_water_temp',
+    'unique_id': 'TEST_GWID_12345_enteringwatertemp',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_loop_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'Test ABC Type Loop temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_loop_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6.0',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_room_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_room_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Room temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -987,14 +929,14 @@
     'original_name': 'Room temperature',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_tstatroomtemp',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'room_temp',
     'unique_id': 'TEST_GWID_12345_tstatroomtemp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_tstatroomtemp-state]
+# name: test_sensors[sensor.test_abc_type_room_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'temperature',
@@ -1003,14 +945,14 @@
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_tstatroomtemp',
+    'entity_id': 'sensor.test_abc_type_room_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '21.2222222222222',
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_waterflowrate-entry]
+# name: test_sensors[sensor.test_abc_type_total_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1026,7 +968,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wf_test_gwid_12345_waterflowrate',
+    'entity_id': 'sensor.test_abc_type_total_power',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1034,7 +976,65 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Total power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Total power',
+    'platform': 'waterfurnace',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_unit_power',
+    'unique_id': 'TEST_GWID_12345_totalunitpower',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_total_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Test ABC Type Total power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_abc_type_total_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1500',
+  })
+# ---
+# name: test_sensors[sensor.test_abc_type_water_flow_rate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_abc_type_water_flow_rate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Water flow rate',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1045,14 +1045,14 @@
     'original_name': 'Water flow rate',
     'platform': 'waterfurnace',
     'previous_unique_id': None,
-    'suggested_object_id': 'wf_test_gwid_12345_waterflowrate',
+    'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'water_flow_rate',
     'unique_id': 'TEST_GWID_12345_waterflowrate',
     'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_MINUTE: 'gal/min'>,
   })
 # ---
-# name: test_sensors[sensor.wf_test_gwid_12345_waterflowrate-state]
+# name: test_sensors[sensor.test_abc_type_water_flow_rate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'volume_flow_rate',
@@ -1061,7 +1061,7 @@
       'unit_of_measurement': <UnitOfVolumeFlowRate.GALLONS_PER_MINUTE: 'gal/min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wf_test_gwid_12345_waterflowrate',
+    'entity_id': 'sensor.test_abc_type_water_flow_rate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/waterfurnace/test_sensor.py
+++ b/tests/components/waterfurnace/test_sensor.py
@@ -36,7 +36,7 @@ async def test_sensor(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test states of the sensor."""
-    state = hass.states.get("sensor.wf_test_gwid_12345_totalunitpower")
+    state = hass.states.get("sensor.test_abc_type_total_power")
     assert state
     assert state.state == "1500"
 
@@ -45,7 +45,7 @@ async def test_sensor(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get("sensor.wf_test_gwid_12345_totalunitpower")
+    state = hass.states.get("sensor.test_abc_type_total_power")
     assert state
     assert state.state == "2000"
 
@@ -65,7 +65,7 @@ async def test_availability(
     side_effect: Exception,
 ) -> None:
     """Ensure that we mark the entities unavailable correctly when service is offline."""
-    entity_id = "sensor.wf_test_gwid_12345_totalunitpower"
+    entity_id = "sensor.test_abc_type_total_power"
 
     state = hass.states.get(entity_id)
     assert state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove assigning `entity_id` manually, relying instead on `_attr_unique_id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Requested in other [PRs](https://github.com/home-assistant/core/pull/165756#discussion_r2947305649)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
