### PR TITLE
Fix KeyError in go2rtc WebRTC session close

### DIFF
--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -341,8 +341,8 @@ class WebRTCProvider(CameraWebRTCProvider):
     @callback
     def async_close_session(self, session_id: str) -> None:
         """Close the session."""
-        ws_client = self._sessions.pop(session_id)
-        self._hass.async_create_task(ws_client.close())
+        if ws_client := self._sessions.pop(session_id, None):
+            self._hass.async_create_task(ws_client.close())
 
     async def async_get_image(
         self,

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -432,9 +432,8 @@ async def test_close_session(
     camera = init_test_integration
     session_id = "session_id"
 
-    # Session doesn't exist
-    with pytest.raises(KeyError):
-        camera.close_webrtc_session(session_id)
+    # Session doesn't exist — should be a no-op (not raise)
+    camera.close_webrtc_session(session_id)
     ws_client.close.assert_not_called()
 
     # Store session
@@ -452,10 +451,9 @@ async def test_close_session(
     camera.close_webrtc_session(session_id)
     ws_client.close.assert_called_once()
 
-    # Close again should raise an error
+    # Close again — should be a no-op (session already removed)
     ws_client.reset_mock()
-    with pytest.raises(KeyError):
-        camera.close_webrtc_session(session_id)
+    camera.close_webrtc_session(session_id)
     ws_client.close.assert_not_called()
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a WebRTC session is closed via the frontend (e.g., navigating away from a camera view), `async_close_session` is called with the `session_id`. If the session was created by a native WebRTC implementation (a camera integration overriding `async_handle_async_webrtc_offer`) rather than the go2rtc provider, the `session_id` won't exist in `self._sessions`, causing an unhandled `KeyError`.

This crashes the WebSocket connection handler, which can affect other camera streams on the same page and cause subsequent WebRTC connections to fail.

```
File "homeassistant/components/camera/__init__.py", line 737, in close_webrtc_session
    self._webrtc_provider.async_close_session(session_id)
File "homeassistant/components/go2rtc/__init__.py", line 344, in async_close_session
    ws_client = self._sessions.pop(session_id)
KeyError: '01KM1NSZSV3GJRG96QR8AMX756'
```

Fix: Use `dict.pop()` with a default of `None` and only close the client if it exists. Update tests to reflect that closing an unknown session is now a safe no-op rather than an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. *Your PR cannot be merged unless tests pass*
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
