### PR TITLE
growatt_server: automatic session re-login for Classic API

### DIFF
--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -353,18 +353,19 @@ async def async_setup_entry(
         if device["deviceType"] in ["inverter", "tlx", "storage", "mix", "min", "sph"]
     }
 
+    # Store runtime data BEFORE first_refresh so the shared lock is available
+    # to coordinators if session expiry occurs during the initial data fetch.
+    config_entry.runtime_data = GrowattRuntimeData(
+        total_coordinator=total_coordinator,
+        devices=device_coordinators,
+    )
+
     # Perform the first refresh for the total coordinator
     await total_coordinator.async_config_entry_first_refresh()
 
     # Perform the first refresh for each device coordinator
     for device_coordinator in device_coordinators.values():
         await device_coordinator.async_config_entry_first_refresh()
-
-    # Store runtime data in the config entry
-    config_entry.runtime_data = GrowattRuntimeData(
-        total_coordinator=total_coordinator,
-        devices=device_coordinators,
-    )
 
     # Set up all the entities
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -341,13 +341,13 @@ async def async_setup_entry(
 
     # Create a coordinator for the total sensors
     total_coordinator = GrowattCoordinator(
-        hass, config_entry, plant_id, "total", plant_id
+        hass, config_entry, plant_id, "total", plant_id, api
     )
 
     # Create coordinators for each device
     device_coordinators = {
         device["deviceSn"]: GrowattCoordinator(
-            hass, config_entry, device["deviceSn"], device["deviceType"], plant_id
+            hass, config_entry, device["deviceSn"], device["deviceType"], plant_id, api
         )
         for device in devices
         if device["deviceType"] in ["inverter", "tlx", "storage", "mix", "min", "sph"]

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -225,9 +225,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self.api_version != "classic":
             return False
 
-        # Guard: config_entry may be None or runtime_data not yet set
-        # (e.g. during async_config_entry_first_refresh)
-        if self.config_entry is None or not hasattr(self.config_entry, "runtime_data"):
+        if self.config_entry is None:
             return False
 
         config_entry = self.config_entry
@@ -284,26 +282,37 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Asynchronously update data via library."""
+        if self.api_version == "classic" and self.config_entry is not None:
+            # Serialize Classic API calls across coordinators: the underlying
+            # requests.Session (and its session cookie) is not thread-safe.
+            runtime_data: GrowattRuntimeData = self.config_entry.runtime_data
+            async with runtime_data.api_lock:
+                try:
+                    return await self.hass.async_add_executor_job(
+                        self._sync_update_data
+                    )
+                except json.decoder.JSONDecodeError as err:
+                    # The server returned an HTML login page instead of JSON — session expired.
+                    _LOGGER.debug(
+                        "Data fetch failed for %s (%s: %s), attempting re-login",
+                        self.device_id,
+                        type(err).__name__,
+                        err,
+                    )
+                    if await self._async_re_login():
+                        try:
+                            return await self.hass.async_add_executor_job(
+                                self._sync_update_data
+                            )
+                        except json.decoder.JSONDecodeError as retry_err:
+                            raise UpdateFailed(
+                                f"Data fetch failed after re-login for {self.device_id}: {retry_err}"
+                            ) from retry_err
+                    raise UpdateFailed(f"Error fetching data: {err}") from err
+
         try:
             return await self.hass.async_add_executor_job(self._sync_update_data)
         except json.decoder.JSONDecodeError as err:
-            if self.api_version == "classic":
-                # The server returned an HTML login page instead of JSON — session expired.
-                _LOGGER.warning(
-                    "Data fetch failed for %s (%s: %s), attempting re-login",
-                    self.device_id,
-                    type(err).__name__,
-                    err,
-                )
-                if await self._async_re_login():
-                    try:
-                        return await self.hass.async_add_executor_job(
-                            self._sync_update_data
-                        )
-                    except json.decoder.JSONDecodeError as retry_err:
-                        raise UpdateFailed(
-                            f"Data fetch failed after re-login for {self.device_id}: {retry_err}"
-                        ) from retry_err
             raise UpdateFailed(f"Error fetching data: {err}") from err
 
     def get_currency(self):

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import datetime
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 import growattServer
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -25,7 +26,6 @@ from .const import (
     BATT_MODE_BATTERY_FIRST,
     BATT_MODE_GRID_FIRST,
     BATT_MODE_LOAD_FIRST,
-    DEFAULT_URL,
     DOMAIN,
     LOGIN_INVALID_AUTH_CODE,
     V1_API_ERROR_NO_PRIVILEGE,
@@ -52,6 +52,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         device_id: str,
         device_type: str,
         plant_id: str,
+        api: growattServer.GrowattApi | growattServer.OpenApiV1,
     ) -> None:
         """Initialize the coordinator."""
         self.api_version = (
@@ -62,24 +63,7 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.plant_id = plant_id
         self.previous_values: dict[str, Any] = {}
         self._pre_reset_values: dict[str, float] = {}
-
-        if self.api_version == "v1":
-            self.username = None
-            self.password = None
-            self.url = config_entry.data.get(CONF_URL, DEFAULT_URL)
-            self.token = config_entry.data["token"]
-            self.api = growattServer.OpenApiV1(token=self.token)
-            self.api.server_url = self.url
-        elif self.api_version == "classic":
-            self.username = config_entry.data.get(CONF_USERNAME)
-            self.password = config_entry.data[CONF_PASSWORD]
-            self.url = config_entry.data.get(CONF_URL, DEFAULT_URL)
-            self.api = growattServer.GrowattApi(
-                add_random_user_id=True, agent_identifier=self.username
-            )
-            self.api.server_url = self.url
-        else:
-            raise ValueError(f"Unknown API version: {self.api_version}")
+        self.api = api
 
         super().__init__(
             hass,
@@ -92,17 +76,6 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _sync_update_data(self) -> dict[str, Any]:
         """Update data via library synchronously."""
         _LOGGER.debug("Updating data for %s (%s)", self.device_id, self.device_type)
-
-        # login only required for classic API
-        if self.api_version == "classic":
-            login_response = self.api.login(self.username, self.password)
-            if not login_response.get("success"):
-                msg = login_response.get("msg", "Unknown error")
-                if msg == LOGIN_INVALID_AUTH_CODE:
-                    raise ConfigEntryAuthFailed(
-                        "Username, password, or URL may be incorrect"
-                    )
-                raise UpdateFailed(f"Growatt login failed: {msg}")
 
         if self.device_type == "total":
             if self.api_version == "v1":
@@ -129,7 +102,8 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 total_info["invTodayPpv"] = total_info["current_power"]
             else:
                 # Classic API: use plant_info as before
-                total_info = self.api.plant_info(self.device_id)
+                # Copy to avoid mutating the dict returned by the API/mock
+                total_info = dict(self.api.plant_info(self.device_id))
                 del total_info["deviceList"]
                 plant_money_text, currency = total_info["plantMoneyText"].split("/")
                 total_info["plantMoneyText"] = plant_money_text
@@ -238,11 +212,98 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return self.data
 
+    async def _async_re_login(self) -> bool:
+        """Attempt to re-login to the Growatt Classic API when session expires.
+
+        Uses a shared lock to prevent multiple coordinators from logging in
+        simultaneously, and a 60-second cooldown to avoid redundant logins when
+        several coordinators detect session expiry at the same time.
+
+        Returns True if re-login succeeded (or was recently done), False on
+        transient failure. Raises ConfigEntryAuthFailed if credentials are invalid.
+        """
+        if self.api_version != "classic":
+            return False
+
+        # Guard: config_entry may be None or runtime_data not yet set
+        # (e.g. during async_config_entry_first_refresh)
+        if self.config_entry is None or not hasattr(self.config_entry, "runtime_data"):
+            return False
+
+        config_entry = self.config_entry
+        runtime_data: GrowattRuntimeData = config_entry.runtime_data
+
+        async with runtime_data.login_lock:
+            # If another coordinator already restored the session within the last
+            # 60 seconds, the shared API instance is already authenticated — skip.
+            now = time.monotonic()
+            if (
+                runtime_data.last_login_time is not None
+                and (now - runtime_data.last_login_time) < 60
+            ):
+                _LOGGER.debug(
+                    "Session recently restored (%.0fs ago), skipping re-login for %s",
+                    now - runtime_data.last_login_time,
+                    self.device_id,
+                )
+                return True
+
+            config = config_entry.data
+            username = config.get(CONF_USERNAME)
+            password = config.get(CONF_PASSWORD)
+
+            if not username or not password:
+                _LOGGER.error(
+                    "Cannot re-login for %s: credentials not available", self.device_id
+                )
+                return False
+
+            try:
+                login_response = await self.hass.async_add_executor_job(
+                    self.api.login, username, password
+                )
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Re-login exception for %s: %s", self.device_id, err)
+                return False
+
+            if login_response.get("success"):
+                runtime_data.last_login_time = now
+                _LOGGER.info(
+                    "Successfully re-authenticated with Growatt API (triggered by %s)",
+                    self.device_id,
+                )
+                return True
+
+            msg = login_response.get("msg", "Unknown error")
+            if msg == LOGIN_INVALID_AUTH_CODE:
+                raise ConfigEntryAuthFailed(
+                    "Username, password, or URL may be incorrect"
+                )
+            _LOGGER.error("Re-login failed for %s: %s", self.device_id, msg)
+            return False
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Asynchronously update data via library."""
         try:
             return await self.hass.async_add_executor_job(self._sync_update_data)
         except json.decoder.JSONDecodeError as err:
+            if self.api_version == "classic":
+                # The server returned an HTML login page instead of JSON — session expired.
+                _LOGGER.warning(
+                    "Data fetch failed for %s (%s: %s), attempting re-login",
+                    self.device_id,
+                    type(err).__name__,
+                    err,
+                )
+                if await self._async_re_login():
+                    try:
+                        return await self.hass.async_add_executor_job(
+                            self._sync_update_data
+                        )
+                    except json.decoder.JSONDecodeError as retry_err:
+                        raise UpdateFailed(
+                            f"Data fetch failed after re-login for {self.device_id}: {retry_err}"
+                        ) from retry_err
             raise UpdateFailed(f"Error fetching data: {err}") from err
 
     def get_currency(self):

--- a/homeassistant/components/growatt_server/models.py
+++ b/homeassistant/components/growatt_server/models.py
@@ -18,3 +18,4 @@ class GrowattRuntimeData:
     devices: dict[str, GrowattCoordinator]
     login_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     last_login_time: float | None = None
+    api_lock: asyncio.Lock = field(default_factory=asyncio.Lock)

--- a/homeassistant/components/growatt_server/models.py
+++ b/homeassistant/components/growatt_server/models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import asyncio
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,3 +16,5 @@ class GrowattRuntimeData:
 
     total_coordinator: GrowattCoordinator
     devices: dict[str, GrowattCoordinator]
+    login_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    last_login_time: float | None = None

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -316,6 +316,8 @@ async def test_classic_api_session_relogin_on_json_error(
     )
     # Verify re-login was called (once for setup, once for re-login)
     assert mock_growatt_classic_api.login.call_count >= 2
+    # Verify the data fetch was retried and succeeded (error + retry)
+    assert mock_growatt_classic_api.tlx_detail.call_count >= 2
 
 
 async def test_classic_api_setup(

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -220,7 +220,13 @@ async def test_classic_api_coordinator_auth_failed_triggers_reauth(
     mock_config_entry_classic: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that invalid classic API credentials during coordinator update trigger reauth."""
+    """Test that session expiry with invalid credentials triggers reauth.
+
+    The coordinator detects a session expiry when the Growatt server returns an
+    HTML login page instead of JSON (JSONDecodeError). It then attempts a
+    re-login. If the credentials are also invalid, ConfigEntryAuthFailed is
+    raised and the HA reauth flow is triggered.
+    """
     mock_growatt_classic_api.device_list.return_value = [
         {"deviceSn": "TLX123456", "deviceType": "tlx"}
     ]
@@ -238,7 +244,11 @@ async def test_classic_api_coordinator_auth_failed_triggers_reauth(
     await setup_integration(hass, mock_config_entry_classic)
     assert mock_config_entry_classic.state is ConfigEntryState.LOADED
 
-    # Credentials expire between updates
+    # Simulate session expiry: data fetch returns HTML (JSONDecodeError) and
+    # re-login attempt fails with invalid credentials
+    mock_growatt_classic_api.tlx_detail.side_effect = json.decoder.JSONDecodeError(
+        "Invalid JSON", "", 0
+    )
     mock_growatt_classic_api.login.return_value = {
         "success": False,
         "msg": LOGIN_INVALID_AUTH_CODE,
@@ -254,7 +264,58 @@ async def test_classic_api_coordinator_auth_failed_triggers_reauth(
         and flow["context"]["entry_id"] == mock_config_entry_classic.entry_id
         for flow in flows
     )
-    assert hass.states.get("sensor.tlx123456_output_power").state == STATE_UNAVAILABLE
+
+
+async def test_classic_api_session_relogin_on_json_error(
+    hass: HomeAssistant,
+    mock_growatt_classic_api,
+    mock_config_entry_classic: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a session expiry (JSONDecodeError) triggers re-login and retries.
+
+    When the Growatt server returns an HTML login page (JSONDecodeError) the
+    coordinator silently re-authenticates using the stored credentials and
+    retries the data fetch. Entities should recover without user intervention.
+    """
+    mock_growatt_classic_api.device_list.return_value = [
+        {"deviceSn": "TLX123456", "deviceType": "tlx"}
+    ]
+    mock_growatt_classic_api.plant_info.return_value = {
+        "deviceList": [],
+        "totalEnergy": 1250.0,
+        "todayEnergy": 12.5,
+        "invTodayPpv": 2500,
+        "plantMoneyText": "123.45/USD",
+    }
+    tlx_response = {"data": {"deviceSn": "TLX123456"}}
+    mock_growatt_classic_api.tlx_detail.return_value = tlx_response
+
+    await setup_integration(hass, mock_config_entry_classic)
+    assert mock_config_entry_classic.state is ConfigEntryState.LOADED
+
+    # Simulate session expiry on first call; second call (retry after re-login) succeeds
+    mock_growatt_classic_api.tlx_detail.side_effect = [
+        json.decoder.JSONDecodeError("Invalid JSON", "", 0),
+        tlx_response,
+    ]
+    # Re-login succeeds (default: success=True in mock)
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Integration should remain loaded — session was silently restored
+    assert mock_config_entry_classic.state is ConfigEntryState.LOADED
+    # No reauth flow should have been triggered
+    flows = hass.config_entries.flow.async_progress()
+    assert not any(
+        flow["context"]["source"] == "reauth"
+        and flow["context"]["entry_id"] == mock_config_entry_classic.entry_id
+        for flow in flows
+    )
+    # Verify re-login was called (once for setup, once for re-login)
+    assert mock_growatt_classic_api.login.call_count >= 2
 
 
 async def test_classic_api_setup(
@@ -704,9 +765,7 @@ async def test_setup_reuses_cached_api_from_migration(
     # Verify log message confirms API reuse (rate limit optimization)
     assert "Reusing logged-in session from migration" in caplog.text
 
-    # Verify login was called with correct credentials
-    # Note: Coordinators also call login() during refresh, so we verify
-    # the call was made but don't assert it was called exactly once
+    # Verify login was called with correct credentials during setup
     mock_growatt_classic_api.login.assert_called_with("test_user", "test_password")
 
     # Verify plant_list was called only once (during migration, not during setup)


### PR DESCRIPTION
## Proposed change

The Growatt Classic API (username/password) uses session cookies that expire. When a session expires, the server returns an HTML login page instead of JSON, causing a `JSONDecodeError`. Previously this would permanently mark entities unavailable until the next HA restart.

This PR adds automatic silent re-authentication:
- The coordinator detects `JSONDecodeError` during data fetch (session expiry indicator for Classic API only)
- It calls `_async_re_login()` which acquires a shared `asyncio.Lock` on `GrowattRuntimeData` to prevent concurrent re-login attempts from multiple coordinators
- A 60-second cooldown (`time.monotonic()`) ensures only one actual re-login call is made even if many coordinators detect expiry simultaneously
- On success, the data fetch is retried transparently — entities never become unavailable
- If credentials are invalid, `ConfigEntryAuthFailed` is raised, triggering HA's standard reauth flow
- V1 API (token-based) is completely unaffected

The shared API instance architecture means a single re-login restores the session for all coordinators at once, since they share the same `GrowattApi` object (and its session cookie).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr