### PR TITLE
Log ffmpeg conversion errors in ESPHome media proxy

### DIFF
--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from http import HTTPStatus
 import logging
+import re
 import secrets
 from typing import Final
 
@@ -23,6 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 
 _MAX_CONVERSIONS_PER_DEVICE: Final[int] = 2
 _MAX_STDERR_LINES: Final[int] = 64
+_SENSITIVE_QUERY_PARAMS: Final[re.Pattern[str]] = re.compile(
+    r"(authSig|token|key|password|secret)=[^&\s]+", re.IGNORECASE
+)
 
 
 @callback
@@ -245,18 +249,29 @@ class FFmpegConvertResponse(web.StreamResponse):
             # Allow conversion info to be removed
             self.convert_info.is_finished = True
 
-            # stop collecting ffmpeg stderr task
-            stderr_task.cancel()
-
             # Terminate hangs, so kill is used
             if proc.returncode is None:
                 proc.kill()
-            elif proc.returncode != 0:
+
+            # Wait for process to exit so returncode is set
+            await proc.wait()
+
+            # Let stderr collector finish draining
+            if not stderr_task.done():
+                try:
+                    await asyncio.wait_for(stderr_task, timeout=1)
+                except (TimeoutError, asyncio.CancelledError):
+                    stderr_task.cancel()
+
+            if proc.returncode != 0:
                 _LOGGER.error(
                     "FFmpeg conversion failed for device %s (return code %s):\n%s",
                     self.device_id,
                     proc.returncode,
-                    "\n".join(stderr_lines),
+                    "\n".join(
+                        _SENSITIVE_QUERY_PARAMS.sub(r"\1=REDACTED", line)
+                        for line in stderr_lines
+                    ),
                 )
 
             # Close connection by writing EOF unless already closing

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -1,8 +1,8 @@
 """HTTP view that converts audio from a URL to a preferred format."""
 
 import asyncio
-import contextlib
 from collections import defaultdict
+import contextlib
 from dataclasses import dataclass, field
 from http import HTTPStatus
 import logging

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 _MAX_CONVERSIONS_PER_DEVICE: Final[int] = 2
 _MAX_STDERR_LINES: Final[int] = 64
 _PROC_WAIT_TIMEOUT: Final[int] = 5
+_STDERR_DRAIN_TIMEOUT: Final[int] = 1
 _SENSITIVE_QUERY_PARAMS: Final[re.Pattern[str]] = re.compile(
     r"(?<=[?&])(authSig|token|key|password|secret)=[^&\s]+", re.IGNORECASE
 )
@@ -264,7 +265,9 @@ class FFmpegConvertResponse(web.StreamResponse):
                 # Let stderr collector finish draining
                 if not stderr_task.done():
                     try:
-                        await asyncio.wait_for(stderr_task, timeout=1)
+                        await asyncio.wait_for(
+                            stderr_task, timeout=_STDERR_DRAIN_TIMEOUT
+                        )
                     except TimeoutError:
                         stderr_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
@@ -280,6 +283,7 @@ class FFmpegConvertResponse(web.StreamResponse):
                 if proc.returncode is None:
                     proc.kill()
                 stderr_task.cancel()
+                raise
 
             if proc.returncode is not None and proc.returncode != 0:
                 _LOGGER.error(
@@ -294,7 +298,7 @@ class FFmpegConvertResponse(web.StreamResponse):
 
             # Close connection by writing EOF unless already closing
             if request.transport and not request.transport.is_closing():
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(ConnectionResetError, RuntimeError, OSError):
                     await writer.write_eof()
 
     async def _collect_ffmpeg_stderr(

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -278,6 +278,8 @@ class FFmpegConvertResponse(web.StreamResponse):
                     self.device_id,
                 )
                 stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stderr_task
             except asyncio.CancelledError:
                 # Kill the process if we were interrupted
                 if proc.returncode is None:

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -1,7 +1,7 @@
 """HTTP view that converts audio from a URL to a preferred format."""
 
 import asyncio
-from collections import defaultdict
+from collections import defaultdict, deque
 import contextlib
 from dataclasses import dataclass, field
 from http import HTTPStatus
@@ -223,7 +223,7 @@ class FFmpegConvertResponse(web.StreamResponse):
         assert proc.stdout is not None
         assert proc.stderr is not None
 
-        stderr_lines: list[str] = []
+        stderr_lines: deque[str] = deque(maxlen=_MAX_STDERR_LINES)
         stderr_task = self.hass.async_create_background_task(
             self._collect_ffmpeg_stderr(proc, stderr_lines),
             "ESPHome media proxy dump stderr",
@@ -304,15 +304,14 @@ class FFmpegConvertResponse(web.StreamResponse):
     async def _collect_ffmpeg_stderr(
         self,
         proc: asyncio.subprocess.Process,
-        stderr_lines: list[str],
+        stderr_lines: deque[str],
     ) -> None:
         """Collect stderr output from ffmpeg for error reporting."""
         assert proc.stderr is not None
 
         while self.hass.is_running and (chunk := await proc.stderr.readline()):
             line = chunk.decode(errors="replace").rstrip()
-            if len(stderr_lines) < _MAX_STDERR_LINES:
-                stderr_lines.append(line)
+            stderr_lines.append(line)
             _LOGGER.debug(
                 "ffmpeg[%s] output: %s",
                 proc.pid,

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -250,23 +250,31 @@ class FFmpegConvertResponse(web.StreamResponse):
             # Allow conversion info to be removed
             self.convert_info.is_finished = True
 
-            # Terminate hangs, so kill is used
-            if proc.returncode is None:
-                proc.kill()
+            # Ensure subprocess and stderr cleanup run even if this task
+            # is cancelled (e.g., during shutdown)
+            try:
+                # Terminate hangs, so kill is used
+                if proc.returncode is None:
+                    proc.kill()
 
-            # Wait for process to exit so returncode is set
-            await proc.wait()
+                # Wait for process to exit so returncode is set
+                await proc.wait()
 
-            # Let stderr collector finish draining
-            if not stderr_task.done():
-                try:
-                    await asyncio.wait_for(stderr_task, timeout=1)
-                except TimeoutError:
-                    stderr_task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await stderr_task
+                # Let stderr collector finish draining
+                if not stderr_task.done():
+                    try:
+                        await asyncio.wait_for(stderr_task, timeout=1)
+                    except TimeoutError:
+                        stderr_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await stderr_task
+            except asyncio.CancelledError:
+                # Kill the process if we were interrupted
+                if proc.returncode is None:
+                    proc.kill()
+                stderr_task.cancel()
 
-            if proc.returncode != 0:
+            if proc.returncode is not None and proc.returncode != 0:
                 _LOGGER.error(
                     "FFmpeg conversion failed for device %s (return code %s):\n%s",
                     self.device_id,
@@ -293,7 +301,11 @@ class FFmpegConvertResponse(web.StreamResponse):
             line = chunk.decode(errors="replace").rstrip()
             if len(stderr_lines) < _MAX_STDERR_LINES:
                 stderr_lines.append(line)
-            _LOGGER.debug("ffmpeg[%s] output: %s", proc.pid, line)
+            _LOGGER.debug(
+                "ffmpeg[%s] output: %s",
+                proc.pid,
+                _SENSITIVE_QUERY_PARAMS.sub(r"\1=REDACTED", line),
+            )
 
 
 class FFmpegProxyView(HomeAssistantView):

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _MAX_CONVERSIONS_PER_DEVICE: Final[int] = 2
 _MAX_STDERR_LINES: Final[int] = 64
+_PROC_WAIT_TIMEOUT: Final[int] = 5
 _SENSITIVE_QUERY_PARAMS: Final[re.Pattern[str]] = re.compile(
     r"(?<=[?&])(authSig|token|key|password|secret)=[^&\s]+", re.IGNORECASE
 )
@@ -258,7 +259,7 @@ class FFmpegConvertResponse(web.StreamResponse):
                     proc.kill()
 
                 # Wait for process to exit so returncode is set
-                await asyncio.wait_for(proc.wait(), timeout=5)
+                await asyncio.wait_for(proc.wait(), timeout=_PROC_WAIT_TIMEOUT)
 
                 # Let stderr collector finish draining
                 if not stderr_task.done():

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -22,6 +22,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 _MAX_CONVERSIONS_PER_DEVICE: Final[int] = 2
+_MAX_STDERR_LINES: Final[int] = 64
 
 
 @callback
@@ -215,8 +216,10 @@ class FFmpegConvertResponse(web.StreamResponse):
         assert proc.stdout is not None
         assert proc.stderr is not None
 
+        stderr_lines: list[str] = []
         stderr_task = self.hass.async_create_background_task(
-            self._dump_ffmpeg_stderr(proc), "ESPHome media proxy dump stderr"
+            self._collect_ffmpeg_stderr(proc, stderr_lines),
+            "ESPHome media proxy dump stderr",
         )
 
         try:
@@ -242,26 +245,37 @@ class FFmpegConvertResponse(web.StreamResponse):
             # Allow conversion info to be removed
             self.convert_info.is_finished = True
 
-            # stop dumping ffmpeg stderr task
+            # stop collecting ffmpeg stderr task
             stderr_task.cancel()
 
             # Terminate hangs, so kill is used
             if proc.returncode is None:
                 proc.kill()
+            elif proc.returncode != 0:
+                _LOGGER.error(
+                    "FFmpeg conversion failed for device %s (return code %s):\n%s",
+                    self.device_id,
+                    proc.returncode,
+                    "\n".join(stderr_lines),
+                )
 
             # Close connection by writing EOF unless already closing
             if request.transport and not request.transport.is_closing():
                 await writer.write_eof()
 
-    async def _dump_ffmpeg_stderr(
+    async def _collect_ffmpeg_stderr(
         self,
         proc: asyncio.subprocess.Process,
+        stderr_lines: list[str],
     ) -> None:
-        assert proc.stdout is not None
+        """Collect stderr output from ffmpeg for error reporting."""
         assert proc.stderr is not None
 
         while self.hass.is_running and (chunk := await proc.stderr.readline()):
-            _LOGGER.debug("ffmpeg[%s] output: %s", proc.pid, chunk.decode().rstrip())
+            line = chunk.decode().rstrip()
+            if len(stderr_lines) < _MAX_STDERR_LINES:
+                stderr_lines.append(line)
+            _LOGGER.debug("ffmpeg[%s] output: %s", proc.pid, line)
 
 
 class FFmpegProxyView(HomeAssistantView):

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -260,7 +260,7 @@ class FFmpegConvertResponse(web.StreamResponse):
             if not stderr_task.done():
                 try:
                     await asyncio.wait_for(stderr_task, timeout=1)
-                except (TimeoutError, asyncio.CancelledError):
+                except TimeoutError, asyncio.CancelledError:
                     stderr_task.cancel()
 
             if proc.returncode != 0:

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -287,7 +287,7 @@ class FFmpegConvertResponse(web.StreamResponse):
                 stderr_task.cancel()
                 raise
 
-            if proc.returncode is not None and proc.returncode != 0:
+            if proc.returncode is not None and proc.returncode > 0:
                 _LOGGER.error(
                     "FFmpeg conversion failed for device %s (return code %s):\n%s",
                     self.device_id,

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -243,7 +243,7 @@ class FFmpegConvertResponse(web.StreamResponse):
             if request.transport:
                 request.transport.abort()
             raise  # don't log error
-        except:
+        except Exception:
             _LOGGER.exception("Unexpected error during ffmpeg conversion")
             raise
         finally:
@@ -258,7 +258,7 @@ class FFmpegConvertResponse(web.StreamResponse):
                     proc.kill()
 
                 # Wait for process to exit so returncode is set
-                await proc.wait()
+                await asyncio.wait_for(proc.wait(), timeout=5)
 
                 # Let stderr collector finish draining
                 if not stderr_task.done():
@@ -268,6 +268,12 @@ class FFmpegConvertResponse(web.StreamResponse):
                         stderr_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
                             await stderr_task
+            except TimeoutError:
+                _LOGGER.warning(
+                    "Timed out waiting for ffmpeg process to exit for device %s",
+                    self.device_id,
+                )
+                stderr_task.cancel()
             except asyncio.CancelledError:
                 # Kill the process if we were interrupted
                 if proc.returncode is None:
@@ -287,7 +293,8 @@ class FFmpegConvertResponse(web.StreamResponse):
 
             # Close connection by writing EOF unless already closing
             if request.transport and not request.transport.is_closing():
-                await writer.write_eof()
+                with contextlib.suppress(Exception):
+                    await writer.write_eof()
 
     async def _collect_ffmpeg_stderr(
         self,

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 _MAX_CONVERSIONS_PER_DEVICE: Final[int] = 2
 _MAX_STDERR_LINES: Final[int] = 64
 _SENSITIVE_QUERY_PARAMS: Final[re.Pattern[str]] = re.compile(
-    r"(authSig|token|key|password|secret)=[^&\s]+", re.IGNORECASE
+    r"(?<=[?&])(authSig|token|key|password|secret)=[^&\s]+", re.IGNORECASE
 )
 
 

--- a/homeassistant/components/esphome/ffmpeg_proxy.py
+++ b/homeassistant/components/esphome/ffmpeg_proxy.py
@@ -1,6 +1,7 @@
 """HTTP view that converts audio from a URL to a preferred format."""
 
 import asyncio
+import contextlib
 from collections import defaultdict
 from dataclasses import dataclass, field
 from http import HTTPStatus
@@ -260,8 +261,10 @@ class FFmpegConvertResponse(web.StreamResponse):
             if not stderr_task.done():
                 try:
                     await asyncio.wait_for(stderr_task, timeout=1)
-                except TimeoutError, asyncio.CancelledError:
+                except TimeoutError:
                     stderr_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await stderr_task
 
             if proc.returncode != 0:
                 _LOGGER.error(
@@ -287,7 +290,7 @@ class FFmpegConvertResponse(web.StreamResponse):
         assert proc.stderr is not None
 
         while self.hass.is_running and (chunk := await proc.stderr.readline()):
-            line = chunk.decode().rstrip()
+            line = chunk.decode(errors="replace").rstrip()
             if len(stderr_lines) < _MAX_STDERR_LINES:
                 stderr_lines.append(line)
             _LOGGER.debug("ffmpeg[%s] output: %s", proc.pid, line)

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -7,7 +7,7 @@ import io
 import logging
 import os
 import tempfile
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.request import pathname2url
 import wave
 
@@ -244,6 +244,147 @@ async def test_ffmpeg_error_redacts_sensitive_urls(
     assert "secret123" not in error_message
     assert "abc456" not in error_message
     assert "other=keep" in error_message
+
+
+async def test_ffmpeg_stderr_drain_timeout(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that stderr drain timeout is handled gracefully."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    never_finish: asyncio.Future[bytes] = asyncio.get_running_loop().create_future()
+
+    call_count = 0
+
+    async def _slow_stderr_readline() -> bytes:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return b"first error line\n"
+        # Block forever on second call so the drain times out
+        return await never_finish
+
+    async def _stdout_read(_size: int = -1) -> bytes:
+        await asyncio.sleep(0)
+        return b""
+
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = _stdout_read
+    mock_proc.stderr.readline = _slow_stderr_readline
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    assert "FFmpeg conversion failed for device" in caplog.text
+    assert "first error line" in caplog.text
+
+
+async def test_ffmpeg_cleanup_on_cancellation(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that ffmpeg process is killed when task is cancelled during cleanup."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    wait_called = asyncio.Event()
+    original_cancelled = False
+
+    async def _stdout_read(_size: int = -1) -> bytes:
+        await asyncio.sleep(0)
+        return b""
+
+    async def _proc_wait() -> None:
+        nonlocal original_cancelled
+        wait_called.set()
+        # Simulate cancellation during proc.wait()
+        raise asyncio.CancelledError
+
+    mock_kill = MagicMock()
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = _stdout_read
+    mock_proc.stderr.readline = AsyncMock(return_value=b"")
+    mock_proc.returncode = None
+    mock_proc.kill = mock_kill
+    mock_proc.wait = _proc_wait
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    # proc.kill should have been called (once in the initial check, once in the
+    # CancelledError handler)
+    assert mock_kill.call_count >= 1
+
+
+async def test_ffmpeg_unexpected_exception(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that unexpected exceptions during ffmpeg conversion are logged."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    async def _stdout_read_error(_size: int = -1) -> bytes:
+        raise RuntimeError("unexpected read error")
+
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = _stdout_read_error
+    mock_proc.stderr.readline = AsyncMock(return_value=b"")
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    assert "Unexpected error during ffmpeg conversion" in caplog.text
+
+
+async def test_max_conversions_kills_running_process(
+    hass: HomeAssistant,
+) -> None:
+    """Test that exceeding max conversions kills a running ffmpeg process."""
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+
+    device_id = "1234"
+
+    # Create max conversions
+    url1 = async_create_proxy_url(hass, device_id, "url1", media_format="mp3")
+    url2 = async_create_proxy_url(hass, device_id, "url2", media_format="mp3")
+
+    # Simulate a running process on the first conversion
+    from homeassistant.components.esphome.ffmpeg_proxy import DATA_FFMPEG_PROXY
+
+    proxy_data = hass.data[DATA_FFMPEG_PROXY]
+    device_conversions = proxy_data.conversions[device_id]
+    mock_kill = MagicMock()
+    mock_proc = MagicMock()
+    mock_proc.returncode = None
+    mock_proc.kill = mock_kill
+    device_conversions[0].proc = mock_proc
+
+    # Adding a third conversion should kill the oldest running process
+    async_create_proxy_url(hass, device_id, "url3", media_format="mp3")
+
+    mock_kill.assert_called_once()
 
 
 async def test_lingering_process(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -280,7 +280,10 @@ async def test_ffmpeg_stderr_drain_timeout(
     mock_proc.stderr.readline = _slow_stderr_readline
     mock_proc.returncode = 1
 
-    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+    with (
+        patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch(f"{FFMPEG_PROXY}._STDERR_DRAIN_TIMEOUT", 0),
+    ):
         url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
         req = await client.get(url)
         assert req.status == HTTPStatus.OK
@@ -358,7 +361,8 @@ async def test_ffmpeg_cleanup_on_cancellation(
         url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
         req = await client.get(url)
         assert req.status == HTTPStatus.OK
-        await req.content.read()
+        with pytest.raises(client_exceptions.ClientPayloadError):
+            await req.content.read()
 
     # proc.kill should have been called (once in the initial check, once in the
     # CancelledError handler)

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -317,13 +317,14 @@ async def test_ffmpeg_proc_wait_timeout(
     mock_proc = AsyncMock()
     mock_proc.stdout.read = _stdout_read
     mock_proc.stderr.readline = AsyncMock(return_value=b"")
-    mock_proc.returncode = 1
+    mock_proc.returncode = None
     mock_proc.kill = MagicMock()
     mock_proc.wait = _proc_wait
 
     with (
         patch("asyncio.create_subprocess_exec", return_value=mock_proc),
         patch(f"{FFMPEG_PROXY}._PROC_WAIT_TIMEOUT", 0),
+        patch(f"{FFMPEG_PROXY}._STDERR_DRAIN_TIMEOUT", 0),
     ):
         url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
         req = await client.get(url)

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -409,7 +409,7 @@ async def test_max_conversions_kills_running_process(
     procs_started = asyncio.Event()
     proc_count = 0
 
-    def _make_mock_proc() -> AsyncMock:
+    def _make_mock_proc(*_args: object, **_kwargs: object) -> AsyncMock:
         """Create a mock ffmpeg process that blocks on stdout read."""
         nonlocal proc_count
         future: asyncio.Future[bytes] = hass.loop.create_future()
@@ -432,7 +432,7 @@ async def test_max_conversions_kills_running_process(
 
     with patch(
         "asyncio.create_subprocess_exec",
-        side_effect=lambda *a, **kw: _make_mock_proc(),
+        side_effect=_make_mock_proc,
     ):
         url1 = async_create_proxy_url(
             hass, device_id, "url1", media_format="mp3"

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -20,12 +20,12 @@ from homeassistant.components.esphome.ffmpeg_proxy import (
     _MAX_STDERR_LINES,
     async_create_proxy_url,
 )
-
-FFMPEG_PROXY = "homeassistant.components.esphome.ffmpeg_proxy"
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.typing import ClientSessionGenerator
+
+FFMPEG_PROXY = "homeassistant.components.esphome.ffmpeg_proxy"
 
 
 @pytest.fixture(name="wav_file_length")
@@ -434,12 +434,8 @@ async def test_max_conversions_kills_running_process(
         "asyncio.create_subprocess_exec",
         side_effect=_make_mock_proc,
     ):
-        url1 = async_create_proxy_url(
-            hass, device_id, "url1", media_format="mp3"
-        )
-        url2 = async_create_proxy_url(
-            hass, device_id, "url2", media_format="mp3"
-        )
+        url1 = async_create_proxy_url(hass, device_id, "url1", media_format="mp3")
+        url2 = async_create_proxy_url(hass, device_id, "url2", media_format="mp3")
 
         # Start both HTTP requests — each spawns an ffmpeg process that blocks
         task1 = hass.async_create_task(client.get(url1))
@@ -450,9 +446,7 @@ async def test_max_conversions_kills_running_process(
         assert len(mock_kills) == 2
 
         # Creating a third conversion should kill the oldest running process
-        async_create_proxy_url(
-            hass, device_id, "url3", media_format="mp3"
-        )
+        async_create_proxy_url(hass, device_id, "url3", media_format="mp3")
         assert "Stopping existing ffmpeg process" in caplog.text
         mock_kills[0].assert_called_once()
 

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -3,9 +3,10 @@
 from collections.abc import Generator
 from http import HTTPStatus
 import io
+import logging
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from urllib.request import pathname2url
 import wave
 
@@ -14,7 +15,10 @@ import mutagen
 import pytest
 
 from homeassistant.components import esphome
-from homeassistant.components.esphome.ffmpeg_proxy import async_create_proxy_url
+from homeassistant.components.esphome.ffmpeg_proxy import (
+    _MAX_STDERR_LINES,
+    async_create_proxy_url,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -119,6 +123,7 @@ async def test_proxy_view(
 async def test_ffmpeg_file_doesnt_exist(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test ffmpeg conversion with a file that doesn't exist."""
     device_id = "1234"
@@ -135,6 +140,57 @@ async def test_ffmpeg_file_doesnt_exist(
     assert req.status == HTTPStatus.OK
     mp3_data = await req.content.read()
     assert not mp3_data
+
+    # ffmpeg failure should be logged at error level
+    assert "FFmpeg conversion failed for device" in caplog.text
+    assert device_id in caplog.text
+
+
+async def test_ffmpeg_error_stderr_truncated(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that ffmpeg stderr output is truncated in error logs."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    total_lines = _MAX_STDERR_LINES + 50
+    stderr_lines_data = [f"stderr line {i}\n".encode() for i in range(total_lines)] + [
+        b""
+    ]
+
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = AsyncMock(return_value=b"")
+    mock_proc.stderr.readline = AsyncMock(side_effect=stderr_lines_data)
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    # Should log an error with stderr content
+    assert "FFmpeg conversion failed for device" in caplog.text
+
+    # Find the error message to verify truncation.
+    # We can't just check caplog.text because lines beyond the limit
+    # are still present at debug level from _collect_ffmpeg_stderr.
+    error_message = next(
+        r.message
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "FFmpeg conversion failed" in r.message
+    )
+
+    # All lines up to the limit should be present
+    for i in range(_MAX_STDERR_LINES):
+        assert f"stderr line {i}" in error_message
+
+    # Lines beyond the limit should not be in the error log
+    assert f"stderr line {_MAX_STDERR_LINES}" not in error_message
 
 
 async def test_lingering_process(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -1,5 +1,6 @@
 """Tests for ffmpeg proxy view."""
 
+import asyncio
 from collections.abc import Generator
 from http import HTTPStatus
 import io
@@ -162,8 +163,13 @@ async def test_ffmpeg_error_stderr_truncated(
         b""
     ]
 
+    async def _stdout_read(_size: int = -1) -> bytes:
+        """Yield to event loop so stderr collector can run, then return EOF."""
+        await asyncio.sleep(0)
+        return b""
+
     mock_proc = AsyncMock()
-    mock_proc.stdout.read = AsyncMock(return_value=b"")
+    mock_proc.stdout.read = _stdout_read
     mock_proc.stderr.readline = AsyncMock(side_effect=stderr_lines_data)
     mock_proc.returncode = 1
 
@@ -191,6 +197,53 @@ async def test_ffmpeg_error_stderr_truncated(
 
     # Lines beyond the limit should not be in the error log
     assert f"stderr line {_MAX_STDERR_LINES}" not in error_message
+
+
+async def test_ffmpeg_error_redacts_sensitive_urls(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that sensitive query params are redacted in error logs."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    sensitive_url = (
+        "https://example.com/api/tts?authSig=secret123&token=abc456&other=keep"
+    )
+    stderr_lines_data = [
+        f"Error opening input file {sensitive_url}\n".encode(),
+        b"",
+    ]
+
+    async def _stdout_read(_size: int = -1) -> bytes:
+        await asyncio.sleep(0)
+        return b""
+
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = _stdout_read
+    mock_proc.stderr.readline = AsyncMock(side_effect=stderr_lines_data)
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    error_message = next(
+        r.message
+        for r in caplog.records
+        if r.levelno >= logging.ERROR and "FFmpeg conversion failed" in r.message
+    )
+
+    assert "authSig=REDACTED" in error_message
+    assert "token=REDACTED" in error_message
+    assert "secret123" not in error_message
+    assert "abc456" not in error_message
+    assert "other=keep" in error_message
 
 
 async def test_lingering_process(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -193,12 +193,14 @@ async def test_ffmpeg_error_stderr_truncated(
         if r.levelno >= logging.ERROR and "FFmpeg conversion failed" in r.message
     )
 
-    # All lines up to the limit should be present
-    for i in range(_MAX_STDERR_LINES):
+    total_lines = _MAX_STDERR_LINES + 50
+
+    # The last _MAX_STDERR_LINES lines should be present
+    for i in range(total_lines - _MAX_STDERR_LINES, total_lines):
         assert f"stderr line {i}" in error_message
 
-    # Lines beyond the limit should not be in the error log
-    assert f"stderr line {_MAX_STDERR_LINES}" not in error_message
+    # Early lines that were evicted should not be in the error log
+    assert "stderr line 0" not in error_message
 
 
 async def test_ffmpeg_error_redacts_sensitive_urls(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -288,6 +288,41 @@ async def test_ffmpeg_stderr_drain_timeout(
     assert "first error line" in caplog.text
 
 
+async def test_ffmpeg_proc_wait_timeout(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that proc.wait() timeout is handled gracefully."""
+    device_id = "1234"
+
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
+
+    async def _stdout_read(_size: int = -1) -> bytes:
+        await asyncio.sleep(0)
+        return b""
+
+    async def _proc_wait() -> None:
+        # Block forever so wait_for times out
+        await asyncio.Future()
+
+    mock_proc = AsyncMock()
+    mock_proc.stdout.read = _stdout_read
+    mock_proc.stderr.readline = AsyncMock(return_value=b"")
+    mock_proc.returncode = 1
+    mock_proc.kill = MagicMock()
+    mock_proc.wait = _proc_wait
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
+        req = await client.get(url)
+        assert req.status == HTTPStatus.OK
+        await req.content.read()
+
+    assert "Timed out waiting for ffmpeg process to exit" in caplog.text
+
+
 async def test_ffmpeg_cleanup_on_cancellation(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -298,16 +298,11 @@ async def test_ffmpeg_cleanup_on_cancellation(
     await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
     client = await hass_client()
 
-    wait_called = asyncio.Event()
-    original_cancelled = False
-
     async def _stdout_read(_size: int = -1) -> bytes:
         await asyncio.sleep(0)
         return b""
 
     async def _proc_wait() -> None:
-        nonlocal original_cancelled
-        wait_called.set()
         # Simulate cancellation during proc.wait()
         raise asyncio.CancelledError
 
@@ -360,31 +355,74 @@ async def test_ffmpeg_unexpected_exception(
 
 async def test_max_conversions_kills_running_process(
     hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that exceeding max conversions kills a running ffmpeg process."""
-    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
-
     device_id = "1234"
 
-    # Create max conversions
-    url1 = async_create_proxy_url(hass, device_id, "url1", media_format="mp3")
-    url2 = async_create_proxy_url(hass, device_id, "url2", media_format="mp3")
+    await async_setup_component(hass, esphome.DOMAIN, {esphome.DOMAIN: {}})
+    client = await hass_client()
 
-    # Simulate a running process on the first conversion
-    from homeassistant.components.esphome.ffmpeg_proxy import DATA_FFMPEG_PROXY
+    stdout_futures: list[asyncio.Future[bytes]] = []
+    mock_kills: list[MagicMock] = []
+    procs_started = asyncio.Event()
+    proc_count = 0
 
-    proxy_data = hass.data[DATA_FFMPEG_PROXY]
-    device_conversions = proxy_data.conversions[device_id]
-    mock_kill = MagicMock()
-    mock_proc = MagicMock()
-    mock_proc.returncode = None
-    mock_proc.kill = mock_kill
-    device_conversions[0].proc = mock_proc
+    def _make_mock_proc() -> AsyncMock:
+        """Create a mock ffmpeg process that blocks on stdout read."""
+        nonlocal proc_count
+        future: asyncio.Future[bytes] = hass.loop.create_future()
+        stdout_futures.append(future)
+        kill = MagicMock()
+        mock_kills.append(kill)
 
-    # Adding a third conversion should kill the oldest running process
-    async_create_proxy_url(hass, device_id, "url3", media_format="mp3")
+        async def _stdout_read(_size: int = -1) -> bytes:
+            return await future
 
-    mock_kill.assert_called_once()
+        mock = AsyncMock()
+        mock.stdout.read = _stdout_read
+        mock.stderr.readline = AsyncMock(return_value=b"")
+        mock.returncode = None
+        mock.kill = kill
+        proc_count += 1
+        if proc_count >= 2:
+            procs_started.set()
+        return mock
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=lambda *a, **kw: _make_mock_proc(),
+    ):
+        url1 = async_create_proxy_url(
+            hass, device_id, "url1", media_format="mp3"
+        )
+        url2 = async_create_proxy_url(
+            hass, device_id, "url2", media_format="mp3"
+        )
+
+        # Start both HTTP requests — each spawns an ffmpeg process that blocks
+        task1 = hass.async_create_task(client.get(url1))
+        task2 = hass.async_create_task(client.get(url2))
+
+        # Wait until both ffmpeg processes have been created
+        await procs_started.wait()
+        assert len(mock_kills) == 2
+
+        # Creating a third conversion should kill the oldest running process
+        async_create_proxy_url(
+            hass, device_id, "url3", media_format="mp3"
+        )
+        assert "Stopping existing ffmpeg process" in caplog.text
+        mock_kills[0].assert_called_once()
+
+        # Unblock stdout reads so background tasks can finish
+        for future in stdout_futures:
+            if not future.done():
+                future.set_result(b"")
+
+        await task1
+        await task2
 
 
 async def test_lingering_process(

--- a/tests/components/esphome/test_ffmpeg_proxy.py
+++ b/tests/components/esphome/test_ffmpeg_proxy.py
@@ -20,6 +20,8 @@ from homeassistant.components.esphome.ffmpeg_proxy import (
     _MAX_STDERR_LINES,
     async_create_proxy_url,
 )
+
+FFMPEG_PROXY = "homeassistant.components.esphome.ffmpeg_proxy"
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -314,7 +316,10 @@ async def test_ffmpeg_proc_wait_timeout(
     mock_proc.kill = MagicMock()
     mock_proc.wait = _proc_wait
 
-    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+    with (
+        patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        patch(f"{FFMPEG_PROXY}._PROC_WAIT_TIMEOUT", 0),
+    ):
         url = async_create_proxy_url(hass, device_id, "dummy-input", media_format="mp3")
         req = await client.get(url)
         assert req.status == HTTPStatus.OK


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When ffmpeg fails to convert audio in the ESPHome media proxy (e.g., TLS errors, unreachable URLs), the proxy silently serves a 0-byte response. This makes it very difficult to diagnose issues like voice assistant TTS failures, since the ffmpeg error output is only visible with debug logging enabled.

This PR checks the ffmpeg process return code after completion and logs collected stderr output at error level when non-zero. Stderr collection is capped at 64 lines to prevent unbounded memory usage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #138813
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr