### PR TITLE
Migrate swisscom device_tracker from DeviceScanner to ScannerEntity

### DIFF
--- a/homeassistant/components/swisscom/device_tracker.py
+++ b/homeassistant/components/swisscom/device_tracker.py
@@ -3,20 +3,27 @@
 from __future__ import annotations
 
 from contextlib import suppress
+from datetime import datetime
 import logging
 
 import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    SCAN_INTERVAL,
+    ScannerEntity,
 )
-from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,87 +34,145 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-def get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> SwisscomDeviceScanner | None:
-    """Return the Swisscom device scanner."""
-    scanner = SwisscomDeviceScanner(config[DEVICE_TRACKER_DOMAIN])
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the Swisscom device tracker platform."""
+    host: str = config[CONF_HOST]
 
-    return scanner if scanner.success_init else None
+    # Test the router is accessible
+    data = await hass.async_add_executor_job(_get_swisscom_data, host)
+    if data is None:
+        return
 
+    tracked: set[str] = set()
+    connected_macs: set[str] = set()
+    device_names: dict[str, str] = {}
+    signal = f"swisscom_update_{host}"
 
-class SwisscomDeviceScanner(DeviceScanner):
-    """Class which queries a router running Swisscom Internet-Box firmware."""
-
-    def __init__(self, config):
-        """Initialize the scanner."""
-        self.host = config[CONF_HOST]
-        self.last_results = {}
-
-        # Test the router is accessible.
-        data = self.get_swisscom_data()
-        self.success_init = data is not None
-
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-        return [client["mac"] for client in self.last_results]
-
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        if not self.last_results:
-            return None
-        for client in self.last_results:
-            if client["mac"] == device:
-                return client["host"]
-        return None
-
-    def _update_info(self):
-        """Ensure the information from the Swisscom router is up to date.
-
-        Return boolean if scanning successful.
-        """
-        if not self.success_init:
-            return False
-
+    async def async_scan_devices(now: datetime | None = None) -> None:
+        """Scan for devices and update state."""
         _LOGGER.debug("Loading data from Swisscom Internet Box")
-        if not (data := self.get_swisscom_data()):
-            return False
+        data = await hass.async_add_executor_job(_get_swisscom_data, host)
+        if not data:
+            return
 
-        active_clients = [client for client in data.values() if client["status"]]
-        self.last_results = active_clients
-        return True
+        active_clients = [
+            client for client in data.values() if client["status"]
+        ]
 
-    def get_swisscom_data(self):
-        """Retrieve data from Swisscom and return parsed result."""
-        url = f"http://{self.host}/ws"
-        headers = {"Content-Type": "application/x-sah-ws-4-call+json"}
-        data = """
-        {"service":"Devices", "method":"get",
-        "parameters":{"expression":"lan and not self"}}"""
+        new_connected = {client["mac"] for client in active_clients}
+        for client in active_clients:
+            device_names[client["mac"]] = client["host"]
 
-        devices = {}
+        connected_macs.clear()
+        connected_macs.update(new_connected)
 
-        try:
-            request = requests.post(url, headers=headers, data=data, timeout=10)
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.Timeout,
-            requests.exceptions.ConnectTimeout,
-        ):
-            _LOGGER.debug("No response from Swisscom Internet Box")
-            return devices
+        new_macs = [mac for mac in new_connected if mac not in tracked]
+        tracked.update(new_macs)
+        if new_macs:
+            async_add_entities(
+                [
+                    SwisscomDeviceTracker(
+                        mac, device_names[mac], connected_macs, device_names, signal
+                    )
+                    for mac in new_macs
+                ]
+            )
 
-        if "status" not in request.json():
-            _LOGGER.debug("No status in response from Swisscom Internet Box")
-            return devices
+        async_dispatcher_send(hass, signal)
 
-        for device in request.json()["status"]:
-            with suppress(KeyError, requests.exceptions.RequestException):
-                devices[device["Key"]] = {
-                    "ip": device["IPAddress"],
-                    "mac": device["PhysAddress"],
-                    "host": device["Name"],
-                    "status": device["Active"],
-                }
+    await async_scan_devices()
+
+    scan_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+    async_track_time_interval(hass, async_scan_devices, scan_interval)
+
+
+def _get_swisscom_data(host: str) -> dict | None:
+    """Retrieve data from Swisscom and return parsed result."""
+    url = f"http://{host}/ws"
+    headers = {"Content-Type": "application/x-sah-ws-4-call+json"}
+    data = (
+        '{"service":"Devices", "method":"get",'
+        '"parameters":{"expression":"lan and not self"}}'
+    )
+
+    devices: dict = {}
+
+    try:
+        request = requests.post(url, headers=headers, data=data, timeout=10)
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ConnectTimeout,
+    ):
+        _LOGGER.debug("No response from Swisscom Internet Box")
         return devices
+
+    if "status" not in request.json():
+        _LOGGER.debug("No status in response from Swisscom Internet Box")
+        return devices
+
+    for device in request.json()["status"]:
+        with suppress(KeyError, requests.exceptions.RequestException):
+            devices[device["Key"]] = {
+                "ip": device["IPAddress"],
+                "mac": device["PhysAddress"],
+                "host": device["Name"],
+                "status": device["Active"],
+            }
+    return devices
+
+
+class SwisscomDeviceTracker(ScannerEntity):
+    """Representation of a Swisscom tracked device."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mac: str,
+        name: str,
+        connected_macs: set[str],
+        device_names: dict[str, str],
+        signal: str,
+    ) -> None:
+        """Initialize a Swisscom device tracker entity."""
+        self._mac = mac
+        self._attr_name = name
+        self._connected_macs = connected_macs
+        self._device_names = device_names
+        self._signal = signal
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self._mac in self._connected_macs
+
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        return self._device_names.get(self._mac)
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._signal,
+                self._async_update_state,
+            )
+        )
+
+    @callback
+    def _async_update_state(self) -> None:
+        """Update the device state."""
+        self.async_write_ha_state()

--- a/tests/components/swisscom/__init__.py
+++ b/tests/components/swisscom/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Swisscom integration."""

--- a/tests/components/swisscom/test_device_tracker.py
+++ b/tests/components/swisscom/test_device_tracker.py
@@ -1,0 +1,229 @@
+"""Tests for the Swisscom device tracker."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.swisscom.device_tracker import (
+    SwisscomDeviceTracker,
+    async_setup_platform,
+)
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from tests.common import async_fire_time_changed
+
+MOCK_DATA = {
+    "device1": {
+        "ip": "192.168.1.10",
+        "mac": "AA:BB:CC:DD:EE:FF",
+        "host": "Device1",
+        "status": True,
+    },
+    "device2": {
+        "ip": "192.168.1.11",
+        "mac": "11:22:33:44:55:66",
+        "host": "Device2",
+        "status": True,
+    },
+}
+
+
+def _collect_entities() -> tuple[list[SwisscomDeviceTracker], Any]:
+    """Create an entity collector and callback."""
+    entities: list[SwisscomDeviceTracker] = []
+
+    def add_entities(
+        new_entities: list[SwisscomDeviceTracker],
+        update_before_add: bool = False,
+    ) -> None:
+        entities.extend(new_entities)
+
+    return entities, add_entities
+
+
+@pytest.fixture
+def mock_get_data() -> MagicMock:
+    """Mock _get_swisscom_data."""
+    with patch(
+        "homeassistant.components.swisscom.device_tracker._get_swisscom_data",
+        return_value=dict(MOCK_DATA),
+    ) as mock_fn:
+        yield mock_fn
+
+
+async def test_setup_platform(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test successful platform setup creates entities."""
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 2
+    macs = {e.mac_address for e in entities}
+    assert "AA:BB:CC:DD:EE:FF" in macs
+    assert "11:22:33:44:55:66" in macs
+    for entity in entities:
+        assert entity.is_connected is True
+
+
+async def test_setup_platform_connection_failure(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test platform setup when router is unreachable."""
+    mock_get_data.return_value = None
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 0
+
+
+async def test_setup_platform_no_active_devices(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test platform setup when no devices are active."""
+    mock_get_data.return_value = {
+        "device1": {
+            "ip": "192.168.1.10",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "host": "Device1",
+            "status": False,
+        },
+    }
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 0
+
+
+async def test_device_becomes_disconnected(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test device shows disconnected when absent from scan."""
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 2
+    assert entities[0].is_connected is True
+    assert entities[1].is_connected is True
+
+    # Next scan returns only the first device as active
+    mock_get_data.return_value = {
+        "device1": {
+            "ip": "192.168.1.10",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "host": "Device1",
+            "status": True,
+        },
+    }
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done()
+
+    # Find entities by mac
+    entity_ff = next(e for e in entities if e.mac_address == "AA:BB:CC:DD:EE:FF")
+    entity_66 = next(e for e in entities if e.mac_address == "11:22:33:44:55:66")
+    assert entity_ff.is_connected is True
+    assert entity_66.is_connected is False
+
+
+async def test_new_device_discovered(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test new devices are discovered on subsequent scans."""
+    mock_get_data.return_value = {
+        "device1": {
+            "ip": "192.168.1.10",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "host": "Device1",
+            "status": True,
+        },
+    }
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 1
+
+    # Second device appears on next scan
+    mock_get_data.return_value = dict(MOCK_DATA)
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done()
+
+    assert len(entities) == 2
+    assert entities[1].mac_address == "11:22:33:44:55:66"
+    assert entities[1].is_connected is True
+
+
+async def test_entity_hostname_updates(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test hostname reflects latest scan data."""
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    entity = next(e for e in entities if e.mac_address == "AA:BB:CC:DD:EE:FF")
+    assert entity.hostname == "Device1"
+
+    # Device name changes on next scan
+    mock_get_data.return_value = {
+        "device1": {
+            "ip": "192.168.1.10",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "host": "NewName",
+            "status": True,
+        },
+    }
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done()
+
+    assert entity.hostname == "NewName"
+
+
+async def test_scan_with_no_data_preserves_state(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test that a failed scan preserves existing state."""
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 2
+    assert entities[0].is_connected is True
+
+    # Next scan fails
+    mock_get_data.return_value = None
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done()
+
+    # State preserved from last successful scan
+    assert entities[0].is_connected is True
+    assert len(entities) == 2
+
+
+async def test_empty_data_returns_no_entities(
+    hass: HomeAssistant,
+    mock_get_data: MagicMock,
+) -> None:
+    """Test empty data dict returns no entities."""
+    mock_get_data.return_value = {}
+    entities, add_entities = _collect_entities()
+
+    await async_setup_platform(hass, {CONF_HOST: "192.168.1.1"}, add_entities)
+
+    assert len(entities) == 0


### PR DESCRIPTION
## Proposed change

Migrate the swisscom device_tracker integration from the legacy DeviceScanner pattern to the modern ScannerEntity pattern.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Closes #143037

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/