### PR TITLE
Fix fritzbox SSDP discovery crash for hostname URLs

### DIFF
--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -119,11 +119,12 @@ class FritzboxConfigFlow(ConfigFlow, domain=DOMAIN):
         host = urlparse(discovery_info.ssdp_location).hostname
         assert isinstance(host, str)
 
-        if (
-            ipaddress.ip_address(host).version == 6
-            and ipaddress.ip_address(host).is_link_local
-        ):
-            return self.async_abort(reason="ignore_ip6_link_local")
+        try:
+            ip = ipaddress.ip_address(host)
+            if ip.version == 6 and ip.is_link_local:
+                return self.async_abort(reason="ignore_ip6_link_local")
+        except ValueError:
+            pass
 
         if uuid := discovery_info.upnp.get(ATTR_UPNP_UDN):
             uuid = uuid.removeprefix("uuid:")

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -53,6 +53,15 @@ MOCK_SSDP_DATA = {
             ATTR_UPNP_UDN: "uuid:only-a-test",
         },
     ),
+    "hostname": SsdpServiceInfo(
+        ssdp_usn="mock_usn",
+        ssdp_st="mock_st",
+        ssdp_location="https://fritz.box:12345/test",
+        upnp={
+            ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
+            ATTR_UPNP_UDN: "uuid:only-a-test",
+        },
+    ),
 }
 
 
@@ -262,6 +271,7 @@ async def test_reconfigure_failed(hass: HomeAssistant, fritz: Mock) -> None:
         (MOCK_SSDP_DATA["ip4_valid"], FlowResultType.FORM),
         (MOCK_SSDP_DATA["ip6_valid"], FlowResultType.FORM),
         (MOCK_SSDP_DATA["ip6_invalid"], FlowResultType.ABORT),
+        (MOCK_SSDP_DATA["hostname"], FlowResultType.FORM),
     ],
 )
 async def test_ssdp(


### PR DESCRIPTION
## Summary

When a FRITZ!Box advertises itself via SSDP with a hostname in the location URL (e.g. `https://fritz.box:12345/...`) instead of an IP address, `urlparse().hostname` returns a plain string. Calling `ipaddress.ip_address()` on a hostname raises `ValueError`, which aborts the SSDP discovery flow unexpectedly.

**Fix:** Wrap the `ip_address()` call in a `try/except ValueError` so hostname-based SSDP locations are handled gracefully — the link-local IPv6 check is simply skipped for non-IP hosts.

## Changes

- `homeassistant/components/fritzbox/config_flow.py`: wrap `ipaddress.ip_address(host)` in `try/except ValueError`
- `tests/components/fritzbox/test_config_flow.py`: add `"hostname"` case to `MOCK_SSDP_DATA` and extend the `test_ssdp` parametrize