### PR TITLE
Add hashability guard to _get_tracked_value in triggers

### DIFF
--- a/homeassistant/helpers/automation.py
+++ b/homeassistant/helpers/automation.py
@@ -1,17 +1,22 @@
 """Helpers for automation."""
 
-from collections.abc import Callable, Mapping
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Mapping
 from dataclasses import dataclass
 from enum import Enum
+import logging
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.const import CONF_OPTIONS
-from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.core import HomeAssistant, State, split_entity_id
 
 from .entity import get_device_class_or_undefined
 from .typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AnyDeviceClassType(Enum):
@@ -43,24 +48,46 @@ class NumericalDomainSpec(DomainSpec):
     """Optional converter for numerical values (e.g. uint8 → percentage)."""
 
 
-def filter_by_domain_specs(
-    hass: HomeAssistant,
-    domain_specs: Mapping[str, DomainSpec],
-    entities: set[str],
-) -> set[str]:
-    """Filter entities matching any of the domain specs."""
-    result: set[str] = set()
-    for entity_id in entities:
-        if not (domain_spec := domain_specs.get(split_entity_id(entity_id)[0])):
-            continue
-        if (
-            domain_spec.device_class is not ANY_DEVICE_CLASS
-            and get_device_class_or_undefined(hass, entity_id)
-            != domain_spec.device_class
-        ):
-            continue
-        result.add(entity_id)
-    return result
+class DomainSpecMixin[DomainSpecT: DomainSpec = DomainSpec]:
+    """Mixin for triggers and conditions that use domain specs."""
+
+    _domain_specs: Mapping[str, DomainSpecT]
+    _hass: HomeAssistant
+
+    def entity_filter(self, entities: set[str]) -> set[str]:
+        """Filter entities matching any of the domain specs."""
+        result: set[str] = set()
+        for entity_id in entities:
+            if not (
+                domain_spec := self._domain_specs.get(split_entity_id(entity_id)[0])
+            ):
+                continue
+            if (
+                domain_spec.device_class is not ANY_DEVICE_CLASS
+                and get_device_class_or_undefined(self._hass, entity_id)
+                != domain_spec.device_class
+            ):
+                continue
+            result.add(entity_id)
+        return result
+
+    def _get_tracked_value(self, state: State) -> Hashable:
+        """Get the tracked value from a state based on the DomainSpec."""
+        domain_spec = self._domain_specs[split_entity_id(state.entity_id)[0]]
+        if domain_spec.value_source is None:
+            return state.state
+        value = state.attributes.get(domain_spec.value_source)
+        if not isinstance(value, Hashable):
+            # mypy treats Any as always compatible with Hashable in isinstance
+            # checks, but attributes can hold unhashable types like list or dict
+            _LOGGER.warning(  # type: ignore[unreachable]
+                "Skipped for entity '%s': attribute '%s' has unhashable type '%s'",
+                state.entity_id,
+                domain_spec.value_source,
+                type(value).__name__,
+            )
+            return None
+        return value
 
 
 def get_absolute_description_key(domain: str, key: str) -> str:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -54,7 +54,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     WEEKDAYS,
 )
-from homeassistant.core import HomeAssistant, State, callback, split_entity_id
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import (
     ConditionError,
     ConditionErrorContainer,
@@ -77,7 +77,7 @@ from homeassistant.util.yaml import load_yaml_dict
 from . import config_validation as cv, entity_registry as er, selector
 from .automation import (
     DomainSpec,
-    filter_by_domain_specs,
+    DomainSpecMixin,
     get_absolute_description_key,
     get_relative_description_key,
     move_options_fields_to_top_level,
@@ -334,10 +334,11 @@ ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL = vol.Schema(
 )
 
 
-class EntityConditionBase[DomainSpecT: DomainSpec = DomainSpec](Condition):
+class EntityConditionBase[DomainSpecT: DomainSpec = DomainSpec](
+    DomainSpecMixin[DomainSpecT], Condition
+):
     """Base class for entity conditions."""
 
-    _domain_specs: Mapping[str, DomainSpecT]
     _schema: vol.Schema = ENTITY_STATE_CONDITION_SCHEMA_ANY_ALL
 
     @override
@@ -356,17 +357,6 @@ class EntityConditionBase[DomainSpecT: DomainSpec = DomainSpec](Condition):
             assert config.options
         self._target_selection = TargetSelection(config.target)
         self._behavior = config.options[ATTR_BEHAVIOR]
-
-    def entity_filter(self, entities: set[str]) -> set[str]:
-        """Filter entities matching any of the domain specs."""
-        return filter_by_domain_specs(self._hass, self._domain_specs, entities)
-
-    def _get_tracked_value(self, entity_state: State) -> Any:
-        """Get the tracked value from a state based on the DomainSpec."""
-        domain_spec = self._domain_specs[split_entity_id(entity_state.entity_id)[0]]
-        if domain_spec.value_source is None:
-            return entity_state.state
-        return entity_state.attributes.get(domain_spec.value_source)
 
     @abc.abstractmethod
     def is_valid_state(self, entity_state: State) -> bool:

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -70,8 +70,8 @@ from homeassistant.util.yaml import load_yaml_dict
 from . import config_validation as cv, selector
 from .automation import (
     DomainSpec,
+    DomainSpecMixin,
     NumericalDomainSpec,
-    filter_by_domain_specs,
     get_absolute_description_key,
     get_relative_description_key,
     move_options_fields_to_top_level,
@@ -336,10 +336,11 @@ ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST = ENTITY_STATE_TRIGGER_SCHEMA.extend(
 )
 
 
-class EntityTriggerBase[DomainSpecT: DomainSpec = DomainSpec](Trigger):
+class EntityTriggerBase[DomainSpecT: DomainSpec = DomainSpec](
+    DomainSpecMixin[DomainSpecT], Trigger
+):
     """Trigger for entity state changes."""
 
-    _domain_specs: Mapping[str, DomainSpecT]
     _schema: vol.Schema = ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST
 
     @override
@@ -357,17 +358,6 @@ class EntityTriggerBase[DomainSpecT: DomainSpec = DomainSpec](Trigger):
             assert config.target is not None
         self._options = config.options or {}
         self._target = config.target
-
-    def entity_filter(self, entities: set[str]) -> set[str]:
-        """Filter entities matching any of the domain specs."""
-        return filter_by_domain_specs(self._hass, self._domain_specs, entities)
-
-    def _get_tracked_value(self, state: State) -> Any:
-        """Get the tracked value from a state based on the DomainSpec."""
-        domain_spec = self._domain_specs[split_entity_id(state.entity_id)[0]]
-        if domain_spec.value_source is None:
-            return state.state
-        return state.attributes.get(domain_spec.value_source)
 
     @abc.abstractmethod
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:
@@ -505,14 +495,14 @@ class EntityOriginStateTriggerBase(EntityTriggerBase):
 
     def is_valid_transition(self, from_state: State, to_state: State) -> bool:
         """Check if the origin state matches the expected one and that the state changed."""
-        return bool(
+        return (
             self._get_tracked_value(from_state) == self._from_state
             and self._get_tracked_value(to_state) != self._from_state
         )
 
     def is_valid_state(self, state: State) -> bool:
         """Check if the new state is not the same as the expected origin state."""
-        return bool(self._get_tracked_value(state) != self._from_state)
+        return self._get_tracked_value(state) != self._from_state
 
 
 def _validate_range[_T: dict[str, Any]](


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Following up on https://github.com/home-assistant/core/pull/165455#discussion_r2938693413, this PR adds a runtime guard in `_get_tracked_value` for unhashable attribute values (e.g. list, dict) from misbehaving (likely custom) integrations, logging a warning and returning `None` instead of crashing. Since we can assume this will be _very_ rare, the log should be enough.
- Extract shared `entity_filter` and `_get_tracked_value` from `EntityTriggerBase` and `EntityConditionBase` into a Mixin class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
