### PR TITLE
Validate port ranges in URL validator

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -868,8 +868,13 @@ def url(
 ) -> str:
     """Validate an URL."""
     url_in = str(value)
+    parsed = urlparse(url_in)
 
-    if urlparse(url_in).scheme in _schema_list:
+    if parsed.scheme in _schema_list:
+        try:
+            parsed.port
+        except ValueError as err:
+            raise vol.Invalid("invalid url") from err
         return cast(str, vol.Schema(vol.Url())(url_in))
 
     raise vol.Invalid("invalid url")

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -870,14 +870,15 @@ def url(
     url_in = str(value)
     parsed = urlparse(url_in)
 
-    if parsed.scheme in _schema_list:
-        try:
-            parsed.port
-        except ValueError as err:
-            raise vol.Invalid("invalid url") from err
-        return cast(str, vol.Schema(vol.Url())(url_in))
+    if parsed.scheme not in _schema_list:
+        raise vol.Invalid("invalid url")
+    
+    try:
+        parsed.port  # noqa: B018
+    except ValueError as err:
+        raise vol.Invalid("invalid url") from err
+    return cast(str, vol.Schema(vol.Url())(url_in))
 
-    raise vol.Invalid("invalid url")
 
 
 def configuration_url(value: Any) -> str:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -872,13 +872,12 @@ def url(
 
     if parsed.scheme not in _schema_list:
         raise vol.Invalid("invalid url")
-    
+
     try:
         parsed.port  # noqa: B018
     except ValueError as err:
         raise vol.Invalid("invalid url") from err
     return cast(str, vol.Schema(vol.Url())(url_in))
-
 
 
 def configuration_url(value: Any) -> str:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -874,7 +874,7 @@ def url(
         raise vol.Invalid("invalid url")
 
     try:
-        parsed.port  # noqa: B018
+        _port = parsed.port
     except ValueError as err:
         raise vol.Invalid("invalid url") from err
     return cast(str, vol.Schema(vol.Url())(url_in))

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -172,6 +172,7 @@ def test_url_no_path() -> None:
     for value in (
         "https://localhost/test/index.html",
         "http://home-assistant.io/test/",
+        "http://invalid-port.local:999999",
     ):
         with pytest.raises(vol.MultipleInvalid):
             schema(value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Was trying to set an invalid external URL to see the error message and got a stack trace. Our URL validator accepted the URL, but then it broke HA internally, because get_url would fail. This fixes it.

```
2026-03-20 19:58:50.155 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [4854687168] Error handling message: Unknown error (unknown_error) Paulus from ::1 (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36)
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/components/websocket_api/connection.py", line 235, in async_handle
    handler(self.hass, self, msg)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/paulus/dev/hass/core/homeassistant/components/network/websocket.py", line 86, in websocket_network_url
    internal_url = get_url(
        hass, allow_internal=True, allow_external=False, allow_cloud=False
    )
  File "/Users/paulus/dev/hass/core/homeassistant/helpers/network.py", line 150, in get_url
    return _get_internal_url(
        hass,
    ...<3 lines>...
        require_standard_port=require_standard_port,
    )
  File "/Users/paulus/dev/hass/core/homeassistant/helpers/network.py", line 243, in _get_internal_url
    internal_url = yarl.URL(hass.config.internal_url)
  File "/Users/paulus/dev/hass/core/.venv/lib/python3.14/site-packages/yarl/_url.py", line 377, in __new__
    return pre_encoded_url(val) if encoded else encode_url(val)
                                                ~~~~~~~~~~^^^^^
  File "/Users/paulus/dev/hass/core/.venv/lib/python3.14/site-packages/yarl/_url.py", line 174, in encode_url
    username, password, host, port = split_netloc(netloc)
                                     ~~~~~~~~~~~~^^^^^^^^
  File "/Users/paulus/dev/hass/core/.venv/lib/python3.14/site-packages/yarl/_parse.py", line 137, in split_netloc
    raise ValueError("Port out of range 0-65535")
ValueError: Port out of range 0-65535
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
