### PR TITLE
bump pyvlx to 0.2.31

### DIFF
--- a/homeassistant/components/velux/binary_sensor.py
+++ b/homeassistant/components/velux/binary_sensor.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from pyvlx import OpeningDevice, Position, Window
 from pyvlx.exception import PyVLXException
-from pyvlx.opening_device import OpeningDevice, Window
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -55,7 +55,7 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
     async def async_update(self) -> None:
         """Fetch the latest state from the device."""
         try:
-            limitation = await self.node.get_limitation()
+            limitation: Position = await self.node.get_limitation_min()
         except (OSError, PyVLXException) as err:
             if not self._unavailable_logged:
                 LOGGER.warning(
@@ -78,4 +78,4 @@ class VeluxRainSensor(VeluxEntity, BinarySensorEntity):
         # So far we've seen 89, 91, 93 (most cases) or 100 (Velux GPU). It probably makes sense to
         # assume that any large enough limitation (we use >=89) means rain is detected.
         # Documentation on this is non-existent AFAIK.
-        self._attr_is_on = limitation.min_value >= 89
+        self._attr_is_on = limitation.position_percent >= 89

--- a/homeassistant/components/velux/manifest.json
+++ b/homeassistant/components/velux/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyvlx"],
   "quality_scale": "silver",
-  "requirements": ["pyvlx==0.2.30"]
+  "requirements": ["pyvlx==0.2.31"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2733,7 +2733,7 @@ pyvesync==3.4.1
 pyvizio==0.1.61
 
 # homeassistant.components.velux
-pyvlx==0.2.30
+pyvlx==0.2.31
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2317,7 +2317,7 @@ pyvesync==3.4.1
 pyvizio==0.1.61
 
 # homeassistant.components.velux
-pyvlx==0.2.30
+pyvlx==0.2.31
 
 # homeassistant.components.volumio
 pyvolumio==0.1.5

--- a/tests/components/velux/conftest.py
+++ b/tests/components/velux/conftest.py
@@ -70,7 +70,7 @@ def mock_window() -> AsyncMock:
     window.name = "Test Window"
     window.rain_sensor = True
     window.serial_number = "123456789"
-    window.get_limitation.return_value = MagicMock(min_value=0)
+    window.get_limitation_min.return_value = MagicMock(position_percent=0)
     window.device_updated_cbs = []
     window.is_opening = False
     window.is_closing = False

--- a/tests/components/velux/test_binary_sensor.py
+++ b/tests/components/velux/test_binary_sensor.py
@@ -43,35 +43,35 @@ async def test_rain_sensor_state(
     assert state.state == STATE_OFF
 
     # simulate rain detected (Velux GPU reports 100)
-    mock_window.get_limitation.return_value.min_value = 100
+    mock_window.get_limitation_min.return_value.position_percent = 100
     await update_polled_entities(hass, freezer)
     state = hass.states.get(test_entity_id)
     assert state is not None
     assert state.state == STATE_ON
 
     # simulate rain detected (most Velux models report 93)
-    mock_window.get_limitation.return_value.min_value = 93
+    mock_window.get_limitation_min.return_value.position_percent = 93
     await update_polled_entities(hass, freezer)
     state = hass.states.get(test_entity_id)
     assert state is not None
     assert state.state == STATE_ON
 
     # simulate rain detected (other Velux models report 89)
-    mock_window.get_limitation.return_value.min_value = 89
+    mock_window.get_limitation_min.return_value.position_percent = 89
     await update_polled_entities(hass, freezer)
     state = hass.states.get(test_entity_id)
     assert state is not None
     assert state.state == STATE_ON
 
     # simulate other limits which do not indicate rain detected
-    mock_window.get_limitation.return_value.min_value = 88
+    mock_window.get_limitation_min.return_value.position_percent = 88
     await update_polled_entities(hass, freezer)
     state = hass.states.get(test_entity_id)
     assert state is not None
     assert state.state == STATE_OFF
 
     # simulate no rain detected again
-    mock_window.get_limitation.return_value.min_value = 0
+    mock_window.get_limitation_min.return_value.position_percent = 0
     await update_polled_entities(hass, freezer)
     state = hass.states.get(test_entity_id)
     assert state is not None
@@ -133,7 +133,7 @@ async def test_rain_sensor_unavailability(
     assert state.state != STATE_UNAVAILABLE
 
     # Simulate communication error
-    mock_window.get_limitation.side_effect = PyVLXException("Connection failed")
+    mock_window.get_limitation_min.side_effect = PyVLXException("Connection failed")
     await update_polled_entities(hass, freezer)
 
     # Entity should now be unavailable
@@ -157,8 +157,8 @@ async def test_rain_sensor_unavailability(
     caplog.clear()
 
     # Simulate recovery
-    mock_window.get_limitation.side_effect = None
-    mock_window.get_limitation.return_value.min_value = 0
+    mock_window.get_limitation_min.side_effect = None
+    mock_window.get_limitation_min.return_value.position_percent = 0
     await update_polled_entities(hass, freezer)
 
     # Entity should be available again


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps the velux integration library to 0.2.31.
Changelog: https://github.com/Julius2342/pyvlx/releases/tag/0.2.31
Full changes: https://github.com/Julius2342/pyvlx/compare/0.2.30...0.2.31

The version bump also includes a minimal code change because one of the methods in the library is now deprecated, so I replaced the calls with the new one. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
