### PR TITLE
Twitch: add configurable poll interval option

### DIFF
--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -17,7 +17,14 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     async_get_config_entry_implementation,
 )
 
-from .const import DOMAIN, OAUTH_SCOPES, PLATFORMS
+from .const import (
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    OAUTH_SCOPES,
+    PLATFORMS,
+)
 from .coordinator import TwitchConfigEntry, TwitchCoordinator
 
 
@@ -60,7 +67,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
     return True
+
+
+_USER_OPTION_DEFAULTS: dict[str, object] = {
+    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+    CONF_CLEANUP_UNFOLLOWED: False,
+}
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: TwitchConfigEntry) -> None:
+    """Reload when user-facing options change (ignore channel-sync updates)."""
+    coordinator = entry.runtime_data
+    prev = coordinator.user_options_snapshot
+    curr = {
+        k: entry.options.get(k, default) for k, default in _USER_OPTION_DEFAULTS.items()
+    }
+    if prev != curr:
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bool:

--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -7,7 +7,6 @@ from typing import cast
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 from twitchAPI.twitch import Twitch
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -55,7 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await client.set_user_authentication(access_token, scope=OAUTH_SCOPES)
 
     coordinator = TwitchCoordinator(hass, client, session, entry)
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -63,13 +61,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
-
-
-async def _async_update_listener(hass: HomeAssistant, entry: TwitchConfigEntry) -> None:
-    """Handle config entry options update (e.g. followed channels changed)."""
-    if entry.state is not ConfigEntryState.LOADED:
-        return
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bool:

--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -7,6 +7,7 @@ from typing import cast
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 from twitchAPI.twitch import Twitch
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -54,6 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await client.set_user_authentication(access_token, scope=OAUTH_SCOPES)
 
     coordinator = TwitchCoordinator(hass, client, session, entry)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -61,6 +63,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: TwitchConfigEntry
+) -> None:
+    """Handle config entry options update (e.g. followed channels changed)."""
+    if entry.state is not ConfigEntryState.LOADED:
+        return
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bool:

--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -65,9 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     return True
 
 
-async def _async_update_listener(
-    hass: HomeAssistant, entry: TwitchConfigEntry
-) -> None:
+async def _async_update_listener(hass: HomeAssistant, entry: TwitchConfigEntry) -> None:
     """Handle config entry options update (e.g. followed channels changed)."""
     if entry.state is not ConfigEntryState.LOADED:
         return

--- a/homeassistant/components/twitch/config_flow.py
+++ b/homeassistant/components/twitch/config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.config_entries import (
     OptionsFlow,
 )
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import LocalOAuth2Implementation
 
@@ -122,6 +123,7 @@ class OAuth2FlowHandler(
         return await self.async_step_user()
 
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Return the options flow handler."""
         return TwitchOptionsFlowHandler()

--- a/homeassistant/components/twitch/config_flow.py
+++ b/homeassistant/components/twitch/config_flow.py
@@ -21,7 +21,15 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import LocalOAuth2Implementation
 
-from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import (
+    CONF_CHANNELS,
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    OAUTH_SCOPES,
+)
 
 
 class OAuth2FlowHandler(
@@ -141,6 +149,7 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                 data={
                     **self.config_entry.options,
                     CONF_CLEANUP_UNFOLLOWED: user_input[CONF_CLEANUP_UNFOLLOWED],
+                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                 }
             )
 
@@ -154,6 +163,12 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                             CONF_CLEANUP_UNFOLLOWED, False
                         ),
                     ): bool,
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=1440)),
                 }
             ),
         )

--- a/homeassistant/components/twitch/config_flow.py
+++ b/homeassistant/components/twitch/config_flow.py
@@ -8,13 +8,19 @@ from typing import Any, cast
 
 from twitchAPI.helper import first
 from twitchAPI.twitch import Twitch
+import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    ConfigEntry,
+    ConfigFlowResult,
+    OptionsFlow,
+)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import LocalOAuth2Implementation
 
-from .const import CONF_CHANNELS, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
 
 
 class OAuth2FlowHandler(
@@ -114,3 +120,38 @@ class OAuth2FlowHandler(
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
         return await self.async_step_user()
+
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler."""
+        return TwitchOptionsFlowHandler()
+
+
+class TwitchOptionsFlowHandler(OptionsFlow):
+    """Handle Twitch options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage Twitch options."""
+        if user_input is not None:
+            return self.async_create_entry(
+                data={
+                    **self.config_entry.options,
+                    CONF_CLEANUP_UNFOLLOWED: user_input[CONF_CLEANUP_UNFOLLOWED],
+                }
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CLEANUP_UNFOLLOWED,
+                        default=self.config_entry.options.get(
+                            CONF_CLEANUP_UNFOLLOWED, False
+                        ),
+                    ): bool,
+                }
+            ),
+        )

--- a/homeassistant/components/twitch/config_flow.py
+++ b/homeassistant/components/twitch/config_flow.py
@@ -21,7 +21,15 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import LocalOAuth2Implementation
 
-from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import (
+    CONF_CHANNELS,
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    OAUTH_SCOPES,
+)
 
 
 class OAuth2FlowHandler(
@@ -141,6 +149,7 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                 data={
                     **self.config_entry.options,
                     CONF_CLEANUP_UNFOLLOWED: user_input[CONF_CLEANUP_UNFOLLOWED],
+                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                 }
             )
 
@@ -154,6 +163,12 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                             CONF_CLEANUP_UNFOLLOWED, False
                         ),
                     ): bool,
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.In([1, 5, 10, 30, 60]),
                 }
             ),
         )

--- a/homeassistant/components/twitch/config_flow.py
+++ b/homeassistant/components/twitch/config_flow.py
@@ -21,15 +21,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.config_entry_oauth2_flow import LocalOAuth2Implementation
 
-from .const import (
-    CONF_CHANNELS,
-    CONF_CLEANUP_UNFOLLOWED,
-    CONF_SCAN_INTERVAL,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    LOGGER,
-    OAUTH_SCOPES,
-)
+from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
 
 
 class OAuth2FlowHandler(
@@ -149,7 +141,6 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                 data={
                     **self.config_entry.options,
                     CONF_CLEANUP_UNFOLLOWED: user_input[CONF_CLEANUP_UNFOLLOWED],
-                    CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
                 }
             )
 
@@ -163,12 +154,6 @@ class TwitchOptionsFlowHandler(OptionsFlow):
                             CONF_CLEANUP_UNFOLLOWED, False
                         ),
                     ): bool,
-                    vol.Required(
-                        CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                        ),
-                    ): vol.In([1, 5, 10, 30, 60]),
                 }
             ),
         )

--- a/homeassistant/components/twitch/const.py
+++ b/homeassistant/components/twitch/const.py
@@ -18,5 +18,7 @@ CONF_REFRESH_TOKEN = "refresh_token"
 DOMAIN = "twitch"
 CONF_CHANNELS = "channels"
 CONF_CLEANUP_UNFOLLOWED = "cleanup_unfollowed"
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 5  # minutes
 
 OAUTH_SCOPES = [AuthScope.USER_READ_SUBSCRIPTIONS, AuthScope.USER_READ_FOLLOWS]

--- a/homeassistant/components/twitch/const.py
+++ b/homeassistant/components/twitch/const.py
@@ -18,7 +18,5 @@ CONF_REFRESH_TOKEN = "refresh_token"
 DOMAIN = "twitch"
 CONF_CHANNELS = "channels"
 CONF_CLEANUP_UNFOLLOWED = "cleanup_unfollowed"
-CONF_SCAN_INTERVAL = "scan_interval"
-DEFAULT_SCAN_INTERVAL = 5  # minutes
 
 OAUTH_SCOPES = [AuthScope.USER_READ_SUBSCRIPTIONS, AuthScope.USER_READ_FOLLOWS]

--- a/homeassistant/components/twitch/const.py
+++ b/homeassistant/components/twitch/const.py
@@ -17,5 +17,6 @@ CONF_REFRESH_TOKEN = "refresh_token"
 
 DOMAIN = "twitch"
 CONF_CHANNELS = "channels"
+CONF_CLEANUP_UNFOLLOWED = "cleanup_unfollowed"
 
 OAUTH_SCOPES = [AuthScope.USER_READ_SUBSCRIPTIONS, AuthScope.USER_READ_FOLLOWS]

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -1,5 +1,6 @@
 """Define a class to manage fetching Twitch data."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -89,7 +90,6 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             self.session.token["refresh_token"],
             False,
         )
-        data: dict[str, TwitchUpdate] = {}
         streams: dict[str, Stream] = {
             s.user_id: s
             async for s in self.twitch.get_followed_streams(
@@ -130,7 +130,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                     [u async for u in self.twitch.get_users(logins=list(chunk))]
                 )
 
-        for channel in self.users:
+        async def _fetch_channel(channel: TwitchUser) -> tuple[str, TwitchUpdate]:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)
             follow = follows.get(channel.id)
@@ -144,7 +144,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             except TwitchAPIException as exc:
                 LOGGER.error("Error response on check_user_subscription: %s", exc)
 
-            data[channel.id] = TwitchUpdate(
+            return channel.id, TwitchUpdate(
                 channel.display_name,
                 followers.total,
                 bool(stream),
@@ -160,4 +160,6 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 follow.followed_at if follow else None,
                 stream.viewer_count if stream else None,
             )
-        return data
+
+        results = await asyncio.gather(*[_fetch_channel(c) for c in self.users])
+        return dict(results)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -69,40 +69,16 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
         self.session = session
 
     async def _async_setup(self) -> None:
+        channels = self.config_entry.options[CONF_CHANNELS]
+        self.users = []
+        # Split channels into chunks of 100 to avoid hitting the rate limit.
+        for chunk in chunk_list(channels, 100):
+            self.users.extend(
+                [channel async for channel in self.twitch.get_users(logins=chunk)]
+            )
         if not (user := await first(self.twitch.get_users())):
             raise UpdateFailed("Logged in user not found")
         self.current_user = user
-
-        # Fetch the authoritative follow list from the API and sync the
-        # config entry so setup always uses up-to-date channels.
-        api_channels = {
-            f.broadcaster_login
-            async for f in await self.twitch.get_followed_channels(
-                user_id=self.current_user.id, first=100
-            )
-        }
-        config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        additions = api_channels - config_channels
-        if additions:
-            LOGGER.info(
-                "Syncing new followed channels on setup: %s",
-                ", ".join(sorted(additions)),
-            )
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                options={
-                    **self.config_entry.options,
-                    CONF_CHANNELS: sorted(config_channels | additions),
-                },
-            )
-
-        # Build self.users from the union of config channels + new follows.
-        channels_to_track = config_channels | additions
-        self.users = []
-        for chunk in chunk_list(sorted(channels_to_track), 100):
-            self.users.extend(
-                [u async for u in self.twitch.get_users(logins=list(chunk))]
-            )
         self.users.append(self.current_user)
 
     async def _async_update_data(self) -> dict[str, TwitchUpdate]:
@@ -146,11 +122,22 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                     CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
-            # Return early — the reload will set up fresh data. Continuing to
-            # fetch here would result in a CancelledError when HA tears down
-            # the current coordinator mid-request.
-            return self.data or {}
+            # Add the new users to self.users so they are included in this
+            # update cycle already.
+            for chunk in chunk_list(sorted(additions), 100):
+                self.users.extend(
+                    [u async for u in self.twitch.get_users(logins=list(chunk))]
+                )
+            # On the first update self.data is None and sensors are created
+            # directly from coordinator.data by async_setup_entry — no reload
+            # needed. On subsequent updates a reload is required to add new
+            # sensor entities. Deferring via call_soon ensures _async_update_data
+            # finishes fully before the reload is triggered.
+            if self.data is not None:
+                entry_id = self.config_entry.entry_id
+                self.hass.loop.call_soon(
+                    self.hass.config_entries.async_schedule_reload, entry_id
+                )
 
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -122,21 +122,12 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                     CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
-            # Add the new users to self.users so they are included in this
-            # update cycle already.
+            # Add the new users to self.users immediately so they are included
+            # in this update cycle. The normal poll interval will keep them
+            # up to date — no reload needed.
             for chunk in chunk_list(sorted(additions), 100):
                 self.users.extend(
                     [u async for u in self.twitch.get_users(logins=list(chunk))]
-                )
-            # On the first update self.data is None and sensors are created
-            # directly from coordinator.data by async_setup_entry — no reload
-            # needed. On subsequent updates a reload is required to add new
-            # sensor entities. Deferring via call_soon ensures _async_update_data
-            # finishes fully before the reload is triggered.
-            if self.data is not None:
-                entry_id = self.config_entry.entry_id
-                self.hass.loop.call_soon(
-                    self.hass.config_entries.async_schedule_reload, entry_id
                 )
 
         for channel in self.users:

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -129,6 +129,22 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 self.hass.config_entries.async_schedule_reload(
                     self.config_entry.entry_id
                 )
+            else:
+                # On the initial update we can't reload, so rebuild self.users
+                # from the API channels so the first platform setup creates
+                # sensors for the correct (up-to-date) channel set.
+                try:
+                    updated_users: list[TwitchUser] = []
+                    for chunk in chunk_list(sorted(api_channels), 100):
+                        updated_users.extend(
+                            [u async for u in self.twitch.get_users(logins=list(chunk))]
+                        )
+                    self.users = updated_users
+                    self.users.append(self.current_user)
+                except TwitchAPIException as exc:
+                    LOGGER.error(
+                        "Error rebuilding users list on initial refresh: %s", exc
+                    )
 
         self._initial_update_done = True
         for channel in self.users:

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -67,20 +67,44 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             config_entry=entry,
         )
         self.session = session
-        self._initial_update_done = False
 
     async def _async_setup(self) -> None:
-        channels = self.config_entry.options[CONF_CHANNELS]
-        self.users = []
-        # Split channels into chunks of 100 to avoid hitting the rate limit
-        for chunk in chunk_list(channels, 100):
-            self.users.extend(
-                [channel async for channel in self.twitch.get_users(logins=chunk)]
-            )
         if not (user := await first(self.twitch.get_users())):
             raise UpdateFailed("Logged in user not found")
         self.current_user = user
-        self.users.append(self.current_user)  # Add current_user to users list.
+
+        # Fetch the authoritative follow list from the API and sync the
+        # config entry so setup always uses up-to-date channels.
+        api_channels = {
+            f.broadcaster_login
+            async for f in await self.twitch.get_followed_channels(
+                user_id=self.current_user.id, first=100
+            )
+        }
+        config_channels = set(self.config_entry.options[CONF_CHANNELS])
+        if api_channels != config_channels:
+            additions = sorted(api_channels - config_channels)
+            removals = sorted(config_channels - api_channels)
+            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+            LOGGER.info(
+                "Syncing followed channels on setup: %s",
+                ", ".join(change_summary),
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={
+                    **self.config_entry.options,
+                    CONF_CHANNELS: sorted(api_channels),
+                },
+            )
+
+        # Build self.users from the authoritative API channel set.
+        self.users = []
+        for chunk in chunk_list(sorted(api_channels), 100):
+            self.users.extend(
+                [u async for u in self.twitch.get_users(logins=list(chunk))]
+            )
+        self.users.append(self.current_user)
 
     async def _async_update_data(self) -> dict[str, TwitchUpdate]:
         await self.session.async_ensure_token_valid()
@@ -123,30 +147,8 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                     CONF_CHANNELS: sorted(api_channels),
                 },
             )
-            # Only reload after the initial setup is complete so we don't
-            # discard entities that are still being set up on first run.
-            if self._initial_update_done:
-                self.hass.config_entries.async_schedule_reload(
-                    self.config_entry.entry_id
-                )
-            else:
-                # On the initial update we can't reload, so rebuild self.users
-                # from the API channels so the first platform setup creates
-                # sensors for the correct (up-to-date) channel set.
-                try:
-                    updated_users: list[TwitchUser] = []
-                    for chunk in chunk_list(sorted(api_channels), 100):
-                        updated_users.extend(
-                            [u async for u in self.twitch.get_users(logins=list(chunk))]
-                        )
-                    self.users = updated_users
-                    self.users.append(self.current_user)
-                except TwitchAPIException as exc:
-                    LOGGER.error(
-                        "Error rebuilding users list on initial refresh: %s", exc
-                    )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
-        self._initial_update_done = True
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -67,6 +67,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             config_entry=entry,
         )
         self.session = session
+        self._initial_update_done = False
 
     async def _async_setup(self) -> None:
         channels = self.config_entry.options[CONF_CHANNELS]
@@ -108,8 +109,8 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
         api_channels = {f.broadcaster_login for f in follows.values()}
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
         if api_channels != config_channels:
-            additions = api_channels - config_channels
-            removals = config_channels - api_channels
+            additions = sorted(api_channels - config_channels)
+            removals = sorted(config_channels - api_channels)
             change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
             LOGGER.info(
                 "Discovered changes to followed channels: %s",
@@ -119,10 +120,17 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: list(api_channels),
+                    CONF_CHANNELS: sorted(api_channels),
                 },
             )
+            # Only reload after the initial setup is complete so we don't
+            # discard entities that are still being set up on first run.
+            if self._initial_update_done:
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
 
+        self._initial_update_done = True
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -104,6 +104,27 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 user_id=self.current_user.id, first=100
             )
         }
+
+        api_channels = {f.broadcaster_login for f in follows.values()}
+        config_channels = set(self.config_entry.options[CONF_CHANNELS])
+        if api_channels != config_channels:
+            additions = api_channels - config_channels
+            removals = config_channels - api_channels
+            change_summary = [f"+{c}" for c in additions] + [
+                f"-{c}" for c in removals
+            ]
+            LOGGER.info(
+                "Discovered changes to followed channels: %s",
+                ", ".join(change_summary),
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={
+                    **self.config_entry.options,
+                    CONF_CHANNELS: list(api_channels),
+                },
+            )
+
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -110,9 +110,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
         if api_channels != config_channels:
             additions = api_channels - config_channels
             removals = config_channels - api_channels
-            change_summary = [f"+{c}" for c in additions] + [
-                f"-{c}" for c in removals
-            ]
+            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
             LOGGER.info(
                 "Discovered changes to followed channels: %s",
                 ", ".join(change_summary),

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -14,7 +14,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import (
+    CONF_CHANNELS,
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    OAUTH_SCOPES,
+)
 
 type TwitchConfigEntry = ConfigEntry[TwitchCoordinator]
 
@@ -60,14 +68,21 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
     ) -> None:
         """Initialize the coordinator."""
         self.twitch = twitch
+        interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=5),
+            update_interval=timedelta(minutes=interval),
             config_entry=entry,
         )
         self.session = session
+        self.user_options_snapshot = {
+            CONF_SCAN_INTERVAL: entry.options.get(
+                CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+            ),
+            CONF_CLEANUP_UNFOLLOWED: entry.options.get(CONF_CLEANUP_UNFOLLOWED, False),
+        }
 
     async def _async_setup(self) -> None:
         channels = self.config_entry.options[CONF_CHANNELS]

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -82,25 +82,24 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             )
         }
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        if api_channels != config_channels:
-            additions = sorted(api_channels - config_channels)
-            removals = sorted(config_channels - api_channels)
-            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+        additions = api_channels - config_channels
+        if additions:
             LOGGER.info(
-                "Syncing followed channels on setup: %s",
-                ", ".join(change_summary),
+                "Syncing new followed channels on setup: %s",
+                ", ".join(sorted(additions)),
             )
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: sorted(api_channels),
+                    CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
 
-        # Build self.users from the authoritative API channel set.
+        # Build self.users from the union of config channels + new follows.
+        channels_to_track = config_channels | additions
         self.users = []
-        for chunk in chunk_list(sorted(api_channels), 100):
+        for chunk in chunk_list(sorted(channels_to_track), 100):
             self.users.extend(
                 [u async for u in self.twitch.get_users(logins=list(chunk))]
             )
@@ -132,19 +131,19 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
 
         api_channels = {f.broadcaster_login for f in follows.values()}
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        if api_channels != config_channels:
-            additions = sorted(api_channels - config_channels)
-            removals = sorted(config_channels - api_channels)
-            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+        # Only sync new follows — channels that were unfollowed are intentionally
+        # kept in the config so they continue to be tracked.
+        additions = api_channels - config_channels
+        if additions:
             LOGGER.info(
-                "Discovered changes to followed channels: %s",
-                ", ".join(change_summary),
+                "Discovered new followed channels: %s",
+                ", ".join(sorted(additions)),
             )
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: sorted(api_channels),
+                    CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -14,15 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_CHANNELS,
-    CONF_CLEANUP_UNFOLLOWED,
-    CONF_SCAN_INTERVAL,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    LOGGER,
-    OAUTH_SCOPES,
-)
+from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
 
 type TwitchConfigEntry = ConfigEntry[TwitchCoordinator]
 
@@ -68,12 +60,11 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
     ) -> None:
         """Initialize the coordinator."""
         self.twitch = twitch
-        interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=interval),
+            update_interval=timedelta(minutes=5),
             config_entry=entry,
         )
         self.session = session
@@ -147,10 +138,10 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                         [u async for u in self.twitch.get_users(logins=list(chunk))]
                     )
             if removals:
-                removal_logins = {r.lower() for r in removals}
-                self.users = [
-                    u for u in self.users if u.login.lower() not in removal_logins
-                ]
+                keep_ids = {f.broadcaster_id for f in follows.values()} | {
+                    self.current_user.id
+                }
+                self.users = [u for u in self.users if u.id in keep_ids]
 
         async def _fetch_channel(channel: TwitchUser) -> tuple[str, TwitchUpdate]:
             followers = await self.twitch.get_channel_followers(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -14,7 +14,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import (
+    CONF_CHANNELS,
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    OAUTH_SCOPES,
+)
 
 type TwitchConfigEntry = ConfigEntry[TwitchCoordinator]
 
@@ -60,11 +68,12 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
     ) -> None:
         """Initialize the coordinator."""
         self.twitch = twitch
+        interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=5),
+            update_interval=timedelta(minutes=interval),
             config_entry=entry,
         )
         self.session = session

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_CHANNELS, DOMAIN, LOGGER, OAUTH_SCOPES
+from .const import CONF_CHANNELS, CONF_CLEANUP_UNFOLLOWED, DOMAIN, LOGGER, OAUTH_SCOPES
 
 type TwitchConfigEntry = ConfigEntry[TwitchCoordinator]
 
@@ -107,28 +107,41 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
 
         api_channels = {f.broadcaster_login for f in follows.values()}
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        # Only sync new follows — channels that were unfollowed are intentionally
-        # kept in the config so they continue to be tracked.
+
         additions = api_channels - config_channels
-        if additions:
-            LOGGER.info(
-                "Discovered new followed channels: %s",
-                ", ".join(sorted(additions)),
-            )
+        removals: set[str] = set()
+        if self.config_entry.options.get(CONF_CLEANUP_UNFOLLOWED, False):
+            removals = config_channels - api_channels
+
+        if additions or removals:
+            updated = sorted((config_channels | additions) - removals)
+            if additions:
+                LOGGER.info(
+                    "Discovered new followed channels: %s",
+                    ", ".join(sorted(additions)),
+                )
+            if removals:
+                LOGGER.info(
+                    "Removing unfollowed channels: %s",
+                    ", ".join(sorted(removals)),
+                )
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: sorted(config_channels | additions),
+                    CONF_CHANNELS: updated,
                 },
             )
-            # Add the new users to self.users immediately so they are included
-            # in this update cycle. The normal poll interval will keep them
-            # up to date — no reload needed.
-            for chunk in chunk_list(sorted(additions), 100):
-                self.users.extend(
-                    [u async for u in self.twitch.get_users(logins=list(chunk))]
-                )
+            if additions:
+                for chunk in chunk_list(sorted(additions), 100):
+                    self.users.extend(
+                        [u async for u in self.twitch.get_users(logins=list(chunk))]
+                    )
+            if removals:
+                removal_logins = {r.lower() for r in removals}
+                self.users = [
+                    u for u in self.users if u.login.lower() not in removal_logins
+                ]
 
         async def _fetch_channel(channel: TwitchUser) -> tuple[str, TwitchUpdate]:
             followers = await self.twitch.get_channel_followers(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -147,6 +147,10 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 },
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            # Return early — the reload will set up fresh data. Continuing to
+            # fetch here would result in a CancelledError when HA tears down
+            # the current coordinator mid-request.
+            return self.data or {}
 
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -6,10 +6,12 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import CONF_CLEANUP_UNFOLLOWED
 from .coordinator import TwitchConfigEntry, TwitchCoordinator, TwitchUpdate
 
 ATTR_GAME = "game"
@@ -41,17 +43,31 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_entities() -> None:
-        """Add sensor entities for newly discovered channels."""
-        new_ids = set(coordinator.data) - known_channel_ids
+        """Add sensor entities for newly discovered channels and clean up removed ones."""
+        current_ids = set(coordinator.data)
+        new_ids = current_ids - known_channel_ids
         if new_ids:
             known_channel_ids.update(new_ids)
             async_add_entities(
                 TwitchSensor(coordinator, channel_id) for channel_id in new_ids
             )
+        if entry.options.get(CONF_CLEANUP_UNFOLLOWED, False):
+            removed_ids = known_channel_ids - current_ids
+            if removed_ids:
+                known_channel_ids.difference_update(removed_ids)
+                entity_registry = er.async_get(hass)
+                for entity_entry in er.async_entries_for_config_entry(
+                    entity_registry, entry.entry_id
+                ):
+                    if (
+                        entity_entry.domain == "sensor"
+                        and entity_entry.unique_id in removed_ids
+                    ):
+                        entity_registry.async_remove(entity_entry.entity_id)
 
     # Create entities for channels already known after first refresh.
     _async_add_new_entities()
-    # On subsequent coordinator updates, create entities for any new follows.
+    # On subsequent coordinator updates, add new entities / remove stale ones.
     entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
 
 

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -43,13 +43,13 @@ async def async_setup_entry(
 
     @callback
     def _async_add_new_entities() -> None:
-        """Add sensor entities for newly discovered channels and clean up removed ones."""
+        """Add sensor entities for new channels and remove unfollowed ones."""
         current_ids = set(coordinator.data)
         new_ids = current_ids - known_channel_ids
         if new_ids:
             known_channel_ids.update(new_ids)
             async_add_entities(
-                TwitchSensor(coordinator, channel_id) for channel_id in new_ids
+                TwitchSensor(coordinator, channel_id) for channel_id in sorted(new_ids)
             )
         if entry.options.get(CONF_CLEANUP_UNFOLLOWED, False):
             removed_ids = known_channel_ids - current_ids
@@ -65,9 +65,23 @@ async def async_setup_entry(
                     ):
                         entity_registry.async_remove(entity_entry.entity_id)
 
+    # Remove stale entity registry entries left from a previous session
+    # (e.g. channels unfollowed while HA was offline).
+    if entry.options.get(CONF_CLEANUP_UNFOLLOWED, False):
+        entity_registry = er.async_get(hass)
+        current_channel_ids = set(coordinator.data)
+        for entity_entry in er.async_entries_for_config_entry(
+            entity_registry, entry.entry_id
+        ):
+            if (
+                entity_entry.domain == "sensor"
+                and entity_entry.unique_id not in current_channel_ids
+            ):
+                entity_registry.async_remove(entity_entry.entity_id)
+
     # Create entities for channels already known after first refresh.
     _async_add_new_entities()
-    # On subsequent coordinator updates, add new entities / remove stale ones.
+    # On subsequent coordinator updates, add new / remove unfollowed entities.
     entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
 
 
@@ -125,6 +139,8 @@ class TwitchSensor(CoordinatorEntity[TwitchCoordinator], SensorEntity):
     @property
     def entity_picture(self) -> str | None:
         """Return the picture of the sensor."""
+        if self.channel_id not in self.coordinator.data:
+            return None
         if self.channel.is_streaming:
             assert self.channel.stream_picture is not None
             return self.channel.stream_picture

--- a/homeassistant/components/twitch/sensor.py
+++ b/homeassistant/components/twitch/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -37,10 +37,22 @@ async def async_setup_entry(
 ) -> None:
     """Initialize entries."""
     coordinator = entry.runtime_data
+    known_channel_ids: set[str] = set()
 
-    async_add_entities(
-        TwitchSensor(coordinator, channel_id) for channel_id in coordinator.data
-    )
+    @callback
+    def _async_add_new_entities() -> None:
+        """Add sensor entities for newly discovered channels."""
+        new_ids = set(coordinator.data) - known_channel_ids
+        if new_ids:
+            known_channel_ids.update(new_ids)
+            async_add_entities(
+                TwitchSensor(coordinator, channel_id) for channel_id in new_ids
+            )
+
+    # Create entities for channels already known after first refresh.
+    _async_add_new_entities()
+    # On subsequent coordinator updates, create entities for any new follows.
+    entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
 
 
 class TwitchSensor(CoordinatorEntity[TwitchCoordinator], SensorEntity):

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -72,10 +72,12 @@
     "step": {
       "init": {
         "data": {
-          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
+          "cleanup_unfollowed": "Remove sensors for unfollowed channels",
+          "scan_interval": "Poll interval (minutes)"
         },
         "data_description": {
-          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
+          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry.",
+          "scan_interval": "How often to poll Twitch for updates. Lower values give faster updates but use more API quota."
         },
         "title": "Twitch options"
       }

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -72,12 +72,10 @@
     "step": {
       "init": {
         "data": {
-          "cleanup_unfollowed": "Remove sensors for unfollowed channels",
-          "scan_interval": "Poll interval (minutes)"
+          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
         },
         "data_description": {
-          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry.",
-          "scan_interval": "How often to poll Twitch for updates. Lower values give faster updates but use more API quota."
+          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
         },
         "title": "Twitch options"
       }

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -72,10 +72,12 @@
     "step": {
       "init": {
         "data": {
-          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
+          "cleanup_unfollowed": "Remove sensors for unfollowed channels",
+          "scan_interval": "Poll interval (minutes)"
         },
         "data_description": {
-          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
+          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry.",
+          "scan_interval": "How often Home Assistant polls Twitch for updates. Lower values give faster updates but use more API quota. Minimum 1 minute, maximum 1440 minutes (24 hours)."
         },
         "title": "Twitch options"
       }

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -21,19 +21,6 @@
       }
     }
   },
-  "options": {
-    "step": {
-      "init": {
-        "title": "Twitch options",
-        "data": {
-          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
-        },
-        "data_description": {
-          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
-        }
-      }
-    }
-  },
   "entity": {
     "sensor": {
       "channel": {
@@ -79,6 +66,19 @@
   "exceptions": {
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
+        },
+        "data_description": {
+          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
+        },
+        "title": "Twitch options"
+      }
     }
   }
 }

--- a/homeassistant/components/twitch/strings.json
+++ b/homeassistant/components/twitch/strings.json
@@ -21,6 +21,19 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Twitch options",
+        "data": {
+          "cleanup_unfollowed": "Automatically remove sensors for unfollowed channels"
+        },
+        "data_description": {
+          "cleanup_unfollowed": "When enabled, sensors for channels you have unfollowed on Twitch will be permanently removed from the entity registry."
+        }
+      }
+    }
+  },
   "entity": {
     "sensor": {
       "channel": {

--- a/tests/components/twitch/fixtures/get_followed_channels_single.json
+++ b/tests/components/twitch/fixtures/get_followed_channels_single.json
@@ -1,0 +1,7 @@
+[
+  {
+    "broadcaster_id": 123,
+    "broadcaster_login": "internetofthings",
+    "followed_at": "2023-08-01"
+  }
+]

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -232,5 +232,7 @@ async def test_unchanged_follows_no_config_update(
         if call.kwargs.get("options") is not None
         or (len(call.args) > 1 and "options" in str(call))
     ]
-    assert options_calls == [], "config entry options must not be updated when channels are in sync"
+    assert options_calls == [], (
+        "config entry options must not be updated when channels are in sync"
+    )
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from aiohttp.client_exceptions import ClientError
 import pytest
+from twitchAPI.object.api import FollowedChannel
 
 from homeassistant.components.twitch.const import DOMAIN, OAUTH2_TOKEN
 from homeassistant.config_entries import ConfigEntryState
@@ -14,7 +15,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
 
-from . import setup_integration
+from . import TwitchIterObject, setup_integration
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -140,3 +141,96 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_new_follow_syncs_config_entry(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Newly followed channel is added to the config entry options."""
+    # config_entry starts with only "internetofthings"
+    # get_followed_channels fixture returns "internetofthings" + "homeassistant"
+    # → coordinator must detect the delta and update the config entry
+
+    await setup_integration(hass, config_entry)
+    await hass.async_block_till_done()
+
+    assert set(config_entry.options["channels"]) == {
+        "internetofthings",
+        "homeassistant",
+    }
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_removed_follow_syncs_config_entry(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Unfollowed channel is removed from the config entry options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={"channels": ["internetofthings", "homeassistant"]},
+    )
+    # API returns only "internetofthings" → "homeassistant" was unfollowed
+    twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
+        hass, "get_followed_channels_single.json", FollowedChannel
+    )
+
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    assert entry.options["channels"] == ["internetofthings"]
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_unchanged_follows_no_config_update(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """When followed channels match the config, no config update is triggered."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        # Channels already match what get_followed_channels.json returns
+        options={"channels": ["internetofthings", "homeassistant"]},
+    )
+
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as mock_update:
+        await setup_integration(hass, entry)
+        await hass.async_block_till_done()
+
+    # async_update_entry must not have been called for options changes
+    options_calls = [
+        call
+        for call in mock_update.call_args_list
+        if call.kwargs.get("options") is not None
+        or (len(call.args) > 1 and "options" in str(call))
+    ]
+    assert options_calls == [], "config entry options must not be updated when channels are in sync"
+    assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -91,7 +91,6 @@ async def test_expired_token_refresh_failure(
     twitch_mock: AsyncMock,
 ) -> None:
     """Test failure while refreshing token with a transient error."""
-
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         OAUTH2_TOKEN,
@@ -102,7 +101,6 @@ async def test_expired_token_refresh_failure(
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Verify a transient failure has occurred
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries[0].state is expected_state
 

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -161,11 +161,11 @@ async def test_new_follow_syncs_config_entry(
     assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_removed_follow_syncs_config_entry(
+async def test_unfollowed_channel_stays_in_config(
     hass: HomeAssistant,
     twitch_mock: AsyncMock,
 ) -> None:
-    """Unfollowed channel is removed from the config entry options."""
+    """Unfollowed channel is kept in config entry options and continues to be tracked."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Test",
@@ -182,6 +182,7 @@ async def test_removed_follow_syncs_config_entry(
         options={"channels": ["internetofthings", "homeassistant"]},
     )
     # API returns only "internetofthings" → "homeassistant" was unfollowed
+    # but should remain in the config so it keeps being tracked.
     twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
         hass, "get_followed_channels_single.json", FollowedChannel
     )
@@ -189,7 +190,8 @@ async def test_removed_follow_syncs_config_entry(
     await setup_integration(hass, entry)
     await hass.async_block_till_done()
 
-    assert entry.options["channels"] == ["internetofthings"]
+    # "homeassistant" must still be in channels — removals are ignored
+    assert set(entry.options["channels"]) == {"internetofthings", "homeassistant"}
     assert entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -9,8 +9,10 @@ import pytest
 from twitchAPI.object.api import FollowedChannel
 
 from homeassistant.components.twitch.const import DOMAIN, OAUTH2_TOKEN
+from homeassistant.components.twitch.coordinator import TwitchUpdate
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
@@ -226,10 +228,58 @@ async def test_unchanged_follows_no_config_update(
         await hass.async_block_till_done()
 
     # async_update_entry must not have been called for options changes
-    options_calls = [
-        call for call in mock_update.call_args_list if "options" in call.kwargs
-    ]
+    options_calls = [c for c in mock_update.call_args_list if "options" in c.kwargs]
     assert options_calls == [], (
         "config entry options must not be updated when channels are in sync"
     )
     assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_new_follow_creates_entity_at_runtime(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """New sensor entity is created at runtime when coordinator data gains a channel."""
+    # Start with the default fixture — config_entry has only "internetofthings",
+    # but the API mock returns both "internetofthings" and "homeassistant".
+    # After the first refresh, the coordinator data will contain both.
+    await setup_integration(hass, config_entry)
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    initial_entities = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+    initial_ids = {e.unique_id for e in initial_entities}
+
+    # Inject a brand-new channel into coordinator data and fire listeners.
+    coordinator = config_entry.runtime_data
+    new_data = dict(coordinator.data)
+    new_data["999"] = TwitchUpdate(
+        name="NewChannel",
+        followers=50,
+        is_streaming=False,
+        game=None,
+        title=None,
+        started_at=None,
+        stream_picture=None,
+        picture="logo.png",
+        subscribed=None,
+        subscription_gifted=None,
+        subscription_tier=None,
+        follows=True,
+        following_since=None,
+        viewers=None,
+    )
+    coordinator.async_set_updated_data(new_data)
+    await hass.async_block_till_done()
+
+    updated_entities = er.async_entries_for_config_entry(
+        entity_registry, config_entry.entry_id
+    )
+    updated_ids = {e.unique_id for e in updated_entities}
+
+    # The listener must have created a new entity for channel "999".
+    assert "999" not in initial_ids
+    assert "999" in updated_ids

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -90,7 +90,7 @@ async def test_expired_token_refresh_failure(
     config_entry: MockConfigEntry,
     twitch_mock: AsyncMock,
 ) -> None:
-    """Test failure while refreshing token with a transient error."""
+    """Test failure while refreshing expired token requiring reauth or retry."""
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         OAUTH2_TOKEN,

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -225,10 +225,7 @@ async def test_unchanged_follows_no_config_update(
 
     # async_update_entry must not have been called for options changes
     options_calls = [
-        call
-        for call in mock_update.call_args_list
-        if call.kwargs.get("options") is not None
-        or (len(call.args) > 1 and "options" in str(call))
+        call for call in mock_update.call_args_list if "options" in call.kwargs
     ]
     assert options_calls == [], (
         "config entry options must not be updated when channels are in sync"

--- a/tests/components/twitch/test_options_flow.py
+++ b/tests/components/twitch/test_options_flow.py
@@ -73,14 +73,19 @@ async def test_cleanup_removes_unfollowed_entity(
         hass, "get_followed_channels_single.json", FollowedChannel
     )
 
-    await setup_integration(hass, entry)
+    # Pre-register the "homeassistant" entity (broadcaster_id 456) so it
+    # actually exists in the registry before cleanup runs.
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create("sensor", DOMAIN, "456", config_entry=entry)
+
+    await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
     remaining_unique_ids = {e.unique_id for e in entries}
 
-    # Only "internetofthings" channel (broadcaster_id 123) should remain
+    # "456" should have been removed by the cleanup logic
     assert "456" not in remaining_unique_ids
 
 

--- a/tests/components/twitch/test_options_flow.py
+++ b/tests/components/twitch/test_options_flow.py
@@ -127,3 +127,51 @@ async def test_no_cleanup_keeps_unfollowed_entity(
     entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
     remaining_unique_ids = {e.unique_id for e in entries}
     assert "456" in remaining_unique_ids
+
+
+async def test_runtime_cleanup_removes_entity(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Entity is removed from registry at runtime when channel disappears from data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={
+            "channels": ["internetofthings", "homeassistant"],
+            CONF_CLEANUP_UNFOLLOWED: True,
+        },
+    )
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data
+    entity_registry = er.async_get(hass)
+
+    # Both channels should have entities after setup.
+    initial = {
+        e.unique_id
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    }
+    assert "123" in initial
+
+    # Simulate a coordinator refresh where channel "123" is gone.
+    reduced = {cid: data for cid, data in coordinator.data.items() if cid != "123"}
+    coordinator.async_set_updated_data(reduced)
+    await hass.async_block_till_done()
+
+    remaining = {
+        e.unique_id
+        for e in er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    }
+    assert "123" not in remaining

--- a/tests/components/twitch/test_options_flow.py
+++ b/tests/components/twitch/test_options_flow.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock
 
 from twitchAPI.object.api import FollowedChannel
 
-from homeassistant.components.twitch.const import CONF_CLEANUP_UNFOLLOWED, DOMAIN
+from homeassistant.components.twitch.const import (
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -39,7 +44,11 @@ async def test_options_flow_enable_cleanup(
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_CLEANUP_UNFOLLOWED: True}
+        result["flow_id"],
+        user_input={
+            CONF_CLEANUP_UNFOLLOWED: True,
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+        },
     )
     assert result["type"] == "create_entry"
     assert config_entry.options[CONF_CLEANUP_UNFOLLOWED] is True

--- a/tests/components/twitch/test_options_flow.py
+++ b/tests/components/twitch/test_options_flow.py
@@ -1,0 +1,124 @@
+"""Tests for the Twitch options flow."""
+
+import time
+from unittest.mock import AsyncMock
+
+from twitchAPI.object.api import FollowedChannel
+
+from homeassistant.components.twitch.const import CONF_CLEANUP_UNFOLLOWED, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import TwitchIterObject, setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_options_flow_default_disabled(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test options flow shows cleanup_unfollowed defaulting to False."""
+    await setup_integration(hass, config_entry)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    schema_keys = {str(k) for k in result["data_schema"].schema}
+    assert CONF_CLEANUP_UNFOLLOWED in schema_keys
+
+
+async def test_options_flow_enable_cleanup(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test enabling cleanup_unfollowed via options flow."""
+    await setup_integration(hass, config_entry)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_CLEANUP_UNFOLLOWED: True}
+    )
+    assert result["type"] == "create_entry"
+    assert config_entry.options[CONF_CLEANUP_UNFOLLOWED] is True
+
+
+async def test_cleanup_removes_unfollowed_entity(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Unfollowed channel entity is removed from registry when cleanup is enabled."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={
+            "channels": ["internetofthings", "homeassistant"],
+            CONF_CLEANUP_UNFOLLOWED: True,
+        },
+    )
+    # API now returns only "internetofthings" → "homeassistant" was unfollowed
+    twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
+        hass, "get_followed_channels_single.json", FollowedChannel
+    )
+
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    remaining_unique_ids = {e.unique_id for e in entries}
+
+    # Only "internetofthings" channel (broadcaster_id 123) should remain
+    assert "456" not in remaining_unique_ids
+
+
+async def test_no_cleanup_keeps_unfollowed_entity(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Unfollowed channel entity stays in registry when cleanup is disabled."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={
+            "channels": ["internetofthings", "homeassistant"],
+            CONF_CLEANUP_UNFOLLOWED: False,
+        },
+    )
+    # API now returns only "internetofthings" → "homeassistant" was unfollowed
+    twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
+        hass, "get_followed_channels_single.json", FollowedChannel
+    )
+    # Pre-register the "homeassistant" entity so we can check it survives
+    entry.add_to_hass(hass)
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create("sensor", DOMAIN, "456", config_entry=entry)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    remaining_unique_ids = {e.unique_id for e in entries}
+    assert "456" in remaining_unique_ids

--- a/tests/components/twitch/test_scan_interval.py
+++ b/tests/components/twitch/test_scan_interval.py
@@ -1,0 +1,94 @@
+"""Tests for the Twitch scan interval options flow."""
+
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant.components.twitch.const import (
+    CONF_CLEANUP_UNFOLLOWED,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_options_flow_shows_scan_interval(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test options flow shows scan_interval field."""
+    await setup_integration(hass, config_entry)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    schema_keys = {str(k) for k in result["data_schema"].schema}
+    assert CONF_SCAN_INTERVAL in schema_keys
+
+
+async def test_options_flow_default_scan_interval(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test default scan interval is 5 minutes."""
+    await setup_integration(hass, config_entry)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    # Find the scan_interval key and check its default
+    for key in result["data_schema"].schema:
+        if str(key) == CONF_SCAN_INTERVAL:
+            assert key.default() == DEFAULT_SCAN_INTERVAL
+            break
+    else:
+        pytest.fail("scan_interval not found in options schema")
+
+
+async def test_options_flow_set_scan_interval(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test setting a custom scan interval."""
+    await setup_integration(hass, config_entry)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_SCAN_INTERVAL: 15, CONF_CLEANUP_UNFOLLOWED: False},
+    )
+    assert result["type"] == "create_entry"
+    assert config_entry.options[CONF_SCAN_INTERVAL] == 15
+
+
+async def test_coordinator_uses_custom_scan_interval(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Test coordinator respects scan_interval from options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={"channels": ["internetofthings"], CONF_SCAN_INTERVAL: 30},
+    )
+    await setup_integration(hass, entry)
+
+    coordinator = entry.runtime_data
+    assert coordinator.update_interval.total_seconds() == 30 * 60


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a configurable poll interval option to the Twitch integration. Users can set how often the coordinator polls the Twitch API (1–1440 minutes, default: 5) via Settings → Devices & Services → Twitch → Configure.

The coordinator reads `scan_interval` from the config entry options at initialization. An update listener in `__init__.py` reloads the integration when user-facing options (`scan_interval`, `cleanup_unfollowed`) change, but ignores config entry updates from the coordinator's channel-sync logic to avoid unnecessary reload cycles.

> **Note:** This PR builds on #166196 (follow-sync) and #166198 (cleanup option). The diff against `dev` includes changes from those parent PRs. The changes specific to this PR are the `scan_interval` option, the reload listener, and corresponding tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #166196, #166198
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr