### PR TITLE
Add RFC9728 OAuth2 Protected Resource metadata endpoint

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -115,6 +115,7 @@ def async_setup(
 ) -> None:
     """Component to allow users to login."""
     hass.http.register_view(WellKnownOAuthInfoView)
+    hass.http.register_view(WellKnownProtectedResourceView)
     hass.http.register_view(AuthProvidersView)
     hass.http.register_view(LoginFlowIndexView(hass.auth.login_flow, store_result))
     hass.http.register_view(LoginFlowResourceView(hass.auth.login_flow, store_result))
@@ -152,6 +153,32 @@ class WellKnownOAuthInfoView(HomeAssistantView):
             metadata["issuer"] = url_prefix
 
         return self.json(metadata)
+
+
+class WellKnownProtectedResourceView(HomeAssistantView):
+    """View to host the OAuth2 Protected Resource Metadata per RFC9728."""
+
+    requires_auth = False
+    url = "/.well-known/oauth-protected-resource"
+    name = "well-known/oauth-protected-resource"
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return the protected resource metadata."""
+        hass = request.app[KEY_HASS]
+        try:
+            url_prefix = get_url(hass, require_current_request=True)
+        except NoURLAvailableError:
+            return self.json_message("No URL available", HTTPStatus.NOT_FOUND)
+
+        return self.json(
+            {
+                "resource": url_prefix,
+                "authorization_servers": [url_prefix],
+                "resource_documentation": (
+                    "https://developers.home-assistant.io/docs/auth_api"
+                ),
+            }
+        )
 
 
 class AuthProvidersView(HomeAssistantView):

--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -26,7 +26,6 @@ from homeassistant.core import Context, HomeAssistant, is_callback
 from homeassistant.util.json import JSON_ENCODE_EXCEPTIONS, format_unserializable_data
 
 from .json import find_paths_unserializable_data, json_bytes, json_dumps
-from .network import NoURLAvailableError, get_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,10 +58,13 @@ def request_handler_factory(
         authenticated = request.get(KEY_AUTHENTICATED, False)
 
         if view.requires_auth and not authenticated:
+            # Import here to avoid circular dependency with network.py
+            from .network import NoURLAvailableError, get_url  # noqa: PLC0415
+
             try:
                 url_prefix = get_url(hass, require_current_request=True)
             except NoURLAvailableError:
-                # Omit header to avoid leaking configured urls
+                # Omit header to avoid leaking configured URLs
                 raise HTTPUnauthorized from None
             raise HTTPUnauthorized(
                 # Include resource metadata endpoint for RFC9728

--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -62,7 +62,7 @@ def request_handler_factory(
             try:
                 url_prefix = get_url(hass, require_current_request=True)
             except NoURLAvailableError:
-                # Omit header to avoid leaking configured urls
+                # Omit header to avoid leaking configured URLs
                 raise HTTPUnauthorized from None
             raise HTTPUnauthorized(
                 # Include resource metadata endpoint for RFC9728

--- a/homeassistant/helpers/http.py
+++ b/homeassistant/helpers/http.py
@@ -26,6 +26,7 @@ from homeassistant.core import Context, HomeAssistant, is_callback
 from homeassistant.util.json import JSON_ENCODE_EXCEPTIONS, format_unserializable_data
 
 from .json import find_paths_unserializable_data, json_bytes, json_dumps
+from .network import NoURLAvailableError, get_url
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,7 +59,20 @@ def request_handler_factory(
         authenticated = request.get(KEY_AUTHENTICATED, False)
 
         if view.requires_auth and not authenticated:
-            raise HTTPUnauthorized
+            try:
+                url_prefix = get_url(hass, require_current_request=True)
+            except NoURLAvailableError:
+                # Omit header to avoid leaking configured urls
+                raise HTTPUnauthorized from None
+            raise HTTPUnauthorized(
+                # Include resource metadata endpoint for RFC9728
+                headers={
+                    "WWW-Authenticate": (
+                        f'Bearer resource_metadata="{url_prefix}'
+                        '/.well-known/oauth-protected-resource"'
+                    )
+                }
+            )
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -428,3 +428,70 @@ async def test_well_known_auth_info(
         "response_types_supported": ["code"],
         "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
     }
+
+
+@pytest.mark.usefixtures("current_request_with_host")  # Has example.com host
+@pytest.mark.parametrize(
+    ("config", "expected_response"),
+    [
+        (
+            {
+                "internal_url": "http://192.168.1.100:8123",
+                # Current request matches external url
+                "external_url": "https://example.com",
+            },
+            {
+                "resource": "https://example.com",
+                "authorization_servers": ["https://example.com"],
+                "resource_documentation": "https://developers.home-assistant.io/docs/auth_api",
+            },
+        ),
+        (
+            {
+                # Current request matches internal url
+                "internal_url": "https://example.com",
+                "external_url": "https://other.com",
+            },
+            {
+                "resource": "https://example.com",
+                "authorization_servers": ["https://example.com"],
+                "resource_documentation": "https://developers.home-assistant.io/docs/auth_api",
+            },
+        ),
+    ],
+    ids=["external_url", "internal_url"],
+)
+async def test_well_known_protected_resource(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    config: dict[str, str],
+    expected_response: dict[str, Any],
+) -> None:
+    """Test the well-known OAuth protected resource metadata endpoint per RFC9728."""
+    await async_process_ha_core_config(hass, config)
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.get(
+        "/.well-known/oauth-protected-resource",
+    )
+    assert resp.status == 200
+    assert await resp.json() == expected_response
+
+
+@pytest.mark.usefixtures("current_request_with_host")  # Has example.com host
+async def test_well_known_protected_resource_no_url(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+) -> None:
+    """Test the protected resource metadata returns 404 when no URL is configured."""
+    await async_process_ha_core_config(
+        hass,
+        {
+            "internal_url": "https://other.com",
+            "external_url": "https://again.com",
+        },
+    )
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.get(
+        "/.well-known/oauth-protected-resource",
+    )
+    assert resp.status == 404

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from http import HTTPStatus
 import json
 import math
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.web_exceptions import (
     HTTPBadRequest,
@@ -20,6 +20,7 @@ from homeassistant.components.http.view import (
     request_handler_factory,
 )
 from homeassistant.exceptions import ServiceNotFound, Unauthorized
+from homeassistant.helpers.network import NoURLAvailableError
 
 
 @pytest.fixture
@@ -99,3 +100,46 @@ async def test_invalid_handler(mock_request: Mock) -> None:
             Mock(requires_auth=False),
             AsyncMock(return_value=["not valid"]),
         )(mock_request)
+
+
+async def test_requires_auth_includes_www_authenticate(
+    mock_request: Mock,
+) -> None:
+    """Test that 401 responses include WWW-Authenticate header per RFC9728."""
+    mock_request.get = Mock(return_value=False)
+    with (
+        patch(
+            "homeassistant.helpers.http.get_url",
+            return_value="https://example.com",
+        ),
+        pytest.raises(HTTPUnauthorized) as exc_info,
+    ):
+        await request_handler_factory(
+            mock_request.app[KEY_HASS],
+            Mock(requires_auth=True),
+            AsyncMock(),
+        )(mock_request)
+    assert exc_info.value.headers["WWW-Authenticate"] == (
+        "Bearer resource_metadata="
+        '"https://example.com/.well-known/oauth-protected-resource"'
+    )
+
+
+async def test_requires_auth_omits_www_authenticate_without_url(
+    mock_request: Mock,
+) -> None:
+    """Test that 401 responses omit WWW-Authenticate header when no URL is configured."""
+    mock_request.get = Mock(return_value=False)
+    with (
+        patch(
+            "homeassistant.helpers.http.get_url",
+            side_effect=NoURLAvailableError,
+        ),
+        pytest.raises(HTTPUnauthorized) as exc_info,
+    ):
+        await request_handler_factory(
+            mock_request.app[KEY_HASS],
+            Mock(requires_auth=True),
+            AsyncMock(),
+        )(mock_request)
+    assert "WWW-Authenticate" not in exc_info.value.headers

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -109,7 +109,7 @@ async def test_requires_auth_includes_www_authenticate(
     mock_request.get = Mock(return_value=False)
     with (
         patch(
-            "homeassistant.helpers.http.get_url",
+            "homeassistant.helpers.network.get_url",
             return_value="https://example.com",
         ),
         pytest.raises(HTTPUnauthorized) as exc_info,
@@ -132,7 +132,7 @@ async def test_requires_auth_omits_www_authenticate_without_url(
     mock_request.get = Mock(return_value=False)
     with (
         patch(
-            "homeassistant.helpers.http.get_url",
+            "homeassistant.helpers.network.get_url",
             side_effect=NoURLAvailableError,
         ),
         pytest.raises(HTTPUnauthorized) as exc_info,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add RFC9728 OAuth2 Protected Resource metadata endpoint and include `WWW-Authenticate` header in 401 responses.

This is PR 1 for https://github.com/home-assistant/architecture/discussions/1332. 
A future PR will add support for RFC8707.


```
$ curl --ver
bose localhost:8123/api/mcp
*   Trying 127.0.0.1:8123...
* Connected to localhost (127.0.0.1) port 8123 (#0)
> GET /api/mcp HTTP/1.1
> Host: localhost:8123
> User-Agent: curl/7.88.1
> Accept: */*
> 
< HTTP/1.1 401 Unauthorized
< WWW-Authenticate: Bearer resource_metadata="http://localhost:8123/.well-known/oauth-protected-resource"
< Content-Type: text/plain; charset=utf-8
< Referrer-Policy: no-referrer
< X-Content-Type-Options: nosniff
< Server: 
< X-Frame-Options: SAMEORIGIN
< Content-Length: 17
< Date: Sun, 22 Mar 2026 18:11:34 GMT
< 
* Connection #0 to host localhost left intact
401: Unauthorized
```

Verifying the endpoint:

```
$ curl -s http://localhost:8123/.well-known/oauth-protected-resource | jq
{
  "resource": "http://localhost:8123",
  "authorization_servers": [
    "http://localhost:8123"
  ],
  "resource_documentation": "https://developers.home-assistant.io/docs/auth_api"
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: https://github.com/home-assistant/core/issues/153820
- This PR is related to architecture discussion: https://github.com/home-assistant/architecture/discussions/1332
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
