### PR TITLE
Migrate bbox device_tracker from DeviceScanner to ScannerEntity

### DIFF
--- a/homeassistant/components/bbox/device_tracker.py
+++ b/homeassistant/components/bbox/device_tracker.py
@@ -2,97 +2,148 @@
 
 from __future__ import annotations
 
-from collections import namedtuple
-from datetime import timedelta
+from datetime import datetime
 import logging
 
 import pybbox
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    SCAN_INTERVAL,
+    ScannerEntity,
 )
-from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_HOST, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import Throttle, dt as dt_util
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HOST = "192.168.1.254"
-
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string}
 )
 
 
-def get_scanner(hass: HomeAssistant, config: ConfigType) -> BboxDeviceScanner | None:
-    """Validate the configuration and return a Bbox scanner."""
-    scanner = BboxDeviceScanner(config[DEVICE_TRACKER_DOMAIN])
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the Bbox device tracker platform."""
+    host: str = config[CONF_HOST]
 
-    return scanner if scanner.success_init else None
+    tracked: set[str] = set()
+    connected_macs: set[str] = set()
+    device_names: dict[str, str] = {}
+    signal = f"bbox_update_{host}"
 
-
-Device = namedtuple("Device", ["mac", "name", "ip", "last_update"])  # noqa: PYI024
-
-
-class BboxDeviceScanner(DeviceScanner):
-    """Scanner for devices connected to the bbox."""
-
-    def __init__(self, config):
-        """Get host from config."""
-
-        self.host = config[CONF_HOST]
-
-        """Initialize the scanner."""
-        self.last_results: list[Device] = []
-
-        self.success_init = self._update_info()
-
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-
-        return [device.mac for device in self.last_results]
-
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        filter_named = [
-            result.name for result in self.last_results if result.mac == device
-        ]
-
-        if filter_named:
-            return filter_named[0]
-        return None
-
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def _update_info(self):
-        """Check the Bbox for devices.
-
-        Returns boolean if scanning successful.
-        """
+    async def async_scan_devices(now: datetime | None = None) -> None:
+        """Scan for devices and update state."""
         _LOGGER.debug("Scanning")
 
-        box = pybbox.Bbox(ip=self.host)
-        result = box.get_all_connected_devices()
+        result = await hass.async_add_executor_job(_get_connected_devices, host)
+        if result is None:
+            return
 
-        now = dt_util.now()
-        last_results = []
-        for device in result:
-            if device["active"] != 1:
+        new_connected: set[str] = set()
+        for device_data in result:
+            if device_data["active"] != 1:
                 continue
-            last_results.append(
-                Device(
-                    device["macaddress"], device["hostname"], device["ipaddress"], now
-                )
+            mac = device_data["macaddress"]
+            new_connected.add(mac)
+            device_names[mac] = device_data["hostname"]
+
+        connected_macs.clear()
+        connected_macs.update(new_connected)
+
+        new_macs = [mac for mac in new_connected if mac not in tracked]
+        tracked.update(new_macs)
+        if new_macs:
+            async_add_entities(
+                [
+                    BboxDeviceTracker(
+                        mac, device_names[mac], connected_macs, device_names, signal
+                    )
+                    for mac in new_macs
+                ]
             )
 
-        self.last_results = last_results
-
+        async_dispatcher_send(hass, signal)
         _LOGGER.debug("Scan successful")
-        return True
+
+    await async_scan_devices()
+
+    scan_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+    async_track_time_interval(hass, async_scan_devices, scan_interval)
+
+
+def _get_connected_devices(host: str) -> list[dict] | None:
+    """Get connected devices from the Bbox router."""
+    try:
+        box = pybbox.Bbox(ip=host)
+        return box.get_all_connected_devices()
+    except Exception:
+        _LOGGER.exception("Failed to scan Bbox devices")
+        return None
+
+
+class BboxDeviceTracker(ScannerEntity):
+    """Representation of a Bbox tracked device."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mac: str,
+        name: str,
+        connected_macs: set[str],
+        device_names: dict[str, str],
+        signal: str,
+    ) -> None:
+        """Initialize a Bbox device tracker entity."""
+        self._mac = mac
+        self._attr_name = name
+        self._connected_macs = connected_macs
+        self._device_names = device_names
+        self._signal = signal
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self._mac in self._connected_macs
+
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        return self._device_names.get(self._mac)
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                self._signal,
+                self._async_update_state,
+            )
+        )
+
+    @callback
+    def _async_update_state(self) -> None:
+        """Update the device state."""
+        self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change

Migrate the bbox device_tracker integration from the legacy DeviceScanner pattern to the modern ScannerEntity pattern.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

Closes #143021

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/