### PR TITLE
Add Linptech PS1BB pressure sensor support to xiaomi_ble

### DIFF
--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -177,6 +177,24 @@ SENSOR_DESCRIPTIONS = {
         native_unit_of_measurement=UnitOfTime.MINUTES,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    # Pressure present duration (in seconds) for Pressure Sensor
+    (
+        ExtendedSensorDeviceClass.PRESSURE_PRESENT_DURATION,
+        Units.TIME_SECONDS,
+    ): SensorEntityDescription(
+        key=str(ExtendedSensorDeviceClass.PRESSURE_PRESENT_DURATION),
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    # Pressure not present duration (in seconds) for Pressure Sensor
+    (
+        ExtendedSensorDeviceClass.PRESSURE_NOT_PRESENT_DURATION,
+        Units.TIME_SECONDS,
+    ): SensorEntityDescription(
+        key=str(ExtendedSensorDeviceClass.PRESSURE_NOT_PRESENT_DURATION),
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
     # Low frequency impedance sensor (ohm)
     (ExtendedSensorDeviceClass.IMPEDANCE_LOW, Units.OHM): SensorEntityDescription(
         key=str(ExtendedSensorDeviceClass.IMPEDANCE_LOW),


### PR DESCRIPTION
## Proposed change

Add support for the Linptech PS1BB seat pressure sensor in the xiaomi_ble integration. This adds two `SENSOR_DESCRIPTIONS` entries for the new sensor types introduced in xiaomi-ble:

- `PRESSURE_PRESENT_DURATION` — how long the seat has been occupied (seconds)
- `PRESSURE_NOT_PRESENT_DURATION` — how long the seat has been vacant (seconds)

These map the new `ExtendedSensorDeviceClass` values from the xiaomi-ble library to Home Assistant `SensorEntityDescription` objects.

Depends on Bluetooth-Devices/xiaomi-ble#283 being released (adds the PS1BB parser, device entry, and the new enum values).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Bluetooth-Devices/xiaomi-ble#273
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
