### PR TITLE
Fix/roborock-state-unknown-comparison

### DIFF
--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==4.26.2",
+    "python-roborock==4.26.3",
     "vacuum-map-parser-roborock==0.1.4"
   ]
 }

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -529,18 +529,20 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
 
     async def async_select_option(self, option: str) -> None:
         """Set the cleaning mode."""
+        # Find the mode that matches the selected option
+        mode = None
+        for clean_mode in YXCleanType:
+            if _map_q10_clean_mode_to_state_key(clean_mode.code) == option:
+                mode = clean_mode
+                break
+
+        if mode is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="select_option_failed",
+            )
+
         try:
-            mode = None
-            for clean_mode in YXCleanType:
-                if _map_q10_clean_mode_to_state_key(clean_mode.code) == option:
-                    mode = clean_mode
-                    break
-            if mode is None:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="command_failed",
-                    translation_placeholders={"command": "set_clean_mode"},
-                )
             await self.coordinator.api.vacuum.set_clean_mode(mode)
         except RoborockException as err:
             raise HomeAssistantError(

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -475,6 +475,16 @@ class RoborockSelectEntityA01(RoborockCoordinatedEntityA01, SelectEntity):
         return str(current_value)
 
 
+def _map_q10_clean_mode_to_state_key(mode: YXCleanType) -> str:
+    """Map Q10 clean mode to HA state key (matching Q7 keys)."""
+    mapping = {
+        YXCleanType.BOTH_WORK: "vac_and_mop",
+        YXCleanType.ONLY_SWEEP: "vacuum",
+        YXCleanType.ONLY_MOP: "mop",
+    }
+    return mapping.get(mode, "unknown")
+
+
 def _get_q10_cleaning_mode(data: Any) -> str | None:
     """Get cleaning mode from Q10 data."""
     if isinstance(data, dict):
@@ -484,11 +494,11 @@ def _get_q10_cleaning_mode(data: Any) -> str | None:
             if isinstance(clean_mode_value, int):
                 try:
                     mode_enum = YXCleanType.from_code(clean_mode_value)
-                    return mode_enum.name.lower()
+                    return _map_q10_clean_mode_to_state_key(mode_enum)
                 except ValueError, AttributeError:
                     return None
             if isinstance(clean_mode_value, YXCleanType):
-                return clean_mode_value.name.lower()
+                return _map_q10_clean_mode_to_state_key(clean_mode_value)
         return None
     # B01Props-like object
     if hasattr(data, "mode") and data.mode:
@@ -517,7 +527,7 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
     def options(self) -> list[str]:
         """Return available cleaning modes."""
         return [
-            option.name.lower()
+            _map_q10_clean_mode_to_state_key(option)
             for option in YXCleanType
             if option != YXCleanType.UNKNOWN
         ]
@@ -532,7 +542,7 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
         try:
             mode = None
             for clean_mode in YXCleanType:
-                if clean_mode.name.lower() == option:
+                if _map_q10_clean_mode_to_state_key(clean_mode) == option:
                     mode = clean_mode
                     break
             if mode is None:

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -475,35 +475,14 @@ class RoborockSelectEntityA01(RoborockCoordinatedEntityA01, SelectEntity):
         return str(current_value)
 
 
-def _map_q10_clean_mode_to_state_key(mode: YXCleanType) -> str:
-    """Map Q10 clean mode to HA state key (matching Q7 keys)."""
+def _map_q10_clean_mode_to_state_key(mode_code: int) -> str | None:
+    """Map Q10 clean mode code to HA state key (matching Q7 keys)."""
     mapping = {
-        YXCleanType.BOTH_WORK: "vac_and_mop",
-        YXCleanType.ONLY_SWEEP: "vacuum",
-        YXCleanType.ONLY_MOP: "mop",
+        1: "vac_and_mop",
+        2: "vacuum",
+        3: "mop",
     }
-    return mapping.get(mode, "unknown")
-
-
-def _get_q10_cleaning_mode(data: Any) -> str | None:
-    """Get cleaning mode from Q10 data."""
-    if isinstance(data, dict):
-        # Q10 dict data - check for CLEAN_MODE key
-        if B01_Q10_DP.CLEAN_MODE in data:
-            clean_mode_value = data[B01_Q10_DP.CLEAN_MODE]
-            if isinstance(clean_mode_value, int):
-                try:
-                    mode_enum = YXCleanType.from_code(clean_mode_value)
-                    return _map_q10_clean_mode_to_state_key(mode_enum)
-                except ValueError, AttributeError:
-                    return None
-            if isinstance(clean_mode_value, YXCleanType):
-                return _map_q10_clean_mode_to_state_key(clean_mode_value)
-        return None
-    # B01Props-like object
-    if hasattr(data, "mode") and data.mode:
-        return data.mode.value
-    return None
+    return mapping.get(mode_code)
 
 
 class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEntity):
@@ -523,26 +502,37 @@ class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEn
             coordinator,
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Register trait listener for push-based status updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.api.status.add_update_listener(self.async_write_ha_state)
+        )
+
     @property
     def options(self) -> list[str]:
         """Return available cleaning modes."""
         return [
-            _map_q10_clean_mode_to_state_key(option)
+            state_key
             for option in YXCleanType
+            if (state_key := _map_q10_clean_mode_to_state_key(option.code)) is not None
             if option != YXCleanType.UNKNOWN
         ]
 
     @property
     def current_option(self) -> str | None:
         """Get the current cleaning mode."""
-        return _get_q10_cleaning_mode(self.coordinator.data)
+        clean_mode = self.coordinator.api.status.clean_mode
+        if clean_mode is None:
+            return None
+        return _map_q10_clean_mode_to_state_key(clean_mode.code)
 
     async def async_select_option(self, option: str) -> None:
         """Set the cleaning mode."""
         try:
             mode = None
             for clean_mode in YXCleanType:
-                if _map_q10_clean_mode_to_state_key(clean_mode) == option:
+                if _map_q10_clean_mode_to_state_key(clean_mode.code) == option:
                     mode = clean_mode
                     break
             if mode is None:

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -20,6 +20,7 @@ from roborock.data import (
     ZeoSpin,
     ZeoTemperature,
 )
+from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXCleanType
 from roborock.devices.traits.b01 import Q7PropertiesApi
 from roborock.devices.traits.v1 import PropertiesApi
 from roborock.devices.traits.v1.home import HomeTrait
@@ -37,6 +38,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import DOMAIN, MAP_SLEEP
 from .coordinator import (
     RoborockB01Q7UpdateCoordinator,
+    RoborockB01Q10UpdateCoordinator,
     RoborockConfigEntry,
     RoborockDataUpdateCoordinator,
     RoborockDataUpdateCoordinatorA01,
@@ -44,6 +46,7 @@ from .coordinator import (
 from .entity import (
     RoborockCoordinatedEntityA01,
     RoborockCoordinatedEntityB01Q7,
+    RoborockCoordinatedEntityB01Q10,
     RoborockCoordinatedEntityV1,
 )
 
@@ -266,6 +269,10 @@ async def async_setup_entry(
         for description in A01_SELECT_DESCRIPTIONS
         if description.data_protocol in coordinator.request_protocols
     )
+    async_add_entities(
+        RoborockQ10CleanModeSelectEntity(coordinator)
+        for coordinator in config_entry.runtime_data.b01_q10
+    )
 
 
 class RoborockB01SelectEntity(RoborockCoordinatedEntityB01Q7, SelectEntity):
@@ -466,3 +473,79 @@ class RoborockSelectEntityA01(RoborockCoordinatedEntityA01, SelectEntity):
             self.entity_description.key,
         )
         return str(current_value)
+
+
+def _get_q10_cleaning_mode(data: Any) -> str | None:
+    """Get cleaning mode from Q10 data."""
+    if isinstance(data, dict):
+        # Q10 dict data - check for CLEAN_MODE key
+        if B01_Q10_DP.CLEAN_MODE in data:
+            clean_mode_value = data[B01_Q10_DP.CLEAN_MODE]
+            if isinstance(clean_mode_value, int):
+                try:
+                    mode_enum = YXCleanType.from_code(clean_mode_value)
+                    return mode_enum.name.lower()
+                except ValueError, AttributeError:
+                    return None
+            if isinstance(clean_mode_value, YXCleanType):
+                return clean_mode_value.name.lower()
+        return None
+    # B01Props-like object
+    if hasattr(data, "mode") and data.mode:
+        return data.mode.value
+    return None
+
+
+class RoborockQ10CleanModeSelectEntity(RoborockCoordinatedEntityB01Q10, SelectEntity):
+    """Select entity for Q10 cleaning mode."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "cleaning_mode"
+    coordinator: RoborockB01Q10UpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: RoborockB01Q10UpdateCoordinator,
+    ) -> None:
+        """Create a select entity for Q10 cleaning mode."""
+        super().__init__(
+            f"cleaning_mode_{coordinator.duid_slug}",
+            coordinator,
+        )
+
+    @property
+    def options(self) -> list[str]:
+        """Return available cleaning modes."""
+        return [
+            option.name.lower()
+            for option in YXCleanType
+            if option != YXCleanType.UNKNOWN
+        ]
+
+    @property
+    def current_option(self) -> str | None:
+        """Get the current cleaning mode."""
+        return _get_q10_cleaning_mode(self.coordinator.data)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the cleaning mode."""
+        try:
+            mode = None
+            for clean_mode in YXCleanType:
+                if clean_mode.name.lower() == option:
+                    mode = clean_mode
+                    break
+            if mode is None:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="command_failed",
+                    translation_placeholders={"command": "set_clean_mode"},
+                )
+            await self.coordinator.api.vacuum.set_clean_mode(mode)
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={"command": "set_clean_mode"},
+            ) from err
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -20,7 +20,7 @@ from roborock.data import (
     ZeoSpin,
     ZeoTemperature,
 )
-from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXCleanType
+from roborock.data.b01_q10.b01_q10_code_mappings import YXCleanType
 from roborock.devices.traits.b01 import Q7PropertiesApi
 from roborock.devices.traits.v1 import PropertiesApi
 from roborock.devices.traits.v1.home import HomeTrait

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -118,10 +118,7 @@
       "cleaning_mode": {
         "name": "Cleaning mode",
         "state": {
-          "both_work": "Vacuum and mop",
           "mop": "Mop only",
-          "only_mop": "Mop only",
-          "only_sweep": "Vacuum only",
           "vac_and_mop": "Vacuum and mop",
           "vacuum": "Vacuum only"
         }

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -118,7 +118,10 @@
       "cleaning_mode": {
         "name": "Cleaning mode",
         "state": {
+          "both_work": "Vacuum and mop",
           "mop": "Mop only",
+          "only_mop": "Mop only",
+          "only_sweep": "Vacuum only",
           "vac_and_mop": "Vacuum and mop",
           "vacuum": "Vacuum only"
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2660,7 +2660,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==4.26.2
+python-roborock==4.26.3
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2256,7 +2256,7 @@ python-pooldose==0.8.6
 python-rabbitair==0.0.8
 
 # homeassistant.components.roborock
-python-roborock==4.26.2
+python-roborock==4.26.3
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -10,12 +10,14 @@ from roborock.data import (
     WaterLevelMapping,
     ZeoProgram,
 )
+from roborock.data.b01_q10.b01_q10_code_mappings import YXCleanType
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockZeoProtocol
 
 from homeassistant.components.roborock import DOMAIN
 from homeassistant.components.roborock.select import (
     A01_SELECT_DESCRIPTIONS,
+    RoborockQ10CleanModeSelectEntity,
     RoborockSelectEntityA01,
 )
 from homeassistant.const import SERVICE_SELECT_OPTION, STATE_UNKNOWN, Platform
@@ -383,3 +385,67 @@ async def test_update_failure_zeo_invalid_option() -> None:
         await entity.async_select_option("invalid_option")
 
     coordinator.api.set_value.assert_not_called()
+
+@pytest.fixture
+def q10_device(fake_devices: list[FakeDevice]) -> FakeDevice:
+    """Get the fake Q10 vacuum device."""
+    # The Q10 is the fifth device in the list (index 4) based on HOME_DATA
+    return fake_devices[4]
+
+
+async def test_q10_cleaning_mode_select_current_option(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    q10_device: FakeDevice,
+) -> None:
+    """Test Q10 cleaning mode select entity current option."""
+    entity_id = "select.roborock_q10_s5_cleaning_mode"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    # Verify the entity exists and has valid options
+    assert state.attributes.get("options") is not None
+
+
+async def test_q10_cleaning_mode_select_update_success(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    q10_device: FakeDevice,
+) -> None:
+    """Test setting Q10 cleaning mode select option."""
+    entity_id = "select.roborock_q10_s5_cleaning_mode"
+    assert hass.states.get(entity_id) is not None
+
+    # Test setting value
+    await hass.services.async_call(
+        "select",
+        SERVICE_SELECT_OPTION,
+        service_data={"option": "both_work"},
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+
+    assert q10_device.b01_q10_properties
+    assert q10_device.b01_q10_properties.vacuum.set_clean_mode.call_count == 1
+
+
+async def test_q10_cleaning_mode_select_update_failure(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    q10_device: FakeDevice,
+) -> None:
+    """Test failure when setting Q10 cleaning mode."""
+    assert q10_device.b01_q10_properties
+    q10_device.b01_q10_properties.vacuum.set_clean_mode.side_effect = (
+        RoborockException
+    )
+    entity_id = "select.roborock_q10_s5_cleaning_mode"
+    assert hass.states.get(entity_id) is not None
+
+    with pytest.raises(HomeAssistantError, match="set_clean_mode"):
+        await hass.services.async_call(
+            "select",
+            SERVICE_SELECT_OPTION,
+            service_data={"option": "both_work"},
+            blocking=True,
+            target={"entity_id": entity_id},
+        )

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -10,7 +10,7 @@ from roborock.data import (
     WaterLevelMapping,
     ZeoProgram,
 )
-from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
+from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP, YXCleanType
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockZeoProtocol
 
@@ -435,6 +435,9 @@ async def test_q10_cleaning_mode_select_update_success(
 
     assert q10_device.b01_q10_properties
     assert q10_device.b01_q10_properties.vacuum.set_clean_mode.call_count == 1
+    q10_device.b01_q10_properties.vacuum.set_clean_mode.assert_called_once_with(
+        YXCleanType.BOTH_WORK
+    )
 
 
 async def test_q10_cleaning_mode_select_update_failure(

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -10,14 +10,13 @@ from roborock.data import (
     WaterLevelMapping,
     ZeoProgram,
 )
-from roborock.data.b01_q10.b01_q10_code_mappings import YXCleanType
+from roborock.data.b01_q10.b01_q10_code_mappings import B01_Q10_DP
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockZeoProtocol
 
 from homeassistant.components.roborock import DOMAIN
 from homeassistant.components.roborock.select import (
     A01_SELECT_DESCRIPTIONS,
-    RoborockQ10CleanModeSelectEntity,
     RoborockSelectEntityA01,
 )
 from homeassistant.const import SERVICE_SELECT_OPTION, STATE_UNKNOWN, Platform
@@ -386,6 +385,7 @@ async def test_update_failure_zeo_invalid_option() -> None:
 
     coordinator.api.set_value.assert_not_called()
 
+
 @pytest.fixture
 def q10_device(fake_devices: list[FakeDevice]) -> FakeDevice:
     """Get the fake Q10 vacuum device."""
@@ -402,8 +402,17 @@ async def test_q10_cleaning_mode_select_current_option(
     entity_id = "select.roborock_q10_s5_cleaning_mode"
     state = hass.states.get(entity_id)
     assert state is not None
-    # Verify the entity exists and has valid options
-    assert state.attributes.get("options") is not None
+    options = state.attributes.get("options")
+    assert options is not None
+
+    assert q10_device.b01_q10_properties
+    q10_device.b01_q10_properties.status.update_from_dps({B01_Q10_DP.CLEAN_MODE: 1})
+    await hass.async_block_till_done()
+
+    updated_state = hass.states.get(entity_id)
+    assert updated_state is not None
+    assert updated_state.state is not STATE_UNKNOWN
+    assert updated_state.state in options
 
 
 async def test_q10_cleaning_mode_select_update_success(
@@ -435,9 +444,7 @@ async def test_q10_cleaning_mode_select_update_failure(
 ) -> None:
     """Test failure when setting Q10 cleaning mode."""
     assert q10_device.b01_q10_properties
-    q10_device.b01_q10_properties.vacuum.set_clean_mode.side_effect = (
-        RoborockException
-    )
+    q10_device.b01_q10_properties.vacuum.set_clean_mode.side_effect = RoborockException
     entity_id = "select.roborock_q10_s5_cleaning_mode"
     assert hass.states.get(entity_id) is not None
 

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -406,7 +406,7 @@ async def test_q10_cleaning_mode_select_current_option(
 
     updated_state = hass.states.get(entity_id)
     assert updated_state is not None
-    assert updated_state.state is not STATE_UNKNOWN
+    assert updated_state.state != STATE_UNKNOWN
     assert updated_state.state == "vac_and_mop"
 
 

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -419,7 +419,7 @@ async def test_q10_cleaning_mode_select_update_success(
     await hass.services.async_call(
         "select",
         SERVICE_SELECT_OPTION,
-        service_data={"option": "both_work"},
+        service_data={"option": "vac_and_mop"},
         blocking=True,
         target={"entity_id": entity_id},
     )
@@ -445,7 +445,7 @@ async def test_q10_cleaning_mode_select_update_failure(
         await hass.services.async_call(
             "select",
             SERVICE_SELECT_OPTION,
-            service_data={"option": "both_work"},
+            service_data={"option": "vac_and_mop"},
             blocking=True,
             target={"entity_id": entity_id},
         )

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -386,17 +386,10 @@ async def test_update_failure_zeo_invalid_option() -> None:
     coordinator.api.set_value.assert_not_called()
 
 
-@pytest.fixture
-def q10_device(fake_devices: list[FakeDevice]) -> FakeDevice:
-    """Get the fake Q10 vacuum device."""
-    # The Q10 is the fifth device in the list (index 4) based on HOME_DATA
-    return fake_devices[4]
-
-
 async def test_q10_cleaning_mode_select_current_option(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    q10_device: FakeDevice,
+    fake_q10_vacuum: FakeDevice,
 ) -> None:
     """Test Q10 cleaning mode select entity current option."""
     entity_id = "select.roborock_q10_s5_cleaning_mode"
@@ -405,8 +398,10 @@ async def test_q10_cleaning_mode_select_current_option(
     options = state.attributes.get("options")
     assert options is not None
 
-    assert q10_device.b01_q10_properties
-    q10_device.b01_q10_properties.status.update_from_dps({B01_Q10_DP.CLEAN_MODE: 1})
+    assert fake_q10_vacuum.b01_q10_properties
+    fake_q10_vacuum.b01_q10_properties.status.update_from_dps(
+        {B01_Q10_DP.CLEAN_MODE: 1}
+    )
     await hass.async_block_till_done()
 
     updated_state = hass.states.get(entity_id)
@@ -418,7 +413,7 @@ async def test_q10_cleaning_mode_select_current_option(
 async def test_q10_cleaning_mode_select_update_success(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    q10_device: FakeDevice,
+    fake_q10_vacuum: FakeDevice,
 ) -> None:
     """Test setting Q10 cleaning mode select option."""
     entity_id = "select.roborock_q10_s5_cleaning_mode"
@@ -433,9 +428,9 @@ async def test_q10_cleaning_mode_select_update_success(
         target={"entity_id": entity_id},
     )
 
-    assert q10_device.b01_q10_properties
-    assert q10_device.b01_q10_properties.vacuum.set_clean_mode.call_count == 1
-    q10_device.b01_q10_properties.vacuum.set_clean_mode.assert_called_once_with(
+    assert fake_q10_vacuum.b01_q10_properties
+    assert fake_q10_vacuum.b01_q10_properties.vacuum.set_clean_mode.call_count == 1
+    fake_q10_vacuum.b01_q10_properties.vacuum.set_clean_mode.assert_called_once_with(
         YXCleanType.BOTH_WORK
     )
 
@@ -443,11 +438,13 @@ async def test_q10_cleaning_mode_select_update_success(
 async def test_q10_cleaning_mode_select_update_failure(
     hass: HomeAssistant,
     setup_entry: MockConfigEntry,
-    q10_device: FakeDevice,
+    fake_q10_vacuum: FakeDevice,
 ) -> None:
     """Test failure when setting Q10 cleaning mode."""
-    assert q10_device.b01_q10_properties
-    q10_device.b01_q10_properties.vacuum.set_clean_mode.side_effect = RoborockException
+    assert fake_q10_vacuum.b01_q10_properties
+    fake_q10_vacuum.b01_q10_properties.vacuum.set_clean_mode.side_effect = (
+        RoborockException
+    )
     entity_id = "select.roborock_q10_s5_cleaning_mode"
     assert hass.states.get(entity_id) is not None
 

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -412,7 +412,7 @@ async def test_q10_cleaning_mode_select_current_option(
     updated_state = hass.states.get(entity_id)
     assert updated_state is not None
     assert updated_state.state is not STATE_UNKNOWN
-    assert updated_state.state in options
+    assert updated_state.state == "vac_and_mop"
 
 
 async def test_q10_cleaning_mode_select_update_success(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Fix applied in test_select.py:**

`STATE_UNKNOWN` is a `str` constant. Using identity comparison (`is not`) is unreliable because Python does not always intern strings, which can cause intermittent test failures. Replaced with an equality comparison (`!=`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
