### PR TITLE
Add cabin overheat protection controls to Tessie climate

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -82,6 +82,7 @@ VEHICLE_DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.RUNNING,
         is_on=lambda x: x == "On",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     TessieBinarySensorEntityDescription(
         key="climate_state_cabin_overheat_protection_actively_cooling",

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from itertools import chain
 from typing import Any
 
+import aiohttp
 from tessie_api import (
     set_climate_keeper_mode,
     set_temperature,
     start_climate_preconditioning,
     stop_climate,
 )
+from tessie_api.tessie_wrapper import tessieRequest
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -17,16 +20,73 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    PRECISION_HALVES,
+    PRECISION_WHOLE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TessieConfigEntry
-from .const import TessieClimateKeeper
+from .const import DOMAIN, TessieClimateKeeper
 from .entity import TessieEntity
 from .models import TessieVehicleData
 
 PARALLEL_UPDATES = 0
+
+COP_MODES = {"Off": HVACMode.OFF, "On": HVACMode.COOL, "FanOnly": HVACMode.FAN_ONLY}
+COP_LEVELS = {"Low": 30, "Medium": 35, "High": 40}
+COP_TEMPERATURES = {30: 0, 35: 1, 40: 2}
+REVERSE_COP_LEVELS = {v: k for k, v in COP_LEVELS.items()}
+
+
+async def set_cabin_overheat_protection(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    on: bool,
+    fan_only: bool,
+    retry_duration: int = 40,
+    wait_for_completion: bool = True,
+) -> dict[str, Any]:
+    """Set cabin overheat protection mode."""
+    return await tessieRequest(
+        session,
+        "GET",
+        f"/{vin}/command/set_cabin_overheat_protection",
+        api_key,
+        params={
+            "on": str(on).lower(),
+            "fan_only": str(fan_only).lower(),
+            "retry_duration": retry_duration,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )
+
+
+async def set_cop_temp(
+    session: aiohttp.ClientSession,
+    vin: str,
+    api_key: str,
+    cop_temp: int,
+    retry_duration: int = 40,
+    wait_for_completion: bool = True,
+) -> dict[str, Any]:
+    """Set cabin overheat protection activation temperature."""
+    return await tessieRequest(
+        session,
+        "GET",
+        f"/{vin}/command/set_cop_temp",
+        api_key,
+        params={
+            "cop_temp": cop_temp,
+            "retry_duration": retry_duration,
+            "wait_for_completion": str(wait_for_completion).lower(),
+        },
+    )
 
 
 async def async_setup_entry(
@@ -37,7 +97,15 @@ async def async_setup_entry(
     """Set up the Tessie Climate platform from a config entry."""
     data = entry.runtime_data
 
-    async_add_entities(TessieClimateEntity(vehicle) for vehicle in data.vehicles)
+    async_add_entities(
+        chain(
+            (TessieClimateEntity(vehicle) for vehicle in data.vehicles),
+            (
+                TessieCabinOverheatProtectionClimateEntity(vehicle)
+                for vehicle in data.vehicles
+            ),
+        )
+    )
 
 
 class TessieClimateEntity(TessieEntity, ClimateEntity):
@@ -144,3 +212,97 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
                 preset_mode != self._attr_preset_modes[0],
             ),
         )
+
+
+class TessieCabinOverheatProtectionClimateEntity(TessieEntity, ClimateEntity):
+    """Vehicle Cabin Overheat Protection."""
+
+    _attr_precision = PRECISION_WHOLE
+    _attr_target_temperature_step = 5
+    _attr_min_temp = 30
+    _attr_max_temp = 40
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = list(COP_MODES.values())
+    _attr_entity_registry_enabled_default = False
+    _attr_supported_features = (
+        ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
+
+    def __init__(
+        self,
+        vehicle: TessieVehicleData,
+    ) -> None:
+        """Initialize the cabin overheat protection climate entity."""
+        super().__init__(vehicle, "climate_state_cabin_overheat_protection")
+
+        if self.get("vehicle_config_cop_user_set_temp_supported"):
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return current cabin overheat protection mode."""
+        if (state := self._value) is None:
+            return None
+        return COP_MODES.get(state)
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the inside temperature."""
+        return self.get("climate_state_inside_temp")
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the activation temperature."""
+        if (level := self.get("climate_state_cop_activation_temperature")) is None:
+            return None
+        return COP_LEVELS.get(level)
+
+    async def async_turn_on(self) -> None:
+        """Set the cabin overheat protection state to on."""
+        await self.async_set_hvac_mode(HVACMode.COOL)
+
+    async def async_turn_off(self) -> None:
+        """Set the cabin overheat protection state to off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the cabin overheat protection activation temperature."""
+        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            if (cop_temp := COP_TEMPERATURES.get(temp)) is None:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_cop_temp",
+                )
+
+            await self.run(set_cop_temp, cop_temp=cop_temp)
+            self.set(
+                ("climate_state_cop_activation_temperature", REVERSE_COP_LEVELS[temp])
+            )
+
+        if mode := kwargs.get(ATTR_HVAC_MODE):
+            await self.async_set_hvac_mode(mode)
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the cabin overheat protection mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self.run(
+                set_cabin_overheat_protection,
+                on=False,
+                fan_only=False,
+            )
+            self.set((self.key, "Off"))
+        elif hvac_mode == HVACMode.COOL:
+            await self.run(
+                set_cabin_overheat_protection,
+                on=True,
+                fan_only=False,
+            )
+            self.set((self.key, "On"))
+        elif hvac_mode == HVACMode.FAN_ONLY:
+            await self.run(
+                set_cabin_overheat_protection,
+                on=True,
+                fan_only=True,
+            )
+            self.set((self.key, "FanOnly"))

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -306,3 +306,8 @@ class TessieCabinOverheatProtectionClimateEntity(TessieEntity, ClimateEntity):
                 fan_only=True,
             )
             self.set((self.key, "FanOnly"))
+        else:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_cop_mode",
+            )

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from itertools import chain
 from typing import Any
 
-import aiohttp
 from tessie_api import (
     set_climate_keeper_mode,
     set_temperature,
+    start_cabin_overheat_protection,
     start_climate_preconditioning,
+    stop_cabin_overheat_protection,
     stop_climate,
 )
-from tessie_api.tessie_wrapper import tessieRequest
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -39,54 +39,6 @@ PARALLEL_UPDATES = 0
 
 COP_MODES = {"Off": HVACMode.OFF, "On": HVACMode.COOL, "FanOnly": HVACMode.FAN_ONLY}
 COP_LEVELS = {"Low": 30, "Medium": 35, "High": 40}
-COP_TEMPERATURES = {30: 0, 35: 1, 40: 2}
-REVERSE_COP_LEVELS = {v: k for k, v in COP_LEVELS.items()}
-
-
-async def set_cabin_overheat_protection(
-    session: aiohttp.ClientSession,
-    vin: str,
-    api_key: str,
-    on: bool,
-    fan_only: bool,
-    retry_duration: int = 40,
-    wait_for_completion: bool = True,
-) -> dict[str, Any]:
-    """Set cabin overheat protection mode."""
-    return await tessieRequest(
-        session,
-        "GET",
-        f"/{vin}/command/set_cabin_overheat_protection",
-        api_key,
-        params={
-            "on": str(on).lower(),
-            "fan_only": str(fan_only).lower(),
-            "retry_duration": retry_duration,
-            "wait_for_completion": str(wait_for_completion).lower(),
-        },
-    )
-
-
-async def set_cop_temp(
-    session: aiohttp.ClientSession,
-    vin: str,
-    api_key: str,
-    cop_temp: int,
-    retry_duration: int = 40,
-    wait_for_completion: bool = True,
-) -> dict[str, Any]:
-    """Set cabin overheat protection activation temperature."""
-    return await tessieRequest(
-        session,
-        "GET",
-        f"/{vin}/command/set_cop_temp",
-        api_key,
-        params={
-            "cop_temp": cop_temp,
-            "retry_duration": retry_duration,
-            "wait_for_completion": str(wait_for_completion).lower(),
-        },
-    )
 
 
 async def async_setup_entry(
@@ -222,7 +174,7 @@ class TessieCabinOverheatProtectionClimateEntity(TessieEntity, ClimateEntity):
     _attr_min_temp = 30
     _attr_max_temp = 40
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = list(COP_MODES.values())
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL]
     _attr_entity_registry_enabled_default = False
     _attr_supported_features = (
         ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
@@ -235,9 +187,6 @@ class TessieCabinOverheatProtectionClimateEntity(TessieEntity, ClimateEntity):
     ) -> None:
         """Initialize the cabin overheat protection climate entity."""
         super().__init__(vehicle, "climate_state_cabin_overheat_protection")
-
-        if self.get("vehicle_config_cop_user_set_temp_supported"):
-            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
     def hvac_mode(self) -> HVACMode | None:
@@ -266,46 +215,14 @@ class TessieCabinOverheatProtectionClimateEntity(TessieEntity, ClimateEntity):
         """Set the cabin overheat protection state to off."""
         await self.async_set_hvac_mode(HVACMode.OFF)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set the cabin overheat protection activation temperature."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            if (cop_temp := COP_TEMPERATURES.get(temp)) is None:
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_cop_temp",
-                )
-
-            await self.run(set_cop_temp, cop_temp=cop_temp)
-            self.set(
-                ("climate_state_cop_activation_temperature", REVERSE_COP_LEVELS[temp])
-            )
-
-        if mode := kwargs.get(ATTR_HVAC_MODE):
-            await self.async_set_hvac_mode(mode)
-
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the cabin overheat protection mode."""
         if hvac_mode == HVACMode.OFF:
-            await self.run(
-                set_cabin_overheat_protection,
-                on=False,
-                fan_only=False,
-            )
+            await self.run(stop_cabin_overheat_protection)
             self.set((self.key, "Off"))
         elif hvac_mode == HVACMode.COOL:
-            await self.run(
-                set_cabin_overheat_protection,
-                on=True,
-                fan_only=False,
-            )
+            await self.run(start_cabin_overheat_protection)
             self.set((self.key, "On"))
-        elif hvac_mode == HVACMode.FAN_ONLY:
-            await self.run(
-                set_cabin_overheat_protection,
-                on=True,
-                fan_only=True,
-            )
-            self.set((self.key, "FanOnly"))
         else:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -95,6 +95,9 @@
       }
     },
     "climate": {
+      "climate_state_cabin_overheat_protection": {
+        "default": "mdi:sun-thermometer"
+      },
       "primary": {
         "state_attributes": {
           "preset_mode": {

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
   "quality_scale": "silver",
-  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==1.4.5"]
+  "requirements": ["tessie-api==0.1.2", "tesla-fleet-api==1.4.5"]
 }

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -154,6 +154,9 @@
       }
     },
     "climate": {
+      "climate_state_cabin_overheat_protection": {
+        "name": "Cabin overheat protection"
+      },
       "primary": {
         "name": "[%key:component::climate::title%]",
         "state_attributes": {
@@ -642,6 +645,9 @@
     },
     "incorrect_pin": {
       "message": "Incorrect PIN for {name}."
+    },
+    "invalid_cop_temp": {
+      "message": "Cabin overheat protection does not support that temperature"
     },
     "invalid_energy_history_data": {
       "message": "Invalid energy history data."

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -646,9 +646,6 @@
     "incorrect_pin": {
       "message": "Incorrect PIN for {name}."
     },
-    "invalid_cop_temp": {
-      "message": "Cabin overheat protection does not support that temperature"
-    },
     "invalid_energy_history_data": {
       "message": "Invalid energy history data."
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3097,7 +3097,7 @@ tesla-wall-connector==1.1.0
 teslemetry-stream==0.9.0
 
 # homeassistant.components.tessie
-tessie-api==0.1.1
+tessie-api==0.1.2
 
 # homeassistant.components.thermobeacon
 thermobeacon-ble==0.10.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2615,7 +2615,7 @@ tesla-wall-connector==1.1.0
 teslemetry-stream==0.9.0
 
 # homeassistant.components.tessie
-tessie-api==0.1.1
+tessie-api==0.1.2
 
 # homeassistant.components.thermobeacon
 thermobeacon-ble==0.10.0

--- a/tests/components/tessie/snapshots/test_climate.ambr
+++ b/tests/components/tessie/snapshots/test_climate.ambr
@@ -9,7 +9,6 @@
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.COOL: 'cool'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
       ]),
       'max_temp': 40,
       'min_temp': 30,
@@ -53,7 +52,6 @@
       'hvac_modes': list([
         <HVACMode.OFF: 'off'>,
         <HVACMode.COOL: 'cool'>,
-        <HVACMode.FAN_ONLY: 'fan_only'>,
       ]),
       'max_temp': 40,
       'min_temp': 30,

--- a/tests/components/tessie/snapshots/test_climate.ambr
+++ b/tests/components/tessie/snapshots/test_climate.ambr
@@ -1,4 +1,73 @@
 # serializer version: 1
+# name: test_climate[climate.test_cabin_overheat_protection-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+      ]),
+      'max_temp': 40,
+      'min_temp': 30,
+      'target_temp_step': 5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.test_cabin_overheat_protection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cabin overheat protection',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cabin overheat protection',
+    'platform': 'tessie',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 384>,
+    'translation_key': 'climate_state_cabin_overheat_protection',
+    'unique_id': 'VINVINVIN-climate_state_cabin_overheat_protection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_climate[climate.test_cabin_overheat_protection-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 30,
+      'friendly_name': 'Test Cabin overheat protection',
+      'hvac_modes': list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.COOL: 'cool'>,
+        <HVACMode.FAN_ONLY: 'fan_only'>,
+      ]),
+      'max_temp': 40,
+      'min_temp': 30,
+      'supported_features': <ClimateEntityFeature: 384>,
+      'target_temp_step': 5,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.test_cabin_overheat_protection',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cool',
+  })
+# ---
 # name: test_climate[climate.test_climate-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -1,7 +1,6 @@
 """Test the Tessie climate platform."""
 
-from copy import deepcopy
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -21,7 +20,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.tessie.const import TessieClimateKeeper
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
@@ -29,7 +28,6 @@ from .common import (
     ERROR_UNKNOWN,
     TEST_RESPONSE,
     TEST_RESPONSE_ERROR,
-    TEST_STATE_OF_ALL_VEHICLES,
     assert_entities,
     setup_platform,
 )
@@ -145,7 +143,7 @@ async def test_climate_cop(
     assert state.state == HVACMode.COOL
 
     with patch(
-        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        "homeassistant.components.tessie.climate.stop_cabin_overheat_protection",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -155,14 +153,12 @@ async def test_climate_cop(
             blocking=True,
         )
         mock_set.assert_called_once()
-        assert mock_set.call_args.kwargs["on"] is False
-        assert mock_set.call_args.kwargs["fan_only"] is False
     state = hass.states.get(entity_id)
     assert state
     assert state.state == HVACMode.OFF
 
     with patch(
-        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        "homeassistant.components.tessie.climate.start_cabin_overheat_protection",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -172,31 +168,12 @@ async def test_climate_cop(
             blocking=True,
         )
         mock_set.assert_called_once()
-        assert mock_set.call_args.kwargs["on"] is True
-        assert mock_set.call_args.kwargs["fan_only"] is False
     state = hass.states.get(entity_id)
     assert state
     assert state.state == HVACMode.COOL
 
     with patch(
-        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_HVAC_MODE,
-            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
-            blocking=True,
-        )
-        mock_set.assert_called_once()
-        assert mock_set.call_args.kwargs["on"] is True
-        assert mock_set.call_args.kwargs["fan_only"] is True
-    state = hass.states.get(entity_id)
-    assert state
-    assert state.state == HVACMode.FAN_ONLY
-
-    with patch(
-        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        "homeassistant.components.tessie.climate.start_cabin_overheat_protection",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -206,14 +183,12 @@ async def test_climate_cop(
             blocking=True,
         )
         mock_set.assert_called_once()
-        assert mock_set.call_args.kwargs["on"] is True
-        assert mock_set.call_args.kwargs["fan_only"] is False
     state = hass.states.get(entity_id)
     assert state
     assert state.state == HVACMode.COOL
 
     with patch(
-        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        "homeassistant.components.tessie.climate.stop_cabin_overheat_protection",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -223,62 +198,9 @@ async def test_climate_cop(
             blocking=True,
         )
         mock_set.assert_called_once()
-        assert mock_set.call_args.kwargs["on"] is False
-        assert mock_set.call_args.kwargs["fan_only"] is False
     state = hass.states.get(entity_id)
     assert state
     assert state.state == HVACMode.OFF
-
-
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_climate_cop_set_temperature(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-    mock_get_state_of_all_vehicles: MagicMock,
-) -> None:
-    """Test cabin overheat protection temperature controls."""
-
-    state_of_all_vehicles = deepcopy(TEST_STATE_OF_ALL_VEHICLES)
-    state_of_all_vehicles["results"][0]["last_state"]["vehicle_config"][
-        "cop_user_set_temp_supported"
-    ] = True
-    mock_get_state_of_all_vehicles.return_value = state_of_all_vehicles
-
-    await setup_platform(hass, [Platform.CLIMATE])
-    entity_id = cop_entity_id(entity_registry)
-
-    with patch(
-        "homeassistant.components.tessie.climate.set_cop_temp",
-        return_value=TEST_RESPONSE,
-    ) as mock_set:
-        for target_temp, cop_temp in ((30, 0), (35, 1), (40, 2)):
-            await hass.services.async_call(
-                CLIMATE_DOMAIN,
-                SERVICE_SET_TEMPERATURE,
-                {
-                    ATTR_ENTITY_ID: [entity_id],
-                    ATTR_TEMPERATURE: target_temp,
-                },
-                blocking=True,
-            )
-            assert mock_set.call_args.kwargs["cop_temp"] == cop_temp
-            mock_set.reset_mock()
-            state = hass.states.get(entity_id)
-            assert state
-            assert state.attributes[ATTR_TEMPERATURE] == target_temp
-
-    with pytest.raises(ServiceValidationError) as error:
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_TEMPERATURE,
-            {
-                ATTR_ENTITY_ID: [entity_id],
-                ATTR_TEMPERATURE: 33,
-            },
-            blocking=True,
-        )
-    assert error.value.translation_domain == "tessie"
-    assert error.value.translation_key == "invalid_cop_temp"
 
 
 async def test_errors(hass: HomeAssistant) -> None:
@@ -356,7 +278,7 @@ async def test_climate_cop_errors(
 
     with (
         patch(
-            "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+            "homeassistant.components.tessie.climate.stop_cabin_overheat_protection",
             side_effect=ERROR_UNKNOWN,
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
@@ -372,7 +294,7 @@ async def test_climate_cop_errors(
 
     with (
         patch(
-            "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+            "homeassistant.components.tessie.climate.start_cabin_overheat_protection",
             return_value=TEST_RESPONSE_ERROR,
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -1,6 +1,7 @@
 """Test the Tessie climate platform."""
 
-from unittest.mock import patch
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -14,23 +15,38 @@ from homeassistant.components.climate import (
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
     SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
     HVACMode,
 )
 from homeassistant.components.tessie.const import TessieClimateKeeper
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
     ERROR_CONNECTION,
     ERROR_UNKNOWN,
     TEST_RESPONSE,
+    TEST_RESPONSE_ERROR,
+    TEST_STATE_OF_ALL_VEHICLES,
     assert_entities,
     setup_platform,
 )
 
 
+def cop_entity_id(entity_registry: er.EntityRegistry) -> str:
+    """Return the cabin overheat protection climate entity ID."""
+    entity_id = entity_registry.async_get_entity_id(
+        CLIMATE_DOMAIN,
+        "tessie",
+        "VINVINVIN-climate_state_cabin_overheat_protection",
+    )
+    assert entity_id
+    return entity_id
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_climate(
     hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
 ) -> None:
@@ -114,6 +130,157 @@ async def test_climate(
     assert state.state == HVACMode.OFF
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_climate_cop(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test cabin overheat protection climate mode controls."""
+
+    await setup_platform(hass, [Platform.CLIMATE])
+    entity_id = cop_entity_id(entity_registry)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.COOL
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.OFF},
+            blocking=True,
+        )
+        mock_set.assert_called_once()
+        assert mock_set.call_args.kwargs["on"] is False
+        assert mock_set.call_args.kwargs["fan_only"] is False
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.OFF
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.COOL},
+            blocking=True,
+        )
+        mock_set.assert_called_once()
+        assert mock_set.call_args.kwargs["on"] is True
+        assert mock_set.call_args.kwargs["fan_only"] is False
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.COOL
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
+            blocking=True,
+        )
+        mock_set.assert_called_once()
+        assert mock_set.call_args.kwargs["on"] is True
+        assert mock_set.call_args.kwargs["fan_only"] is True
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.FAN_ONLY
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        mock_set.assert_called_once()
+        assert mock_set.call_args.kwargs["on"] is True
+        assert mock_set.call_args.kwargs["fan_only"] is False
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.COOL
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        mock_set.assert_called_once()
+        assert mock_set.call_args.kwargs["on"] is False
+        assert mock_set.call_args.kwargs["fan_only"] is False
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == HVACMode.OFF
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_climate_cop_set_temperature(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_get_state_of_all_vehicles: MagicMock,
+) -> None:
+    """Test cabin overheat protection temperature controls."""
+
+    state_of_all_vehicles = deepcopy(TEST_STATE_OF_ALL_VEHICLES)
+    state_of_all_vehicles["results"][0]["last_state"]["vehicle_config"][
+        "cop_user_set_temp_supported"
+    ] = True
+    mock_get_state_of_all_vehicles.return_value = state_of_all_vehicles
+
+    await setup_platform(hass, [Platform.CLIMATE])
+    entity_id = cop_entity_id(entity_registry)
+
+    with patch(
+        "homeassistant.components.tessie.climate.set_cop_temp",
+        return_value=TEST_RESPONSE,
+    ) as mock_set:
+        for target_temp, cop_temp in ((30, 0), (35, 1), (40, 2)):
+            await hass.services.async_call(
+                CLIMATE_DOMAIN,
+                SERVICE_SET_TEMPERATURE,
+                {
+                    ATTR_ENTITY_ID: [entity_id],
+                    ATTR_TEMPERATURE: target_temp,
+                },
+                blocking=True,
+            )
+            assert mock_set.call_args.kwargs["cop_temp"] == cop_temp
+            mock_set.reset_mock()
+            state = hass.states.get(entity_id)
+            assert state
+            assert state.attributes[ATTR_TEMPERATURE] == target_temp
+
+    with pytest.raises(ServiceValidationError) as error:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {
+                ATTR_ENTITY_ID: [entity_id],
+                ATTR_TEMPERATURE: 33,
+            },
+            blocking=True,
+        )
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "invalid_cop_temp"
+
+
 async def test_errors(hass: HomeAssistant) -> None:
     """Tests errors are handled."""
 
@@ -175,3 +342,47 @@ async def test_errors(hass: HomeAssistant) -> None:
     mock_set.assert_called_once()
     assert error.value.translation_domain == "tessie"
     assert error.value.translation_key == "cpd_enabled"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_climate_cop_errors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test cabin overheat protection command errors are handled."""
+
+    await setup_platform(hass, [Platform.CLIMATE])
+    entity_id = cop_entity_id(entity_registry)
+
+    with (
+        patch(
+            "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+            side_effect=ERROR_UNKNOWN,
+        ) as mock_set,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.OFF},
+            blocking=True,
+        )
+    mock_set.assert_called_once()
+    assert error.value.__cause__ == ERROR_UNKNOWN
+
+    with (
+        patch(
+            "homeassistant.components.tessie.climate.set_cabin_overheat_protection",
+            return_value=TEST_RESPONSE_ERROR,
+        ) as mock_set,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: [entity_id], ATTR_HVAC_MODE: HVACMode.COOL},
+            blocking=True,
+        )
+    mock_set.assert_called_once()
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "command_failed"


### PR DESCRIPTION
## Proposed change
Adds a dedicated cabin overheat protection climate entity to Tessie with OFF/COOL/FAN_ONLY mode control and COP temperature selection (30/35/40 C) when supported by the vehicle.
Implements Tessie command wrappers for `set_cabin_overheat_protection` and `set_cop_temp`, updates entity metadata/icons/translations, and keeps the legacy COP binary sensor for compatibility by setting it disabled by default.
Extends Tessie climate tests and snapshots to cover COP mode/temperature behavior and error handling.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr