### PR TITLE
Bump xiaomi-ble to 1.10.0

### DIFF
--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -25,5 +25,5 @@
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["xiaomi-ble==1.6.0"]
+  "requirements": ["xiaomi-ble==1.10.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3319,7 +3319,7 @@ wsdot==0.0.1
 wyoming==1.7.2
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==1.6.0
+xiaomi-ble==1.10.0
 
 # homeassistant.components.knx
 xknx==3.15.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2801,7 +2801,7 @@ wsdot==0.0.1
 wyoming==1.7.2
 
 # homeassistant.components.xiaomi_ble
-xiaomi-ble==1.6.0
+xiaomi-ble==1.10.0
 
 # homeassistant.components.knx
 xknx==3.15.0


### PR DESCRIPTION
## Proposed change

Bump xiaomi-ble to 1.10.0

Changelog: https://github.com/Bluetooth-Devices/xiaomi-ble/compare/v1.6.0...v1.10.0

Release notes:
- https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v1.10.0
- https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v1.9.0
- https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v1.8.0
- https://github.com/Bluetooth-Devices/xiaomi-ble/releases/tag/v1.7.0

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
