### PR TITLE
Fix fritzbox: re-login in-place instead of scheduling a full reload on error

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -183,14 +183,24 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             new_data = await self.hass.async_add_executor_job(
                 self._update_fritz_devices
             )
-        except (RequestConnectionError, HTTPError) as ex:
+        except (RequestConnectionError, HTTPError, LoginError) as ex:
             LOGGER.debug(
-                "Reload %s due to error '%s' to ensure proper re-login",
+                "Error fetching %s data, attempting re-login: '%s'",
                 self.config_entry.title,
                 ex,
             )
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-            raise UpdateFailed from ex
+            try:
+                await self.hass.async_add_executor_job(self.fritz.login)
+            except LoginError as login_ex:
+                raise ConfigEntryAuthFailed from login_ex
+            except (RequestConnectionError, HTTPError) as conn_ex:
+                raise UpdateFailed(conn_ex) from conn_ex
+            try:
+                new_data = await self.hass.async_add_executor_job(
+                    self._update_fritz_devices
+                )
+            except (RequestConnectionError, HTTPError, LoginError) as retry_ex:
+                raise UpdateFailed(retry_ex) from retry_ex
 
         for device in new_data.devices.values():
             # create device registry entry for new main devices

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -33,7 +33,36 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_coordinator_update_after_reboot(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator after reboot."""
+    """Test coordinator re-login after a transient HTTP error during update.
+
+    When _update_fritz_devices raises HTTPError the coordinator attempts a
+    re-login and retries.  If both the re-login and the retry succeed the
+    entry stays loaded without triggering a full reload.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    # First update call succeeds; second raises HTTPError to simulate a reboot
+    fritz().update_devices.side_effect = ["", HTTPError(), ""]
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    assert fritz().login.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Re-login was attempted once more (total 2: initial setup + re-login)
+    assert fritz().login.call_count == 2
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_coordinator_update_after_reboot_relogin_fails(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
+    """Test coordinator when re-login itself fails after an HTTP error."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
@@ -41,18 +70,14 @@ async def test_coordinator_update_after_reboot(
     )
     entry.add_to_hass(hass)
     fritz().update_devices.side_effect = ["", HTTPError()]
+    fritz().login.side_effect = [None, ConnectionError()]
 
     assert await hass.config_entries.async_setup(entry.entry_id)
-    assert fritz().update_devices.call_count == 1
-    assert fritz().update_templates.call_count == 1
-    assert fritz().get_devices.call_count == 1
-    assert fritz().get_templates.call_count == 1
-    assert fritz().login.call_count == 1
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_coordinator_update_after_password_change(
@@ -71,17 +96,41 @@ async def test_coordinator_update_after_password_change(
     assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_coordinator_update_when_unreachable(
+async def test_coordinator_update_relogin_detects_password_change(
     hass: HomeAssistant, fritz: Mock
 ) -> None:
-    """Test coordinator after reboot."""
+    """Test coordinator triggers reauth when re-login fails with LoginError."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
         unique_id="any",
     )
     entry.add_to_hass(hass)
+    fritz().update_devices.side_effect = ["", HTTPError()]
+    # Initial login succeeds; re-login fails with LoginError (password changed)
+    fritz().login.side_effect = [None, LoginError("some_user")]
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_coordinator_update_when_unreachable(
+    hass: HomeAssistant, fritz: Mock
+) -> None:
+    """Test coordinator when device is unreachable during initial setup."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG[DOMAIN][CONF_DEVICES][0],
+        unique_id="any",
+    )
+    entry.add_to_hass(hass)
+    # Both the initial update and the re-login attempt fail immediately
     fritz().update_devices.side_effect = [ConnectionError()]
+    fritz().login.side_effect = [None, ConnectionError()]
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/fritzbox/test_coordinator.py
+++ b/tests/components/fritzbox/test_coordinator.py
@@ -11,7 +11,7 @@ from requests.exceptions import ConnectionError, HTTPError
 
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_DEVICES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -115,7 +115,12 @@ async def test_coordinator_update_relogin_detects_password_change(
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=35))
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.LOADED
+    flows = hass.config_entries.flow.async_progress()
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"]["source"] == SOURCE_REAUTH
+        for flow in flows
+    )
 
 
 async def test_coordinator_update_when_unreachable(


### PR DESCRIPTION
## Summary

When `_update_fritz_devices` raises a connection or HTTP error, the current coordinator calls `async_schedule_reload()`. A full reload tears down all entities (marking them unavailable), waits for HA to re-run `async_setup_entry`, and forces a re-login from scratch — adding significant disruption for short-lived connection blips such as a Fritz!Box rebooting after a firmware update.

This PR replaces the reload with an in-place re-login + retry strategy:

1. On any fetch error (`RequestConnectionError`, `HTTPError`, `LoginError`), call `fritz.login()` directly in the coordinator.
2. If re-login raises `LoginError` → surface as `ConfigEntryAuthFailed` so HA triggers a reauth flow immediately (password was changed).
3. If re-login raises a connection error → raise `UpdateFailed`; the coordinator's own back-off handles retries.
4. If re-login succeeds → retry `_update_fritz_devices` once. A second failure raises `UpdateFailed`.

## Benefits

- Entities stay **available** during transient errors instead of being torn down.
- No full integration reload overhead for every connection hiccup.
- `LoginError` during polling is now caught and surfaces as `ConfigEntryAuthFailed` instead of being silently swallowed by a reload.

## Changes

- `homeassistant/components/fritzbox/coordinator.py`: replace `async_schedule_reload` with re-login + retry in `_async_update_data`
- `tests/components/fritzbox/test_coordinator.py`:
  - Update `test_coordinator_update_after_reboot` to reflect new behaviour (re-login succeeds → entry stays `LOADED`)
  - Update `test_coordinator_update_when_unreachable` to reflect new behaviour
  - Add `test_coordinator_update_after_reboot_relogin_fails`: re-login connection error → `UpdateFailed`
  - Add `test_coordinator_update_relogin_detects_password_change`: re-login `LoginError` → `ConfigEntryAuthFailed`