### PR TITLE
Refactor fritzbox: replace # type: ignore with explicit cast() calls

### DIFF
--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -115,15 +115,15 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
     def current_temperature(self) -> float:
         """Return the current temperature."""
         if self.data.has_temperature_sensor and self.data.temperature is not None:
-            return self.data.temperature  # type: ignore [no-any-return]
-        return self.data.actual_temperature  # type: ignore [no-any-return]
+            return cast(float, self.data.temperature)
+        return cast(float, self.data.actual_temperature)
 
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
         if self.data.target_temperature in [ON_API_TEMPERATURE, OFF_API_TEMPERATURE]:
             return None
-        return self.data.target_temperature  # type: ignore [no-any-return]
+        return cast(float, self.data.target_temperature)
 
     async def async_set_hkr_state(self, hkr_state: str) -> None:
         """Set the state of the climate."""

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -70,7 +70,7 @@ class FritzboxCover(FritzBoxDeviceEntity, CoverEntity):
         """Return if the cover is closed."""
         if self.data.levelpercentage is None:
             return None
-        return self.data.levelpercentage == 100  # type: ignore [no-any-return]
+        return cast(bool, self.data.levelpercentage == 100)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""

--- a/homeassistant/components/fritzbox/light.py
+++ b/homeassistant/components/fritzbox/light.py
@@ -88,12 +88,12 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
     @property
     def is_on(self) -> bool:
         """If the light is currently on or off."""
-        return self.data.state  # type: ignore [no-any-return]
+        return cast(bool, self.data.state)
 
     @property
     def brightness(self) -> int:
         """Return the current Brightness."""
-        return self.data.level  # type: ignore [no-any-return]
+        return cast(int, self.data.level)
 
     @property
     def hs_color(self) -> tuple[float, float]:
@@ -106,7 +106,7 @@ class FritzboxLight(FritzBoxDeviceEntity, LightEntity):
     @property
     def color_temp_kelvin(self) -> int:
         """Return the CT color value."""
-        return self.data.color_temp  # type: ignore [no-any-return]
+        return cast(int, self.data.color_temp)
 
     @property
     def color_mode(self) -> ColorMode:

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pyfritzhome.devicetypes import FritzhomeTrigger
 
@@ -58,7 +58,7 @@ class FritzboxSwitch(FritzBoxDeviceEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.data.switch_state  # type: ignore [no-any-return]
+        return cast(bool, self.data.switch_state)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -103,7 +103,7 @@ class FritzboxTrigger(FritzBoxEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the trigger is active."""
-        return self.data.active  # type: ignore [no-any-return]
+        return cast(bool, self.data.active)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Activate the trigger."""


### PR DESCRIPTION
## Summary

Several `pyfritzhome` properties are typed as `Any`, which causes mypy `no-any-return` errors when returned from typed properties. These were previously suppressed with `# type: ignore [no-any-return]` comments.

Replace all suppressions with explicit `cast()` calls to make the expected return types visible in the code without silencing the type checker.

## Changes

- `switch.py`: `cast(bool, self.data.switch_state)`, `cast(bool, self.data.active)`
- `cover.py`: `cast(bool, self.data.levelpercentage == 100)`
- `climate.py`: `cast(float, ...)` for `temperature`, `actual_temperature`, `target_temperature`
- `light.py`: `cast(bool, self.data.state)`, `cast(int, self.data.level)`, `cast(int, self.data.color_temp)`