### PR TITLE
husqvarna_automower_ble: Report mower not pairable just before connection

### DIFF
--- a/homeassistant/components/husqvarna_automower_ble/config_flow.py
+++ b/homeassistant/components/husqvarna_automower_ble/config_flow.py
@@ -37,43 +37,6 @@ USER_SCHEMA = vol.Schema(
 REAUTH_SCHEMA = BLUETOOTH_SCHEMA
 
 
-def _is_supported(discovery_info: BluetoothServiceInfo):
-    """Check if device is supported."""
-    if ScanService not in discovery_info.service_uuids:
-        LOGGER.debug(
-            "Unsupported device, missing service %s: %s", ScanService, discovery_info
-        )
-        return False
-
-    if not (data := discovery_info.manufacturer_data.get(ManufacturerData.company)):
-        LOGGER.debug(
-            "Unsupported device, missing manufacturer data %s: %s",
-            ManufacturerData.company,
-            discovery_info,
-        )
-        return False
-
-    manufacturer_data = ManufacturerData.decode(data)
-    product_type = ProductType.from_manufacturer_data(manufacturer_data)
-
-    # Some mowers only expose the serial number in the manufacturer data
-    # and not the product type, so we allow None here as well.
-    if product_type not in (ProductType.MOWER, ProductType.UNKNOWN):
-        LOGGER.debug("Unsupported device: %s (%s)", manufacturer_data, discovery_info)
-        return False
-
-    if not manufacturer_data.pairable:
-        LOGGER.error(
-            "The mower does not appear to be pairable. "
-            "Ensure the mower is in pairing mode before continuing. "
-            "If the mower isn't pariable you will receive authentication "
-            "errors and be unable to connect"
-        )
-
-    LOGGER.debug("Supported device: %s", manufacturer_data)
-    return True
-
-
 def _pin_valid(pin: str) -> bool:
     """Check if the pin is valid."""
     try:
@@ -91,6 +54,41 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
     address: str | None = None
     mower_name: str = ""
     pin: str | None = None
+    pairable: bool = True
+
+    def _is_supported(self, discovery_info: BluetoothServiceInfo):
+        """Check if device is supported."""
+        if ScanService not in discovery_info.service_uuids:
+            LOGGER.debug(
+                "Unsupported device, missing service %s: %s",
+                ScanService,
+                discovery_info,
+            )
+            return False
+
+        if not (data := discovery_info.manufacturer_data.get(ManufacturerData.company)):
+            LOGGER.debug(
+                "Unsupported device, missing manufacturer data %s: %s",
+                ManufacturerData.company,
+                discovery_info,
+            )
+            return False
+
+        manufacturer_data = ManufacturerData.decode(data)
+        product_type = ProductType.from_manufacturer_data(manufacturer_data)
+
+        # Some mowers only expose the serial number in the manufacturer data
+        # and not the product type, so we allow UNKNOWN here as well.
+        if product_type not in (ProductType.MOWER, ProductType.UNKNOWN):
+            LOGGER.debug(
+                "Unsupported device: %s (%s)", manufacturer_data, discovery_info
+            )
+            return False
+
+        self.pairable = manufacturer_data.pairable
+
+        LOGGER.debug("Supported device: %s", manufacturer_data)
+        return True
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfo
@@ -98,7 +96,7 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the bluetooth discovery step."""
 
         LOGGER.debug("Discovered device: %s", discovery_info)
-        if not _is_supported(discovery_info):
+        if not self._is_supported(discovery_info):
             return self.async_abort(reason="no_devices_found")
 
         self.context["title_placeholders"] = {
@@ -116,6 +114,14 @@ class HusqvarnaAutomowerBleConfigFlow(ConfigFlow, domain=DOMAIN):
         """Confirm Bluetooth discovery."""
         assert self.address
         errors: dict[str, str] = {}
+
+        if not self.pairable:
+            LOGGER.error(
+                "The mower does not appear to be pairable. "
+                "Ensure the mower is in pairing mode before continuing. "
+                "If the mower isn't pairable you will receive authentication "
+                "errors and be unable to connect"
+            )
 
         if user_input is not None:
             if not _pin_valid(user_input[CONF_PIN]):


### PR DESCRIPTION
## Proposed change

Only report that the mower isn't pairable just before we try to connect to it.

The mower needs to be in pairing mode for the initial connection to work. Every model does this a little differently, so there isn't one simple step. Confusingly if the mower isn't in pairing mode the BLE connection will still work and the mower will pair. BUT the communication won't, we just get an authentication error. So it isn't an obvious error for users.

For a range of mowers it's not a simple step to enter pairing mode. It involves rebooting the mower and then starting the connection quick enough to get the timing right. Users have trouble getting this right and there are numerous issues opened thinking that the integration isn't working, when in fact they just didn't have the mower in pairing mode.

So, the idea is to warn users that the mower isn't in pairing mode.

Here's the tricky part. The Mower provides this bool to indicate if the mower is in pairing mode. I don't have enough data to know if that bool is reliable for all models and all firmware versions. So I can't rely on the bool. Which means I don't want to abort the process if the mower reports that it isn't in pairing mode. Hence the log. The idea is that if it doesn't work users will check the log, see the message and try again, while not blocking anyone from trying if the bool is incorrect.

This is a re-open of https://github.com/home-assistant/core/pull/160426 as it was closed

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156482
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
