### PR TITLE
Allow listing non-USB serial ports with `scan_serial_ports`

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/__init__.py
+++ b/homeassistant/components/homeassistant_sky_connect/__init__.py
@@ -172,6 +172,8 @@ async def async_migrate_entry(
                         f"USB device {device} is missing, cannot migrate"
                     )
 
+                assert isinstance(usb_info, USBDevice)
+
                 hass.config_entries.async_update_entry(
                     config_entry,
                     data={

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -425,11 +425,16 @@ class USBDiscovery:
 
     async def _async_scan_serial(self) -> None:
         """Scan serial ports."""
-        _LOGGER.debug("Executing comports scan")
+        _LOGGER.debug("Executing USB serial device scan")
         async with self._scan_lock:
-            await self._async_process_ports(
-                await self.hass.async_add_executor_job(scan_serial_ports)
-            )
+            # Only consider USB-serial ports for discovery
+            usb_ports = [
+                p
+                for p in await self.hass.async_add_executor_job(scan_serial_ports)
+                if isinstance(p, USBDevice)
+            ]
+
+            await self._async_process_ports(usb_ports)
         if self.initial_scan_done:
             return
 

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -32,7 +32,10 @@ from homeassistant.loader import USBMatcher, async_get_usb
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
-from .models import USBDevice
+from .models import (
+    SerialDevice,  # noqa: F401
+    USBDevice,
+)
 from .utils import (
     scan_serial_ports,
     usb_device_from_path,  # noqa: F401

--- a/homeassistant/components/usb/models.py
+++ b/homeassistant/components/usb/models.py
@@ -6,12 +6,18 @@ from dataclasses import dataclass
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)
-class USBDevice:
-    """A usb device."""
+class SerialDevice:
+    """A serial device."""
 
     device: str
-    vid: str
-    pid: str
     serial_number: str | None
     manufacturer: str | None
     description: str | None
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class USBDevice(SerialDevice):
+    """A usb device."""
+
+    vid: str
+    pid: str

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -52,7 +52,7 @@ def usb_serial_device_from_port(port: ListPortInfo) -> USBDevice | SerialDevice:
 
 
 def scan_serial_ports() -> Sequence[USBDevice | SerialDevice]:
-    """Scan serial ports for USB devices."""
+    """Scan serial ports and return USB and other serial devices."""
 
     # Scan all symlinks first
     by_id = "/dev/serial/by-id"

--- a/homeassistant/components/usb/utils.py
+++ b/homeassistant/components/usb/utils.py
@@ -13,11 +13,14 @@ from serial.tools.list_ports_common import ListPortInfo
 from homeassistant.helpers.service_info.usb import UsbServiceInfo
 from homeassistant.loader import USBMatcher
 
-from .models import USBDevice
+from .models import SerialDevice, USBDevice
 
 
 def usb_device_from_port(port: ListPortInfo) -> USBDevice:
     """Convert serial ListPortInfo to USBDevice."""
+    assert port.vid is not None
+    assert port.pid is not None
+
     return USBDevice(
         device=port.device,
         vid=f"{hex(port.vid)[2:]:0>4}".upper(),
@@ -28,7 +31,27 @@ def usb_device_from_port(port: ListPortInfo) -> USBDevice:
     )
 
 
-def scan_serial_ports() -> Sequence[USBDevice]:
+def serial_device_from_port(port: ListPortInfo) -> SerialDevice:
+    """Convert serial ListPortInfo to SerialDevice."""
+    return SerialDevice(
+        device=port.device,
+        serial_number=port.serial_number,
+        manufacturer=port.manufacturer,
+        description=port.description,
+    )
+
+
+def usb_serial_device_from_port(port: ListPortInfo) -> USBDevice | SerialDevice:
+    """Convert serial ListPortInfo to USBDevice or SerialDevice."""
+    if port.vid is not None or port.pid is not None:
+        assert port.vid is not None
+        assert port.pid is not None
+
+        return usb_device_from_port(port)
+    return serial_device_from_port(port)
+
+
+def scan_serial_ports() -> Sequence[USBDevice | SerialDevice]:
     """Scan serial ports for USB devices."""
 
     # Scan all symlinks first
@@ -41,15 +64,14 @@ def scan_serial_ports() -> Sequence[USBDevice]:
     serial_ports = []
 
     for port in comports():
-        if port.vid is not None or port.pid is not None:
-            usb_device = usb_device_from_port(port)
-            device_path = realpath_to_by_id.get(port.device, port.device)
+        device = usb_serial_device_from_port(port)
+        device_path = realpath_to_by_id.get(port.device, port.device)
 
-            if device_path != port.device:
-                # Prefer the unique /dev/serial/by-id/ path if it exists
-                usb_device = dataclasses.replace(usb_device, device=device_path)
+        if device_path != port.device:
+            # Prefer the unique /dev/serial/by-id/ path if it exists
+            device = dataclasses.replace(device, device=device_path)
 
-            serial_ports.append(usb_device)
+        serial_ports.append(device)
 
     return serial_ports
 
@@ -60,6 +82,10 @@ def usb_device_from_path(device_path: str) -> USBDevice | None:
     device_path_real = os.path.realpath(device_path)
 
     for device in scan_serial_ports():
+        # Skip non-USB serial devices
+        if not isinstance(device, USBDevice):
+            continue
+
         if os.path.realpath(device.device) == device_path_real:
             return device
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -26,7 +26,7 @@ from homeassistant.components.homeassistant_hardware.firmware_config_flow import
     ZigbeeFlowStrategy,
 )
 from homeassistant.components.homeassistant_yellow import hardware as yellow_hardware
-from homeassistant.components.usb import USBDevice, scan_serial_ports
+from homeassistant.components.usb import SerialDevice, USBDevice, scan_serial_ports
 from homeassistant.config_entries import (
     SOURCE_IGNORE,
     SOURCE_ZEROCONF,
@@ -134,9 +134,9 @@ def _format_backup_choice(
     return f"{dt_util.as_local(backup.backup_time).strftime('%c')} ({identifier})"
 
 
-async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice]:
+async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice | SerialDevice]:
     """List all serial ports, including the Yellow radio and the multi-PAN addon."""
-    ports: list[USBDevice] = []
+    ports: list[USBDevice | SerialDevice] = []
     ports.extend(await hass.async_add_executor_job(scan_serial_ports))
 
     # Add useful info to the Yellow's serial port selection screen
@@ -147,10 +147,8 @@ async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice]:
     else:
         # PySerial does not properly handle the Yellow's serial port with the CM5
         # so we manually include it
-        port = USBDevice(
+        port = SerialDevice(
             device="/dev/ttyAMA1",
-            vid="ffff",  # This is technically not a USB device
-            pid="ffff",
             serial_number=None,
             manufacturer="Nabu Casa",
             description="Yellow Zigbee module",
@@ -171,10 +169,8 @@ async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice]:
             addon_info = None
 
         if addon_info is not None and addon_info.state != AddonState.NOT_INSTALLED:
-            addon_port = USBDevice(
+            addon_port = SerialDevice(
                 device=silabs_multiprotocol_addon.get_zigbee_socket(),
-                vid="ffff",  # This is technically not a USB device
-                pid="ffff",
                 serial_number=None,
                 manufacturer="Nabu Casa",
                 description="Silicon Labs Multiprotocol add-on",

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -134,6 +134,24 @@ def _format_backup_choice(
     return f"{dt_util.as_local(backup.backup_time).strftime('%c')} ({identifier})"
 
 
+def _format_serial_port_choice(
+    serial_port: USBDevice | SerialDevice, resolved_paths: dict[str, str]
+) -> str:
+    """Format a serial port selector entry into a line of text."""
+    text = resolved_paths[serial_port.device]
+
+    if serial_port.description:
+        text += f" - {serial_port.description}"
+
+    if serial_port.serial_number:
+        text += f", s/n: {serial_port.serial_number}"
+
+    if serial_port.manufacturer:
+        text += f" - {serial_port.manufacturer}"
+
+    return text
+
+
 async def list_serial_ports(hass: HomeAssistant) -> list[USBDevice | SerialDevice]:
     """List all serial ports, including the Yellow radio and the multi-PAN addon."""
     ports: list[USBDevice | SerialDevice] = []
@@ -258,11 +276,7 @@ class BaseZhaFlow(ConfigEntryBaseFlow):
             for p in ports
         }
 
-        list_of_ports = [
-            f"{resolved_paths[p.device]} - {p.description}{', s/n: ' + p.serial_number if p.serial_number else ''}"
-            + (f" - {p.manufacturer}" if p.manufacturer else "")
-            for p in ports
-        ]
+        list_of_ports = [_format_serial_port_choice(p, resolved_paths) for p in ports]
 
         if not list_of_ports:
             return await self.async_step_manual_pick_radio_type()

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1390,9 +1390,8 @@ def test_scan_serial_ports_no_vid_pid() -> None:
         devices = scan_serial_ports()
 
     assert len(devices) == 1
+    assert isinstance(devices[0], SerialDevice)
     assert devices[0].device == "/dev/ttyAMA1"
-    assert devices[0].vid is None
-    assert devices[0].pid is None
     assert devices[0].serial_number is None
     assert devices[0].manufacturer is None
     assert devices[0].description is None
@@ -1640,17 +1639,3 @@ async def test_removal_aborts_discovery_flows(
         final_flows = hass.config_entries.flow.async_progress()
         assert len(final_flows) == 1
         assert final_flows[0]["handler"] == "test2"
-
-
-def test_usb_service_info_from_device_no_vid_pid() -> None:
-    """Test usb_service_info_from_device rejects devices without VID or PID."""
-    device = USBDevice(
-        device="/dev/ttyUSB0",
-        vid=None,
-        pid=None,
-        serial_number="ABC123",
-        manufacturer="Test Manufacturer",
-        description="Test Device",
-    )
-
-    assert usb.usb_service_info_from_device(device) is None

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1321,6 +1321,35 @@ def test_scan_serial_ports_without_unique_symlinks() -> None:
     assert devices[0].vid == "1234"
 
 
+def test_scan_serial_ports_no_vid_pid() -> None:
+    """Test scan_serial_ports returns devices without VID:PID."""
+    mock_port = MagicMock()
+    mock_port.device = "/dev/ttyAMA1"
+    mock_port.vid = None
+    mock_port.pid = None
+    mock_port.serial_number = None
+    mock_port.manufacturer = None
+    mock_port.description = None
+
+    with (
+        patch("os.path.isdir", return_value=False),
+        patch("os.path.realpath", side_effect=lambda x: x),
+        patch(
+            "homeassistant.components.usb.utils.comports",
+            return_value=[mock_port],
+        ),
+    ):
+        devices = scan_serial_ports()
+
+    assert len(devices) == 1
+    assert devices[0].device == "/dev/ttyAMA1"
+    assert devices[0].vid is None
+    assert devices[0].pid is None
+    assert devices[0].serial_number is None
+    assert devices[0].manufacturer is None
+    assert devices[0].description is None
+
+
 def test_usb_device_from_path_finds_by_symlink() -> None:
     """Test usb_device_from_path finds device by symlink path."""
     scanned_device = USBDevice(
@@ -1563,3 +1592,17 @@ async def test_removal_aborts_discovery_flows(
         final_flows = hass.config_entries.flow.async_progress()
         assert len(final_flows) == 1
         assert final_flows[0]["handler"] == "test2"
+
+
+def test_usb_service_info_from_device_no_vid_pid() -> None:
+    """Test usb_service_info_from_device rejects devices without VID or PID."""
+    device = USBDevice(
+        device="/dev/ttyUSB0",
+        vid=None,
+        pid=None,
+        serial_number="ABC123",
+        manufacturer="Test Manufacturer",
+        description="Test Device",
+    )
+
+    assert usb.usb_service_info_from_device(device) is None

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -11,7 +11,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import usb
 from homeassistant.components.usb import DOMAIN
-from homeassistant.components.usb.models import USBDevice
+from homeassistant.components.usb.models import SerialDevice, USBDevice
 from homeassistant.components.usb.utils import scan_serial_ports, usb_device_from_path
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -285,6 +285,54 @@ async def test_discovered_by_websocket_scan_limited_by_description_matcher(
 
     assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+
+@pytest.mark.usefixtures("force_usb_polling_watcher")
+async def test_non_usb_ignored_by_discovery(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test that polling ignores native serial ports."""
+    new_usb = [
+        {"domain": "everything_matches"},
+    ]
+
+    with (
+        patch("sys.platform", "linux"),
+        patch(
+            "homeassistant.components.usb.POLLING_MONITOR_SCAN_PERIOD",
+            timedelta(seconds=0.01),
+        ),
+        patch("homeassistant.components.usb.async_get_usb", return_value=new_usb),
+        patch_scanned_serial_ports(
+            return_value=[
+                USBDevice(
+                    device=slae_sh_device.device,
+                    vid="3039",
+                    pid="3039",
+                    serial_number=slae_sh_device.serial_number,
+                    manufacturer=slae_sh_device.manufacturer,
+                    description=slae_sh_device.description,
+                ),
+                # Non-USB serial devices are skipped for now
+                SerialDevice(
+                    device="/dev/ttyAMA1",
+                    serial_number=None,
+                    manufacturer=None,
+                    description=None,
+                ),
+            ]
+        ),
+        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
+    ):
+        assert await async_setup_component(hass, DOMAIN, {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    # Only one config flow should be started
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0].args[0] == "everything_matches"
+    assert mock_config_flow.mock_calls[0].kwargs["data"].device == slae_sh_device.device
 
 
 @pytest.mark.usefixtures("force_usb_polling_watcher")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Yes and no. This technically changes the return type of `usb.scan_serial_ports` from a list of `USBDevice` to a list of `USBDevice | SerialDevice` but there is exactly one codepath in Home Assistant that needed to be modified (just ZHA and just types). No custom components I can find online use this function.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To properly work with non-USB serial ports in Home Assistant, we should allow listing serial ports that do not have a USB VID or a PID (e.g. ESPHome serial proxies or embedded ports). This will allow us to extend `manifest.json` discovery in the future.

An upcoming PR will replace integration-internal usage of pyserial's `comports` function with `homeassistant.components.usb.list_serial_ports`.

(An alternative to this PR would be to completely delete the USB integration and absorb this functionality into the better-named `serial` integration, which currently is used by 260 people and is technically a better fit than `usb`.)

Part of https://github.com/home-assistant/roadmap/issues/77

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
