### PR TITLE
Twitch: fix CancelledError when new follows trigger a reload

### DIFF
--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -7,7 +7,6 @@ from typing import cast
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 from twitchAPI.twitch import Twitch
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -55,7 +54,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await client.set_user_authentication(access_token, scope=OAUTH_SCOPES)
 
     coordinator = TwitchCoordinator(hass, client, session, entry)
-    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -63,13 +61,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
-
-
-async def _async_update_listener(hass: HomeAssistant, entry: TwitchConfigEntry) -> None:
-    """Handle config entry options update (e.g. followed channels changed)."""
-    if entry.state is not ConfigEntryState.LOADED:
-        return
-    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bool:

--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -7,6 +7,7 @@ from typing import cast
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 from twitchAPI.twitch import Twitch
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
@@ -54,6 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await client.set_user_authentication(access_token, scope=OAUTH_SCOPES)
 
     coordinator = TwitchCoordinator(hass, client, session, entry)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
@@ -61,6 +63,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: TwitchConfigEntry
+) -> None:
+    """Handle config entry options update (e.g. followed channels changed)."""
+    if entry.state is not ConfigEntryState.LOADED:
+        return
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bool:

--- a/homeassistant/components/twitch/__init__.py
+++ b/homeassistant/components/twitch/__init__.py
@@ -65,9 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TwitchConfigEntry) -> bo
     return True
 
 
-async def _async_update_listener(
-    hass: HomeAssistant, entry: TwitchConfigEntry
-) -> None:
+async def _async_update_listener(hass: HomeAssistant, entry: TwitchConfigEntry) -> None:
     """Handle config entry options update (e.g. followed channels changed)."""
     if entry.state is not ConfigEntryState.LOADED:
         return

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -129,6 +129,22 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 self.hass.config_entries.async_schedule_reload(
                     self.config_entry.entry_id
                 )
+            else:
+                # On the initial update we can't reload, so rebuild self.users
+                # from the API channels so the first platform setup creates
+                # sensors for the correct (up-to-date) channel set.
+                try:
+                    updated_users: list[TwitchUser] = []
+                    for chunk in chunk_list(sorted(api_channels), 100):
+                        updated_users.extend(
+                            [u async for u in self.twitch.get_users(logins=list(chunk))]
+                        )
+                    self.users = updated_users
+                    self.users.append(self.current_user)
+                except TwitchAPIException as exc:
+                    LOGGER.error(
+                        "Error rebuilding users list on initial refresh: %s", exc
+                    )
 
         self._initial_update_done = True
         for channel in self.users:

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -67,20 +67,44 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             config_entry=entry,
         )
         self.session = session
-        self._initial_update_done = False
 
     async def _async_setup(self) -> None:
-        channels = self.config_entry.options[CONF_CHANNELS]
-        self.users = []
-        # Split channels into chunks of 100 to avoid hitting the rate limit
-        for chunk in chunk_list(channels, 100):
-            self.users.extend(
-                [channel async for channel in self.twitch.get_users(logins=chunk)]
-            )
         if not (user := await first(self.twitch.get_users())):
             raise UpdateFailed("Logged in user not found")
         self.current_user = user
-        self.users.append(self.current_user)  # Add current_user to users list.
+
+        # Fetch the authoritative follow list from the API and sync the
+        # config entry so setup always uses up-to-date channels.
+        api_channels = {
+            f.broadcaster_login
+            async for f in await self.twitch.get_followed_channels(
+                user_id=self.current_user.id, first=100
+            )
+        }
+        config_channels = set(self.config_entry.options[CONF_CHANNELS])
+        if api_channels != config_channels:
+            additions = sorted(api_channels - config_channels)
+            removals = sorted(config_channels - api_channels)
+            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+            LOGGER.info(
+                "Syncing followed channels on setup: %s",
+                ", ".join(change_summary),
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={
+                    **self.config_entry.options,
+                    CONF_CHANNELS: sorted(api_channels),
+                },
+            )
+
+        # Build self.users from the authoritative API channel set.
+        self.users = []
+        for chunk in chunk_list(sorted(api_channels), 100):
+            self.users.extend(
+                [u async for u in self.twitch.get_users(logins=list(chunk))]
+            )
+        self.users.append(self.current_user)
 
     async def _async_update_data(self) -> dict[str, TwitchUpdate]:
         await self.session.async_ensure_token_valid()
@@ -123,30 +147,8 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                     CONF_CHANNELS: sorted(api_channels),
                 },
             )
-            # Only reload after the initial setup is complete so we don't
-            # discard entities that are still being set up on first run.
-            if self._initial_update_done:
-                self.hass.config_entries.async_schedule_reload(
-                    self.config_entry.entry_id
-                )
-            else:
-                # On the initial update we can't reload, so rebuild self.users
-                # from the API channels so the first platform setup creates
-                # sensors for the correct (up-to-date) channel set.
-                try:
-                    updated_users: list[TwitchUser] = []
-                    for chunk in chunk_list(sorted(api_channels), 100):
-                        updated_users.extend(
-                            [u async for u in self.twitch.get_users(logins=list(chunk))]
-                        )
-                    self.users = updated_users
-                    self.users.append(self.current_user)
-                except TwitchAPIException as exc:
-                    LOGGER.error(
-                        "Error rebuilding users list on initial refresh: %s", exc
-                    )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
 
-        self._initial_update_done = True
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -67,6 +67,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             config_entry=entry,
         )
         self.session = session
+        self._initial_update_done = False
 
     async def _async_setup(self) -> None:
         channels = self.config_entry.options[CONF_CHANNELS]
@@ -108,8 +109,8 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
         api_channels = {f.broadcaster_login for f in follows.values()}
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
         if api_channels != config_channels:
-            additions = api_channels - config_channels
-            removals = config_channels - api_channels
+            additions = sorted(api_channels - config_channels)
+            removals = sorted(config_channels - api_channels)
             change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
             LOGGER.info(
                 "Discovered changes to followed channels: %s",
@@ -119,10 +120,17 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: list(api_channels),
+                    CONF_CHANNELS: sorted(api_channels),
                 },
             )
+            # Only reload after the initial setup is complete so we don't
+            # discard entities that are still being set up on first run.
+            if self._initial_update_done:
+                self.hass.config_entries.async_schedule_reload(
+                    self.config_entry.entry_id
+                )
 
+        self._initial_update_done = True
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -104,6 +104,27 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 user_id=self.current_user.id, first=100
             )
         }
+
+        api_channels = {f.broadcaster_login for f in follows.values()}
+        config_channels = set(self.config_entry.options[CONF_CHANNELS])
+        if api_channels != config_channels:
+            additions = api_channels - config_channels
+            removals = config_channels - api_channels
+            change_summary = [f"+{c}" for c in additions] + [
+                f"-{c}" for c in removals
+            ]
+            LOGGER.info(
+                "Discovered changes to followed channels: %s",
+                ", ".join(change_summary),
+            )
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                options={
+                    **self.config_entry.options,
+                    CONF_CHANNELS: list(api_channels),
+                },
+            )
+
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)
             stream = streams.get(channel.id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -110,9 +110,7 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
         if api_channels != config_channels:
             additions = api_channels - config_channels
             removals = config_channels - api_channels
-            change_summary = [f"+{c}" for c in additions] + [
-                f"-{c}" for c in removals
-            ]
+            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
             LOGGER.info(
                 "Discovered changes to followed channels: %s",
                 ", ".join(change_summary),

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -82,25 +82,24 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
             )
         }
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        if api_channels != config_channels:
-            additions = sorted(api_channels - config_channels)
-            removals = sorted(config_channels - api_channels)
-            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+        additions = api_channels - config_channels
+        if additions:
             LOGGER.info(
-                "Syncing followed channels on setup: %s",
-                ", ".join(change_summary),
+                "Syncing new followed channels on setup: %s",
+                ", ".join(sorted(additions)),
             )
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: sorted(api_channels),
+                    CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
 
-        # Build self.users from the authoritative API channel set.
+        # Build self.users from the union of config channels + new follows.
+        channels_to_track = config_channels | additions
         self.users = []
-        for chunk in chunk_list(sorted(api_channels), 100):
+        for chunk in chunk_list(sorted(channels_to_track), 100):
             self.users.extend(
                 [u async for u in self.twitch.get_users(logins=list(chunk))]
             )
@@ -132,19 +131,19 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
 
         api_channels = {f.broadcaster_login for f in follows.values()}
         config_channels = set(self.config_entry.options[CONF_CHANNELS])
-        if api_channels != config_channels:
-            additions = sorted(api_channels - config_channels)
-            removals = sorted(config_channels - api_channels)
-            change_summary = [f"+{c}" for c in additions] + [f"-{c}" for c in removals]
+        # Only sync new follows — channels that were unfollowed are intentionally
+        # kept in the config so they continue to be tracked.
+        additions = api_channels - config_channels
+        if additions:
             LOGGER.info(
-                "Discovered changes to followed channels: %s",
-                ", ".join(change_summary),
+                "Discovered new followed channels: %s",
+                ", ".join(sorted(additions)),
             )
             self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 options={
                     **self.config_entry.options,
-                    CONF_CHANNELS: sorted(api_channels),
+                    CONF_CHANNELS: sorted(config_channels | additions),
                 },
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)

--- a/homeassistant/components/twitch/coordinator.py
+++ b/homeassistant/components/twitch/coordinator.py
@@ -147,6 +147,10 @@ class TwitchCoordinator(DataUpdateCoordinator[dict[str, TwitchUpdate]]):
                 },
             )
             self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+            # Return early — the reload will set up fresh data. Continuing to
+            # fetch here would result in a CancelledError when HA tears down
+            # the current coordinator mid-request.
+            return self.data or {}
 
         for channel in self.users:
             followers = await self.twitch.get_channel_followers(channel.id)

--- a/tests/components/twitch/fixtures/get_followed_channels_single.json
+++ b/tests/components/twitch/fixtures/get_followed_channels_single.json
@@ -1,0 +1,7 @@
+[
+  {
+    "broadcaster_id": 123,
+    "broadcaster_login": "internetofthings",
+    "followed_at": "2023-08-01"
+  }
+]

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -232,5 +232,7 @@ async def test_unchanged_follows_no_config_update(
         if call.kwargs.get("options") is not None
         or (len(call.args) > 1 and "options" in str(call))
     ]
-    assert options_calls == [], "config entry options must not be updated when channels are in sync"
+    assert options_calls == [], (
+        "config entry options must not be updated when channels are in sync"
+    )
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 from aiohttp.client_exceptions import ClientError
 import pytest
+from twitchAPI.object.api import FollowedChannel
 
 from homeassistant.components.twitch.const import DOMAIN, OAUTH2_TOKEN
 from homeassistant.config_entries import ConfigEntryState
@@ -14,7 +15,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
 
-from . import setup_integration
+from . import TwitchIterObject, setup_integration
 
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -140,3 +141,96 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_new_follow_syncs_config_entry(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Newly followed channel is added to the config entry options."""
+    # config_entry starts with only "internetofthings"
+    # get_followed_channels fixture returns "internetofthings" + "homeassistant"
+    # → coordinator must detect the delta and update the config entry
+
+    await setup_integration(hass, config_entry)
+    await hass.async_block_till_done()
+
+    assert set(config_entry.options["channels"]) == {
+        "internetofthings",
+        "homeassistant",
+    }
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_removed_follow_syncs_config_entry(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """Unfollowed channel is removed from the config entry options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        options={"channels": ["internetofthings", "homeassistant"]},
+    )
+    # API returns only "internetofthings" → "homeassistant" was unfollowed
+    twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
+        hass, "get_followed_channels_single.json", FollowedChannel
+    )
+
+    await setup_integration(hass, entry)
+    await hass.async_block_till_done()
+
+    assert entry.options["channels"] == ["internetofthings"]
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_unchanged_follows_no_config_update(
+    hass: HomeAssistant,
+    twitch_mock: AsyncMock,
+) -> None:
+    """When followed channels match the config, no config update is triggered."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        unique_id="123",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": time.time() + 3600,
+                "scope": "user:read:follows user:read:subscriptions",
+            },
+        },
+        # Channels already match what get_followed_channels.json returns
+        options={"channels": ["internetofthings", "homeassistant"]},
+    )
+
+    with patch.object(
+        hass.config_entries,
+        "async_update_entry",
+        wraps=hass.config_entries.async_update_entry,
+    ) as mock_update:
+        await setup_integration(hass, entry)
+        await hass.async_block_till_done()
+
+    # async_update_entry must not have been called for options changes
+    options_calls = [
+        call
+        for call in mock_update.call_args_list
+        if call.kwargs.get("options") is not None
+        or (len(call.args) > 1 and "options" in str(call))
+    ]
+    assert options_calls == [], "config entry options must not be updated when channels are in sync"
+    assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -91,7 +91,6 @@ async def test_expired_token_refresh_failure(
     twitch_mock: AsyncMock,
 ) -> None:
     """Test failure while refreshing token with a transient error."""
-
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         OAUTH2_TOKEN,
@@ -102,7 +101,6 @@ async def test_expired_token_refresh_failure(
     assert not await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # Verify a transient failure has occurred
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries[0].state is expected_state
 

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -161,11 +161,11 @@ async def test_new_follow_syncs_config_entry(
     assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_removed_follow_syncs_config_entry(
+async def test_unfollowed_channel_stays_in_config(
     hass: HomeAssistant,
     twitch_mock: AsyncMock,
 ) -> None:
-    """Unfollowed channel is removed from the config entry options."""
+    """Unfollowed channel is kept in config entry options and continues to be tracked."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Test",
@@ -182,6 +182,7 @@ async def test_removed_follow_syncs_config_entry(
         options={"channels": ["internetofthings", "homeassistant"]},
     )
     # API returns only "internetofthings" → "homeassistant" was unfollowed
+    # but should remain in the config so it keeps being tracked.
     twitch_mock.return_value.get_followed_channels.return_value = TwitchIterObject(
         hass, "get_followed_channels_single.json", FollowedChannel
     )
@@ -189,7 +190,8 @@ async def test_removed_follow_syncs_config_entry(
     await setup_integration(hass, entry)
     await hass.async_block_till_done()
 
-    assert entry.options["channels"] == ["internetofthings"]
+    # "homeassistant" must still be in channels — removals are ignored
+    assert set(entry.options["channels"]) == {"internetofthings", "homeassistant"}
     assert entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/twitch/test_init.py
+++ b/tests/components/twitch/test_init.py
@@ -225,10 +225,7 @@ async def test_unchanged_follows_no_config_update(
 
     # async_update_entry must not have been called for options changes
     options_calls = [
-        call
-        for call in mock_update.call_args_list
-        if call.kwargs.get("options") is not None
-        or (len(call.args) > 1 and "options" in str(call))
+        call for call in mock_update.call_args_list if "options" in call.kwargs
     ]
     assert options_calls == [], (
         "config entry options must not be updated when channels are in sync"


### PR DESCRIPTION
## Proposed change

When `_async_update_data` detects newly followed channels, it calls `async_schedule_reload`. HA then cancels the running coordinator refresh mid-execution, which causes a `CancelledError` in the subsequent `get_channel_followers` API call and logs:

```
Setup of config entry for twitch integration cancelled
asyncio.exceptions.CancelledError
```

Fix: return early with the existing data immediately after scheduling the reload. The reload sets up a fresh coordinator that fetches correct data anyway, so continuing the current refresh is unnecessary.

This bug is present in the current HA Core Twitch integration (not introduced by #166196).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
## Additional information

- This PR is related to: #166196
## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.