### PR TITLE
fix(tibber): refresh websocket init token on OAuth token update

### DIFF
--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -56,6 +56,13 @@ class TibberRuntimeData:
                 ssl=ssl_util.get_default_context(),
             )
         self._client.set_access_token(access_token)
+        # Update the websocket transport's init_payload so that reconnection
+        # attempts by the watchdog use the refreshed OAuth token instead of
+        # the stale one baked in at transport creation time.
+        if (sub_manager := self._client.realtime.sub_manager) is not None and hasattr(
+            sub_manager.transport, "init_payload"
+        ):
+            sub_manager.transport.init_payload = {"token": access_token}
         return self._client
 
 

--- a/tests/components/tibber/conftest.py
+++ b/tests/components/tibber/conftest.py
@@ -185,6 +185,10 @@ def tibber_mock() -> AsyncGenerator[MagicMock]:
         tibber_mock.get_homes = MagicMock(return_value=[])
         tibber_mock.set_access_token = MagicMock()
 
+        realtime_mock = MagicMock()
+        realtime_mock.sub_manager = None
+        tibber_mock.realtime = realtime_mock
+
         data_api_mock = MagicMock()
         data_api_mock.get_all_devices = AsyncMock(return_value={})
         data_api_mock.update_devices = AsyncMock(return_value={})

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -89,3 +89,34 @@ async def test_setup_requires_data_api_reauth(hass: HomeAssistant) -> None:
 
     with pytest.raises(ConfigEntryAuthFailed):
         await async_setup_entry(hass, entry)
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_async_get_client_updates_websocket_init_payload(
+    hass: HomeAssistant,
+) -> None:
+    """Ensure the websocket transport init_payload is updated with the fresh token."""
+    session = MagicMock()
+    session.async_ensure_token_valid = AsyncMock()
+    session.token = {CONF_ACCESS_TOKEN: "new-token"}
+
+    runtime = TibberRuntimeData(session=session)
+
+    with patch("homeassistant.components.tibber.tibber.Tibber") as mock_client_cls:
+        mock_transport = MagicMock()
+        mock_transport.init_payload = {"token": "old-token"}
+
+        mock_sub_manager = MagicMock()
+        mock_sub_manager.transport = mock_transport
+
+        mock_realtime = MagicMock()
+        mock_realtime.sub_manager = mock_sub_manager
+
+        mock_client = MagicMock()
+        mock_client.set_access_token = MagicMock()
+        mock_client.realtime = mock_realtime
+        mock_client_cls.return_value = mock_client
+
+        await runtime.async_get_client(hass)
+
+        assert mock_transport.init_payload == {"token": "new-token"}

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -95,16 +95,16 @@ async def test_setup_requires_data_api_reauth(hass: HomeAssistant) -> None:
 async def test_async_get_client_updates_websocket_init_payload(
     hass: HomeAssistant,
 ) -> None:
-    """Ensure the websocket transport init_payload is updated with the fresh token."""
+    """Ensure the websocket transport init_payload is refreshed on token rotation."""
     session = MagicMock()
     session.async_ensure_token_valid = AsyncMock()
-    session.token = {CONF_ACCESS_TOKEN: "new-token"}
+    session.token = {CONF_ACCESS_TOKEN: "initial-token"}
 
     runtime = TibberRuntimeData(session=session)
 
     with patch("homeassistant.components.tibber.tibber.Tibber") as mock_client_cls:
         mock_transport = MagicMock()
-        mock_transport.init_payload = {"token": "old-token"}
+        mock_transport.init_payload = {"token": "initial-token"}
 
         mock_sub_manager = MagicMock()
         mock_sub_manager.transport = mock_transport
@@ -117,6 +117,13 @@ async def test_async_get_client_updates_websocket_init_payload(
         mock_client.realtime = mock_realtime
         mock_client_cls.return_value = mock_client
 
+        # First call creates and caches the client with the initial token.
         await runtime.async_get_client(hass)
+        assert mock_transport.init_payload == {"token": "initial-token"}
 
-        assert mock_transport.init_payload == {"token": "new-token"}
+        # Simulate OAuth token rotation while the client is cached.
+        session.token = {CONF_ACCESS_TOKEN: "rotated-token"}
+
+        # Second call reuses the cached client; init_payload must be refreshed.
+        await runtime.async_get_client(hass)
+        assert mock_transport.init_payload == {"token": "rotated-token"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes Tibber realtime token refresh reliability after OAuth token rotation.

The current token refresh path updates the Tibber client token, but websocket reconnects can still use a stale token in the websocket connection init payload, which leads to 4403 Invalid token errors and stopped realtime updates.

This change updates the websocket init payload with the refreshed access token when the runtime client token is refreshed, so reconnect attempts use the latest valid token.

It also adds/updates tests to verify the new behavior.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #162395

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr