### PR TITLE
Fix SwitchBot Blind Tilt KeyError on motionDirection in BLE callback

### DIFF
--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -220,8 +220,8 @@ class SwitchBotBlindTiltEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         self._attr_is_closed = (_tilt < self.CLOSED_DOWN_THRESHOLD) or (
             _tilt > self.CLOSED_UP_THRESHOLD
         )
-        self._attr_is_opening = self.parsed_data["motionDirection"]["opening"]
-        self._attr_is_closing = self.parsed_data["motionDirection"]["closing"]
+        self._attr_is_opening = self._device.is_opening()
+        self._attr_is_closing = self._device.is_closing()
         self.async_write_ha_state()
 
 


### PR DESCRIPTION
## Summary

Fixes `KeyError: 'motionDirection'` in `SwitchBotBlindTiltEntity._handle_coordinator_update()` when receiving BLE advertisement callbacks.

The `motionDirection` key is only present in the return value of `get_basic_info()` (an active BLE query), but is never set by the passive BLE advertisement parser (`_set_parsed_data()` in pySwitchbot). When HA receives a passive BLE advertisement and tries to update the cover entity state, `parsed_data["motionDirection"]` raises `KeyError`.

The fix replaces the direct `parsed_data` access with `self._device.is_opening()` / `self._device.is_closing()`, which are methods on `SwitchbotBaseCover` that correctly return motion state regardless of whether data came from an advertisement or a BLE query. This matches the pattern already used by `SwitchBotCurtainEntity` and `SwitchBotRollerShadeEntity` in their `_handle_coordinator_update()` methods.

## Details

**Before (broken):**
```python
self._attr_is_opening = self.parsed_data["motionDirection"]["opening"]
self._attr_is_closing = self.parsed_data["motionDirection"]["closing"]
```

**After (fixed):**
```python
self._attr_is_opening = self._device.is_opening()
self._attr_is_closing = self._device.is_closing()
```

## Related issues

- Fixes #160940
- Fixes #108087 (closed as stale without resolution)

## Type of change

- Bug fix (non-breaking change which fixes an issue)