### PR TITLE
Fix mixed-language Splunk setup errors in exception translations

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -178,14 +178,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             connectivity=False, token=True, busy=False
         )
     except ClientConnectionError as err:
+        error_message = str(err)
+        _LOGGER.exception(error_message)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
-            translation_key="connection_error",
-            translation_placeholders={
-                "host": host,
-                "port": str(port),
-                "error": str(err),
-            },
+            translation_key="cannot_connect",
+            translation_placeholders={"host": host, "port": str(port)},
         ) from err
     except TimeoutError as err:
         raise ConfigEntryNotReady(
@@ -194,15 +192,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_placeholders={"host": host, "port": str(port)},
         ) from err
     except Exception as err:
-        _LOGGER.exception("Unexpected error setting up Splunk")
+        error_message = str(err)
+        _LOGGER.exception(error_message)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
-            translation_key="unexpected_error",
-            translation_placeholders={
-                "host": host,
-                "port": str(port),
-                "error": str(err),
-            },
+            translation_key="unexpected_connect_error",
         ) from err
 
     if not connectivity_ok:

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -178,22 +178,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             connectivity=False, token=True, busy=False
         )
     except ClientConnectionError as err:
-        error_message = str(err)
-        _LOGGER.exception(error_message)
+        _LOGGER.debug("Connection error during setup at %s:%s: %s", host, port, err)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
             translation_placeholders={"host": host, "port": str(port)},
         ) from err
     except TimeoutError as err:
+        _LOGGER.debug("Timeout during setup at %s:%s: %s", host, port, err)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="timeout_connect",
             translation_placeholders={"host": host, "port": str(port)},
         ) from err
     except Exception as err:
-        error_message = str(err)
-        _LOGGER.exception(error_message)
+        _LOGGER.exception("Unexpected setup error at %s:%s", host, port)
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
             translation_key="unexpected_connect_error",

--- a/homeassistant/components/splunk/strings.json
+++ b/homeassistant/components/splunk/strings.json
@@ -33,7 +33,7 @@
           "name": "[%key:common::config_flow::data::name%]",
           "port": "[%key:common::config_flow::data::port%]",
           "ssl": "[%key:common::config_flow::data::ssl%]",
-          "token": "HTTP Event Collector token",
+          "token": "[%key:component::splunk::config::step::user::data::token%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
         },
         "data_description": {

--- a/homeassistant/components/splunk/strings.json
+++ b/homeassistant/components/splunk/strings.json
@@ -72,17 +72,14 @@
     "cannot_connect": {
       "message": "Unable to connect to Splunk at {host}:{port}."
     },
-    "connection_error": {
-      "message": "Unable to connect to Splunk at {host}:{port}: {error}."
-    },
     "invalid_auth": {
       "message": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "timeout_connect": {
       "message": "Connection to Splunk at {host}:{port} timed out."
     },
-    "unexpected_error": {
-      "message": "Unexpected error while connecting to Splunk at {host}:{port}: {error}."
+    "unexpected_connect_error": {
+      "message": "Unexpected error while connecting to Splunk."
     }
   },
   "issues": {

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -47,13 +47,13 @@ async def test_setup_entry_success(
         (
             ClientConnectionError("Connection failed"),
             ConfigEntryState.SETUP_RETRY,
-            "connection_error",
+            "cannot_connect",
         ),
         (TimeoutError(), ConfigEntryState.SETUP_RETRY, "timeout_connect"),
         (
             Exception("Unexpected error"),
             ConfigEntryState.SETUP_RETRY,
-            "unexpected_error",
+            "unexpected_connect_error",
         ),
         ([True, False], ConfigEntryState.SETUP_ERROR, "invalid_auth"),
     ],


### PR DESCRIPTION
## Proposed change
This updates Splunk setup failures to use translated exception keys instead of raw f-string exceptions.
Upstream exception text is now logged via `_LOGGER.exception`, while translated `cannot_connect` and `unexpected_connect_error` messages remain generic to avoid mixed-language user-facing errors.
This PR also marks the Splunk quality scale `exception-translations` rule as complete.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr