### PR TITLE
Abort WiiM config flow when Home Assistant URL is unavailable

### DIFF
--- a/homeassistant/components/wiim/__init__.py
+++ b/homeassistant/components/wiim/__init__.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from urllib.parse import urlparse
-
 from wiim.controller import WiimController
 from wiim.discovery import async_create_wiim_device
 from wiim.exceptions import WiimDeviceException, WiimRequestException
@@ -13,10 +10,10 @@ from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.network import NoURLAvailableError, get_url
 
 from .const import DATA_WIIM, DOMAIN, LOGGER, PLATFORMS, UPNP_PORT, WiimConfigEntry
 from .models import WiimData
+from .util import InvalidHomeAssistantURLError, get_homeassistant_local_host
 
 DEFAULT_AVAILABILITY_POLLING_INTERVAL = 60
 
@@ -54,13 +51,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: WiimConfigEntry) -> bool
     upnp_location = f"http://{host}:{UPNP_PORT}/description.xml"
 
     try:
-        base_url = get_url(hass, prefer_external=False)
-    except NoURLAvailableError as err:
+        local_host = get_homeassistant_local_host(hass)
+    except InvalidHomeAssistantURLError as err:
         raise ConfigEntryNotReady("Failed to determine Home Assistant URL") from err
-
-    local_host = urlparse(base_url).hostname
-    if TYPE_CHECKING:
-        assert local_host is not None
 
     try:
         wiim_device = await async_create_wiim_device(

--- a/homeassistant/components/wiim/config_flow.py
+++ b/homeassistant/components/wiim/config_flow.py
@@ -10,12 +10,13 @@ from wiim.models import WiimProbeResult
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN, LOGGER, UPNP_PORT
+from .util import InvalidHomeAssistantURLError, get_homeassistant_local_host
 
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
@@ -44,10 +45,22 @@ class WiimConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _discovered_info: WiimProbeResult | None = None
 
+    @callback
+    def _async_abort_if_homeassistant_url_invalid(self) -> ConfigFlowResult | None:
+        """Abort if Home Assistant does not expose a usable URL for WiiM."""
+        try:
+            get_homeassistant_local_host(self.hass)
+        except InvalidHomeAssistantURLError:
+            return self.async_abort(reason="missing_homeassistant_url")
+        return None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step when user adds integration manually."""
+        if invalid_url_result := self._async_abort_if_homeassistant_url_invalid():
+            return invalid_url_result
+
         errors: dict[str, str] = {}
         if user_input is not None:
             host = user_input[CONF_HOST]
@@ -77,6 +90,9 @@ class WiimConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle Zeroconf discovery."""
+        if invalid_url_result := self._async_abort_if_homeassistant_url_invalid():
+            return invalid_url_result
+
         LOGGER.debug(
             "Zeroconf discovery received: Name: %s, Host: %s, Port: %s, Properties: %s",
             discovery_info.name,

--- a/homeassistant/components/wiim/config_flow.py
+++ b/homeassistant/components/wiim/config_flow.py
@@ -10,7 +10,7 @@ from wiim.models import WiimProbeResult
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -45,21 +45,14 @@ class WiimConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _discovered_info: WiimProbeResult | None = None
 
-    @callback
-    def _async_abort_if_homeassistant_url_invalid(self) -> ConfigFlowResult | None:
-        """Abort if Home Assistant does not expose a usable URL for WiiM."""
-        try:
-            get_homeassistant_local_host(self.hass)
-        except InvalidHomeAssistantURLError:
-            return self.async_abort(reason="missing_homeassistant_url")
-        return None
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step when user adds integration manually."""
-        if invalid_url_result := self._async_abort_if_homeassistant_url_invalid():
-            return invalid_url_result
+        try:
+            get_homeassistant_local_host(self.hass)
+        except InvalidHomeAssistantURLError:
+            return self.async_abort(reason="missing_homeassistant_url")
 
         errors: dict[str, str] = {}
         if user_input is not None:
@@ -90,9 +83,6 @@ class WiimConfigFlow(ConfigFlow, domain=DOMAIN):
         self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle Zeroconf discovery."""
-        if invalid_url_result := self._async_abort_if_homeassistant_url_invalid():
-            return invalid_url_result
-
         LOGGER.debug(
             "Zeroconf discovery received: Name: %s, Host: %s, Port: %s, Properties: %s",
             discovery_info.name,

--- a/homeassistant/components/wiim/strings.json
+++ b/homeassistant/components/wiim/strings.json
@@ -3,7 +3,8 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "missing_homeassistant_url": "Failed to determine Home Assistant URL"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/wiim/strings.json
+++ b/homeassistant/components/wiim/strings.json
@@ -4,7 +4,7 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "missing_homeassistant_url": "Failed to determine Home Assistant URL"
+      "missing_homeassistant_url": "Failed to determine Home Assistant URL. Please make sure you have an internal URL set."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/wiim/util.py
+++ b/homeassistant/components/wiim/util.py
@@ -1,0 +1,28 @@
+"""Utility helpers for the WiiM integration."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.network import NoURLAvailableError, get_url
+
+
+class InvalidHomeAssistantURLError(HomeAssistantError):
+    """Error to indicate Home Assistant does not expose a usable URL."""
+
+
+def get_homeassistant_local_host(hass: HomeAssistant) -> str:
+    """Return the Home Assistant hostname that WiiM devices should use."""
+    try:
+        base_url = get_url(hass, prefer_external=False)
+    except NoURLAvailableError as err:
+        raise InvalidHomeAssistantURLError(
+            "Failed to determine Home Assistant URL"
+        ) from err
+
+    if local_host := urlparse(base_url).hostname:
+        return local_host
+
+    raise InvalidHomeAssistantURLError("Failed to determine Home Assistant URL")

--- a/tests/components/wiim/test_config_flow.py
+++ b/tests/components/wiim/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the WiiM config flow."""
 
 from ipaddress import ip_address
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -9,6 +9,7 @@ from homeassistant.components.wiim.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
@@ -25,6 +26,16 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
     properties={"uuid": "uuid:test-udn-1234"},
     type="_linkplay._tcp.local.",
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_get_url() -> MagicMock:
+    """Mock Home Assistant URL discovery."""
+    with patch(
+        "homeassistant.components.wiim.util.get_url",
+        return_value="http://192.168.1.10:8123",
+    ) as mock_get_url:
+        yield mock_get_url
 
 
 @pytest.mark.usefixtures("mock_probe_player", "mock_setup_entry")
@@ -46,6 +57,23 @@ async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
     assert result["title"] == "WiiM Pro"
     assert result["data"] == {CONF_HOST: "192.168.1.100"}
     assert result["result"].unique_id == "uuid:test-udn-1234"
+
+
+async def test_user_flow_abort_when_homeassistant_url_missing(
+    hass: HomeAssistant,
+    mock_probe_player: AsyncMock,
+    mock_get_url: MagicMock,
+) -> None:
+    """Test the user flow aborts before probing when no URL is available."""
+    mock_get_url.side_effect = NoURLAvailableError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_homeassistant_url"
+    mock_probe_player.assert_not_called()
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -148,6 +176,25 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     assert result["title"] == "WiiM Pro"
     assert result["data"] == {CONF_HOST: "192.168.1.100"}
     assert result["result"].unique_id == "uuid:test-udn-1234"
+
+
+async def test_zeroconf_flow_abort_when_homeassistant_url_missing(
+    hass: HomeAssistant,
+    mock_probe_player: AsyncMock,
+    mock_get_url: MagicMock,
+) -> None:
+    """Test zeroconf aborts before probing when no URL is available."""
+    mock_get_url.side_effect = NoURLAvailableError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "missing_homeassistant_url"
+    mock_probe_player.assert_not_called()
 
 
 async def test_zeroconf_flow_cannot_connect(

--- a/tests/components/wiim/test_config_flow.py
+++ b/tests/components/wiim/test_config_flow.py
@@ -9,8 +9,8 @@ from homeassistant.components.wiim.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from tests.common import MockConfigEntry
@@ -176,25 +176,6 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     assert result["title"] == "WiiM Pro"
     assert result["data"] == {CONF_HOST: "192.168.1.100"}
     assert result["result"].unique_id == "uuid:test-udn-1234"
-
-
-async def test_zeroconf_flow_abort_when_homeassistant_url_missing(
-    hass: HomeAssistant,
-    mock_probe_player: AsyncMock,
-    mock_get_url: MagicMock,
-) -> None:
-    """Test zeroconf aborts before probing when no URL is available."""
-    mock_get_url.side_effect = NoURLAvailableError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data=DISCOVERY_INFO,
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "missing_homeassistant_url"
-    mock_probe_player.assert_not_called()
 
 
 async def test_zeroconf_flow_cannot_connect(

--- a/tests/components/wiim/test_config_flow.py
+++ b/tests/components/wiim/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the WiiM config flow."""
 
 from ipaddress import ip_address
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -9,6 +9,7 @@ from homeassistant.components.wiim.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.network import NoURLAvailableError
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
@@ -29,13 +30,12 @@ DISCOVERY_INFO = ZeroconfServiceInfo(
 
 
 @pytest.fixture(autouse=True)
-def mock_get_url() -> MagicMock:
-    """Mock Home Assistant URL discovery."""
-    with patch(
-        "homeassistant.components.wiim.util.get_url",
-        return_value="http://192.168.1.10:8123",
-    ) as mock_get_url:
-        yield mock_get_url
+async def setup_internal_url(hass: HomeAssistant) -> None:
+    """Make sure internal url configured."""
+    await async_process_ha_core_config(
+        hass,
+        {"internal_url": "http://192.168.1.10:8123"},
+    )
 
 
 @pytest.mark.usefixtures("mock_probe_player", "mock_setup_entry")
@@ -62,14 +62,15 @@ async def test_user_flow_create_entry(hass: HomeAssistant) -> None:
 async def test_user_flow_abort_when_homeassistant_url_missing(
     hass: HomeAssistant,
     mock_probe_player: AsyncMock,
-    mock_get_url: MagicMock,
 ) -> None:
     """Test the user flow aborts before probing when no URL is available."""
-    mock_get_url.side_effect = NoURLAvailableError
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    with patch(
+        "homeassistant.components.wiim.util.get_url",
+        side_effect=NoURLAvailableError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "missing_homeassistant_url"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wiim requires Home Assistant to be locally accessible. This check was done during setup_entry, but is now also done during the config flow. Thanks to Joost for suggestion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
