### PR TITLE
Add support for finding related dashboards referencing entities

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -483,8 +483,7 @@ def _async_create_yaml_mode_repair(hass: HomeAssistant) -> None:
     )
 
 
-@callback
-def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
+async def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
     """Return dashboard/view combinations referencing an entity."""
     if LOVELACE_DATA not in hass.data:
         return []
@@ -492,11 +491,12 @@ def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
     dashboard_views: list[str] = []
 
     for dashboard_config in hass.data[LOVELACE_DATA].dashboards.values():
-        config = dashboard_config.loaded_config
-        if config is None:
+        try:
+            config = await dashboard_config.async_load(False)
+        except dashboard.ConfigNotFound:
             continue
 
-        dashboard_path = dashboard_config.url_path or "lovelace"
+        dashboard_path = dashboard_config.url_path or DOMAIN
 
         for idx, view in enumerate(config.get("views", [])):
             if not _view_references_entity(view, entity_id):

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -56,6 +56,7 @@ from .const import (  # noqa: F401
 from .system_health import system_health_info  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
+ENTITY_REFERENCE_KEYS = {"entity", "entity_id", "entities"}
 
 
 def _validate_url_slug(value: Any) -> str:
@@ -490,7 +491,7 @@ async def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[st
 
     dashboard_views: list[str] = []
 
-    for dashboard_config in hass.data[LOVELACE_DATA].dashboards.values():
+    for dashboard_config in list(hass.data[LOVELACE_DATA].dashboards.values()):
         try:
             config = await dashboard_config.async_load(False)
         except dashboard.ConfigNotFound:
@@ -502,7 +503,7 @@ async def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[st
             if not _view_references_entity(view, entity_id):
                 continue
 
-            view_path = view.get("path", str(idx))
+            view_path = view.get("path") or str(idx)
             dashboard_views.append(f"{dashboard_path}/{view_path}")
 
     return dashboard_views
@@ -511,13 +512,36 @@ async def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[st
 @callback
 def _view_references_entity(value: Any, entity_id: str) -> bool:
     """Return if a view config value references an entity."""
-    if isinstance(value, str):
-        return value == entity_id
-
     if isinstance(value, list):
         return any(_view_references_entity(item, entity_id) for item in value)
 
     if isinstance(value, dict):
-        return any(_view_references_entity(item, entity_id) for item in value.values())
+        for key, item in value.items():
+            if key in ENTITY_REFERENCE_KEYS and _entity_reference_matches(
+                item, entity_id
+            ):
+                return True
+
+            if isinstance(item, dict | list) and _view_references_entity(
+                item, entity_id
+            ):
+                return True
+
+    return False
+
+
+@callback
+def _entity_reference_matches(value: Any, entity_id: str) -> bool:
+    """Return if a known entity reference value matches an entity."""
+    if isinstance(value, str):
+        return value == entity_id
+
+    if isinstance(value, list):
+        return any(_entity_reference_matches(item, entity_id) for item in value)
+
+    if isinstance(value, dict):
+        return any(
+            _entity_reference_matches(item, entity_id) for item in value.values()
+        )
 
     return False

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -481,3 +481,43 @@ def _async_create_yaml_mode_repair(hass: HomeAssistant) -> None:
         translation_key="yaml_mode_deprecated",
         translation_placeholders={"config_file": LOVELACE_CONFIG_FILE},
     )
+
+
+@callback
+def dashboards_with_entity(hass: HomeAssistant, entity_id: str) -> list[str]:
+    """Return dashboard/view combinations referencing an entity."""
+    if LOVELACE_DATA not in hass.data:
+        return []
+
+    dashboard_views: list[str] = []
+
+    for dashboard_config in hass.data[LOVELACE_DATA].dashboards.values():
+        config = dashboard_config.loaded_config
+        if config is None:
+            continue
+
+        dashboard_path = dashboard_config.url_path or "lovelace"
+
+        for idx, view in enumerate(config.get("views", [])):
+            if not _view_references_entity(view, entity_id):
+                continue
+
+            view_path = view.get("path", str(idx))
+            dashboard_views.append(f"{dashboard_path}/{view_path}")
+
+    return dashboard_views
+
+
+@callback
+def _view_references_entity(value: Any, entity_id: str) -> bool:
+    """Return if a view config value references an entity."""
+    if isinstance(value, str):
+        return value == entity_id
+
+    if isinstance(value, list):
+        return any(_view_references_entity(item, entity_id) for item in value)
+
+    if isinstance(value, dict):
+        return any(_view_references_entity(item, entity_id) for item in value.values())
+
+    return False

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -66,6 +66,11 @@ class LovelaceConfig(ABC):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
 
+    @property
+    @abstractmethod
+    def loaded_config(self) -> dict[str, Any] | None:
+        """Return the currently loaded config, if available."""
+
     @abstractmethod
     async def async_get_info(self) -> dict[str, Any]:
         """Return the config info."""
@@ -116,6 +121,11 @@ class LovelaceStorage(LovelaceConfig):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
         return MODE_STORAGE
+
+    @property
+    def loaded_config(self) -> dict[str, Any] | None:
+        """Return the currently loaded config, if available."""
+        return self._data.get("config") if self._data else None
 
     async def async_get_info(self) -> dict[str, Any]:
         """Return the Lovelace storage info."""
@@ -200,6 +210,11 @@ class LovelaceYAML(LovelaceConfig):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
         return MODE_YAML
+
+    @property
+    def loaded_config(self) -> dict[str, Any] | None:
+        """Return the currently loaded config, if available."""
+        return self._cache[0] if self._cache else None
 
     async def async_get_info(self) -> dict[str, Any]:
         """Return the YAML storage mode."""

--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -66,11 +66,6 @@ class LovelaceConfig(ABC):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
 
-    @property
-    @abstractmethod
-    def loaded_config(self) -> dict[str, Any] | None:
-        """Return the currently loaded config, if available."""
-
     @abstractmethod
     async def async_get_info(self) -> dict[str, Any]:
         """Return the config info."""
@@ -121,11 +116,6 @@ class LovelaceStorage(LovelaceConfig):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
         return MODE_STORAGE
-
-    @property
-    def loaded_config(self) -> dict[str, Any] | None:
-        """Return the currently loaded config, if available."""
-        return self._data.get("config") if self._data else None
 
     async def async_get_info(self) -> dict[str, Any]:
         """Return the Lovelace storage info."""
@@ -210,11 +200,6 @@ class LovelaceYAML(LovelaceConfig):
     def mode(self) -> str:
         """Return mode of the lovelace config."""
         return MODE_YAML
-
-    @property
-    def loaded_config(self) -> dict[str, Any] | None:
-        """Return the currently loaded config, if available."""
-        return self._cache[0] if self._cache else None
 
     async def async_get_info(self) -> dict[str, Any]:
         """Return the YAML storage mode."""

--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from enum import StrEnum
+from inspect import isawaitable
 import logging
 from typing import Any
 
@@ -72,8 +73,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         vol.Required("item_id"): str,
     }
 )
-@callback
-def websocket_search_related(
+@websocket_api.async_response
+async def websocket_search_related(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
@@ -81,7 +82,7 @@ def websocket_search_related(
     """Handle search."""
     searcher = Searcher(hass, get_entity_sources(hass))
     connection.send_result(
-        msg["id"], searcher.async_search(msg["item_type"], msg["item_id"])
+        msg["id"], await searcher.async_search(msg["item_type"], msg["item_id"])
     )
 
 
@@ -103,11 +104,14 @@ class Searcher:
         self._entity_sources = entity_sources
         self.results: defaultdict[ItemType, set[str]] = defaultdict(set)
 
-    @callback
-    def async_search(self, item_type: ItemType, item_id: str) -> dict[str, set[str]]:
+    async def async_search(
+        self, item_type: ItemType, item_id: str
+    ) -> dict[str, set[str]]:
         """Find results."""
         _LOGGER.debug("Searching for %s/%s", item_type, item_id)
-        getattr(self, f"_async_search_{item_type}")(item_id)
+        result = getattr(self, f"_async_search_{item_type}")(item_id)
+        if isawaitable(result):
+            await result
 
         # Remove the original requested item from the results (if present)
         if item_type in self.results and item_id in self.results[item_type]:
@@ -284,23 +288,23 @@ class Searcher:
             automation.automations_with_blueprint(self.hass, blueprint_path),
         )
 
-    @callback
-    def _async_search_config_entry(self, config_entry_id: str) -> None:
+    async def _async_search_config_entry(self, config_entry_id: str) -> None:
         """Find results for a config entry."""
         for device_entry in dr.async_entries_for_config_entry(
             self._device_registry, config_entry_id
         ):
             self._add(ItemType.DEVICE, device_entry.id)
-            self._async_search_device(device_entry.id, entry_point=False)
+            await self._async_search_device(device_entry.id, entry_point=False)
 
         for entity_entry in er.async_entries_for_config_entry(
             self._entity_registry, config_entry_id
         ):
             self._add(ItemType.ENTITY, entity_entry.entity_id)
-            self._async_search_entity(entity_entry.entity_id, entry_point=False)
+            await self._async_search_entity(entity_entry.entity_id, entry_point=False)
 
-    @callback
-    def _async_search_device(self, device_id: str, *, entry_point: bool = True) -> None:
+    async def _async_search_device(
+        self, device_id: str, *, entry_point: bool = True
+    ) -> None:
         """Find results for a device."""
         if not (device_entry := self._async_resolve_up_device(device_id)):
             return
@@ -324,10 +328,11 @@ class Searcher:
         ):
             self._add(ItemType.ENTITY, entity_entry.entity_id)
             # Add all entity information as well
-            self._async_search_entity(entity_entry.entity_id, entry_point=False)
+            await self._async_search_entity(entity_entry.entity_id, entry_point=False)
 
-    @callback
-    def _async_search_entity(self, entity_id: str, *, entry_point: bool = True) -> None:
+    async def _async_search_entity(
+        self, entity_id: str, *, entry_point: bool = True
+    ) -> None:
         """Find results for an entity."""
         # Resolve up the entity itself
         entity_entry = self._async_resolve_up_entity(entity_id)
@@ -357,7 +362,7 @@ class Searcher:
         # Dashboard/view combinations referencing this entity
         self._add(
             ItemType.DASHBOARD,
-            lovelace.dashboards_with_entity(self.hass, entity_id),
+            await lovelace.dashboards_with_entity(self.hass, entity_id),
         )
 
     @callback

--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -109,7 +109,12 @@ class Searcher:
     ) -> dict[str, set[str]]:
         """Find results."""
         _LOGGER.debug("Searching for %s/%s", item_type, item_id)
-        result = getattr(self, f"_async_search_{item_type}")(item_id)
+        search_method = getattr(self, f"_async_search_{item_type}", None)
+        if search_method is None:
+            _LOGGER.debug("No search handler for item type %s", item_type)
+            return {}
+
+        result = search_method(item_id)
         if isawaitable(result):
             await result
 

--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -10,7 +10,14 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components import automation, group, person, script, websocket_api
+from homeassistant.components import (
+    automation,
+    group,
+    lovelace,
+    person,
+    script,
+    websocket_api,
+)
 from homeassistant.components.homeassistant import scene
 from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.helpers import (
@@ -40,6 +47,7 @@ class ItemType(StrEnum):
     AUTOMATION_BLUEPRINT = "automation_blueprint"
     CONFIG_ENTRY = "config_entry"
     DEVICE = "device"
+    DASHBOARD = "dashboard"
     ENTITY = "entity"
     FLOOR = "floor"
     GROUP = "group"
@@ -345,6 +353,12 @@ class Searcher:
 
         # Scenes referencing this entity
         self._add(ItemType.SCENE, scene.scenes_with_entity(self.hass, entity_id))
+
+        # Dashboard/view combinations referencing this entity
+        self._add(
+            ItemType.DASHBOARD,
+            lovelace.dashboards_with_entity(self.hass, entity_id),
+        )
 
     @callback
     def _async_search_floor(self, floor_id: str) -> None:

--- a/homeassistant/components/search/manifest.json
+++ b/homeassistant/components/search/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "search",
   "name": "Search",
+  "after_dependencies": ["lovelace"],
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/search",

--- a/homeassistant/components/search/manifest.json
+++ b/homeassistant/components/search/manifest.json
@@ -1,9 +1,8 @@
 {
   "domain": "search",
   "name": "Search",
-  "after_dependencies": ["lovelace"],
   "codeowners": ["@home-assistant/core"],
-  "dependencies": ["websocket_api"],
+  "dependencies": ["websocket_api", "lovelace"],
   "documentation": "https://www.home-assistant.io/integrations/search",
   "integration_type": "system",
   "quality_scale": "internal"

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components import frontend
+from homeassistant.components import frontend, lovelace
 from homeassistant.components.lovelace import const, dashboard
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_capture_events
@@ -847,3 +847,68 @@ async def test_lovelace_info_yaml_mode_fallback(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {"resource_mode": "yaml"}
+
+
+async def test_dashboards_with_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test looking up dashboards that reference an entity."""
+    assert await async_setup_component(hass, "lovelace", {})
+
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "dashboard-light",
+        suggested_object_id="dashboard_light",
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "lovelace/dashboards/create",
+            "url_path": "test-dashboard",
+            "title": "Test dashboard",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await (
+        hass.data[const.LOVELACE_DATA]
+        .dashboards["test-dashboard"]
+        .async_save(
+            {
+                "views": [
+                    {
+                        "path": "badges-view",
+                        "badges": [{"entity": entity_entry.entity_id}],
+                    },
+                    {
+                        "path": "sections-view",
+                        "sections": [
+                            {
+                                "cards": [
+                                    {
+                                        "type": "tile",
+                                        "entity": entity_entry.entity_id,
+                                    }
+                                ]
+                            }
+                        ],
+                    },
+                    {
+                        "path": "other-view",
+                        "cards": [{"type": "entity", "entity": "light.other"}],
+                    },
+                ]
+            }
+        )
+    )
+
+    assert set(lovelace.dashboards_with_entity(hass, entity_entry.entity_id)) == {
+        "test-dashboard/badges-view",
+        "test-dashboard/sections-view",
+    }

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -908,7 +908,54 @@ async def test_dashboards_with_entity(
         )
     )
 
-    assert set(lovelace.dashboards_with_entity(hass, entity_entry.entity_id)) == {
+    assert set(await lovelace.dashboards_with_entity(hass, entity_entry.entity_id)) == {
         "test-dashboard/badges-view",
         "test-dashboard/sections-view",
     }
+
+
+async def test_dashboards_with_entity_loads_unloaded_yaml_dashboard(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test dashboard lookup loads YAML configs that are not yet in memory."""
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "dashboard-light-yaml",
+        suggested_object_id="dashboard_light_yaml",
+    )
+
+    with patch(
+        "homeassistant.components.lovelace.dashboard.load_yaml_dict",
+        return_value={
+            "views": [
+                {
+                    "path": "yaml-view",
+                    "cards": [{"type": "entity", "entity": entity_entry.entity_id}],
+                }
+            ]
+        },
+    ):
+        assert await async_setup_component(
+            hass,
+            "lovelace",
+            {
+                "lovelace": {
+                    "dashboards": {
+                        "test-dashboard": {
+                            "mode": "yaml",
+                            "title": "Test dashboard",
+                            "icon": "mdi:view-dashboard",
+                            "show_in_sidebar": True,
+                            "require_admin": False,
+                            "filename": "test-dashboard.yaml",
+                        }
+                    }
+                }
+            },
+        )
+
+        assert set(
+            await lovelace.dashboards_with_entity(hass, entity_entry.entity_id)
+        ) == {"test-dashboard/yaml-view"}

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -959,3 +959,96 @@ async def test_dashboards_with_entity_loads_unloaded_yaml_dashboard(
         assert set(
             await lovelace.dashboards_with_entity(hass, entity_entry.entity_id)
         ) == {"test-dashboard/yaml-view"}
+
+
+async def test_dashboards_with_entity_ignores_false_positive_strings_and_null_path(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test dashboard lookup only matches known entity keys and normalizes null paths."""
+    assert await async_setup_component(hass, "lovelace", {})
+
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "dashboard-light-false-positive",
+        suggested_object_id="dashboard_light_false_positive",
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "lovelace/dashboards/create",
+            "url_path": "test-dashboard",
+            "title": "Test dashboard",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await (
+        hass.data[const.LOVELACE_DATA]
+        .dashboards["test-dashboard"]
+        .async_save(
+            {
+                "views": [
+                    {
+                        "path": None,
+                        "title": entity_entry.entity_id,
+                        "cards": [
+                            {"type": "markdown", "content": entity_entry.entity_id}
+                        ],
+                    },
+                    {
+                        "path": "entity-view",
+                        "cards": [{"type": "entity", "entity": entity_entry.entity_id}],
+                    },
+                ]
+            }
+        )
+    )
+
+    assert set(await lovelace.dashboards_with_entity(hass, entity_entry.entity_id)) == {
+        "test-dashboard/entity-view",
+    }
+
+
+async def test_dashboards_with_entity_uses_snapshot_while_loading(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test dashboard lookup does not fail if dashboards change during loading."""
+    assert await async_setup_component(hass, "lovelace", {})
+
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "dashboard-light-snapshot",
+        suggested_object_id="dashboard_light_snapshot",
+    )
+
+    dashboards = hass.data[const.LOVELACE_DATA].dashboards
+
+    class MutableDashboard:
+        """Dashboard that mutates the dashboards dict while loading."""
+
+        url_path = "mutable-dashboard"
+
+        async def async_load(self, force: bool) -> dict[str, Any]:
+            dashboards["added-during-iteration"] = dashboards[None]
+            return {
+                "views": [
+                    {
+                        "path": "mutable-view",
+                        "cards": [{"type": "entity", "entity": entity_entry.entity_id}],
+                    }
+                ]
+            }
+
+    dashboards["mutable-dashboard"] = MutableDashboard()  # type: ignore[assignment]
+
+    assert set(await lovelace.dashboards_with_entity(hass, entity_entry.entity_id)) == {
+        "mutable-dashboard/mutable-view",
+    }

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -2,6 +2,7 @@
 
 from pytest_unordered import unordered
 
+from homeassistant.components.lovelace import LOVELACE_DATA
 from homeassistant.components.search import ItemType, Searcher
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -1006,4 +1007,73 @@ async def test_search(
             ["scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id]
         ),
         ItemType.SCRIPT: unordered(["script.device", "script.hue"]),
+    }
+
+
+async def test_search_entity_dashboard_views(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test searching an entity includes Lovelace dashboard views."""
+    assert await async_setup_component(hass, "lovelace", {})
+    assert await async_setup_component(hass, "search", {})
+
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "dashboard-light",
+        suggested_object_id="dashboard_light",
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "lovelace/dashboards/create",
+            "url_path": "test-dashboard",
+            "title": "Test dashboard",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await (
+        hass.data[LOVELACE_DATA]
+        .dashboards["test-dashboard"]
+        .async_save(
+            {
+                "views": [
+                    {
+                        "path": "badges-view",
+                        "badges": [{"entity": entity_entry.entity_id}],
+                    },
+                    {
+                        "path": "sections-view",
+                        "sections": [
+                            {
+                                "cards": [
+                                    {
+                                        "type": "tile",
+                                        "entity": entity_entry.entity_id,
+                                    }
+                                ]
+                            }
+                        ],
+                    },
+                    {
+                        "path": "other-view",
+                        "cards": [{"type": "entity", "entity": "light.other"}],
+                    },
+                ]
+            }
+        )
+    )
+
+    searcher = Searcher(hass, {})
+    assert searcher.async_search(ItemType.ENTITY, entity_entry.entity_id) == {
+        ItemType.DASHBOARD: {
+            "test-dashboard/badges-view",
+            "test-dashboard/sections-view",
+        }
     }

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -474,6 +474,7 @@ async def test_search(
     # Tests
     #
     assert not await search(ItemType.AREA, "unknown")
+    assert not await search(ItemType.DASHBOARD, "test-dashboard/test-view")
     assert await search(ItemType.AREA, bedroom_area.id) == {
         ItemType.AUTOMATION: {"automation.scene", "automation.script"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -465,16 +465,16 @@ async def test_search(
         },
     )
 
-    def search(item_type: ItemType, item_id: str) -> dict[str, set[str]]:
+    async def search(item_type: ItemType, item_id: str) -> dict[str, set[str]]:
         """Search."""
         searcher = Searcher(hass, entity_sources)
-        return searcher.async_search(item_type, item_id)
+        return await searcher.async_search(item_type, item_id)
 
     #
     # Tests
     #
-    assert not search(ItemType.AREA, "unknown")
-    assert search(ItemType.AREA, bedroom_area.id) == {
+    assert not await search(ItemType.AREA, "unknown")
+    assert await search(ItemType.AREA, bedroom_area.id) == {
         ItemType.AUTOMATION: {"automation.scene", "automation.script"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.ENTITY: {
@@ -490,7 +490,7 @@ async def test_search(
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {script_scene_entity.entity_id, "script.nested"},
     }
-    assert search(ItemType.AREA, living_room_area.id) == {
+    assert await search(ItemType.AREA, living_room_area.id) == {
         ItemType.AUTOMATION: {"automation.wled_device", "automation.wled_entity"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -500,7 +500,7 @@ async def test_search(
         ItemType.SCENE: {"scene.scene_wled_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.wled"},
     }
-    assert search(ItemType.AREA, kitchen_area.id) == {
+    assert await search(ItemType.AREA, kitchen_area.id) == {
         ItemType.AUTOMATION: {"automation.area"},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -514,16 +514,16 @@ async def test_search(
         ItemType.SCRIPT: {"script.area", "script.device", "script.hue"},
     }
 
-    assert not search(ItemType.AUTOMATION, "automation.unknown")
-    assert search(ItemType.AUTOMATION, "automation.blueprint_automation_1") == {
+    assert not await search(ItemType.AUTOMATION, "automation.unknown")
+    assert await search(ItemType.AUTOMATION, "automation.blueprint_automation_1") == {
         ItemType.AUTOMATION_BLUEPRINT: {"test_event_service.yaml"},
         ItemType.ENTITY: {"light.kitchen"},
     }
-    assert search(ItemType.AUTOMATION, "automation.blueprint_automation_2") == {
+    assert await search(ItemType.AUTOMATION, "automation.blueprint_automation_2") == {
         ItemType.AUTOMATION_BLUEPRINT: {"test_event_service.yaml"},
         ItemType.ENTITY: {"light.kitchen"},
     }
-    assert search(ItemType.AUTOMATION, "automation.wled_entity") == {
+    assert await search(ItemType.AUTOMATION, "automation.wled_entity") == {
         ItemType.AREA: {living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -531,21 +531,21 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"wled"},
     }
-    assert search(ItemType.AUTOMATION, "automation.wled_device") == {
+    assert await search(ItemType.AUTOMATION, "automation.wled_device") == {
         ItemType.AREA: {living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"wled"},
     }
-    assert search(ItemType.AUTOMATION, "automation.floor") == {
+    assert await search(ItemType.AUTOMATION, "automation.floor") == {
         ItemType.FLOOR: {first_floor.floor_id},
     }
-    assert search(ItemType.AUTOMATION, "automation.area") == {
+    assert await search(ItemType.AUTOMATION, "automation.area") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.FLOOR: {first_floor.floor_id},
     }
-    assert search(ItemType.AUTOMATION, "automation.group") == {
+    assert await search(ItemType.AUTOMATION, "automation.group") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -560,7 +560,7 @@ async def test_search(
         ItemType.GROUP: {"group.wled_hue"},
         ItemType.INTEGRATION: {"hue", "wled"},
     }
-    assert search(ItemType.AUTOMATION, "automation.scene") == {
+    assert await search(ItemType.AUTOMATION, "automation.scene") == {
         ItemType.AREA: {bedroom_area.id, kitchen_area.id, living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -575,7 +575,7 @@ async def test_search(
         ItemType.INTEGRATION: {"hue", "wled"},
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
     }
-    assert search(ItemType.AUTOMATION, "automation.script") == {
+    assert await search(ItemType.AUTOMATION, "automation.script") == {
         ItemType.AREA: {bedroom_area.id, kitchen_area.id, living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -593,16 +593,16 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id},
     }
 
-    assert not search(ItemType.AUTOMATION_BLUEPRINT, "unknown.yaml")
-    assert search(ItemType.AUTOMATION_BLUEPRINT, "test_event_service.yaml") == {
+    assert not await search(ItemType.AUTOMATION_BLUEPRINT, "unknown.yaml")
+    assert await search(ItemType.AUTOMATION_BLUEPRINT, "test_event_service.yaml") == {
         ItemType.AUTOMATION: {
             "automation.blueprint_automation_1",
             "automation.blueprint_automation_2",
         }
     }
 
-    assert not search(ItemType.CONFIG_ENTRY, "unknown")
-    assert search(ItemType.CONFIG_ENTRY, hue_config_entry.entry_id) == {
+    assert not await search(ItemType.CONFIG_ENTRY, "unknown")
+    assert await search(ItemType.CONFIG_ENTRY, hue_config_entry.entry_id) == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.DEVICE: {hue_device.id},
         ItemType.ENTITY: {
@@ -615,7 +615,7 @@ async def test_search(
         ItemType.SCENE: {"scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.device", "script.hue"},
     }
-    assert search(ItemType.CONFIG_ENTRY, wled_config_entry.entry_id) == {
+    assert await search(ItemType.CONFIG_ENTRY, wled_config_entry.entry_id) == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id},
         ItemType.AUTOMATION: {"automation.wled_entity", "automation.wled_device"},
         ItemType.DEVICE: {wled_device.id},
@@ -630,8 +630,8 @@ async def test_search(
         ItemType.SCRIPT: {"script.wled"},
     }
 
-    assert not search(ItemType.DEVICE, "unknown")
-    assert search(ItemType.DEVICE, wled_device.id) == {
+    assert not await search(ItemType.DEVICE, "unknown")
+    assert await search(ItemType.DEVICE, wled_device.id) == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id},
         ItemType.AUTOMATION: {"automation.wled_entity", "automation.wled_device"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
@@ -646,7 +646,7 @@ async def test_search(
         ItemType.SCENE: {"scene.scene_wled_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.wled"},
     }
-    assert search(ItemType.DEVICE, hue_device.id) == {
+    assert await search(ItemType.DEVICE, hue_device.id) == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.ENTITY: {
@@ -660,8 +660,8 @@ async def test_search(
         ItemType.SCRIPT: {"script.device", "script.hue"},
     }
 
-    assert not search(ItemType.ENTITY, "sensor.unknown")
-    assert search(ItemType.ENTITY, wled_segment_1_entity.entity_id) == {
+    assert not await search(ItemType.ENTITY, "sensor.unknown")
+    assert await search(ItemType.ENTITY, wled_segment_1_entity.entity_id) == {
         ItemType.AREA: {living_room_area.id},
         ItemType.AUTOMATION: {"automation.wled_entity"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
@@ -672,7 +672,7 @@ async def test_search(
         ItemType.SCENE: {"scene.scene_wled_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.wled"},
     }
-    assert search(ItemType.ENTITY, wled_segment_2_entity.entity_id) == {
+    assert await search(ItemType.ENTITY, wled_segment_2_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -681,7 +681,7 @@ async def test_search(
         ItemType.INTEGRATION: {"wled"},
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
     }
-    assert search(ItemType.ENTITY, hue_segment_1_entity.entity_id) == {
+    assert await search(ItemType.ENTITY, hue_segment_1_entity.entity_id) == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -692,7 +692,7 @@ async def test_search(
         ItemType.SCENE: {"scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id},
         ItemType.SCRIPT: {"script.hue"},
     }
-    assert search(ItemType.ENTITY, hue_segment_2_entity.entity_id) == {
+    assert await search(ItemType.ENTITY, hue_segment_2_entity.entity_id) == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -701,40 +701,40 @@ async def test_search(
         ItemType.INTEGRATION: {"hue"},
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
     }
-    assert not search(ItemType.ENTITY, "automation.wled")
-    assert search(ItemType.ENTITY, script_scene_entity.entity_id) == {
+    assert not await search(ItemType.ENTITY, "automation.wled")
+    assert await search(ItemType.ENTITY, script_scene_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.AUTOMATION: {"automation.script"},
         ItemType.FLOOR: {second_floor.floor_id},
         ItemType.LABEL: {label_other.label_id},
         ItemType.SCRIPT: {"script.nested"},
     }
-    assert search(ItemType.ENTITY, "group.wled_hue") == {
+    assert await search(ItemType.ENTITY, "group.wled_hue") == {
         ItemType.AUTOMATION: {"automation.group"},
         ItemType.SCRIPT: {"script.group"},
     }
-    assert search(ItemType.ENTITY, person_paulus_entity.entity_id) == {
+    assert await search(ItemType.ENTITY, person_paulus_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.FLOOR: {second_floor.floor_id},
         ItemType.LABEL: {label_other.label_id},
     }
-    assert search(ItemType.ENTITY, scene_wled_hue_entity.entity_id) == {
+    assert await search(ItemType.ENTITY, scene_wled_hue_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.AUTOMATION: {"automation.scene"},
         ItemType.FLOOR: {second_floor.floor_id},
         ItemType.LABEL: {label_other.label_id},
         ItemType.SCRIPT: {script_scene_entity.entity_id},
     }
-    assert search(ItemType.ENTITY, "device_tracker.paulus_iphone") == {
+    assert await search(ItemType.ENTITY, "device_tracker.paulus_iphone") == {
         ItemType.PERSON: {person_paulus_entity.entity_id},
     }
-    assert search(ItemType.ENTITY, "light.wled_config_entry_source") == {
+    assert await search(ItemType.ENTITY, "light.wled_config_entry_source") == {
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.INTEGRATION: {"wled"},
     }
 
-    assert not search(ItemType.FLOOR, "unknown")
-    assert search(ItemType.FLOOR, first_floor.floor_id) == {
+    assert not await search(ItemType.FLOOR, "unknown")
+    assert await search(ItemType.FLOOR, first_floor.floor_id) == {
         ItemType.AREA: {kitchen_area.id, living_room_area.id},
         ItemType.AUTOMATION: {
             "automation.area",
@@ -763,7 +763,7 @@ async def test_search(
             "script.wled",
         },
     }
-    assert search(ItemType.FLOOR, second_floor.floor_id) == {
+    assert await search(ItemType.FLOOR, second_floor.floor_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.AUTOMATION: {"automation.scene", "automation.script"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
@@ -779,8 +779,8 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id, "script.nested"},
     }
 
-    assert not search(ItemType.GROUP, "group.unknown")
-    assert search(ItemType.GROUP, "group.wled") == {
+    assert not await search(ItemType.GROUP, "group.unknown")
+    assert await search(ItemType.GROUP, "group.wled") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -791,7 +791,7 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id, second_floor.floor_id},
         ItemType.INTEGRATION: {"wled"},
     }
-    assert search(ItemType.GROUP, "group.hue") == {
+    assert await search(ItemType.GROUP, "group.hue") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -802,7 +802,7 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"hue"},
     }
-    assert search(ItemType.GROUP, "group.wled_hue") == {
+    assert await search(ItemType.GROUP, "group.wled_hue") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},
         ItemType.AUTOMATION: {"automation.group"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
@@ -818,15 +818,15 @@ async def test_search(
         ItemType.SCRIPT: {"script.group"},
     }
 
-    assert not search(ItemType.LABEL, "unknown")
-    assert search(ItemType.LABEL, label_christmas.label_id) == {
+    assert not await search(ItemType.LABEL, "unknown")
+    assert await search(ItemType.LABEL, label_christmas.label_id) == {
         ItemType.AUTOMATION: {"automation.label"},
         ItemType.DEVICE: {wled_device.id},
     }
-    assert search(ItemType.LABEL, label_energy.label_id) == {
+    assert await search(ItemType.LABEL, label_energy.label_id) == {
         ItemType.ENTITY: {hue_segment_1_entity.entity_id},
     }
-    assert search(ItemType.LABEL, label_other.label_id) == {
+    assert await search(ItemType.LABEL, label_other.label_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.ENTITY: {
             scene_wled_hue_entity.entity_id,
@@ -838,16 +838,16 @@ async def test_search(
         ItemType.SCRIPT: {"script.label", script_scene_entity.entity_id},
     }
 
-    assert not search(ItemType.PERSON, "person.unknown")
-    assert search(ItemType.PERSON, person_paulus_entity.entity_id) == {
+    assert not await search(ItemType.PERSON, "person.unknown")
+    assert await search(ItemType.PERSON, person_paulus_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id},
         ItemType.ENTITY: {"device_tracker.paulus_iphone"},
         ItemType.FLOOR: {second_floor.floor_id},
         ItemType.LABEL: {label_other.label_id},
     }
 
-    assert not search(ItemType.SCENE, "scene.unknown")
-    assert search(ItemType.SCENE, "scene.scene_wled_seg_1") == {
+    assert not await search(ItemType.SCENE, "scene.unknown")
+    assert await search(ItemType.SCENE, "scene.scene_wled_seg_1") == {
         ItemType.AREA: {living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -855,7 +855,7 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"wled"},
     }
-    assert search(ItemType.SCENE, "scene.scene_hue_seg_1") == {
+    assert await search(ItemType.SCENE, "scene.scene_hue_seg_1") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -863,7 +863,7 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"hue"},
     }
-    assert search(ItemType.SCENE, scene_wled_hue_entity.entity_id) == {
+    assert await search(ItemType.SCENE, scene_wled_hue_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},
         ItemType.AUTOMATION: {"automation.scene"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
@@ -880,16 +880,16 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id},
     }
 
-    assert not search(ItemType.SCRIPT, "script.unknown")
-    assert search(ItemType.SCRIPT, "script.blueprint_script_1") == {
+    assert not await search(ItemType.SCRIPT, "script.unknown")
+    assert await search(ItemType.SCRIPT, "script.blueprint_script_1") == {
         ItemType.ENTITY: {"light.kitchen"},
         ItemType.SCRIPT_BLUEPRINT: {"test_service.yaml"},
     }
-    assert search(ItemType.SCRIPT, "script.blueprint_script_2") == {
+    assert await search(ItemType.SCRIPT, "script.blueprint_script_2") == {
         ItemType.ENTITY: {"light.kitchen"},
         ItemType.SCRIPT_BLUEPRINT: {"test_service.yaml"},
     }
-    assert search(ItemType.SCRIPT, "script.wled") == {
+    assert await search(ItemType.SCRIPT, "script.wled") == {
         ItemType.AREA: {living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
@@ -897,7 +897,7 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"wled"},
     }
-    assert search(ItemType.SCRIPT, "script.hue") == {
+    assert await search(ItemType.SCRIPT, "script.hue") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
@@ -905,22 +905,22 @@ async def test_search(
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"hue"},
     }
-    assert search(ItemType.SCRIPT, "script.script_with_templated_services") == {}
-    assert search(ItemType.SCRIPT, "script.device") == {
+    assert await search(ItemType.SCRIPT, "script.script_with_templated_services") == {}
+    assert await search(ItemType.SCRIPT, "script.device") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id},
         ItemType.FLOOR: {first_floor.floor_id},
         ItemType.INTEGRATION: {"hue"},
     }
-    assert search(ItemType.SCRIPT, "script.floor") == {
+    assert await search(ItemType.SCRIPT, "script.floor") == {
         ItemType.FLOOR: {first_floor.floor_id},
     }
-    assert search(ItemType.SCRIPT, "script.area") == {
+    assert await search(ItemType.SCRIPT, "script.area") == {
         ItemType.AREA: {kitchen_area.id},
         ItemType.FLOOR: {first_floor.floor_id},
     }
-    assert search(ItemType.SCRIPT, "script.group") == {
+    assert await search(ItemType.SCRIPT, "script.group") == {
         ItemType.AREA: {bedroom_area.id, living_room_area.id, kitchen_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -935,7 +935,7 @@ async def test_search(
         ItemType.GROUP: {"group.wled_hue"},
         ItemType.INTEGRATION: {"hue", "wled"},
     }
-    assert search(ItemType.SCRIPT, script_scene_entity.entity_id) == {
+    assert await search(ItemType.SCRIPT, script_scene_entity.entity_id) == {
         ItemType.AREA: {bedroom_area.id, kitchen_area.id, living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -951,7 +951,7 @@ async def test_search(
         ItemType.LABEL: {label_other.label_id},
         ItemType.SCENE: {scene_wled_hue_entity.entity_id},
     }
-    assert search(ItemType.SCRIPT, "script.nested") == {
+    assert await search(ItemType.SCRIPT, "script.nested") == {
         ItemType.AREA: {bedroom_area.id, kitchen_area.id, living_room_area.id},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id, hue_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id, hue_device.id},
@@ -969,8 +969,8 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id},
     }
 
-    assert not search(ItemType.SCRIPT_BLUEPRINT, "unknown.yaml")
-    assert search(ItemType.SCRIPT_BLUEPRINT, "test_service.yaml") == {
+    assert not await search(ItemType.SCRIPT_BLUEPRINT, "unknown.yaml")
+    assert await search(ItemType.SCRIPT_BLUEPRINT, "test_service.yaml") == {
         ItemType.SCRIPT: {"script.blueprint_script_1", "script.blueprint_script_2"},
     }
 
@@ -1071,7 +1071,7 @@ async def test_search_entity_dashboard_views(
     )
 
     searcher = Searcher(hass, {})
-    assert searcher.async_search(ItemType.ENTITY, entity_entry.entity_id) == {
+    assert await searcher.async_search(ItemType.ENTITY, entity_entry.entity_id) == {
         ItemType.DASHBOARD: {
             "test-dashboard/badges-view",
             "test-dashboard/sections-view",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for finding related dashboards referencing entities, this way the frontend can show then along the related automation/scripts in the more info dialog. We also discussed on Discord the idea of displaying the number of e.g. dashboards in which an entity is used when deleting that entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
