### PR TITLE
fix(roborock): prevent map entity state spam during cleaning

### DIFF
--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -98,8 +98,7 @@ class RoborockMap(RoborockCoordinatedEntityV1, ImageEntity):
         if self.cached_map != map_content.image_content:
             self.cached_map = map_content.image_content
             self._attr_image_last_updated = self.coordinator.last_home_update
-
-        super()._handle_coordinator_update()
+            super()._handle_coordinator_update()
 
     async def async_image(self) -> bytes | None:
         """Get the cached image."""


### PR DESCRIPTION
## Proposed change

This PR fixes an issue where the Roborock map image entity was triggering state change events even when the map content hadn't changed, causing Activity log spam during vacuum cleaning.

### Problem

The `_handle_coordinator_update()` method in `image.py` was calling `super()._handle_coordinator_update()` on every coordinator update, regardless of whether the map content actually changed. This caused `async_write_ha_state()` to be called unnecessarily, generating state change events that flooded the Activity log.

### Solution

Only call `super()._handle_coordinator_update()` when the map content has actually changed:

```python
if self.cached_map != map_content.image_content:
    self.cached_map = map_content.image_content
    self._attr_image_last_updated = self.coordinator.last_home_update
    super()._handle_coordinator_update()  # Only called when content changes
```

### Testing

- Existing tests continue to pass (they test the happy path where map content changes)
- The fix prevents unnecessary state events when map content is unchanged
- Map image still updates correctly when content does change

Fixes #161039