### PR TITLE
Updates for Casper glow Integraiton - Add Buttons

### DIFF
--- a/homeassistant/components/casper_glow/__init__.py
+++ b/homeassistant/components/casper_glow/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .coordinator import CasperGlowConfigEntry, CasperGlowCoordinator
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.LIGHT]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.LIGHT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CasperGlowConfigEntry) -> bool:

--- a/homeassistant/components/casper_glow/button.py
+++ b/homeassistant/components/casper_glow/button.py
@@ -1,0 +1,73 @@
+"""Casper Glow integration button platform."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from pycasperglow import CasperGlow
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import CasperGlowConfigEntry, CasperGlowCoordinator
+from .entity import CasperGlowEntity
+
+PARALLEL_UPDATES = 1
+
+
+@dataclass(frozen=True, kw_only=True)
+class CasperGlowButtonEntityDescription(ButtonEntityDescription):
+    """Describe a Casper Glow button entity."""
+
+    press_fn: Callable[[CasperGlow], Awaitable[None]]
+
+
+BUTTON_DESCRIPTIONS: tuple[CasperGlowButtonEntityDescription, ...] = (
+    CasperGlowButtonEntityDescription(
+        key="pause",
+        translation_key="pause",
+        press_fn=lambda device: device.pause(),
+    ),
+    CasperGlowButtonEntityDescription(
+        key="resume",
+        translation_key="resume",
+        press_fn=lambda device: device.resume(),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: CasperGlowConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the button platform for Casper Glow."""
+    async_add_entities(
+        CasperGlowButton(entry.runtime_data, description)
+        for description in BUTTON_DESCRIPTIONS
+    )
+
+
+class CasperGlowButton(CasperGlowEntity, ButtonEntity):
+    """A Casper Glow button entity."""
+
+    entity_description: CasperGlowButtonEntityDescription
+
+    def __init__(
+        self,
+        coordinator: CasperGlowCoordinator,
+        description: CasperGlowButtonEntityDescription,
+    ) -> None:
+        """Initialize a Casper Glow button."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{format_mac(coordinator.device.address)}_{description.key}"
+        )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        await self._async_command(self.entity_description.press_fn(self._device))

--- a/homeassistant/components/casper_glow/icons.json
+++ b/homeassistant/components/casper_glow/icons.json
@@ -4,6 +4,14 @@
       "paused": {
         "default": "mdi:timer-pause"
       }
+    },
+    "button": {
+      "pause": {
+        "default": "mdi:pause"
+      },
+      "resume": {
+        "default": "mdi:play"
+      }
     }
   }
 }

--- a/homeassistant/components/casper_glow/manifest.json
+++ b/homeassistant/components/casper_glow/manifest.json
@@ -14,6 +14,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pycasperglow"],
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["pycasperglow==1.1.0"]
 }

--- a/homeassistant/components/casper_glow/quality_scale.yaml
+++ b/homeassistant/components/casper_glow/quality_scale.yaml
@@ -32,7 +32,9 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow:
+    status: exempt
+    comment: Bluetooth device with no authentication credentials.
   test-coverage: done
 
   # Gold
@@ -53,15 +55,9 @@ rules:
   entity-category: todo
   entity-device-class: todo
   entity-disabled-by-default: todo
-  entity-translations:
-    status: exempt
-    comment: No entity translations needed.
-  exception-translations:
-    status: exempt
-    comment: No custom services that raise exceptions.
-  icon-translations:
-    status: exempt
-    comment: No icon translations needed.
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices: todo

--- a/homeassistant/components/casper_glow/strings.json
+++ b/homeassistant/components/casper_glow/strings.json
@@ -31,6 +31,14 @@
       "paused": {
         "name": "Dimming paused"
       }
+    },
+    "button": {
+      "pause": {
+        "name": "Pause dimming"
+      },
+      "resume": {
+        "name": "Resume dimming"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/casper_glow/snapshots/test_button.ambr
+++ b/tests/components/casper_glow/snapshots/test_button.ambr
@@ -1,0 +1,101 @@
+# serializer version: 1
+# name: test_entities[button.jar_pause_dimming-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.jar_pause_dimming',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Pause dimming',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Pause dimming',
+    'platform': 'casper_glow',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pause',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_pause',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.jar_pause_dimming-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Jar Pause dimming',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.jar_pause_dimming',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entities[button.jar_resume_dimming-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.jar_resume_dimming',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Resume dimming',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Resume dimming',
+    'platform': 'casper_glow',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'resume',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_resume',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[button.jar_resume_dimming-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Jar Resume dimming',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.jar_resume_dimming',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/casper_glow/test_button.py
+++ b/tests/components/casper_glow/test_button.py
@@ -1,0 +1,85 @@
+"""Test the Casper Glow button platform."""
+
+from unittest.mock import MagicMock, patch
+
+from pycasperglow import CasperGlowError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+PAUSE_ENTITY_ID = "button.jar_pause_dimming"
+RESUME_ENTITY_ID = "button.jar_resume_dimming"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test all button entities match the snapshot."""
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.BUTTON]):
+        await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        (PAUSE_ENTITY_ID, "pause"),
+        (RESUME_ENTITY_ID, "resume"),
+    ],
+)
+async def test_button_press_calls_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test that pressing a button calls the correct device method."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    getattr(mock_casper_glow, method).assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "method"),
+    [
+        (PAUSE_ENTITY_ID, "pause"),
+        (RESUME_ENTITY_ID, "resume"),
+    ],
+)
+async def test_button_raises_homeassistant_error_on_failure(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    entity_id: str,
+    method: str,
+) -> None:
+    """Test that a CasperGlowError is converted to HomeAssistantError."""
+    getattr(mock_casper_glow, method).side_effect = CasperGlowError("connection lost")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add buttons for pause and resume of the automatic dimming for Casper Glow integration.
Bump quality scale to silver.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44214
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
