### PR TITLE
Add unit of measurement handling to numeric climate triggers

### DIFF
--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -462,6 +462,10 @@
         "below": {
           "description": "Trigger when the target temperature is below this value.",
           "name": "Below"
+        },
+        "unit": {
+          "description": "All values will be converted to this unit when evaluating the trigger.",
+          "name": "Unit of measurement"
         }
       },
       "name": "Climate-control device target temperature changed"
@@ -480,6 +484,10 @@
         "threshold_type": {
           "description": "Type of threshold crossing to trigger on.",
           "name": "Threshold type"
+        },
+        "unit": {
+          "description": "[%key:component::climate::triggers::target_temperature_changed::fields::unit::description%]",
+          "name": "[%key:component::climate::triggers::target_temperature_changed::fields::unit::name%]"
         },
         "upper_limit": {
           "description": "Upper threshold limit.",

--- a/homeassistant/components/climate/trigger.py
+++ b/homeassistant/components/climate/trigger.py
@@ -2,12 +2,15 @@
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_TEMPERATURE, CONF_OPTIONS
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_TEMPERATURE, CONF_OPTIONS, UnitOfTemperature
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.automation import DomainSpec, NumericalDomainSpec
 from homeassistant.helpers.trigger import (
     ENTITY_STATE_TRIGGER_SCHEMA_FIRST_LAST,
+    EntityNumericalStateChangedTriggerWithUnitBase,
+    EntityNumericalStateCrossedThresholdTriggerWithUnitBase,
+    EntityNumericalStateTriggerWithUnitBase,
     EntityTargetStateTriggerBase,
     Trigger,
     TriggerConfig,
@@ -16,6 +19,7 @@ from homeassistant.helpers.trigger import (
     make_entity_target_state_trigger,
     make_entity_transition_trigger,
 )
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import ATTR_HUMIDITY, ATTR_HVAC_ACTION, DOMAIN, HVACAction, HVACMode
 
@@ -44,6 +48,33 @@ class HVACModeChangedTrigger(EntityTargetStateTriggerBase):
         self._to_states = set(self._options[CONF_HVAC_MODE])
 
 
+class _ClimateTargetTemperatureTriggerMixin(EntityNumericalStateTriggerWithUnitBase):
+    """Mixin for climate target temperature triggers with unit conversion."""
+
+    _base_unit = UnitOfTemperature.CELSIUS
+    _domain_specs = {DOMAIN: NumericalDomainSpec(value_source=ATTR_TEMPERATURE)}
+    _unit_converter = TemperatureConverter
+
+    def _get_entity_unit(self, state: State) -> str | None:
+        """Get the temperature unit of a climate entity from its state."""
+        # Climate entities convert temperatures to the system unit via show_temp
+        return self._hass.config.units.temperature_unit
+
+
+class ClimateTargetTemperatureChangedTrigger(
+    _ClimateTargetTemperatureTriggerMixin,
+    EntityNumericalStateChangedTriggerWithUnitBase,
+):
+    """Trigger for climate target temperature value changes."""
+
+
+class ClimateTargetTemperatureCrossedThresholdTrigger(
+    _ClimateTargetTemperatureTriggerMixin,
+    EntityNumericalStateCrossedThresholdTriggerWithUnitBase,
+):
+    """Trigger for climate target temperature value crossing a threshold."""
+
+
 TRIGGERS: dict[str, type[Trigger]] = {
     "hvac_mode_changed": HVACModeChangedTrigger,
     "started_cooling": make_entity_target_state_trigger(
@@ -53,17 +84,15 @@ TRIGGERS: dict[str, type[Trigger]] = {
         {DOMAIN: DomainSpec(value_source=ATTR_HVAC_ACTION)}, HVACAction.DRYING
     ),
     "target_humidity_changed": make_entity_numerical_state_changed_trigger(
-        {DOMAIN: NumericalDomainSpec(value_source=ATTR_HUMIDITY)}
+        {DOMAIN: NumericalDomainSpec(value_source=ATTR_HUMIDITY)},
+        valid_unit="%",
     ),
     "target_humidity_crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
-        {DOMAIN: NumericalDomainSpec(value_source=ATTR_HUMIDITY)}
+        {DOMAIN: NumericalDomainSpec(value_source=ATTR_HUMIDITY)},
+        valid_unit="%",
     ),
-    "target_temperature_changed": make_entity_numerical_state_changed_trigger(
-        {DOMAIN: NumericalDomainSpec(value_source=ATTR_TEMPERATURE)}
-    ),
-    "target_temperature_crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
-        {DOMAIN: NumericalDomainSpec(value_source=ATTR_TEMPERATURE)}
-    ),
+    "target_temperature_changed": ClimateTargetTemperatureChangedTrigger,
+    "target_temperature_crossed_threshold": ClimateTargetTemperatureCrossedThresholdTrigger,
     "turned_off": make_entity_target_state_trigger(DOMAIN, HVACMode.OFF),
     "turned_on": make_entity_transition_trigger(
         DOMAIN,

--- a/homeassistant/components/climate/triggers.yaml
+++ b/homeassistant/components/climate/triggers.yaml
@@ -14,7 +14,29 @@
             - last
             - any
 
-.number_or_entity: &number_or_entity
+.number_or_entity_humidity: &number_or_entity_humidity
+  required: false
+  selector:
+    choose:
+      choices:
+        number:
+          selector:
+            number:
+              mode: box
+              unit_of_measurement: "%"
+        entity:
+          selector:
+            entity:
+              filter:
+                - domain: input_number
+                  unit_of_measurement: "%"
+                - domain: sensor
+                  device_class: humidity
+                - domain: number
+                  device_class: humidity
+      translation_key: number_or_entity
+
+.number_or_entity_temperature: &number_or_entity_temperature
   required: false
   selector:
     choose:
@@ -27,11 +49,23 @@
           selector:
             entity:
               filter:
-                domain:
-                  - input_number
-                  - number
-                  - sensor
+                - domain: input_number
+                  unit_of_measurement:
+                    - "°C"
+                    - "°F"
+                - domain: sensor
+                  device_class: temperature
+                - domain: number
+                  device_class: temperature
       translation_key: number_or_entity
+
+.trigger_unit_temperature: &trigger_unit_temperature
+  required: false
+  selector:
+    select:
+      options:
+        - "°C"
+        - "°F"
 
 .trigger_threshold_type: &trigger_threshold_type
   required: true
@@ -69,27 +103,29 @@ hvac_mode_changed:
 target_humidity_changed:
   target: *trigger_climate_target
   fields:
-    above: *number_or_entity
-    below: *number_or_entity
+    above: *number_or_entity_humidity
+    below: *number_or_entity_humidity
 
 target_humidity_crossed_threshold:
   target: *trigger_climate_target
   fields:
     behavior: *trigger_behavior
     threshold_type: *trigger_threshold_type
-    lower_limit: *number_or_entity
-    upper_limit: *number_or_entity
+    lower_limit: *number_or_entity_humidity
+    upper_limit: *number_or_entity_humidity
 
 target_temperature_changed:
   target: *trigger_climate_target
   fields:
-    above: *number_or_entity
-    below: *number_or_entity
+    above: *number_or_entity_temperature
+    below: *number_or_entity_temperature
+    unit: *trigger_unit_temperature
 
 target_temperature_crossed_threshold:
   target: *trigger_climate_target
   fields:
     behavior: *trigger_behavior
     threshold_type: *trigger_threshold_type
-    lower_limit: *number_or_entity
-    upper_limit: *number_or_entity
+    lower_limit: *number_or_entity_temperature
+    upper_limit: *number_or_entity_temperature
+    unit: *trigger_unit_temperature

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -84,7 +84,7 @@ from .target import (
     async_track_target_selector_state_change_event,
 )
 from .template import Template
-from .typing import ConfigType, TemplateVarsType
+from .typing import UNDEFINED, ConfigType, TemplateVarsType, UndefinedType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -602,11 +602,22 @@ NUMERICAL_ATTRIBUTE_CHANGED_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA.extend(
 class EntityNumericalStateTriggerBase(EntityTriggerBase[NumericalDomainSpec]):
     """Base class for numerical state and state attribute triggers."""
 
+    _valid_unit: str | None | UndefinedType = UNDEFINED
+
+    def _is_valid_unit(self, unit: str | None) -> bool:
+        """Check if the given unit is valid for this trigger."""
+        if isinstance(self._valid_unit, UndefinedType):
+            return True
+        return unit == self._valid_unit
+
     def _get_numerical_value(self, entity_or_float: float | str) -> float | None:
         """Get numerical value from float or entity state."""
         if isinstance(entity_or_float, str):
             if not (state := self._hass.states.get(entity_or_float)):
                 # Entity not found
+                return None
+            if not self._is_valid_unit(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+                # Entity unit does not match the expected unit
                 return None
             try:
                 return float(state.state)
@@ -620,6 +631,8 @@ class EntityNumericalStateTriggerBase(EntityTriggerBase[NumericalDomainSpec]):
         domain_spec = self._domain_specs[state.domain]
         raw_value: Any
         if domain_spec.value_source is None:
+            if not self._is_valid_unit(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)):
+                return None
             raw_value = state.state
         else:
             raw_value = state.attributes.get(domain_spec.value_source)
@@ -1016,6 +1029,7 @@ def make_entity_origin_state_trigger(
 
 def make_entity_numerical_state_changed_trigger(
     domain_specs: Mapping[str, NumericalDomainSpec],
+    valid_unit: str | None | UndefinedType = UNDEFINED,
 ) -> type[EntityNumericalStateChangedTriggerBase]:
     """Create a trigger for numerical state value change."""
 
@@ -1023,12 +1037,14 @@ def make_entity_numerical_state_changed_trigger(
         """Trigger for numerical state value changes."""
 
         _domain_specs = domain_specs
+        _valid_unit = valid_unit
 
     return CustomTrigger
 
 
 def make_entity_numerical_state_crossed_threshold_trigger(
     domain_specs: Mapping[str, NumericalDomainSpec],
+    valid_unit: str | None | UndefinedType = UNDEFINED,
 ) -> type[EntityNumericalStateCrossedThresholdTriggerBase]:
     """Create a trigger for numerical state value crossing a threshold."""
 
@@ -1036,6 +1052,7 @@ def make_entity_numerical_state_crossed_threshold_trigger(
         """Trigger for numerical state value crossing a threshold."""
 
         _domain_specs = domain_specs
+        _valid_unit = valid_unit
 
     return CustomTrigger
 

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_OPTIONS,
     CONF_TARGET,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.trigger import async_validate_trigger_config
@@ -35,6 +36,8 @@ from tests.components.common import (
     parametrize_trigger_states,
     target_entities,
 )
+
+_TEMPERATURE_TRIGGER_OPTIONS = {"unit": UnitOfTemperature.CELSIUS}
 
 
 @pytest.fixture
@@ -191,7 +194,10 @@ async def test_climate_state_trigger_behavior_any(
             "climate.target_humidity_changed", HVACMode.AUTO, ATTR_HUMIDITY
         ),
         *parametrize_numerical_attribute_changed_trigger_states(
-            "climate.target_temperature_changed", HVACMode.AUTO, ATTR_TEMPERATURE
+            "climate.target_temperature_changed",
+            HVACMode.AUTO,
+            ATTR_TEMPERATURE,
+            trigger_options=_TEMPERATURE_TRIGGER_OPTIONS,
         ),
         *parametrize_numerical_attribute_crossed_threshold_trigger_states(
             "climate.target_humidity_crossed_threshold", HVACMode.AUTO, ATTR_HUMIDITY
@@ -200,6 +206,7 @@ async def test_climate_state_trigger_behavior_any(
             "climate.target_temperature_crossed_threshold",
             HVACMode.AUTO,
             ATTR_TEMPERATURE,
+            trigger_options=_TEMPERATURE_TRIGGER_OPTIONS,
         ),
         *parametrize_trigger_states(
             trigger="climate.started_cooling",
@@ -318,6 +325,7 @@ async def test_climate_state_trigger_behavior_first(
             "climate.target_temperature_crossed_threshold",
             HVACMode.AUTO,
             ATTR_TEMPERATURE,
+            trigger_options=_TEMPERATURE_TRIGGER_OPTIONS,
         ),
         *parametrize_trigger_states(
             trigger="climate.started_cooling",
@@ -436,6 +444,7 @@ async def test_climate_state_trigger_behavior_last(
             "climate.target_temperature_crossed_threshold",
             HVACMode.AUTO,
             ATTR_TEMPERATURE,
+            trigger_options=_TEMPERATURE_TRIGGER_OPTIONS,
         ),
         *parametrize_trigger_states(
             trigger="climate.started_cooling",

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -1539,6 +1539,88 @@ async def test_numerical_state_attribute_changed_error_handling(
         assert len(service_calls) == 0
 
 
+async def test_numerical_state_attribute_changed_entity_limit_unit_validation(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that entity limits with wrong unit are rejected."""
+
+    async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+        return {
+            "attribute_changed": make_entity_numerical_state_changed_trigger(
+                {"test": NumericalDomainSpec(value_source="test_attribute")},
+                valid_unit="%",
+            ),
+        }
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 20})
+
+    options = {
+        CONF_OPTIONS: {CONF_ABOVE: "sensor.above", CONF_BELOW: "sensor.below"},
+    }
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    CONF_PLATFORM: "test.attribute_changed",
+                    CONF_TARGET: {CONF_ENTITY_ID: "test.test_entity"},
+                }
+                | options,
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {CONF_ENTITY_ID: "{{ trigger.entity_id }}"},
+                },
+            }
+        },
+    )
+
+    assert len(service_calls) == 0
+
+    # Test the trigger works with correct unit on limit entities
+    hass.states.async_set("sensor.above", "10", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+    hass.states.async_set("sensor.below", "90", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    service_calls.clear()
+
+    # Test the trigger does not fire when the above sensor has wrong unit
+    hass.states.async_set("sensor.above", "10", {ATTR_UNIT_OF_MEASUREMENT: "°C"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": None})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Test the trigger does not fire when the above sensor has no unit
+    hass.states.async_set("sensor.above", "10")
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": None})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Reset the above sensor to correct unit
+    hass.states.async_set("sensor.above", "10", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+
+    # Test the trigger does not fire when the below sensor has wrong unit
+    hass.states.async_set("sensor.below", "90", {ATTR_UNIT_OF_MEASUREMENT: "°C"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": None})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Test the trigger does not fire when the below sensor has no unit
+    hass.states.async_set("sensor.below", "90")
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": None})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+
 async def test_numerical_state_attribute_changed_with_unit_error_handling(
     hass: HomeAssistant, service_calls: list[ServiceCall]
 ) -> None:
@@ -2279,6 +2361,92 @@ async def test_numerical_state_attribute_crossed_threshold_error_handling(
         hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
         await hass.async_block_till_done()
         assert len(service_calls) == 0
+
+
+async def test_numerical_state_attribute_crossed_threshold_entity_limit_unit_validation(
+    hass: HomeAssistant, service_calls: list[ServiceCall]
+) -> None:
+    """Test that entity limits with wrong unit are rejected for crossed threshold."""
+
+    async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+        return {
+            "crossed_threshold": make_entity_numerical_state_crossed_threshold_trigger(
+                {"test": NumericalDomainSpec(value_source="test_attribute")},
+                valid_unit="%",
+            ),
+        }
+
+    mock_integration(hass, MockModule("test"))
+    mock_platform(hass, "test.trigger", Mock(async_get_triggers=async_get_triggers))
+
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 0})
+
+    options = {
+        CONF_OPTIONS: {
+            CONF_THRESHOLD_TYPE: "between",
+            CONF_LOWER_LIMIT: "sensor.lower",
+            CONF_UPPER_LIMIT: "sensor.upper",
+        },
+    }
+
+    await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    CONF_PLATFORM: "test.crossed_threshold",
+                    CONF_TARGET: {CONF_ENTITY_ID: "test.test_entity"},
+                }
+                | options,
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {CONF_ENTITY_ID: "{{ trigger.entity_id }}"},
+                },
+            }
+        },
+    )
+
+    assert len(service_calls) == 0
+
+    # Test the trigger works with correct unit on limit entities
+    hass.states.async_set("sensor.lower", "10", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+    hass.states.async_set("sensor.upper", "90", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    service_calls.clear()
+
+    # Test the trigger does not fire when the lower sensor has wrong unit
+    hass.states.async_set("sensor.lower", "10", {ATTR_UNIT_OF_MEASUREMENT: "°C"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 0})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Test the trigger does not fire when the lower sensor has no unit
+    hass.states.async_set("sensor.lower", "10")
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 0})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Reset the lower sensor to correct unit
+    hass.states.async_set("sensor.lower", "10", {ATTR_UNIT_OF_MEASUREMENT: "%"})
+
+    # Test the trigger does not fire when the upper sensor has wrong unit
+    hass.states.async_set("sensor.upper", "90", {ATTR_UNIT_OF_MEASUREMENT: "°C"})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 0})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    # Test the trigger does not fire when the upper sensor has no unit
+    hass.states.async_set("sensor.upper", "90")
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 0})
+    hass.states.async_set("test.test_entity", "on", {"test_attribute": 50})
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
 
 
 async def test_numerical_state_attribute_crossed_threshold_with_unit_error_handling(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add unit of measurement handling to numeric climate triggers:
- `climate.target_humidity_changed` and `climate.target_humidity_crossed_threshold` updated to restrict limit entities to unit `%`
- `climate.target_temperature_changed` and `climate.target_temperature_crossed_threshold` updated to handle unit conversion like the `temperature.xxx` triggers do

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
