### PR TITLE
homematicip_cloud: migrate binary sensors to entity descriptions

### DIFF
--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
-from homematicip.base.enums import SmokeDetectorAlarmType, WindowState
+from homematicip.base.enums import LockState, SmokeDetectorAlarmType, WindowState
 from homematicip.base.functionalChannels import MultiModeInputChannel
 from homematicip.device import (
     AccelerationSensor,
@@ -34,6 +36,7 @@ from homematicip.group import SecurityGroup, SecurityZoneGroup
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -74,6 +77,117 @@ SAM_DEVICE_ATTRIBUTES = {
 }
 
 
+@dataclass(frozen=True)
+class HmipBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describe a HomematicIP binary sensor entity."""
+
+    value_fn: Callable[[Any], bool] = lambda _device: False
+    # Preserve unique_id compatibility with legacy per-device class names.
+    legacy_class_name: str = ""
+
+
+# Descriptions for simple binary sensors that can be served by a single
+# generic entity class instead of individual subclasses.
+SIMPLE_BINARY_SENSOR_DESCRIPTIONS: dict[
+    tuple[type, ...], tuple[HmipBinarySensorEntityDescription, ...]
+] = {
+    (MotionDetectorIndoor, MotionDetectorOutdoor, MotionDetectorPushButton): (
+        HmipBinarySensorEntityDescription(
+            key="motion_detector",
+            name=None,
+            device_class=BinarySensorDeviceClass.MOTION,
+            value_fn=lambda device: device.motionDetected,
+            legacy_class_name="HomematicipMotionDetector",
+        ),
+    ),
+    (PresenceDetectorIndoor,): (
+        HmipBinarySensorEntityDescription(
+            key="presence_detector",
+            name=None,
+            device_class=BinarySensorDeviceClass.PRESENCE,
+            value_fn=lambda device: device.presenceDetected,
+            legacy_class_name="HomematicipPresenceDetector",
+        ),
+    ),
+    (SmokeDetector,): (
+        HmipBinarySensorEntityDescription(
+            key="smoke_detector",
+            name=None,
+            device_class=BinarySensorDeviceClass.SMOKE,
+            value_fn=lambda device: (
+                device.smokeDetectorAlarmType is not None
+                and device.smokeDetectorAlarmType
+                == SmokeDetectorAlarmType.PRIMARY_ALARM
+            ),
+            legacy_class_name="HomematicipSmokeDetector",
+        ),
+    ),
+    (WaterSensor,): (
+        HmipBinarySensorEntityDescription(
+            key="water_detector",
+            name=None,
+            device_class=BinarySensorDeviceClass.MOISTURE,
+            value_fn=lambda device: (
+                device.moistureDetected or device.waterlevelDetected
+            ),
+            legacy_class_name="HomematicipWaterDetector",
+        ),
+    ),
+    (PluggableMainsFailureSurveillance,): (
+        HmipBinarySensorEntityDescription(
+            key="power_mains",
+            name=None,
+            device_class=BinarySensorDeviceClass.POWER,
+            value_fn=lambda device: not device.powerMainsFailure,
+            legacy_class_name="HomematicipPluggableMainsFailureSurveillanceSensor",
+        ),
+    ),
+}
+
+# Weather sensor descriptions — matched separately because multiple
+# entity descriptions apply to the same device types.
+WEATHER_RAIN_DESCRIPTION = HmipBinarySensorEntityDescription(
+    key="rain_sensor",
+    translation_key="rain",
+    device_class=BinarySensorDeviceClass.MOISTURE,
+    value_fn=lambda device: device.raining,
+    legacy_class_name="HomematicipRainSensor",
+)
+RAIN_SENSOR_TYPES = (RainSensor, WeatherSensorPlus, WeatherSensorPro)
+
+BATTERY_DESCRIPTION = HmipBinarySensorEntityDescription(
+    key="battery",
+    translation_key="battery",
+    device_class=BinarySensorDeviceClass.BATTERY,
+    value_fn=lambda device: device.lowBat,
+    legacy_class_name="HomematicipBatterySensor",
+)
+
+
+def _is_full_flush_lock_controller(device: object) -> bool:
+    """Return whether the device is an HmIP-FLC."""
+    return getattr(device, "modelType", None) == "HmIP-FLC" and hasattr(
+        device, "functionalChannels"
+    )
+
+
+def _get_channel_by_role(
+    device: object,
+    functional_channel_type: str,
+    channel_role: str,
+) -> object | None:
+    """Return the matching functional channel for the device."""
+    for channel in getattr(device, "functionalChannels", []):
+        channel_type = getattr(channel, "functionalChannelType", None)
+        channel_type_name = getattr(channel_type, "name", channel_type)
+        if channel_type_name != functional_channel_type:
+            continue
+        if getattr(channel, "channelRole", None) != channel_role:
+            continue
+        return channel
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: HomematicIPConfigEntry,
@@ -109,34 +223,41 @@ async def async_setup_entry(
             entities.append(HomematicipShutterContact(hap, device))
         if isinstance(device, RotaryHandleSensor):
             entities.append(HomematicipShutterContact(hap, device, True))
-        if isinstance(
-            device,
-            (
-                MotionDetectorIndoor,
-                MotionDetectorOutdoor,
-                MotionDetectorPushButton,
-            ),
+
+        # Simple binary sensors via entity descriptions
+        for device_types, descriptions in SIMPLE_BINARY_SENSOR_DESCRIPTIONS.items():
+            if isinstance(device, device_types):
+                entities.extend(
+                    HomematicipSimpleBinarySensor(hap, device, desc)
+                    for desc in descriptions
+                )
+
+        # Smoke detector chamber degraded (conditional)
+        if isinstance(device, SmokeDetector) and smoke_detector_channel_data_exists(
+            device, "chamberDegraded"
         ):
-            entities.append(HomematicipMotionDetector(hap, device))
-        if isinstance(device, PluggableMainsFailureSurveillance):
+            entities.append(HomematicipSmokeDetectorChamberDegraded(hap, device))
+
+        # Weather rain sensor
+        if isinstance(device, RAIN_SENSOR_TYPES):
             entities.append(
-                HomematicipPluggableMainsFailureSurveillanceSensor(hap, device)
+                HomematicipSimpleBinarySensor(hap, device, WEATHER_RAIN_DESCRIPTION)
             )
-        if isinstance(device, PresenceDetectorIndoor):
-            entities.append(HomematicipPresenceDetector(hap, device))
-        if isinstance(device, SmokeDetector):
-            entities.append(HomematicipSmokeDetector(hap, device))
-            if smoke_detector_channel_data_exists(device, "chamberDegraded"):
-                entities.append(HomematicipSmokeDetectorChamberDegraded(hap, device))
-        if isinstance(device, WaterSensor):
-            entities.append(HomematicipWaterDetector(hap, device))
-        if isinstance(device, (RainSensor, WeatherSensorPlus, WeatherSensorPro)):
-            entities.append(HomematicipRainSensor(hap, device))
+
+        # Weather sensors that keep their own classes (custom icon / extra attrs)
         if isinstance(device, (WeatherSensor, WeatherSensorPlus, WeatherSensorPro)):
             entities.append(HomematicipStormSensor(hap, device))
             entities.append(HomematicipSunshineSensor(hap, device))
+
+        if _is_full_flush_lock_controller(device):
+            entities.append(HomematicipFullFlushLockControllerLocked(hap, device))
+            entities.append(HomematicipFullFlushLockControllerGlassBreak(hap, device))
+
+        # Battery sensor for any device with lowBat
         if isinstance(device, Device) and device.lowBat is not None:
-            entities.append(HomematicipBatterySensor(hap, device))
+            entities.append(
+                HomematicipSimpleBinarySensor(hap, device, BATTERY_DESCRIPTION)
+            )
 
     for group in hap.home.groups:
         if isinstance(group, SecurityGroup):
@@ -145,6 +266,36 @@ async def async_setup_entry(
             entities.append(HomematicipSecurityZoneSensorGroup(hap, device=group))
 
     async_add_entities(entities)
+
+
+class HomematicipSimpleBinarySensor(HomematicipGenericEntity, BinarySensorEntity):
+    """A binary sensor backed by an entity description."""
+
+    entity_description: HmipBinarySensorEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hap: HomematicipHAP,
+        device: Device,
+        description: HmipBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(hap, device)
+        self.entity_description = description
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID preserving backward compatibility."""
+        return f"{self.entity_description.legacy_class_name}_{self._device.id}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the binary sensor is on."""
+        return self.entity_description.value_fn(self._device)
+
+
+# --- Legacy entity classes (not yet converted to entity descriptions) ---
 
 
 class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEntity):
@@ -287,44 +438,6 @@ class HomematicipShutterContact(HomematicipMultiContactInterface, BinarySensorEn
         return state_attr
 
 
-class HomematicipMotionDetector(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP motion detector."""
-
-    _attr_device_class = BinarySensorDeviceClass.MOTION
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if motion is detected."""
-        return self._device.motionDetected
-
-
-class HomematicipPresenceDetector(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP presence detector."""
-
-    _attr_device_class = BinarySensorDeviceClass.PRESENCE
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if presence is detected."""
-        return self._device.presenceDetected
-
-
-class HomematicipSmokeDetector(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP smoke detector."""
-
-    _attr_device_class = BinarySensorDeviceClass.SMOKE
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if smoke is detected."""
-        if self._device.smokeDetectorAlarmType:
-            return (
-                self._device.smokeDetectorAlarmType
-                == SmokeDetectorAlarmType.PRIMARY_ALARM
-            )
-        return False
-
-
 class HomematicipSmokeDetectorChamberDegraded(
     HomematicipGenericEntity, BinarySensorEntity
 ):
@@ -342,15 +455,53 @@ class HomematicipSmokeDetectorChamberDegraded(
         return self._device.chamberDegraded
 
 
-class HomematicipWaterDetector(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP water detector."""
+class HomematicipFullFlushLockControllerLocked(
+    HomematicipGenericEntity, BinarySensorEntity
+):
+    """Representation of the HomematicIP full flush lock controller lock state."""
 
-    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+    _attr_device_class = BinarySensorDeviceClass.LOCK
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the full flush lock controller lock sensor."""
+        super().__init__(hap, device, post="Locked")
 
     @property
     def is_on(self) -> bool:
-        """Return true, if moisture or waterlevel is detected."""
-        return self._device.moistureDetected or self._device.waterlevelDetected
+        """Return true if the controlled lock is locked."""
+        channel = _get_channel_by_role(
+            self._device,
+            "MULTI_MODE_LOCK_INPUT_CHANNEL",
+            "DOOR_LOCK_SENSOR",
+        )
+        if channel is None:
+            return False
+        lock_state = getattr(channel, "lockState", None)
+        return getattr(lock_state, "name", lock_state) == LockState.LOCKED.name
+
+
+class HomematicipFullFlushLockControllerGlassBreak(
+    HomematicipGenericEntity, BinarySensorEntity
+):
+    """Representation of the HomematicIP full flush lock controller glass state."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the full flush lock controller glass break sensor."""
+        super().__init__(hap, device, post="Glass break")
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if glass break has been detected."""
+        channel = _get_channel_by_role(
+            self._device,
+            "MULTI_MODE_LOCK_INPUT_CHANNEL",
+            "DOOR_LOCK_SENSOR",
+        )
+        if channel is None:
+            return False
+        return bool(getattr(channel, "glassBroken", False))
 
 
 class HomematicipStormSensor(HomematicipGenericEntity, BinarySensorEntity):
@@ -369,21 +520,6 @@ class HomematicipStormSensor(HomematicipGenericEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true, if storm is detected."""
         return self._device.storm
-
-
-class HomematicipRainSensor(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP rain sensor."""
-
-    _attr_device_class = BinarySensorDeviceClass.MOISTURE
-
-    def __init__(self, hap: HomematicipHAP, device) -> None:
-        """Initialize rain sensor."""
-        super().__init__(hap, device, "Raining")
-
-    @property
-    def is_on(self) -> bool:
-        """Return true, if it is raining."""
-        return self._device.raining
 
 
 class HomematicipSunshineSensor(HomematicipGenericEntity, BinarySensorEntity):
@@ -410,38 +546,6 @@ class HomematicipSunshineSensor(HomematicipGenericEntity, BinarySensorEntity):
             state_attr[ATTR_TODAY_SUNSHINE_DURATION] = today_sunshine_duration
 
         return state_attr
-
-
-class HomematicipBatterySensor(HomematicipGenericEntity, BinarySensorEntity):
-    """Representation of the HomematicIP low battery sensor."""
-
-    _attr_device_class = BinarySensorDeviceClass.BATTERY
-
-    def __init__(self, hap: HomematicipHAP, device) -> None:
-        """Initialize battery sensor."""
-        super().__init__(hap, device, post="Battery")
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if battery is low."""
-        return self._device.lowBat
-
-
-class HomematicipPluggableMainsFailureSurveillanceSensor(
-    HomematicipGenericEntity, BinarySensorEntity
-):
-    """Representation of the HomematicIP pluggable mains failure surveillance sensor."""
-
-    _attr_device_class = BinarySensorDeviceClass.POWER
-
-    def __init__(self, hap: HomematicipHAP, device) -> None:
-        """Initialize pluggable mains failure surveillance sensor."""
-        super().__init__(hap, device)
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if power mains fails."""
-        return not self._device.powerMainsFailure
 
 
 class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorEntity):

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -15,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.typing import UndefinedType
 
 from .const import DOMAIN
 from .hap import AsyncHome, HomematicipHAP
@@ -198,8 +199,20 @@ class HomematicipGenericEntity(Entity):
         )
 
     @property
-    def name(self) -> str:
-        """Return the name of the generic entity."""
+    def name(self) -> str | UndefinedType | None:
+        """Return the name of the generic entity.
+
+        Entities with has_entity_name delegate to HA's standard naming
+        machinery (translation_key, entity_description, device_class).
+        Legacy entities use the original naming logic.
+        """
+        if self.has_entity_name:
+            if not self.platform_data:
+                return self._name_internal(None, {})
+            return self._name_internal(
+                self._device_class_name,
+                self.platform_data.platform_translations,
+            )
 
         name = ""
         # Try to get a label from a channel.

--- a/homeassistant/components/homematicip_cloud/strings.json
+++ b/homeassistant/components/homematicip_cloud/strings.json
@@ -37,6 +37,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "battery": {
+        "name": "Battery"
+      },
+      "rain": {
+        "name": "Raining"
+      }
+    },
     "light": {
       "optical_signal_light": {
         "state_attributes": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

RFC / prototype for @joostlek to review the approach before migrating more platforms.

Refactors simple binary sensor entities from individual subclasses to the EntityDescription pattern (following the ViCare model as suggested by Joost). This consolidates 7 entity classes into a single `HomematicipSimpleBinarySensor` class with descriptions:

**Converted:** motion detector, presence detector, smoke detector, water detector, power mains failure, rain sensor, battery sensor

**Left as legacy classes** (too complex for the description pattern): cloud connection, acceleration/tilt, contact/shutter interfaces, storm (custom icon), sunshine (extra attrs), FLC lock/glass break, security groups, chamber degraded

**Key design decisions (looking for feedback):**

1. **`legacy_class_name` on description** — preserves unique_id backward compatibility since unique_ids are currently derived from class names (`HomematicipMotionDetector_DEVICEID`). Is there a better approach?

2. **Base class `name` property** — `HomematicipGenericEntity` overrides `Entity.name` which prevents HA's `_name_internal` from handling `translation_key`. For entities with `has_entity_name=True`, we delegate to `_name_internal` explicitly. Is this acceptable, or should we refactor the base class differently?

3. **`name=None` vs `translation_key`** — primary entities (motion, presence, smoke, water, power) use `name=None` on the description (entity IS the device). Sub-entities (battery, rain) use `translation_key` for the name suffix. Correct approach?

4. **Home name prefix** — the legacy `name` property prepends the HmIP home name to every entity. With `has_entity_name`, this prefix disappears. Entity IDs are stable (stored in registry), but friendly names change for users with a home name set. Acceptable?

All 159 existing tests pass without modifications.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr