### PR TITLE
Fix internet access switch flip-flop in FRITZ!Box Tools

### DIFF
--- a/homeassistant/components/fritz/models.py
+++ b/homeassistant/components/fritz/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import NotRequired, TypedDict
 
 from homeassistant.util import dt as dt_util
@@ -86,11 +86,13 @@ class FritzDevice:
     _name: str
     _ssid: str | None
     _wan_access: bool | None
+    _wan_access_skip_until: datetime | None
 
     def __init__(self, mac: str, dev_info: Device, consider_home: float) -> None:
         """Initialize device info."""
         self._mac = mac
         self._last_activity = None
+        self._wan_access_skip_until = None
         self.update(dev_info, consider_home)
 
     def update(self, dev_info: Device, consider_home: float) -> None:
@@ -115,7 +117,18 @@ class FritzDevice:
         self._connection_type = dev_info.connection_type
         self._ip_address = dev_info.ip_address
         self._ssid = dev_info.ssid
-        self._wan_access = dev_info.wan_access
+        if (
+            self._wan_access_skip_until is not None
+            and utc_point_in_time < self._wan_access_skip_until
+            and dev_info.wan_access != self._wan_access
+        ):
+            # After a manual wan_access toggle, skip polled updates that
+            # differ from the verified state. get_hosts_attributes can
+            # return stale X_AVM-DE_WANAccess for ~10s after a change.
+            pass
+        else:
+            self._wan_access_skip_until = None
+            self._wan_access = dev_info.wan_access
 
     @property
     def connected_to(self) -> str:
@@ -166,6 +179,7 @@ class FritzDevice:
     def wan_access(self, allowed: bool) -> None:
         """Set device wan access."""
         self._wan_access = allowed
+        self._wan_access_skip_until = dt_util.utcnow() + timedelta(seconds=60)
 
 
 class SwitchInfo(TypedDict):

--- a/homeassistant/components/fritz/models.py
+++ b/homeassistant/components/fritz/models.py
@@ -120,11 +120,14 @@ class FritzDevice:
         if (
             self._wan_access_skip_until is not None
             and utc_point_in_time < self._wan_access_skip_until
+            and isinstance(dev_info.wan_access, bool)
             and dev_info.wan_access != self._wan_access
         ):
-            # After a manual wan_access toggle, skip polled updates that
+            # After a manual wan_access toggle, skip polled bool updates that
             # differ from the verified state. get_hosts_attributes can
             # return stale X_AVM-DE_WANAccess for ~10s after a change.
+            # Non-bool values (None for unknown/unavailable) always propagate
+            # and end the skip window so device removal isn't suppressed.
             pass
         else:
             self._wan_access_skip_until = None

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -599,7 +599,16 @@ class FritzBoxProfileSwitch(FritzBoxBaseCoordinatorSwitch):
         await self.coordinator.async_set_allow_wan_access(
             self._device.ip_address, turn_on
         )
-        self._device.wan_access = turn_on
+        # Clear cached Get results so the verification read below fetches
+        # the actual state from the FritzBox, not a stale cached value.
+        self.coordinator.connection.clear_cache()
+        # Verify the actual state using GetWANAccessByIP which reflects
+        # changes immediately, unlike get_hosts_attributes which can be
+        # stale for up to ~10s after a change.
+        wan_access = await self.coordinator._async_get_wan_access(  # noqa: SLF001
+            self._device.ip_address
+        )
+        self._device.wan_access = wan_access if wan_access is not None else turn_on
         self.async_write_ha_state()
 
 

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -12,6 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.fritz import switch as fritz_switch
 from homeassistant.components.fritz.const import DOMAIN
+from homeassistant.components.fritz.coordinator import Device
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
@@ -445,9 +446,16 @@ async def test_switch_turn_on_off(
     assert (state := hass.states.get(entity_id))
     assert state.state == STATE_ON
 
-    with patch(
-        f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
-    ) as mock_set_action:
+    with (
+        patch(
+            f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
+        ) as mock_set_action,
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_OFF,
@@ -459,9 +467,16 @@ async def test_switch_turn_on_off(
     assert (state := hass.states.get(entity_id))
     assert state.state == STATE_OFF
 
-    with patch(
-        f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
-    ) as mock_set_action_2:
+    with (
+        patch(
+            f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}",
+        ) as mock_set_action_2,
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -606,3 +621,149 @@ def test_wifi_naming_helper(
 ) -> None:
     """Test Wi-Fi naming helper covers supported and fallback branches."""
     assert fritz_switch._wifi_naming({}, wifi_index, wifi_count) == expected_name
+
+
+async def test_profile_switch_verify_after_toggle(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test that internet access switch verifies state via GetWANAccessByIP after toggle."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    fc_class_mock.return_value = FritzConnectionMock(
+        MOCK_FB_SERVICES | MOCK_CALL_DEFLECTION_DATA
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "switch.printer_internet_access"
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON
+
+    # Toggle OFF — _async_get_wan_access confirms the block succeeded
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper.async_set_allow_wan_access",
+        ),
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as mock_verify,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+        mock_verify.assert_called_once()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_OFF
+
+
+async def test_profile_switch_verify_fallback_on_error(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test that switch falls back to requested value if verification fails."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    fc_class_mock.return_value = FritzConnectionMock(
+        MOCK_FB_SERVICES | MOCK_CALL_DEFLECTION_DATA
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "switch.printer_internet_access"
+
+    # Toggle OFF — _async_get_wan_access returns None (error), fallback to requested value
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper.async_set_allow_wan_access",
+        ),
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_OFF
+
+
+async def test_profile_switch_skip_stale_poll(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test that stale polled data does not overwrite a recently toggled state."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    mock_conn = FritzConnectionMock(MOCK_FB_SERVICES | MOCK_CALL_DEFLECTION_DATA)
+    fc_class_mock.return_value = mock_conn
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "switch.printer_internet_access"
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    # Toggle OFF with verified state
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper.async_set_allow_wan_access",
+        ),
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    # Simulate a poll refresh with stale data (wan_access=True, i.e. "granted")
+    coordinator = entry.runtime_data
+    device = coordinator.devices["AA:BB:CC:00:11:22"]
+
+    stale_info = Device(
+        name=device.hostname,
+        connected=True,
+        connected_to="",
+        connection_type="",
+        ip_address=device.ip_address,
+        ssid=None,
+        wan_access=True,  # stale!
+    )
+    device.update(stale_info, 0)
+
+    # The stale wan_access=True should be ignored during the skip window
+    assert device.wan_access is False

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -688,7 +688,7 @@ async def test_profile_switch_verify_fallback_on_error(
 
     entity_id = "switch.printer_internet_access"
 
-    # Toggle OFF — _async_get_wan_access returns None (error), fallback to requested value
+    # Toggle OFF — _async_get_wan_access returns None (error), fallback to requested off value
     with (
         patch(
             "homeassistant.components.fritz.coordinator.AvmWrapper.async_set_allow_wan_access",
@@ -767,3 +767,74 @@ async def test_profile_switch_skip_stale_poll(
 
     # The stale wan_access=True should be ignored during the skip window
     assert device.wan_access is False
+
+
+async def test_profile_switch_skip_window_allows_none(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+) -> None:
+    """Test that a None wan_access value propagates and ends the skip window."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
+    entry.add_to_hass(hass)
+
+    mock_conn = FritzConnectionMock(MOCK_FB_SERVICES | MOCK_CALL_DEFLECTION_DATA)
+    fc_class_mock.return_value = mock_conn
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "switch.printer_internet_access"
+    assert hass.states.get(entity_id).state == STATE_ON
+
+    with (
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper.async_set_allow_wan_access",
+        ),
+        patch(
+            "homeassistant.components.fritz.coordinator.AvmWrapper._async_get_wan_access",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    coordinator = entry.runtime_data
+    device = coordinator.devices["AA:BB:CC:00:11:22"]
+
+    # A poll with wan_access=None (device gone offline / attr missing) must
+    # propagate through the skip window so unavailability is not suppressed.
+    none_info = Device(
+        name=device.hostname,
+        connected=True,
+        connected_to="",
+        connection_type="",
+        ip_address=device.ip_address,
+        ssid=None,
+        wan_access=None,
+    )
+    device.update(none_info, 0)
+    assert device.wan_access is None
+
+    # The skip window must be cleared so a subsequent bool poll propagates
+    # immediately instead of being gated.
+    stale_info = Device(
+        name=device.hostname,
+        connected=True,
+        connected_to="",
+        connection_type="",
+        ip_address=device.ip_address,
+        ssid=None,
+        wan_access=True,
+    )
+    device.update(stale_info, 0)
+    assert device.wan_access is True


### PR DESCRIPTION
## Proposed change

Fix the internet access profile switch flipping back to its previous state after toggling, before eventually settling on the correct state.

The FritzBox exposes two ways to read a device's WAN access state:
1. `GetWANAccessByIP` — reflects changes immediately (~0.4s)
2. `get_hosts_attributes` (bulk host query) — returns stale `X_AVM-DE_WANAccess` for ~10-13s after a change

The integration's 30s refresh cycle uses `get_hosts_attributes` for efficiency. If the refresh happens within the ~10s stale window after a toggle, the stale value overwrites the local state, causing the switch to flip back.

**Fix (2 files, 3 changes):**

1. **`switch.py`**: After sending `DisallowWANAccessByIP`, clear the call cache and verify the actual state via `GetWANAccessByIP` (immediate, not stale). Use the verified value instead of blindly trusting the requested value. Note: the verification calls `_async_get_wan_access` which is a private method on `AvmWrapper` — the `noqa: SLF001` is intentional since this is an internal call within the same integration package, and making the method public would require renaming it across coordinator and all tests for no functional benefit.

2. **`models.py`**: After the verified state is set via the `wan_access` setter, protect it from stale polled data for up to 60s. The protection expires automatically either when the polled value catches up (confirms the change) or after the timeout.

**Testing:** FritzBox 6490 Cable with 3 mesh repeaters, HA 2026.3.3, fritzconnection 1.15.1.
- Before fix: flip-flop in 2/5 test cycles (~33%, matching 10s stale / 30s poll)
- After fix: 0/10 flip-flops, correct state in all cycles

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #160942
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr