### PR TITLE
Handle go2rtc stream list deserialization errors gracefully

### DIFF
--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -397,7 +397,10 @@ class WebRTCProvider(CameraWebRTCProvider):
                 case Orientation.ROTATE_RIGHT:
                     stream_source += "#rotate=90"
 
-        streams = await self._rest_client.streams.list()
+        try:
+            streams = await self._rest_client.streams.list()
+        except Exception:  # noqa: BLE001
+            streams = {}
 
         if (stream := streams.get(camera.entity_id)) is None or not any(
             stream_source == producer.url for producer in stream.producers

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -424,6 +424,34 @@ async def test_on_candidate(
 
 
 @pytest.mark.usefixtures("init_integration")
+async def test_streams_list_error_fallback(
+    rest_client: AsyncMock,
+    ws_client: Mock,
+    init_test_integration: MockCamera,
+) -> None:
+    """Test that streams.list() deserialization errors are handled gracefully."""
+    camera = init_test_integration
+    entity_id = camera.entity_id
+
+    # Simulate streams.list() raising (e.g., deserialization error)
+    rest_client.streams.list.side_effect = Go2RtcClientError("deserialization failed")
+    receive_message_callback = Mock(spec_set=WebRTCSendMessage)
+
+    await camera.async_handle_async_webrtc_offer(
+        OFFER_SDP, "session_error", receive_message_callback
+    )
+
+    # Should fall through to adding the stream
+    rest_client.streams.add.assert_called_once_with(
+        entity_id,
+        [
+            "rtsp://stream",
+            f"ffmpeg:{camera.entity_id}#audio=opus#query=log_level=debug",
+        ],
+    )
+
+
+@pytest.mark.usefixtures("init_integration")
 async def test_close_session(
     ws_client: Mock,
     init_test_integration: MockCamera,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`_update_stream_source` calls `self._rest_client.streams.list()` to check if a stream is already registered in go2rtc before adding it. If `go2rtc_client` fails to deserialize the response from go2rtc (e.g., due to newer go2rtc versions returning additional fields in producer codec data), the entire WebRTC offer fails with an unhandled `Go2RtcClientError` wrapping a `mashumaro.exceptions.InvalidFieldValue`.

```
mashumaro.exceptions.InvalidFieldValue: Field "producers" of type list[Producer] in Stream has invalid value [{'id': 26, 'format_name': 'h264', 'protocol': 'pipe', 'source': '...', 'medias': ['video, recvonly, H264'], 'receivers': [{'id': 27, 'codec': {'codec_name': 'h264', 'codec_type': 'video', 'level': 40, 'profile': 'High'}, ...}], 'bytes_recv': 9363489}]
```

This occurs because go2rtc 1.9.14 returns codec fields (`level`, `profile`) that `go2rtc_client` 0.4.0's `Producer` model doesn't expect.

Fix: Catch exceptions from `streams.list()` and fall back to an empty dict. This causes the stream to be re-added via the API, which is the correct and safe behavior since go2rtc handles duplicate stream additions idempotently.

Added ⁠ test_streams_list_error_fallback ⁠ to verify the graceful fallback: when ⁠ streams.list() ⁠ raises a ⁠ Go2RtcClientError ⁠, the stream is re-added via ⁠ streams.add() ⁠ as expected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. *Your PR cannot be merged unless tests pass*
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr