### PR TITLE
Fix enable/disable device tracking feature during setup of FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/config_flow.py
+++ b/homeassistant/components/fritz/config_flow.py
@@ -283,6 +283,7 @@ class FritzBoxToolsFlowHandler(ConfigFlow, domain=DOMAIN):
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
         self._use_tls = user_input[CONF_SSL]
+        self._feature_device_discovery = user_input[CONF_FEATURE_DEVICE_TRACKING]
 
         self._port = self._determine_port(user_input)
 

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -57,7 +57,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("show_advanced_options", "user_input", "expected_config"),
+    ("show_advanced_options", "user_input", "expected_config", "expected_options"),
     [
         (
             True,
@@ -68,6 +68,11 @@ from tests.common import MockConfigEntry
                 CONF_USERNAME: "fake_user",
                 CONF_PORT: 1234,
                 CONF_SSL: False,
+            },
+            {
+                CONF_OLD_DISCOVERY: False,
+                CONF_CONSIDER_HOME: DEFAULT_CONSIDER_HOME.total_seconds(),
+                CONF_FEATURE_DEVICE_TRACKING: True,
             },
         ),
         (
@@ -80,16 +85,30 @@ from tests.common import MockConfigEntry
                 CONF_PORT: 49000,
                 CONF_SSL: False,
             },
+            {
+                CONF_OLD_DISCOVERY: False,
+                CONF_CONSIDER_HOME: DEFAULT_CONSIDER_HOME.total_seconds(),
+                CONF_FEATURE_DEVICE_TRACKING: True,
+            },
         ),
         (
             False,
-            {**MOCK_USER_INPUT_SIMPLE, CONF_SSL: True},
+            {
+                **MOCK_USER_INPUT_SIMPLE,
+                CONF_SSL: True,
+                CONF_FEATURE_DEVICE_TRACKING: False,
+            },
             {
                 CONF_HOST: "fake_host",
                 CONF_PASSWORD: "fake_pass",
                 CONF_USERNAME: "fake_user",
                 CONF_PORT: 49443,
                 CONF_SSL: True,
+            },
+            {
+                CONF_OLD_DISCOVERY: False,
+                CONF_CONSIDER_HOME: DEFAULT_CONSIDER_HOME.total_seconds(),
+                CONF_FEATURE_DEVICE_TRACKING: False,
             },
         ),
     ],
@@ -100,6 +119,7 @@ async def test_user(
     show_advanced_options: bool,
     user_input: dict,
     expected_config: dict,
+    expected_options: dict,
 ) -> None:
     """Test starting a flow by user."""
     with (
@@ -143,10 +163,7 @@ async def test_user(
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"] == expected_config
-        assert (
-            result["options"][CONF_CONSIDER_HOME]
-            == DEFAULT_CONSIDER_HOME.total_seconds()
-        )
+        assert result["options"] == expected_options
         assert not result["result"].unique_id
 
     assert mock_setup_entry.called


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The option wasn't set correct (_always used the default value, instead of the users choice_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166016
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
