### PR TITLE
Fix mypy no-any-return errors in matter component

### DIFF
--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -276,8 +276,12 @@ class MatterEntity(Entity):
         self, attribute: type[ClusterAttributeDescriptor]
     ) -> str:
         """Return AttributePath by providing the endpoint and Attribute class."""
-        return create_attribute_path(
-            self._endpoint.endpoint_id, attribute.cluster_id, attribute.attribute_id
+        return str(
+            create_attribute_path(
+                self._endpoint.endpoint_id,
+                attribute.cluster_id,
+                attribute.attribute_id,
+            )
         )
 
     @catch_matter_error

--- a/homeassistant/components/matter/update.py
+++ b/homeassistant/components/matter/update.py
@@ -131,7 +131,7 @@ class MatterUpdate(MatterEntity, UpdateEntity):
         self, update_information: MatterSoftwareVersion
     ) -> str | None:
         """Return the version string to expose in Home Assistant."""
-        latest_version = update_information.software_version_string
+        latest_version: str = update_information.software_version_string
         if self._installed_software_version is None:
             return latest_version
 


### PR DESCRIPTION
## Summary
- Add explicit `str()` cast around `create_attribute_path()` return value in `entity.py` to satisfy mypy's `no-any-return` check
- Add type annotation (`str`) to `latest_version` assignment from `software_version_string` in `update.py` to resolve `no-any-return` on multiple return paths

## Test plan
- [ ] Verify `mypy homeassistant/components/matter/entity.py` passes without `no-any-return` errors
- [ ] Verify `mypy homeassistant/components/matter/update.py` passes without `no-any-return` errors
- [ ] Existing matter tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)