### PR TITLE
Add exception translations to Tessie

### DIFF
--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING, Any
 
-from aiohttp import ClientResponseError
+from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import TeslaEnergyPeriod
 from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
 from tesla_fleet_api.tessie import EnergySite
@@ -87,7 +87,13 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
             ) from e
+        except ClientError as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
         return flatten(vehicle)
+
 
 class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching energy site live status from the Tessie API."""

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -83,9 +83,11 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
                 raise ConfigEntryAuthFailed from e
-            raise
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
         return flatten(vehicle)
-
 
 class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching energy site live status from the Tessie API."""
@@ -123,7 +125,10 @@ class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except (InvalidToken, MissingToken) as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
-            raise UpdateFailed(e.message) from e
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
 
         # Convert Wall Connectors from array to dict
         data["wall_connectors"] = {
@@ -159,7 +164,10 @@ class TessieEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except (InvalidToken, MissingToken) as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
-            raise UpdateFailed(e.message) from e
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
 
         return flatten(data)
 
@@ -197,7 +205,10 @@ class TessieEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_key="auth_failed",
             ) from e
         except TeslaFleetError as e:
-            raise UpdateFailed(e.message) from e
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
 
         if (
             not data

--- a/homeassistant/components/tessie/entity.py
+++ b/homeassistant/components/tessie/entity.py
@@ -104,7 +104,10 @@ class TessieEntity(TessieBaseEntity):
                 **kargs,
             )
         except ClientResponseError as e:
-            raise HomeAssistantError from e
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
         if response["result"] is False:
             name: str = getattr(self, "name", self.entity_id)
             reason: str = response.get("reason", "unknown")

--- a/homeassistant/components/tessie/entity.py
+++ b/homeassistant/components/tessie/entity.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from aiohttp import ClientResponseError
+from aiohttp import ClientError
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -103,7 +103,7 @@ class TessieEntity(TessieBaseEntity):
                 api_key=self._api_key,
                 **kargs,
             )
-        except ClientResponseError as e:
+        except ClientError as e:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",

--- a/homeassistant/components/tessie/quality_scale.yaml
+++ b/homeassistant/components/tessie/quality_scale.yaml
@@ -72,13 +72,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations:
-    status: todo
-    comment: |
-      Most user-facing exceptions have translations (HomeAssistantError and
-      ServiceValidationError use translation keys from strings.json). Remaining:
-      entity.py raises bare HomeAssistantError for ClientResponseError, and
-      coordinators raise UpdateFailed with untranslated messages.
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo

--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -631,6 +631,9 @@
     "cable_connected": {
       "message": "Charge cable is connected."
     },
+    "cannot_connect": {
+      "message": "[%key:common::config_flow::error::cannot_connect%]"
+    },
     "command_failed": {
       "message": "Command failed, {message}"
     },

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -22,7 +22,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import ERROR_UNKNOWN, TEST_RESPONSE, assert_entities, setup_platform
+from .common import (
+    ERROR_CONNECTION,
+    ERROR_UNKNOWN,
+    TEST_RESPONSE,
+    assert_entities,
+    setup_platform,
+)
 
 
 async def test_climate(
@@ -130,6 +136,25 @@ async def test_errors(hass: HomeAssistant) -> None:
         )
     mock_set.assert_called_once()
     assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"
+
+    # Test setting climate on with connection error
+    with (
+        patch(
+            "homeassistant.components.tessie.climate.stop_climate",
+            side_effect=ERROR_CONNECTION,
+        ) as mock_set,
+        pytest.raises(HomeAssistantError) as error,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+    mock_set.assert_called_once()
+    assert error.value.__cause__ == ERROR_CONNECTION
     assert error.value.translation_domain == "tessie"
     assert error.value.translation_key == "cannot_connect"
 

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -130,6 +130,8 @@ async def test_errors(hass: HomeAssistant) -> None:
         )
     mock_set.assert_called_once()
     assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"
 
     # Test setting climate with child presence detection error
     with (

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -78,12 +78,17 @@ async def test_coordinator_connection(
     """Tests that the coordinator handles connection errors."""
 
     mock_get_state.side_effect = ERROR_CONNECTION
-    await setup_platform(hass, [Platform.BINARY_SENSOR])
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_get_state.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
+
 
 async def test_coordinator_live_error(
     hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -7,6 +7,7 @@ import pytest
 from tesla_fleet_api.exceptions import Forbidden, InvalidToken, MissingToken
 
 from homeassistant.components.tessie import PLATFORMS
+from homeassistant.components.tessie.const import DOMAIN
 from homeassistant.components.tessie.coordinator import (
     TESSIE_ENERGY_HISTORY_INTERVAL,
     TESSIE_FLEET_API_SYNC_INTERVAL,
@@ -15,6 +16,7 @@ from homeassistant.components.tessie.coordinator import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .common import ERROR_AUTH, ERROR_CONNECTION, ERROR_UNKNOWN, setup_platform
 
@@ -43,13 +45,17 @@ async def test_coordinator_clienterror(
     """Tests that the coordinator handles client errors."""
 
     mock_get_state.side_effect = ERROR_UNKNOWN
-    await setup_platform(hass, [Platform.BINARY_SENSOR])
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
 
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_get_state.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
 async def test_coordinator_auth(
@@ -79,13 +85,14 @@ async def test_coordinator_connection(
     mock_get_state.assert_called_once()
     assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
 
-
 async def test_coordinator_live_error(
     hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that the energy live coordinator handles fleet errors."""
 
-    await setup_platform(hass, [Platform.SENSOR])
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].live_coordinator
+    assert coordinator is not None
 
     mock_live_status.reset_mock()
     mock_live_status.side_effect = Forbidden
@@ -94,6 +101,9 @@ async def test_coordinator_live_error(
     await hass.async_block_till_done()
     mock_live_status.assert_called_once()
     assert hass.states.get("sensor.energy_site_solar_power").state == STATE_UNAVAILABLE
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
 async def test_coordinator_info_error(
@@ -101,7 +111,8 @@ async def test_coordinator_info_error(
 ) -> None:
     """Tests that the energy info coordinator handles fleet errors."""
 
-    await setup_platform(hass, [Platform.SENSOR])
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].info_coordinator
 
     mock_site_info.reset_mock()
     mock_site_info.side_effect = Forbidden
@@ -113,6 +124,9 @@ async def test_coordinator_info_error(
         hass.states.get("sensor.energy_site_vpp_backup_reserve").state
         == STATE_UNAVAILABLE
     )
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
 @pytest.mark.parametrize(
@@ -144,7 +158,9 @@ async def test_coordinator_energy_history_error(
 ) -> None:
     """Tests that the energy history coordinator handles fleet errors."""
 
-    await setup_platform(hass, [Platform.SENSOR])
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].history_coordinator
+    assert coordinator is not None
 
     mock_energy_history.reset_mock()
     mock_energy_history.side_effect = Forbidden
@@ -155,6 +171,9 @@ async def test_coordinator_energy_history_error(
     assert (
         hass.states.get("sensor.energy_site_grid_imported").state == STATE_UNAVAILABLE
     )
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
 async def test_coordinator_energy_history_invalid_data(
@@ -162,7 +181,9 @@ async def test_coordinator_energy_history_invalid_data(
 ) -> None:
     """Tests that the energy history coordinator handles invalid data."""
 
-    await setup_platform(hass, [Platform.SENSOR])
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].history_coordinator
+    assert coordinator is not None
 
     mock_energy_history.reset_mock()
     mock_energy_history.side_effect = lambda *a, **kw: {"response": {}}
@@ -173,3 +194,6 @@ async def test_coordinator_energy_history_invalid_data(
     assert (
         hass.states.get("sensor.energy_site_grid_imported").state == STATE_UNAVAILABLE
     )
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "invalid_energy_history_data"

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -96,6 +96,8 @@ async def test_errors(hass: HomeAssistant) -> None:
         )
     mock_set.assert_called_once()
     assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"
 
     # Test setting cover open with unknown error
     with (

--- a/tests/components/tessie/test_select.py
+++ b/tests/components/tessie/test_select.py
@@ -125,6 +125,8 @@ async def test_errors(hass: HomeAssistant) -> None:
         )
     mock_set.assert_called_once()
     assert error.value.__cause__ == ERROR_UNKNOWN
+    assert error.value.translation_domain == "tessie"
+    assert error.value.translation_key == "cannot_connect"
 
     # Test changing energy select with unknown error
     with (


### PR DESCRIPTION
## Proposed change
Add translated `cannot_connect` exceptions for Tessie entity command failures and coordinator update failures so user-facing errors are localized instead of raw API messages. Add/extend Tessie tests to assert translation metadata on these failure paths and mark the `exception-translations` quality scale item as done.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr