### PR TITLE
Add initial quality scale file to Monarch Money

### DIFF
--- a/homeassistant/components/monarch_money/quality_scale.yaml
+++ b/homeassistant/components/monarch_money/quality_scale.yaml
@@ -1,0 +1,167 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow:
+    status: todo
+    comment: |
+      The config flow step is missing data_description translations for: email,
+      password, mfa_code, mfa_secret.
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: |
+      This integration does not provide additional actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions:
+    status: todo
+    comment: |
+      The documentation page does not include a section describing how to remove
+      the integration.
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities use CoordinatorEntity and do not subscribe to any additional events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: |
+      This integration does not provide service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: todo
+    comment: |
+      The documentation page does not describe the configuration parameters
+      (email, password, MFA code) in detail.
+  docs-installation-parameters:
+    status: todo
+    comment: |
+      The documentation page does not describe each installation parameter
+      individually (email, password, MFA secret/code).
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates:
+    status: todo
+    comment: |
+      The sensor platform does not define a PARALLEL_UPDATES constant.
+  reauthentication-flow:
+    status: todo
+    comment: |
+      The config flow does not implement async_step_reauth to handle expired or
+      revoked tokens without requiring the user to delete and re-add the entry.
+  test-coverage:
+    status: todo
+    comment: |
+      Only a single snapshot test exists for the sensor platform. Overall test
+      coverage has not been verified to exceed 95%.
+
+  # Gold
+  devices: done
+  diagnostics:
+    status: todo
+    comment: |
+      No diagnostics.py file exists for this integration.
+  discovery-update-info:
+    status: exempt
+    comment: |
+      This is a cloud service integration; network-level discovery is not applicable.
+  discovery:
+    status: exempt
+    comment: |
+      This is a cloud service integration; DHCP/SSDP/Zeroconf/USB discovery is not
+      applicable.
+  docs-data-update:
+    status: todo
+    comment: |
+      The documentation does not describe the 4-hour polling interval or how data
+      is fetched and updated.
+  docs-examples:
+    status: todo
+    comment: |
+      The documentation does not include any usage examples (e.g. automation or
+      dashboard snippets).
+  docs-known-limitations:
+    status: todo
+    comment: |
+      The documentation does not include a known limitations section.
+  docs-supported-devices:
+    status: todo
+    comment: |
+      The documentation does not enumerate the supported Monarch Money account
+      types and subtypes.
+  docs-supported-functions:
+    status: todo
+    comment: |
+      The documentation does not fully describe all available sensors (cashflow
+      income, expense, savings, savings rate, balance, value, age).
+  docs-troubleshooting:
+    status: todo
+    comment: |
+      The documentation does not include a troubleshooting section.
+  docs-use-cases:
+    status: todo
+    comment: |
+      The documentation does not include a use-cases section describing what users
+      can accomplish with this integration.
+  dynamic-devices:
+    status: todo
+    comment: |
+      Entities are created once at setup. There is no mechanism to discover and add
+      new devices (Monarch Money accounts) that are created after the initial setup,
+      or to remove devices whose accounts have been closed.
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: todo
+    comment: |
+      Less important sensors such as the account age/timestamp diagnostic sensor
+      are not disabled by default.
+  entity-translations: todo
+  exception-translations:
+    status: todo
+    comment: |
+      Exceptions raised in the config flow (e.g. invalid auth, connection errors)
+      do not use translated messages via HomeAssistantError or similar.
+  icon-translations: done
+  reconfiguration-flow:
+    status: todo
+    comment: |
+      The config flow does not implement async_step_reconfigure.
+  repair-issues:
+    status: todo
+    comment: |
+      No repair issues are raised. With no reauthentication flow, token expiry
+      has no user-facing repair path.
+  stale-devices:
+    status: todo
+    comment: |
+      The integration does not remove device registry entries when Monarch Money
+      accounts are deleted or become unavailable.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: todo
+    comment: |
+      TypedMonarchMoney does not accept an aiohttp.ClientSession parameter;
+      the integration cannot inject HA's managed session.
+  strict-typing:
+    status: todo
+    comment: |
+      No .strict-typing marker file exists and the integration has not been
+      verified to pass mypy --strict.

--- a/homeassistant/components/monarch_money/quality_scale.yaml
+++ b/homeassistant/components/monarch_money/quality_scale.yaml
@@ -131,7 +131,11 @@ rules:
     comment: |
       Less important sensors such as the account age/timestamp diagnostic sensor
       are not disabled by default.
-  entity-translations: todo
+  entity-translations:
+    status: done
+    comment: |
+      translation_key is set on all entity descriptions in sensor.py
+      (value, balance, age, sum_income, sum_expense, savings, savings_rate).
   exception-translations:
     status: todo
     comment: |

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -623,7 +623,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "modern_forms",
     "moehlenhoff_alpha2",
     "mold_indicator",
-    "monarch_money",
     "monoprice",
     "monzo",
     "moon",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Initial QA File -> Almost bronze but not there yet. 

## Bronze — Evidence

| Rule | Status | Evidence |
|------|--------|----------|
| `action-setup` | exempt | No `hass.services.async_register` calls anywhere in the integration |
| `appropriate-polling` | done | [`coordinator.py#L54`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/coordinator.py#L54) — `update_interval=timedelta(hours=4)` |
| `brands` | done | Integration is published in HA core; brand assets exist in the external brands repo |
| `common-modules` | done | Coordinator logic in `coordinator.py`; constants in `const.py` |
| `config-flow-test-coverage` | done | [`test_config_flow.py`](https://github.com/home-assistant/core/blob/dev/tests/components/monarch_money/test_config_flow.py) — 4 scenarios: success, duplicate entry, invalid auth, MFA flow |
| `config-flow` | **todo** | Missing `data_description` translations for `email`, `password`, `mfa_code`, `mfa_secret` in `strings.json` |
| `dependency-transparency` | done | `manifest.json` lists `typedmonarchmoney==0.7.0` in `requirements` |
| `docs-actions` | exempt | No service actions registered |
| `docs-high-level-description` | done | [Docs page](https://www.home-assistant.io/integrations/monarch_money/) has a description of the Monarch Money service |
| `docs-installation-instructions` | done | Docs page has step-by-step installation instructions |
| `docs-removal-instructions` | **todo** | Docs page has no removal instructions section |
| `entity-event-setup` | exempt | All entities extend `CoordinatorEntity`; no additional event subscriptions |
| `entity-unique-id` | done | [`entity.py#L29-L31`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/entity.py#L29-L31) (cashflow) and [`entity.py#L61-L63`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/entity.py#L61-L63) (accounts) |
| `has-entity-name` | done | [`entity.py#L16`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/entity.py#L16) — `_attr_has_entity_name = True` |
| `runtime-data` | done | [`__init__.py#L23`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/__init__.py#L23) — `entry.runtime_data = mm_coordinator` |
| `test-before-configure` | done | `config_flow.py` calls `validate_login()` before `async_create_entry` |
| `test-before-setup` | done | [`__init__.py#L22`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/__init__.py#L22) — `async_config_entry_first_refresh()` triggers `_async_setup` which raises `ConfigEntryError` on auth failure |
| `unique-config-entry` | done | [`config_flow.py#L140-L141`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/config_flow.py#L140-L141) — `async_set_unique_id` + `_abort_if_unique_id_configured` |

---


## Silver — Evidence

| Rule | Status | Evidence |
|------|--------|----------|
| `action-exceptions` | exempt | No service actions |
| `config-entry-unloading` | done | [`__init__.py#L28-L32`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/__init__.py#L28) — `async_unload_entry` implemented |
| `docs-configuration-parameters` | **todo** | Docs page does not describe configuration parameters in detail |
| `docs-installation-parameters` | **todo** | Docs page does not describe each parameter (email, password, MFA code) individually |
| `entity-unavailable` | done | `CoordinatorEntity` marks entities unavailable automatically; `MonarchMoneyAccountEntity.available` also checks account presence |
| `integration-owner` | done | `manifest.json` — `codeowners: ["@jeeftor"]` |
| `log-when-unavailable` | done | `DataUpdateCoordinator` handles unavailability logging automatically |
| `parallel-updates` | **todo** | `PARALLEL_UPDATES` constant not defined in `sensor.py` |
| `reauthentication-flow` | **todo** | No `async_step_reauth` in `config_flow.py` |
| `test-coverage` | **todo** | Only one snapshot test for the sensor platform; overall coverage not verified >95% |

---

## Gold — Evidence

| Rule | Status | Evidence |
|------|--------|----------|
| `devices` | done | [`entity.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/entity.py) — both entity classes populate `DeviceInfo` |
| `diagnostics` | **todo** | No `diagnostics.py` file |
| `discovery-update-info` | exempt | Cloud service; network discovery not applicable |
| `discovery` | exempt | Cloud service; no DHCP/SSDP/Zeroconf/USB discovery |
| `docs-data-update` | **todo** | Docs do not describe the 4-hour polling interval |
| `docs-examples` | **todo** | No usage examples in docs |
| `docs-known-limitations` | **todo** | No known limitations section in docs |
| `docs-supported-devices` | **todo** | Supported account types/subtypes not enumerated in docs |
| `docs-supported-functions` | **todo** | Not all sensors (income, expense, savings, savings rate, balance, value, age) described in docs |
| `docs-troubleshooting` | **todo** | No troubleshooting section in docs |
| `docs-use-cases` | **todo** | No use-cases section in docs |
| `dynamic-devices` | **todo** | No mechanism to add/remove devices after initial setup |
| `entity-category` | done | [`sensor.py#L71`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/monarch_money/sensor.py#L71) — `EntityCategory.DIAGNOSTIC` on age sensor |
| `entity-device-class` | done | `SensorDeviceClass.MONETARY` and `SensorDeviceClass.TIMESTAMP` used in `sensor.py` |
| `entity-disabled-by-default` | **todo** | Diagnostic age sensor and lesser-used sensors are not disabled by default |
| `entity-translations` | done | `translation_key` set on all entity descriptions in `sensor.py` |
| `exception-translations` | **todo** | Config flow exceptions do not use translated messages |
| `icon-translations` | done | `icons.json` provides icons for sensor entities |
| `reconfiguration-flow` | **todo** | No `async_step_reconfigure` in `config_flow.py` |
| `repair-issues` | **todo** | No repair issues raised; no reauthentication path for token expiry |
| `stale-devices` | **todo** | Closed/removed Monarch Money accounts are not purged from the device registry |

---

## Platinum — Evidence

| Rule | Status | Evidence |
|------|--------|----------|
| `async-dependency` | done | `typedmonarchmoney` is fully async (built on `gql`/`aiohttp`); `coordinator.py` imports `ClientResponseError` from `aiohttp` |
| `inject-websession` | **todo** | `TypedMonarchMoney.__init__` accepts `(session_file, timeout, token)` — no `aiohttp.ClientSession` injection supported |
| `strict-typing` | **todo** | No `.strict-typing` marker file; not verified against `mypy --strict` |

---

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
