### PR TITLE
Handle validation error when starting stream from audio

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -24,7 +24,7 @@ from .const import (
     SAMPLE_WIDTH,
     SAMPLES_PER_CHUNK,
 )
-from .error import PipelineNotFound
+from .error import PipelineError, PipelineNotFound
 from .pipeline import (
     AudioSettings,
     Pipeline,
@@ -137,5 +137,21 @@ async def async_pipeline_from_audio_stream(
                 audio_settings=audio_settings or AudioSettings(),
             ),
         )
-        await pipeline_input.validate()
+        try:
+            await pipeline_input.validate()
+        except PipelineError as err:
+            pipeline_input.run.start(
+                conversation_id=session.conversation_id,
+                device_id=device_id,
+                satellite_id=satellite_id,
+            )
+            pipeline_input.run.process_event(
+                PipelineEvent(
+                    PipelineEventType.ERROR,
+                    {"code": err.code, "message": err.message},
+                )
+            )
+            await pipeline_input.run.end()
+            return
+
         await pipeline_input.execute()

--- a/tests/components/assist_pipeline/test_init.py
+++ b/tests/components/assist_pipeline/test_init.py
@@ -330,6 +330,49 @@ async def test_pipeline_from_audio_stream_unknown_pipeline(
     assert not events
 
 
+async def test_pipeline_from_audio_stream_validation_pipeline_error(
+    hass: HomeAssistant,
+    mock_stt_provider_entity: MockSTTProviderEntity,
+    init_components,
+) -> None:
+    """Test validation pipeline errors are emitted as terminal events."""
+    events: list[assist_pipeline.PipelineEvent] = []
+
+    await assist_pipeline.async_update_pipeline(
+        hass,
+        assist_pipeline.async_get_pipeline(hass),
+        conversation_engine="conversation.non_existing",
+    )
+
+    async def audio_data():
+        yield b"audio"
+
+    await assist_pipeline.async_pipeline_from_audio_stream(
+        hass,
+        context=Context(),
+        event_callback=events.append,
+        stt_metadata=stt.SpeechMetadata(
+            language="",
+            format=stt.AudioFormats.WAV,
+            codec=stt.AudioCodecs.PCM,
+            bit_rate=stt.AudioBitRates.BITRATE_16,
+            sample_rate=stt.AudioSampleRates.SAMPLERATE_16000,
+            channel=stt.AudioChannels.CHANNEL_MONO,
+        ),
+        stt_stream=audio_data(),
+        end_stage=assist_pipeline.PipelineStage.INTENT,
+    )
+
+    assert len(events) == 3
+    assert events[0].type == assist_pipeline.PipelineEventType.RUN_START
+    assert events[1].type == assist_pipeline.PipelineEventType.ERROR
+    assert events[1].data == {
+        "code": "intent-not-supported",
+        "message": "Intent recognition engine conversation.non_existing is not found",
+    }
+    assert events[2].type == assist_pipeline.PipelineEventType.RUN_END
+
+
 async def test_pipeline_from_audio_stream_wake_word(
     hass: HomeAssistant,
     mock_stt_provider_entity: MockSTTProviderEntity,

--- a/tests/components/assist_satellite/test_entity.py
+++ b/tests/components/assist_satellite/test_entity.py
@@ -184,6 +184,43 @@ async def test_new_pipeline_cancels_pipeline(
             await pipeline2_finished.wait()
 
 
+async def test_pipeline_validation_error_ends_pipeline(
+    hass: HomeAssistant,
+    init_components: ConfigEntry,
+    entity: MockAssistSatellite,
+) -> None:
+    """Test validation pipeline errors end the satellite pipeline cleanly."""
+    await async_update_pipeline(
+        hass,
+        async_get_pipeline(hass),
+        stt_engine="test-stt-engine",
+        stt_language="en",
+        conversation_engine="conversation.non_existing",
+    )
+
+    with patch(
+        "homeassistant.components.assist_pipeline.pipeline.PipelineRun.prepare_speech_to_text"
+    ):
+        await entity.async_accept_pipeline_from_satellite(
+            object(),  # type: ignore[arg-type]
+            end_stage=PipelineStage.INTENT,
+        )
+
+    assert [event.type for event in entity.events[-3:]] == [
+        PipelineEventType.RUN_START,
+        PipelineEventType.ERROR,
+        PipelineEventType.RUN_END,
+    ]
+    assert entity.events[-2].data == {
+        "code": "intent-not-supported",
+        "message": "Intent recognition engine conversation.non_existing is not found",
+    }
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == AssistSatelliteState.IDLE
+
+
 @pytest.mark.parametrize(
     ("service_data", "expected_params"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When you remove the conversation entity that a pipeline is configured to use, a validation error is raised when the pipeline is started from a Voice PE. This error is not handled.

```
Logger: homeassistant
Source: components/assist_pipeline/pipeline.py:1074
First occurred: 07:29:46 (2 occurrences)
Last logged: 07:29:58

Error doing job: Task exception was never retrieved (task: None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/assist_satellite/entity.py", line 540, in async_accept_pipeline_from_satellite
    await self._pipeline_task
  File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/__init__.py", line 140, in async_pipeline_from_audio_stream
    await pipeline_input.validate()
  File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/pipeline.py", line 1877, in validate
    await asyncio.gather(*prepare_tasks)
  File "/usr/src/homeassistant/homeassistant/components/assist_pipeline/pipeline.py", line 1074, in prepare_recognize_intent
    raise IntentRecognitionError(
    ...<2 lines>...
    )
homeassistant.components.assist_pipeline.error.IntentRecognitionError: Pipeline error code=intent-not-supported, message=Intent recognition engine conversation.chatgpt_2 is not found
```

This PR handles this error and now the Voice PE will correctly show the error light, indicating to the user something is wrong + being able to see in the pipeline debug screen what went wrong (previously it said no events recorded!).

However, I don't know if I am happy with the result:

When a pipeline is started via a WebSocket command, this error is handled inside `assist_pipeline/websocket_api.py:247` and does not result in a pipeline run, but instead fails the WebSocket command itself. 

I feel like the two should align execution, which would mean that both end up as a failed run. I did not include that change in this PR, wanted to align first with voice team.

@synesthesiam @arturpragacz what do you think? 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
