### PR TITLE
Fix fritzbox entity cleanup for AINs with underscores and trigger entities

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -95,12 +95,15 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
 
     def cleanup_removed_devices(self, data: FritzboxCoordinatorData) -> None:
         """Cleanup entity and device registry from removed devices."""
-        available_ains = list(data.devices) + list(data.templates)
+        available_ains = list(data.devices) + list(data.templates) + list(data.triggers)
         entity_reg = er.async_get(self.hass)
         for entity in er.async_entries_for_config_entry(
             entity_reg, self.config_entry.entry_id
         ):
-            if entity.unique_id.split("_")[0] not in available_ains:
+            if not any(
+                entity.unique_id == ain or entity.unique_id.startswith(f"{ain}_")
+                for ain in available_ains
+            ):
                 LOGGER.debug("Removing obsolete entity entry %s", entity.entity_id)
                 entity_reg.async_remove(entity.entity_id)
 

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import Mock
 
 from pyfritzhome import LoginError
+import pytest
 from requests.exceptions import ConnectionError, HTTPError
 
 from homeassistant.components.fritzbox.const import DOMAIN
@@ -297,6 +298,14 @@ async def test_coordinator_cleanup_preserves_trigger_entities(
     assert len(trigger_entities_after) == 1
 
 
+@pytest.mark.parametrize(
+    ("trigger", "side_effect", "switch_entity_count"),
+    [
+        (None, None, 0),
+        (None, HTTPError(), 0),
+        (FritzTriggerMock(), None, 1),
+    ],
+)
 async def test_coordinator_has_triggers(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -192,14 +192,6 @@ async def test_coordinator_workaround_sub_units_without_main_device(
     assert device_entries[1].identifiers == {(DOMAIN, "bad_device")}
 
 
-@pytest.mark.parametrize(
-    ("trigger", "side_effect", "switch_entity_count"),
-    [
-        (None, None, 0),
-        (None, HTTPError(), 0),
-        (FritzTriggerMock(), None, 1),
-    ],
-)
 async def test_coordinator_cleanup_ain_with_underscore(
     hass: HomeAssistant,
     fritz: Mock,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -200,6 +200,110 @@ async def test_coordinator_workaround_sub_units_without_main_device(
         (FritzTriggerMock(), None, 1),
     ],
 )
+async def test_coordinator_cleanup_ain_with_underscore(
+    hass: HomeAssistant,
+    fritz: Mock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test cleanup does not wrongly remove entities for devices with underscore in AIN.
+
+    The old split("_")[0] check extracted only the first segment of an AIN
+    containing underscores, causing active entities to be removed incorrectly.
+    """
+    device_underscore = FritzDeviceSwitchMock(
+        ain="fake_ain_switch",
+        device_and_unit_id=("fake_ain_switch", None),
+        name="fake_switch_underscore",
+    )
+    device_normal = FritzDeviceSwitchMock(
+        ain="fake ain cover",
+        device_and_unit_id=("fake ain cover", None),
+        name="fake_switch_normal",
+    )
+    fritz().get_devices.return_value = [device_underscore, device_normal]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    count_before = len(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
+    assert count_before > 0
+
+    # Remove device_normal to trigger cleanup_removed_devices()
+    fritz().get_devices.return_value = [device_underscore]
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    remaining = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert all("fake_ain_switch" in e.unique_id for e in remaining)
+    assert not any("fake ain cover" in e.unique_id for e in remaining)
+
+
+async def test_coordinator_cleanup_preserves_trigger_entities(
+    hass: HomeAssistant,
+    fritz: Mock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that trigger entities are not wrongly removed when a device is deleted.
+
+    The old cleanup code only included devices and templates in available_ains,
+    so trigger AINs were never found and trigger entities were deleted on every
+    cleanup run, even when the trigger itself was still active.
+    """
+    fritz().get_triggers.return_value = [FritzTriggerMock()]
+    fritz().get_devices.return_value = [
+        FritzDeviceSwitchMock(
+            ain="fake ain switch 1",
+            device_and_unit_id=("fake ain switch 1", None),
+            name="fake_switch_1",
+        ),
+        FritzDeviceSwitchMock(
+            ain="fake ain switch 2",
+            device_and_unit_id=("fake ain switch 2", None),
+            name="fake_switch_2",
+        ),
+    ]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    trigger_entities_before = [
+        e
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if FritzTriggerMock.ain in e.unique_id
+    ]
+    assert len(trigger_entities_before) == 1
+
+    # Remove one device to trigger cleanup_removed_devices()
+    fritz().get_devices.return_value = [
+        FritzDeviceSwitchMock(
+            ain="fake ain switch 1",
+            device_and_unit_id=("fake ain switch 1", None),
+            name="fake_switch_1",
+        ),
+    ]
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    trigger_entities_after = [
+        e
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        if FritzTriggerMock.ain in e.unique_id
+    ]
+    assert len(trigger_entities_after) == 1
+
+
 async def test_coordinator_has_triggers(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from unittest.mock import Mock
 
 from pyfritzhome import LoginError
-import pytest
 from requests.exceptions import ConnectionError, HTTPError
 
 from homeassistant.components.fritzbox.const import DOMAIN

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -231,7 +231,9 @@ async def test_coordinator_cleanup_ain_with_underscore(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    count_before = len(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
+    count_before = len(
+        er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    )
     assert count_before > 0
 
     # Remove device_normal to trigger cleanup_removed_devices()


### PR DESCRIPTION
## Summary

Two bugs in `cleanup_removed_devices()`:

**1. AINs with underscores cause wrong entity removal**
The old check `entity.unique_id.split("_")[0] not in available_ains` only extracts the first underscore-separated segment. For a device with AIN `"fake_ain_switch"`, `split("_")[0]` yields `"fake"` — which is never found in `available_ains` — so all entities of that still-active device get incorrectly removed.

**2. Trigger entities always removed during cleanup**
`available_ains` only included `data.devices` and `data.templates`, never `data.triggers`. Any time cleanup ran (e.g. when a device was removed), all trigger entities were treated as obsolete and deleted, even while their trigger was still active.

## Changes

- `homeassistant/components/fritzbox/coordinator.py`:
  - Add `list(data.triggers)` to `available_ains`
  - Replace `split("_")[0]` check with `unique_id == ain or unique_id.startswith(f"{ain}_")`
- `tests/components/fritzbox/test_coordinator.py`:
  - `test_coordinator_cleanup_ain_with_underscore`: verifies entities of a device with underscore AIN survive cleanup
  - `test_coordinator_cleanup_preserves_trigger_entities`: verifies trigger entities are not removed when an unrelated device is deleted