### PR TITLE
Migrate snmp device_tracker from DeviceScanner to ScannerEntity

### DIFF
--- a/homeassistant/components/snmp/device_tracker.py
+++ b/homeassistant/components/snmp/device_tracker.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import binascii
+from datetime import timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pysnmp.error import PySnmpError
 from pysnmp.hlapi.v3arch.asyncio import (
@@ -18,14 +19,20 @@ from pysnmp.hlapi.v3arch.asyncio import (
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    ScannerEntity,
 )
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
     CONF_AUTH_KEY,
@@ -44,6 +51,10 @@ from .util import RequestArgsType, async_create_request_cmd_args
 
 _LOGGER = logging.getLogger(__name__)
 
+SCAN_INTERVAL = timedelta(seconds=120)
+
+SIGNAL_SNMP_UPDATE = "snmp_update"
+
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_BASEOID): cv.string,
@@ -55,24 +66,52 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> SnmpScanner | None:
-    """Validate the configuration and return an SNMP scanner."""
-    scanner = await SnmpScanner.create(config[DEVICE_TRACKER_DOMAIN])
-    await scanner.async_init(hass)
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the SNMP device tracker platform."""
+    scanner = SnmpData(hass, config)
 
-    return scanner if scanner.success_init else None
+    success = await scanner.async_init()
+    if not success:
+        raise PlatformNotReady("Unable to connect to SNMP host")
+
+    tracked: set[str] = set()
+
+    @callback
+    def _async_add_new_entities() -> None:
+        """Add new entities for newly discovered devices."""
+        new_entities: list[SnmpDeviceEntity] = []
+        for mac in scanner.devices:
+            if mac not in tracked:
+                tracked.add(mac)
+                new_entities.append(SnmpDeviceEntity(scanner, mac))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    async def _async_update(_now: Any = None) -> None:
+        """Periodically update device data."""
+        await scanner.async_update()
+        _async_add_new_entities()
+        async_dispatcher_send(hass, SIGNAL_SNMP_UPDATE)
+
+    _async_add_new_entities()
+    async_track_time_interval(hass, _async_update, SCAN_INTERVAL)
 
 
-class SnmpScanner(DeviceScanner):
-    """Queries any SNMP capable Access Point for connected devices."""
+class SnmpData:
+    """Handle communication with SNMP-capable access points."""
 
-    def __init__(self, config):
-        """Initialize the scanner after testing the target device."""
+    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+        """Initialize the SNMP data handler."""
+        self._hass = hass
 
         community = config[CONF_COMMUNITY]
-        baseoid = config[CONF_BASEOID]
+        self._baseoid = config[CONF_BASEOID]
+        self._host = config[CONF_HOST]
         authkey = config.get(CONF_AUTH_KEY)
         authproto = DEFAULT_AUTH_PROTOCOL
         privkey = config.get(CONF_PRIV_KEY)
@@ -84,7 +123,7 @@ class SnmpScanner(DeviceScanner):
             if not privkey:
                 privproto = "none"
 
-            self._auth_data = UsmUserData(
+            self._auth_data: UsmUserData | CommunityData = UsmUserData(
                 community,
                 authKey=authkey or None,
                 privKey=privkey or None,
@@ -96,85 +135,57 @@ class SnmpScanner(DeviceScanner):
                 community, mpModel=SNMP_VERSIONS[DEFAULT_VERSION]
             )
 
-        self._target: UdpTransportTarget | Udp6TransportTarget
-        self.request_args: RequestArgsType | None = None
-        self.baseoid = baseoid
-        self.last_results = []
-        self.success_init = False
+        self._target: UdpTransportTarget | Udp6TransportTarget | None = None
+        self._request_args: RequestArgsType | None = None
+        self.connected_macs: set[str] = set()
+        self.devices: dict[str, dict[str, str | None]] = {}
 
-    @classmethod
-    async def create(cls, config):
-        """Asynchronously test the target device before fully initializing the scanner."""
-        host = config[CONF_HOST]
-
+    async def async_init(self) -> bool:
+        """Initialize the SNMP target and test connectivity."""
         try:
-            # Try IPv4 first.
             target = await UdpTransportTarget.create(
-                (host, DEFAULT_PORT), timeout=DEFAULT_TIMEOUT
+                (self._host, DEFAULT_PORT), timeout=DEFAULT_TIMEOUT
             )
         except PySnmpError:
-            # Then try IPv6.
             try:
                 target = Udp6TransportTarget(
-                    (host, DEFAULT_PORT), timeout=DEFAULT_TIMEOUT
+                    (self._host, DEFAULT_PORT), timeout=DEFAULT_TIMEOUT
                 )
             except PySnmpError as err:
                 _LOGGER.error("Invalid SNMP host: %s", err)
-                return None
-        instance = cls(config)
-        instance._target = target
+                return False
 
-        return instance
-
-    async def async_init(self, hass: HomeAssistant) -> None:
-        """Make a one-off read to check if the target device is reachable and readable."""
-        self.request_args = await async_create_request_cmd_args(
-            hass,
+        self._target = target
+        self._request_args = await async_create_request_cmd_args(
+            self._hass,
             self._auth_data,
             self._target,
-            self.baseoid,
+            self._baseoid,
         )
-        data = await self.async_get_snmp_data()
-        self.success_init = data is not None
+        data = await self._async_get_snmp_data()
+        return data is not None
 
-    async def async_scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        await self._async_update_info()
-        return [client["mac"] for client in self.last_results if client.get("mac")]
-
-    async def async_get_device_name(self, device: str) -> str | None:
-        """Return the name of the given device or None if we don't know."""
-        # We have no names
-        return None
-
-    async def async_get_extra_attributes(self, device: str) -> dict:
-        """Return the extra attributes of the given device or an empty dictionary if we have none."""
-        for client in self.last_results:
-            if client.get("mac") and device == client["mac"]:
-                return {"mac": client["mac"]}
-        return {}
-
-    async def _async_update_info(self):
-        """Ensure the information from the device is up to date.
-
-        Return boolean if scanning successful.
-        """
-        if not self.success_init:
+    async def async_update(self) -> bool:
+        """Fetch latest data from the SNMP device."""
+        if not (data := await self._async_get_snmp_data()):
             return False
 
-        if not (data := await self.async_get_snmp_data()):
-            return False
+        self.connected_macs = set()
+        self.devices = {}
+        for entry in data:
+            mac = entry["mac"]
+            self.connected_macs.add(mac)
+            self.devices[mac] = {"mac": mac}
 
-        self.last_results = data
         return True
 
-    async def async_get_snmp_data(self):
+    async def _async_get_snmp_data(self) -> list[dict[str, str]] | None:
         """Fetch MAC addresses from access point via SNMP."""
-        devices = []
+        devices: list[dict[str, str]] = []
         if TYPE_CHECKING:
-            assert self.request_args is not None
+            assert self._request_args is not None
 
-        engine, auth_data, target, context_data, object_type = self.request_args
+        engine, auth_data, target, context_data, object_type = self._request_args
         walker = bulk_walk_cmd(
             engine,
             auth_data,
@@ -207,3 +218,45 @@ class SnmpScanner(DeviceScanner):
                     mac = ":".join([mac[i : i + 2] for i in range(0, len(mac), 2)])
                     devices.append({"mac": mac})
         return devices
+
+
+class SnmpDeviceEntity(ScannerEntity):
+    """Representation of a device discovered via SNMP."""
+
+    _attr_should_poll = False
+
+    def __init__(self, scanner: SnmpData, mac: str) -> None:
+        """Initialize the entity."""
+        self._scanner = scanner
+        self._mac = mac
+        self._attr_name = mac
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self._mac in self._scanner.connected_macs
+
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        return None
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_SNMP_UPDATE,
+                self._handle_update,
+            )
+        )
+
+    @callback
+    def _handle_update(self) -> None:
+        """Handle updated data from the scanner."""
+        self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change

Migrate the snmp device_tracker integration from the legacy DeviceScanner pattern to the modern ScannerEntity pattern.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Closes #143036

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/