### PR TITLE
Remove unused type: ignore comments in stream component

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -108,7 +108,7 @@ class RecorderOutput(StreamOutput):
             # Create output on first segment
             if not output:
                 container_options: dict[str, str] = {
-                    "video_track_timescale": str(int(1 / source_v.time_base)),  # type: ignore[operator]
+                    "video_track_timescale": str(int(1 / source_v.time_base)),
                     "movflags": "frag_keyframe+empty_moov",
                     "min_frag_duration": str(self.stream_settings.min_segment_duration),
                 }
@@ -131,20 +131,20 @@ class RecorderOutput(StreamOutput):
                 last_stream_id = segment.stream_id
                 pts_adjuster["video"] = int(
                     (running_duration - source.start_time)
-                    / (av.time_base * source_v.time_base)  # type: ignore[operator]
+                    / (av.time_base * source_v.time_base)
                 )
                 if source_a:
                     pts_adjuster["audio"] = int(
                         (running_duration - source.start_time)
-                        / (av.time_base * source_a.time_base)  # type: ignore[operator]
+                        / (av.time_base * source_a.time_base)
                     )
 
             # Remux video
             for packet in source.demux():
                 if packet.pts is None:
                     continue
-                packet.pts += pts_adjuster[packet.stream.type]  # type: ignore[operator]
-                packet.dts += pts_adjuster[packet.stream.type]  # type: ignore[operator]
+                packet.pts += pts_adjuster[packet.stream.type]
+                packet.dts += pts_adjuster[packet.stream.type]
                 stream = output_v if packet.stream.type == "video" else output_a
                 assert stream
                 packet.stream = stream

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -177,7 +177,7 @@ class StreamMuxer:
             # in test_durations
             "avoid_negative_ts": "make_non_negative",
             "fragment_index": str(sequence + 1),
-            "video_track_timescale": str(int(1 / input_vstream.time_base)),  # type: ignore[operator]
+            "video_track_timescale": str(int(1 / input_vstream.time_base)),
             # Only do extra fragmenting if we are using ll_hls
             # Let ffmpeg do the work using frag_duration
             # Fragment durations may exceed the 15% allowed variance but it seems ok
@@ -594,8 +594,8 @@ def stream_worker(
         stream_state.diagnostics.set_value("audio_codec", audio_stream.name)
 
     dts_validator = TimestampValidator(
-        int(1 / video_stream.time_base),  # type: ignore[operator]
-        int(1 / audio_stream.time_base) if audio_stream else 1,  # type: ignore[operator]
+        int(1 / video_stream.time_base),
+        int(1 / audio_stream.time_base) if audio_stream else 1,
     )
     container_packets = PeekIterator(
         filter(dts_validator.is_valid, container.demux((video_stream, audio_stream)))


### PR DESCRIPTION
## Summary
- Remove 7 unused `# type: ignore[operator]` comments from the stream component (`recorder.py` and `worker.py`)
- The PyAV library now ships proper type stubs, so these suppression comments are no longer needed and trigger `unused-ignore` errors in mypy strict mode

## Test plan
- [ ] Verify CI passes with no new mypy errors in the stream component

🤖 Generated with [Claude Code](https://claude.com/claude-code)