### PR TITLE
Simplify mocking of Tuya device notifications

### DIFF
--- a/tests/components/tuya/__init__.py
+++ b/tests/components/tuya/__init__.py
@@ -33,14 +33,31 @@ DEVICE_MOCKS = sorted(
 class MockDeviceListener(DeviceListener):
     """Mocked DeviceListener for testing."""
 
+    async def _async_update_device(
+        self,
+        device: CustomerDevice,
+        updated_status_properties: list[str] | None,
+        dp_timestamps: dict[str, int] | None,
+    ) -> None:
+        """Trigger dispatcher_send for device update and wait for entity tasks to complete."""
+        self.update_device(device, updated_status_properties, dp_timestamps)
+        await self.hass.async_block_till_done()
+
+    async def async_mock_online(self, device: CustomerDevice) -> None:
+        """Mock online event from the manager."""
+        device.online = True
+        await self._async_update_device(device, None, None)
+
+    async def async_mock_offline(self, device: CustomerDevice) -> None:
+        """Mock offline event from the manager."""
+        device.online = False
+        await self._async_update_device(device, None, None)
+
     async def async_send_device_update(
         self,
-        hass: HomeAssistant,
         device: CustomerDevice,
         updated_status_properties: dict[str, Any] | None = None,
         dp_timestamps: dict[str, int] | None = None,
-        *,
-        online: bool | None = None,
     ) -> None:
         """Mock update device method."""
         property_list: list[str] | None = None
@@ -53,10 +70,7 @@ class MockDeviceListener(DeviceListener):
                     )
                 device.status[key] = value
                 property_list.append(key)
-        if online is not None:
-            device.online = online
-        self.update_device(device, property_list, dp_timestamps)
-        await hass.async_block_till_done()
+        await self._async_update_device(device, property_list, dp_timestamps)
 
 
 async def create_device(hass: HomeAssistant, mock_device_code: str) -> CustomerDevice:
@@ -198,13 +212,13 @@ async def check_selective_state_update(
 
     # Trigger device offline
     freezer.tick(10)
-    await mock_listener.async_send_device_update(hass, mock_device, online=False)
+    await mock_listener.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     assert hass.states.get(entity_id).last_reported.isoformat() == unavailable_reported
 
     # Trigger device online
     freezer.tick(10)
-    await mock_listener.async_send_device_update(hass, mock_device, online=True)
+    await mock_listener.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
@@ -212,12 +226,12 @@ async def check_selective_state_update(
     # in updated properties - state should not change
     freezer.tick(10)
     mock_device.status[dpcode] = None
-    await mock_listener.async_send_device_update(hass, mock_device, {})
+    await mock_listener.async_send_device_update(mock_device, {})
     assert hass.states.get(entity_id).state == initial_state
     assert hass.states.get(entity_id).last_reported.isoformat() == available_reported
 
     # Trigger device update with provided updates
     freezer.tick(30)
-    await mock_listener.async_send_device_update(hass, mock_device, updates)
+    await mock_listener.async_send_device_update(mock_device, updates)
     assert hass.states.get(entity_id).state == expected_state
     assert hass.states.get(entity_id).last_reported.isoformat() == last_reported

--- a/tests/components/tuya/test_binary_sensor.py
+++ b/tests/components/tuya/test_binary_sensor.py
@@ -117,9 +117,7 @@ async def test_bitmap(
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == "off"
     assert hass.states.get("binary_sensor.dehumidifier_wet").state == "off"
 
-    await mock_listener.async_send_device_update(
-        hass, mock_device, {"fault": fault_value}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"fault": fault_value})
 
     assert hass.states.get("binary_sensor.dehumidifier_tank_full").state == tankfull
     assert hass.states.get("binary_sensor.dehumidifier_defrost").state == defrost

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -35,9 +35,7 @@ async def test_platform_setup_and_discovery(
 
     for mock_device in mock_devices:
         # Simulate an initial device update to generate events
-        await mock_listener.async_send_device_update(
-            hass, mock_device, mock_device.status
-        )
+        await mock_listener.async_send_device_update(mock_device, mock_device.status)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -78,7 +76,7 @@ async def test_alarm_message_event(
 
     mock_device.status[dpcode] = value
 
-    await mock_listener.async_send_device_update(hass, mock_device, mock_device.status)
+    await mock_listener.async_send_device_update(mock_device, mock_device.status)
 
     # Verify event was triggered with correct type and decoded URL
     state = hass.states.get(entity_id)
@@ -109,35 +107,27 @@ async def test_selective_state_update(
 
     # Device receives a data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(
-        hass, mock_device, {"switch_mode1": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device goes offline
     freezer.tick(10)
-    mock_device.online = False
-    await mock_listener.async_send_device_update(hass, mock_device, None)
+    await mock_listener.async_mock_offline(hass, mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Device comes back online - state should go back to last known value,
     # not new datetime since no new data update has come in
     freezer.tick(10)
-    mock_device.online = True
-    await mock_listener.async_send_device_update(hass, mock_device, None)
+    await mock_listener.async_mock_online(hass, mock_device)
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device receives a new data update - event gets triggered and state gets updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(
-        hass, mock_device, {"switch_mode1": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode1": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"
 
     # Device receives a data update on a different datapoint - event doesn't
     # get triggered and state doesn't get updated
     freezer.tick(10)
-    await mock_listener.async_send_device_update(
-        hass, mock_device, {"switch_mode2": "click"}
-    )
+    await mock_listener.async_send_device_update(mock_device, {"switch_mode2": "click"})
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:40.000+00:00"

--- a/tests/components/tuya/test_event.py
+++ b/tests/components/tuya/test_event.py
@@ -112,13 +112,13 @@ async def test_selective_state_update(
 
     # Device goes offline
     freezer.tick(10)
-    await mock_listener.async_mock_offline(hass, mock_device)
+    await mock_listener.async_mock_offline(mock_device)
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # Device comes back online - state should go back to last known value,
     # not new datetime since no new data update has come in
     freezer.tick(10)
-    await mock_listener.async_mock_online(hass, mock_device)
+    await mock_listener.async_mock_online(mock_device)
     assert hass.states.get(entity_id).state == "2024-01-01T00:00:10.000+00:00"
 
     # Device receives a new data update - event gets triggered and state gets updated

--- a/tests/components/tuya/test_sensor.py
+++ b/tests/components/tuya/test_sensor.py
@@ -107,7 +107,6 @@ async def test_delta_report_sensor(
 
     # Send delta update
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": 200},
         {"add_ele": timestamp},
@@ -119,7 +118,6 @@ async def test_delta_report_sensor(
     # Send delta update (multiple dpcode)
     timestamp += 100
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": 300, "switch_1": True},
         {"add_ele": timestamp, "switch_1": timestamp},
@@ -130,7 +128,6 @@ async def test_delta_report_sensor(
 
     # Send delta update (timestamp not incremented)
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": 500},
         {"add_ele": timestamp},  # same timestamp
@@ -141,7 +138,6 @@ async def test_delta_report_sensor(
 
     # Send delta update (unrelated dpcode)
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"switch_1": False},
         {"switch_1": timestamp + 100},
@@ -153,7 +149,6 @@ async def test_delta_report_sensor(
     # Send delta update
     timestamp += 100
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": 100},
         {"add_ele": timestamp},
@@ -166,7 +161,6 @@ async def test_delta_report_sensor(
     timestamp += 100
     mock_device.status["add_ele"] = None
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": None},
         {"add_ele": timestamp},
@@ -178,7 +172,6 @@ async def test_delta_report_sensor(
     # Send delta update (no timestamp - skipped)
     mock_device.status["add_ele"] = 200
     await mock_listener.async_send_device_update(
-        hass,
         mock_device,
         {"add_ele": 200},
         None,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- `hass` object is already available as an attribute of `DeviceListener`
- use a separate method for `online`/`offline` events as they should always have `updated_status_properties=None` and `dp_timestamps=None`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
