### PR TITLE
feat(roborock): Add Q10 empty dustbin button entity

### DIFF
--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -107,7 +107,6 @@ Q10_BUTTON_DESCRIPTIONS = [
     ButtonEntityDescription(
         key="empty_dustbin",
         translation_key="empty_dustbin",
-        entity_category=EntityCategory.CONFIG,
     ),
 ]
 

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -103,6 +103,15 @@ ZEO_BUTTON_DESCRIPTIONS = [
 ]
 
 
+Q10_BUTTON_DESCRIPTIONS = [
+    ButtonEntityDescription(
+        key="empty_dustbin",
+        translation_key="empty_dustbin",
+        entity_category=EntityCategory.CONFIG,
+    ),
+]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: RoborockConfigEntry,
@@ -146,9 +155,13 @@ async def async_setup_entry(
                 for description in ZEO_BUTTON_DESCRIPTIONS
             ),
             (
-                RoborockQ10EmptyDustbinButtonEntity(coordinator)
+                RoborockQ10EmptyDustbinButtonEntity(
+                    coordinator,
+                    description,
+                )
                 for coordinator in config_entry.runtime_data.b01_q10
                 if isinstance(coordinator, RoborockB01Q10UpdateCoordinator)
+                for description in Q10_BUTTON_DESCRIPTIONS
             ),
         )
     )
@@ -251,18 +264,18 @@ class RoborockQ10EmptyDustbinButtonEntity(
 ):
     """A class to define Q10 empty dustbin button entity."""
 
-    _attr_name = None
-    _attr_translation_key = "empty_dustbin"
-    _attr_entity_category = EntityCategory.CONFIG
+    entity_description: ButtonEntityDescription
     coordinator: RoborockB01Q10UpdateCoordinator
 
     def __init__(
         self,
         coordinator: RoborockB01Q10UpdateCoordinator,
+        entity_description: ButtonEntityDescription,
     ) -> None:
         """Create a Q10 empty dustbin button entity."""
+        self.entity_description = entity_description
         super().__init__(
-            f"empty_dustbin_{coordinator.duid_slug}",
+            f"{entity_description.key}_{coordinator.duid_slug}",
             coordinator,
         )
 

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -20,12 +20,18 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (
+    RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
     RoborockWashingMachineUpdateCoordinator,
 )
-from .entity import RoborockCoordinatedEntityA01, RoborockEntity, RoborockEntityV1
+from .entity import (
+    RoborockCoordinatedEntityA01,
+    RoborockCoordinatedEntityB01Q10,
+    RoborockEntity,
+    RoborockEntityV1,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,6 +145,11 @@ async def async_setup_entry(
                 if isinstance(coordinator, RoborockWashingMachineUpdateCoordinator)
                 for description in ZEO_BUTTON_DESCRIPTIONS
             ),
+            (
+                RoborockQ10EmptyDustbinButtonEntity(coordinator)
+                for coordinator in config_entry.runtime_data.b01_q10
+                if isinstance(coordinator, RoborockB01Q10UpdateCoordinator)
+            ),
         )
     )
 
@@ -233,3 +244,36 @@ class RoborockButtonEntityA01(RoborockCoordinatedEntityA01, ButtonEntity):
             ) from err
         finally:
             await self.coordinator.async_request_refresh()
+
+
+class RoborockQ10EmptyDustbinButtonEntity(
+    RoborockCoordinatedEntityB01Q10, ButtonEntity
+):
+    """A class to define Q10 empty dustbin button entity."""
+
+    _attr_name = "Empty dustbin"
+    _attr_entity_category = EntityCategory.CONFIG
+    coordinator: RoborockB01Q10UpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: RoborockB01Q10UpdateCoordinator,
+    ) -> None:
+        """Create a Q10 empty dustbin button entity."""
+        super().__init__(
+            f"empty_dustbin_{coordinator.duid_slug}",
+            coordinator,
+        )
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Press the button to empty dustbin."""
+        try:
+            await self.coordinator.api.vacuum.empty_dustbin()
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={
+                    "command": "empty_dustbin",
+                },
+            ) from err

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -251,7 +251,8 @@ class RoborockQ10EmptyDustbinButtonEntity(
 ):
     """A class to define Q10 empty dustbin button entity."""
 
-    _attr_name = "Empty dustbin"
+    _attr_name = None
+    _attr_translation_key = "empty_dustbin"
     _attr_entity_category = EntityCategory.CONFIG
     coordinator: RoborockB01Q10UpdateCoordinator
 

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -84,6 +84,9 @@
       }
     },
     "button": {
+      "empty_dustbin": {
+        "name": "Empty dustbin"
+      },
       "pause": {
         "name": "Pause"
       },

--- a/tests/components/roborock/snapshots/test_button.ambr
+++ b/tests/components/roborock/snapshots/test_button.ambr
@@ -31,7 +31,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'empty_dustbin',
     'unique_id': 'empty_dustbin_q10_duid',
     'unit_of_measurement': None,
   })

--- a/tests/components/roborock/snapshots/test_button.ambr
+++ b/tests/components/roborock/snapshots/test_button.ambr
@@ -1,4 +1,54 @@
 # serializer version: 1
+# name: test_buttons[button.roborock_q10_s5_empty_dustbin-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.roborock_q10_s5_empty_dustbin',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Empty dustbin',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Empty dustbin',
+    'platform': 'roborock',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'empty_dustbin_q10_duid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.roborock_q10_s5_empty_dustbin-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Roborock Q10 S5+ Empty dustbin',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.roborock_q10_s5_empty_dustbin',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_buttons[button.roborock_s7_2_reset_air_filter_consumable-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/roborock/snapshots/test_button.ambr
+++ b/tests/components/roborock/snapshots/test_button.ambr
@@ -12,7 +12,7 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'button',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_category': None,
     'entity_id': 'button.roborock_q10_s5_empty_dustbin',
     'has_entity_name': True,
     'hidden_by': None,

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -314,7 +314,7 @@ async def test_press_q10_empty_dustbin_button_failure(
     )
 
     assert hass.states.get(entity_id) is not None
-    with pytest.raises(HomeAssistantError, match="empty_dustbin"):
+    with pytest.raises(HomeAssistantError, match="Error while calling empty_dustbin"):
         await hass.services.async_call(
             "button",
             SERVICE_PRESS,

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -272,3 +272,55 @@ async def test_press_a01_button_failure(
 
     washing_machine.zeo.set_value.assert_called_once()
     assert hass.states.get(entity_id).state == "2023-10-30T08:50:00+00:00"
+
+
+@pytest.mark.freeze_time("2023-10-30 08:50:00")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_press_q10_empty_dustbin_button_success(
+    hass: HomeAssistant,
+    bypass_api_client_fixture: None,
+    setup_entry: MockConfigEntry,
+    fake_q10_vacuum: FakeDevice,
+) -> None:
+    """Test pressing Q10 empty dustbin button entity."""
+    entity_id = "button.roborock_q10_s5_empty_dustbin"
+
+    assert hass.states.get(entity_id) is not None
+    await hass.services.async_call(
+        "button",
+        SERVICE_PRESS,
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+
+    assert fake_q10_vacuum.b01_q10_properties is not None
+    fake_q10_vacuum.b01_q10_properties.vacuum.empty_dustbin.assert_called_once()
+    assert hass.states.get(entity_id).state == "2023-10-30T08:50:00+00:00"
+
+
+@pytest.mark.freeze_time("2023-10-30 08:50:00")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_press_q10_empty_dustbin_button_failure(
+    hass: HomeAssistant,
+    bypass_api_client_fixture: None,
+    setup_entry: MockConfigEntry,
+    fake_q10_vacuum: FakeDevice,
+) -> None:
+    """Test failure while pressing Q10 empty dustbin button entity."""
+    entity_id = "button.roborock_q10_s5_empty_dustbin"
+    assert fake_q10_vacuum.b01_q10_properties is not None
+    fake_q10_vacuum.b01_q10_properties.vacuum.empty_dustbin.side_effect = (
+        RoborockException
+    )
+
+    assert hass.states.get(entity_id) is not None
+    with pytest.raises(HomeAssistantError, match="empty_dustbin"):
+        await hass.services.async_call(
+            "button",
+            SERVICE_PRESS,
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+
+    fake_q10_vacuum.b01_q10_properties.vacuum.empty_dustbin.assert_called_once()
+    assert hass.states.get(entity_id).state == "2023-10-30T08:50:00+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for a new Roborock Q10 button entity in Home Assistant.

- Added a **Q10 “Empty dustbin” button** to button.py.
- Integrated the entity in platform setup for **Q10 coordinators only**.
- Implemented button action to call `coordinator.api.vacuum.empty_dustbin()`.
- Added proper error handling using Home Assistant translated `command_failed` errors.
- Updated button snapshots to include the new entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/144138
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
