### PR TITLE
Properly handle buttons of SMLIGHT SLZB-MRxU devices

### DIFF
--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -1,4 +1,4 @@
-"""Support for SLZB-06 buttons."""
+"""Support for SLZB buttons."""
 
 from __future__ import annotations
 
@@ -35,24 +35,25 @@ class SmButtonDescription(ButtonEntityDescription):
     press_fn: Callable[[CmdWrapper, int], Awaitable[None]]
 
 
-BUTTONS: list[SmButtonDescription] = [
-    SmButtonDescription(
-        key="core_restart",
-        translation_key="core_restart",
-        device_class=ButtonDeviceClass.RESTART,
-        press_fn=lambda cmd, idx: cmd.reboot(),
-    ),
+CORE_BUTTON = SmButtonDescription(
+    key="core_restart",
+    translation_key="core_restart",
+    device_class=ButtonDeviceClass.RESTART,
+    press_fn=lambda cmd, idx: cmd.reboot(),
+)
+
+RADIO_BUTTONS: list[SmButtonDescription] = [
     SmButtonDescription(
         key="zigbee_restart",
         translation_key="zigbee_restart",
         device_class=ButtonDeviceClass.RESTART,
-        press_fn=lambda cmd, idx: cmd.zb_restart(),
+        press_fn=lambda cmd, idx: cmd.zb_restart(idx=idx),
     ),
     SmButtonDescription(
         key="zigbee_flash_mode",
         translation_key="zigbee_flash_mode",
         entity_registry_enabled_default=False,
-        press_fn=lambda cmd, idx: cmd.zb_bootloader(),
+        press_fn=lambda cmd, idx: cmd.zb_bootloader(idx=idx),
     ),
 ]
 
@@ -73,7 +74,13 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.data
     radios = coordinator.data.info.radios
 
-    async_add_entities(SmButton(coordinator, button) for button in BUTTONS)
+    entities = [SmButton(coordinator, CORE_BUTTON)]
+    count = len(radios) if coordinator.data.info.u_device else 1
+
+    for idx in range(count):
+        entities.extend(SmButton(coordinator, button, idx) for button in RADIO_BUTTONS)
+
+    async_add_entities(entities)
     entity_created = [False] * len(radios)
 
     @callback
@@ -103,7 +110,7 @@ async def async_setup_entry(
 
 
 class SmButton(SmEntity, ButtonEntity):
-    """Defines a SLZB-06 button."""
+    """Defines a SLZB button."""
 
     coordinator: SmDataUpdateCoordinator
     entity_description: SmButtonDescription
@@ -115,7 +122,7 @@ class SmButton(SmEntity, ButtonEntity):
         description: SmButtonDescription,
         idx: int = 0,
     ) -> None:
-        """Initialize SLZB-06 button entity."""
+        """Initialize SLZB button entity."""
         super().__init__(coordinator)
 
         self.entity_description = description

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -147,6 +147,62 @@ async def test_remove_router_reconnect(
     assert entity is None
 
 
+@pytest.mark.parametrize(
+    ("key", "idx"),
+    [
+        ("zigbee_restart", 0),
+        ("zigbee_flash_mode", 0),
+        ("zigbee_restart", 1),
+        ("zigbee_flash_mode", 1),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_multi_radio_buttons_u_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    key: str,
+    idx: int,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test per-radio restart and flash mode buttons on a u-device."""
+    mock_smlight_client.get_info.side_effect = None
+    info = Info.from_dict(
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
+    )
+    info.u_device = True
+    mock_smlight_client.get_info.return_value = info
+
+    await setup_integration(hass, mock_config_entry)
+
+    unique_id_suffix = f"_{idx}" if idx else ""
+    unique_id = f"aa:bb:cc:dd:ee:ff-{key}{unique_id_suffix}"
+    assert (
+        entity_registry.async_get_entity_id(BUTTON_DOMAIN, DOMAIN, unique_id)
+        is not None
+    )
+
+
+@pytest.mark.parametrize("key", ["zigbee_restart", "zigbee_flash_mode"])
+async def test_multi_radio_buttons_shared_non_u_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    key: str,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test that idx>0 radio buttons are not created for non-u-devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info.from_dict(
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    assert not entity_registry.async_get_entity_id(
+        BUTTON_DOMAIN, DOMAIN, f"aa:bb:cc:dd:ee:ff-{key}_1"
+    )
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_router_button_with_3_radios(
     hass: HomeAssistant,

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -183,6 +183,52 @@ async def test_multi_radio_buttons_u_device(
     )
 
 
+@pytest.mark.parametrize(
+    ("key", "method", "idx"),
+    [
+        ("zigbee_restart", "zb_restart", 0),
+        ("zigbee_restart", "zb_restart", 1),
+        ("zigbee_flash_mode", "zb_bootloader", 0),
+        ("zigbee_flash_mode", "zb_bootloader", 1),
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_multi_radio_press_calls_idx(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    key: str,
+    method: str,
+    idx: int,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test pressing per-radio buttons passes the correct idx to the command."""
+    mock_smlight_client.get_info.side_effect = None
+    info = Info.from_dict(
+        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
+    )
+    info.u_device = True
+    mock_smlight_client.get_info.return_value = info
+
+    await setup_integration(hass, mock_config_entry)
+
+    unique_id_suffix = f"_{idx}" if idx else ""
+    unique_id = f"aa:bb:cc:dd:ee:ff-{key}{unique_id_suffix}"
+    entity_id = entity_registry.async_get_entity_id(BUTTON_DOMAIN, DOMAIN, unique_id)
+    assert entity_id is not None
+
+    mock_method = getattr(mock_smlight_client.cmds, method)
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_method.assert_called_once_with(idx=idx)
+
+
 @pytest.mark.parametrize("key", ["zigbee_restart", "zigbee_flash_mode"])
 async def test_multi_radio_buttons_shared_non_u_device(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SLZB-MRxU devices have individual restart and flash mode buttons for each radio. The older SLZB-MRx devices only had shared buttons for both radios.


Add support for these to the Button platform, and add tests for both variants.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166049
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
