### PR TITLE
Add diagnostics platform to air-Q integration

### DIFF
--- a/homeassistant/components/airq/diagnostics.py
+++ b/homeassistant/components/airq/diagnostics.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_PASSWORD
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
 from . import AirQConfigEntry
 
-REDACT_CONFIG = {CONF_PASSWORD}
-REDACT_DATA = {"device_id"}
+REDACT_CONFIG = {CONF_PASSWORD, CONF_UNIQUE_ID, CONF_IP_ADDRESS, "title"}
+REDACT_DEVICE_INFO = {"identifiers", "name"}
+REDACT_COORDINATOR_DATA = {"DeviceID"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -22,8 +23,12 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "config_entry": async_redact_data(entry.as_dict(), REDACT_CONFIG),
-        "device_info": async_redact_data(dict(coordinator.device_info), REDACT_DATA),
-        "coordinator_data": coordinator.data,
+        "device_info": async_redact_data(
+            dict(coordinator.device_info), REDACT_DEVICE_INFO
+        ),
+        "coordinator_data": async_redact_data(
+            coordinator.data, REDACT_COORDINATOR_DATA
+        ),
         "options": {
             "clip_negative": coordinator.clip_negative,
             "return_average": coordinator.return_average,

--- a/homeassistant/components/airq/diagnostics.py
+++ b/homeassistant/components/airq/diagnostics.py
@@ -1,0 +1,31 @@
+"""Diagnostics support for air-Q."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from . import AirQConfigEntry
+
+REDACT_CONFIG = {CONF_PASSWORD}
+REDACT_DATA = {"device_id"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: AirQConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+
+    return {
+        "config_entry": async_redact_data(entry.as_dict(), REDACT_CONFIG),
+        "device_info": async_redact_data(dict(coordinator.device_info), REDACT_DATA),
+        "coordinator_data": coordinator.data,
+        "options": {
+            "clip_negative": coordinator.clip_negative,
+            "return_average": coordinator.return_average,
+        },
+    }

--- a/tests/components/airq/snapshots/test_diagnostics.ambr
+++ b/tests/components/airq/snapshots/test_diagnostics.ambr
@@ -2,7 +2,7 @@
 # name: test_entry_diagnostics
   dict({
     'config_entry': dict({
-      'created_at': '2026-03-20T11:10:48.218455+00:00',
+      'created_at': '2025-01-01T00:00:00+00:00',
       'data': dict({
         'ip_address': '**REDACTED**',
         'password': '**REDACTED**',
@@ -11,9 +11,9 @@
       'discovery_keys': dict({
       }),
       'domain': 'airq',
-      'entry_id': '01KM5F1MWTJ31AJGSNG4D2YM2G',
+      'entry_id': '01JGFJJZ008DNE3BKJ7ZE14YFE',
       'minor_version': 1,
-      'modified_at': '2026-03-20T11:10:48.218459+00:00',
+      'modified_at': '2025-01-01T00:00:00+00:00',
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/airq/snapshots/test_diagnostics.ambr
+++ b/tests/components/airq/snapshots/test_diagnostics.ambr
@@ -1,0 +1,46 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'config_entry': dict({
+      'created_at': '2026-03-20T11:10:48.218455+00:00',
+      'data': dict({
+        'ip_address': '**REDACTED**',
+        'password': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'airq',
+      'entry_id': '01KM5F1MWTJ31AJGSNG4D2YM2G',
+      'minor_version': 1,
+      'modified_at': '2026-03-20T11:10:48.218459+00:00',
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': '**REDACTED**',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+    'coordinator_data': dict({
+      'Status': 'OK',
+      'brightness': 42,
+      'co2': 500.0,
+    }),
+    'device_info': dict({
+      'hw_version': 'hw',
+      'identifiers': '**REDACTED**',
+      'manufacturer': 'CorantGmbH',
+      'model': 'model',
+      'name': '**REDACTED**',
+      'sw_version': 'sw',
+    }),
+    'options': dict({
+      'clip_negative': True,
+      'return_average': True,
+    }),
+  })
+# ---

--- a/tests/components/airq/test_diagnostics.py
+++ b/tests/components/airq/test_diagnostics.py
@@ -1,5 +1,6 @@
 """Test air-Q diagnostics."""
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.airq.const import DOMAIN
@@ -11,7 +12,10 @@ from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
+FIXED_MOCK_ENTRY_ID = "01JGFJJZ008DNE3BKJ7ZE14YFE"
 
+
+@pytest.mark.freeze_time("2025-01-01T00:00:00+00:00")
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -20,7 +24,10 @@ async def test_entry_diagnostics(
 ) -> None:
     """Test config entry diagnostics."""
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data=TEST_USER_DATA, unique_id=TEST_DEVICE_INFO["id"]
+        domain=DOMAIN,
+        data=TEST_USER_DATA,
+        unique_id=TEST_DEVICE_INFO["id"],
+        entry_id=FIXED_MOCK_ENTRY_ID,
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/airq/test_diagnostics.py
+++ b/tests/components/airq/test_diagnostics.py
@@ -2,7 +2,10 @@
 
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.airq.const import DOMAIN
 from homeassistant.core import HomeAssistant
+
+from .common import TEST_DEVICE_INFO, TEST_USER_DATA
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
@@ -12,17 +15,17 @@ from tests.typing import ClientSessionGenerator
 async def test_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_config_entry: MockConfigEntry,
     mock_airq,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=TEST_USER_DATA, unique_id=TEST_DEVICE_INFO["id"]
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    result = await get_diagnostics_for_config_entry(
-        hass, hass_client, mock_config_entry
-    )
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
 
     assert result == snapshot

--- a/tests/components/airq/test_diagnostics.py
+++ b/tests/components/airq/test_diagnostics.py
@@ -1,0 +1,28 @@
+"""Test air-Q diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_airq,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert result == snapshot


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add diagnostics platform to the air-Q integration. The diagnostics output
includes the config entry, device info, coordinator data, and integration
options, with sensitive fields (password, IP address, unique ID, device 
name, and identifiers) redacted.

This PR supersedes #166041

Co-authored-by: claw-explorer 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
