### PR TITLE
Create action setup 5

### DIFF
--- a/Dependabot/GitHub actions/pnpm/action setup 5
+++ b/Dependabot/GitHub actions/pnpm/action setup 5
@@ -1,0 +1,96 @@
+# 🤖 Dependabot for GitHub Actions & `pnpm/action-setup@v5`
+
+Dependabot can automatically keep your GitHub Actions workflows up‑to‑date by monitoring the versions of actions you use. This includes the popular `pnpm/action-setup` action.
+
+## 📁 Configuring Dependabot for GitHub Actions
+
+Create a file at `.github/dependabot.yml` in your repository with the following content:
+
+```yaml
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Optionally, specify which actions to ignore or target
+    # target-branch: "develop"
+    # labels:
+    #   - "dependencies"
+    #   - "github-actions"
+```
+
+This configuration tells Dependabot to check for updates to any GitHub Actions used in your workflows every week.
+
+## 🛠️ Using `pnpm/action-setup@v5` in a Workflow
+
+To use `pnpm/action-setup@v5` in your GitHub Actions workflow, add a step like this:
+
+```yaml
+- name: Install pnpm
+  uses: pnpm/action-setup@v5
+  with:
+    version: 8  # or a specific version like 8.6.0
+```
+
+Dependabot will detect this usage and, when a new version of `pnpm/action-setup` is released (e.g., `v5.1.0` or `v6`), it will open a pull request to update the version tag in your workflow file.
+
+## 🎯 Customising Dependabot for `pnpm/action-setup`
+
+You can fine‑tune how Dependabot handles updates for this specific action by adding `ignore` or `allow` rules. For example, to only receive updates for the `v5` major version (i.e., patch and minor updates, but not major bumps to v6), use:
+
+```yaml
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]
+```
+
+This will ignore major version updates (like `v5` → `v6`) but still propose minor and patch updates within `v5`.
+
+## 📦 Example: Complete Workflow with Dependabot
+
+**Workflow file (`.github/workflows/ci.yml`)**:
+```yaml
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm test
+```
+
+**Dependabot config (`.github/dependabot.yml`)**:
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Now Dependabot will automatically open PRs when new versions of `actions/checkout`, `pnpm/action-setup`, or `actions/setup-node` are released.
+
+## 🔍 Additional Tips
+
+- Dependabot also supports other ecosystems like npm, pip, etc. – add separate entries for those.
+- You can set a custom `target-branch` if you want PRs against a development branch.
+- Review and merge Dependabot PRs to keep your workflows secure and up‑to‑date.
+
+For more details, check the [GitHub Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file). 😊


### PR DESCRIPTION
# 🚀 Using `pnpm/action-setup@v5` in GitHub Actions

Here's a complete workflow example that uses the latest `pnpm/action-setup@v5` to install pnpm and cache dependencies.

## 📁 `.github/workflows/ci.yml`

```yaml
name: CI

on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v4

      - name: Install pnpm
        uses: pnpm/action-setup@v5
        with:
          version: 8   # Specify pnpm version (e.g., 8, 8.6.0, or use 'latest')
          run_install: false  # If true, runs `pnpm install` immediately

      - name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: 18
          cache: 'pnpm'   # Automatically caches pnpm store

      - name: Install dependencies
        run: pnpm install

      - name: Run tests
        run: pnpm test
```

## 🔧 What this workflow does

1. **Checks out** your code.
2. **Installs pnpm** using `pnpm/action-setup@v5` with version 8.
3. **Sets up Node.js** (v18) and enables pnpm caching.
4. **Installs dependencies** via `pnpm install`.
5. **Runs tests** with `pnpm test`.

## 🤖 Dependabot Integration

To keep `pnpm/action-setup` (and other actions) up‑to‑date, add this Dependabot configuration:

**`.github/dependabot.yml`**
```yaml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

Dependabot will automatically open pull requests when new versions of `pnpm/action-setup` are released (e.g., v5.1.0 or v6).

## 📝 Notes

- The `@v5` tag always points to the latest v5 release. For a specific version, use e.g., `@v5.0.0`.
- Set `run_install: true` if you want the action to run `pnpm install` for you (handy for simpler workflows).
- For more options, see the [official action documentation](https://github.com/pnpm/action-setup).

Let me know if you need any adjustments! 😊

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
