### PR TITLE
feat(citybikes): add number of ebikes attribute

### DIFF
--- a/homeassistant/components/citybikes/sensor.py
+++ b/homeassistant/components/citybikes/sensor.py
@@ -52,6 +52,7 @@ ATTR_LONGITUDE = "longitude"
 ATTR_EMPTY_SLOTS = "empty_slots"
 ATTR_FREE_EBIKES = "free_ebikes"
 ATTR_TIMESTAMP = "timestamp"
+EXTRA_EBIKES = "ebikes"
 
 CONF_NETWORK = "network"
 CONF_STATIONS_LIST = "stations"
@@ -239,6 +240,6 @@ class CityBikesStation(SensorEntity):
             ATTR_LATITUDE: station.latitude,
             ATTR_LONGITUDE: station.longitude,
             ATTR_EMPTY_SLOTS: station.empty_slots,
-            ATTR_FREE_EBIKES: station.extra.get("ebikes"),
+            ATTR_FREE_EBIKES: station.extra.get(EXTRA_EBIKES),
             ATTR_TIMESTAMP: station.timestamp,
         }

--- a/homeassistant/components/citybikes/sensor.py
+++ b/homeassistant/components/citybikes/sensor.py
@@ -50,6 +50,7 @@ ATTR_UID = "uid"
 ATTR_LATITUDE = "latitude"
 ATTR_LONGITUDE = "longitude"
 ATTR_EMPTY_SLOTS = "empty_slots"
+ATTR_FREE_EBIKES = "free_ebikes"
 ATTR_TIMESTAMP = "timestamp"
 
 CONF_NETWORK = "network"
@@ -238,5 +239,6 @@ class CityBikesStation(SensorEntity):
             ATTR_LATITUDE: station.latitude,
             ATTR_LONGITUDE: station.longitude,
             ATTR_EMPTY_SLOTS: station.empty_slots,
+            ATTR_FREE_EBIKES: station.extra.get("ebikes"),
             ATTR_TIMESTAMP: station.timestamp,
         }

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2185,6 +2185,9 @@ python-awair==0.2.5
 # homeassistant.components.bsblan
 python-bsblan==5.1.2
 
+# homeassistant.components.citybikes
+python-citybikes==0.3.3
+
 # homeassistant.components.dropbox
 python-dropbox-api==0.1.3
 

--- a/tests/components/citybikes/__init__.py
+++ b/tests/components/citybikes/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the CityBikes integration."""

--- a/tests/components/citybikes/__init__.py
+++ b/tests/components/citybikes/__init__.py
@@ -43,4 +43,4 @@ async def setup_integration(
             ]
         },
     )
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.async_block_till_done()

--- a/tests/components/citybikes/__init__.py
+++ b/tests/components/citybikes/__init__.py
@@ -1,1 +1,46 @@
 """Tests for the CityBikes integration."""
+
+from unittest.mock import AsyncMock, Mock
+
+from citybikes import model as citybikes_model
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def setup_integration(
+    hass: HomeAssistant,
+    mock_citybikes_client: Mock,
+    station: citybikes_model.Station,
+) -> None:
+    """Set up the CityBikes sensor platform for testing."""
+    network = citybikes_model.Network.from_dict(
+        {
+            "id": "mock-network",
+            "name": "Mock Network",
+            "location": {
+                "latitude": 40.0,
+                "longitude": -73.0,
+                "city": "Test City",
+                "country": "US",
+            },
+            "href": "/v2/networks/mock-network",
+            "stations": [station.__dict__],
+        }
+    )
+    mock_citybikes_client.network.return_value.fetch = AsyncMock(return_value=network)
+
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": [
+                {
+                    "platform": "citybikes",
+                    "network": "mock-network",
+                    "stations": ["station-1"],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/citybikes/snapshots/test_sensor.ambr
+++ b/tests/components/citybikes/snapshots/test_sensor.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: test_sensor_state[with_ebikes][with_ebikes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Information provided by the CityBikes Project (https://citybik.es/#about)',
+      'empty_slots': 8,
+      'free_ebikes': 2,
+      'friendly_name': 'Station 1',
+      'icon': 'mdi:bike',
+      'latitude': 40.0,
+      'longitude': -73.0,
+      'timestamp': '2026-03-22T00:00:00Z',
+      'uid': 'uid-1',
+      'unit_of_measurement': 'bikes',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_network_station_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---
+# name: test_sensor_state[without_ebikes][without_ebikes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Information provided by the CityBikes Project (https://citybik.es/#about)',
+      'empty_slots': 8,
+      'free_ebikes': None,
+      'friendly_name': 'Station 1',
+      'icon': 'mdi:bike',
+      'latitude': 40.0,
+      'longitude': -73.0,
+      'timestamp': '2026-03-22T00:00:00Z',
+      'uid': 'uid-1',
+      'unit_of_measurement': 'bikes',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_network_station_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
+  })
+# ---

--- a/tests/components/citybikes/snapshots/test_sensor.ambr
+++ b/tests/components/citybikes/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensor_state[with_ebikes][with_ebikes]
+# name: test_sensor_state[with_ebikes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Information provided by the CityBikes Project (https://citybik.es/#about)',
@@ -21,7 +21,7 @@
     'state': '5',
   })
 # ---
-# name: test_sensor_state[without_ebikes][without_ebikes]
+# name: test_sensor_state[without_ebikes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Information provided by the CityBikes Project (https://citybik.es/#about)',

--- a/tests/components/citybikes/test_sensor.py
+++ b/tests/components/citybikes/test_sensor.py
@@ -1,31 +1,21 @@
 """Tests for the CityBikes sensor platform."""
 
-from importlib import import_module
-import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+
+from homeassistant.components.citybikes.sensor import (
+    ATTR_EMPTY_SLOTS,
+    ATTR_FREE_EBIKES,
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    ATTR_TIMESTAMP,
+    ATTR_UID,
+    CityBikesStation,
+)
 
 
-def _import_citybikes_sensor_module():
-    """Import the citybikes sensor module with a stubbed client library."""
-    citybikes_module = SimpleNamespace(__version__="0.0.0")
-    citybikes_asyncio_module = SimpleNamespace(Client=object)
-
-    sys.modules.pop("homeassistant.components.citybikes.sensor", None)
-    with patch.dict(
-        sys.modules,
-        {
-            "citybikes": citybikes_module,
-            "citybikes.asyncio": citybikes_asyncio_module,
-        },
-    ):
-        return import_module("homeassistant.components.citybikes.sensor")
-
-
-async def test_citybikes_station_exposes_ebikes_from_station_extra() -> None:
-    """Test CityBikesStation exposes free ebikes from station.extra."""
-    citybikes_sensor = _import_citybikes_sensor_module()
-    station = SimpleNamespace(
+def _create_station(extra: dict[str, object]) -> SimpleNamespace:
+    """Create a CityBikes station test double."""
+    return SimpleNamespace(
         id="station-1",
         name="Station 1",
         free_bikes=5,
@@ -33,40 +23,35 @@ async def test_citybikes_station_exposes_ebikes_from_station_extra() -> None:
         latitude=40.0,
         longitude=-73.0,
         timestamp="2026-03-22T00:00:00Z",
-        extra={citybikes_sensor.ATTR_UID: "uid-1", "ebikes": 2},
+        extra=extra,
     )
+
+
+async def test_citybikes_station_exposes_ebikes_from_station_extra() -> None:
+    """Test CityBikesStation exposes free ebikes from station.extra."""
+    station = _create_station({ATTR_UID: "uid-1", "ebikes": 2})
     network = SimpleNamespace(stations=[station])
-    entity = citybikes_sensor.CityBikesStation(network, "station-1", "sensor.station_1")
+    entity = CityBikesStation(network, "station-1", "sensor.station_1")
 
     await entity.async_update()
 
     assert entity.native_value == 5
     assert entity.extra_state_attributes == {
-        citybikes_sensor.ATTR_UID: "uid-1",
-        citybikes_sensor.ATTR_LATITUDE: 40.0,
-        citybikes_sensor.ATTR_LONGITUDE: -73.0,
-        citybikes_sensor.ATTR_EMPTY_SLOTS: 8,
-        citybikes_sensor.ATTR_FREE_EBIKES: 2,
-        citybikes_sensor.ATTR_TIMESTAMP: "2026-03-22T00:00:00Z",
+        ATTR_UID: "uid-1",
+        ATTR_LATITUDE: 40.0,
+        ATTR_LONGITUDE: -73.0,
+        ATTR_EMPTY_SLOTS: 8,
+        ATTR_FREE_EBIKES: 2,
+        ATTR_TIMESTAMP: "2026-03-22T00:00:00Z",
     }
 
 
 async def test_citybikes_station_handles_missing_ebikes() -> None:
     """Test CityBikesStation handles stations without ebike data."""
-    citybikes_sensor = _import_citybikes_sensor_module()
-    station = SimpleNamespace(
-        id="station-1",
-        name="Station 1",
-        free_bikes=5,
-        empty_slots=8,
-        latitude=40.0,
-        longitude=-73.0,
-        timestamp="2026-03-22T00:00:00Z",
-        extra={citybikes_sensor.ATTR_UID: "uid-1"},
-    )
+    station = _create_station({ATTR_UID: "uid-1"})
     network = SimpleNamespace(stations=[station])
-    entity = citybikes_sensor.CityBikesStation(network, "station-1", "sensor.station_1")
+    entity = CityBikesStation(network, "station-1", "sensor.station_1")
 
     await entity.async_update()
 
-    assert entity.extra_state_attributes[citybikes_sensor.ATTR_FREE_EBIKES] is None
+    assert entity.extra_state_attributes[ATTR_FREE_EBIKES] is None

--- a/tests/components/citybikes/test_sensor.py
+++ b/tests/components/citybikes/test_sensor.py
@@ -1,21 +1,21 @@
 """Tests for the CityBikes sensor platform."""
 
-from types import SimpleNamespace
+from collections.abc import Callable, Generator
+from unittest.mock import AsyncMock, Mock, patch
 
-from homeassistant.components.citybikes.sensor import (
-    ATTR_EMPTY_SLOTS,
-    ATTR_FREE_EBIKES,
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    ATTR_TIMESTAMP,
-    ATTR_UID,
-    CityBikesStation,
-)
+from citybikes import model as citybikes_model
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.citybikes import sensor as citybikes_sensor
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 
-def _create_station(extra: dict[str, object]) -> SimpleNamespace:
-    """Create a CityBikes station test double."""
-    return SimpleNamespace(
+@pytest.fixture(name="station_factory")
+def station_factory_fixture() -> Callable[[dict[str, object]], citybikes_model.Station]:
+    """Create CityBikes station objects."""
+    return lambda extra: citybikes_model.Station(
         id="station-1",
         name="Station 1",
         free_bikes=5,
@@ -27,31 +27,79 @@ def _create_station(extra: dict[str, object]) -> SimpleNamespace:
     )
 
 
-async def test_citybikes_station_exposes_ebikes_from_station_extra() -> None:
-    """Test CityBikesStation exposes free ebikes from station.extra."""
-    station = _create_station({ATTR_UID: "uid-1", "ebikes": 2})
-    network = SimpleNamespace(stations=[station])
-    entity = CityBikesStation(network, "station-1", "sensor.station_1")
-
-    await entity.async_update()
-
-    assert entity.native_value == 5
-    assert entity.extra_state_attributes == {
-        ATTR_UID: "uid-1",
-        ATTR_LATITUDE: 40.0,
-        ATTR_LONGITUDE: -73.0,
-        ATTR_EMPTY_SLOTS: 8,
-        ATTR_FREE_EBIKES: 2,
-        ATTR_TIMESTAMP: "2026-03-22T00:00:00Z",
-    }
+@pytest.fixture(name="mock_citybikes_client")
+def mock_citybikes_client_fixture() -> Generator[Mock]:
+    """Mock the CityBikes client."""
+    with patch.object(citybikes_sensor, "CitybikesClient") as mock_client:
+        mock_client.return_value.close = AsyncMock()
+        yield mock_client.return_value
 
 
-async def test_citybikes_station_handles_missing_ebikes() -> None:
-    """Test CityBikesStation handles stations without ebike data."""
-    station = _create_station({ATTR_UID: "uid-1"})
-    network = SimpleNamespace(stations=[station])
-    entity = CityBikesStation(network, "station-1", "sensor.station_1")
+async def _async_setup_citybikes_sensor(
+    hass: HomeAssistant,
+    mock_citybikes_client: Mock,
+    station: citybikes_model.Station,
+) -> None:
+    """Set up the CityBikes sensor platform."""
+    network = citybikes_model.Network.from_dict(
+        {
+            "id": "mock-network",
+            "name": "Mock Network",
+            "location": {
+                "latitude": 40.0,
+                "longitude": -73.0,
+                "city": "Test City",
+                "country": "US",
+            },
+            "href": "/v2/networks/mock-network",
+            "stations": [station.__dict__],
+        }
+    )
+    mock_citybikes_client.network.return_value.fetch = AsyncMock(return_value=network)
 
-    await entity.async_update()
+    assert await async_setup_component(
+        hass,
+        "sensor",
+        {
+            "sensor": [
+                {
+                    "platform": "citybikes",
+                    "network": "mock-network",
+                    "stations": ["station-1"],
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert entity.extra_state_attributes[ATTR_FREE_EBIKES] is None
+
+@pytest.mark.parametrize(
+    ("extra", "snapshot_name"),
+    [
+        pytest.param(
+            {citybikes_sensor.ATTR_UID: "uid-1", "ebikes": 2},
+            "with_ebikes",
+            id="with_ebikes",
+        ),
+        pytest.param(
+            {citybikes_sensor.ATTR_UID: "uid-1"},
+            "without_ebikes",
+            id="without_ebikes",
+        ),
+    ],
+)
+async def test_sensor_state(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_citybikes_client: Mock,
+    station_factory: Callable[[dict[str, object]], citybikes_model.Station],
+    extra: dict[str, object],
+    snapshot_name: str,
+) -> None:
+    """Test CityBikes sensor state snapshots."""
+    await _async_setup_citybikes_sensor(
+        hass, mock_citybikes_client, station_factory(extra)
+    )
+
+    assert (state := hass.states.get("sensor.mock_network_station_1"))
+    assert state == snapshot(name=snapshot_name)

--- a/tests/components/citybikes/test_sensor.py
+++ b/tests/components/citybikes/test_sensor.py
@@ -9,7 +9,8 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.citybikes import sensor as citybikes_sensor
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+
+from . import setup_integration
 
 
 @pytest.fixture(name="station_factory")
@@ -35,49 +36,11 @@ def mock_citybikes_client_fixture() -> Generator[Mock]:
         yield mock_client.return_value
 
 
-async def _async_setup_citybikes_sensor(
-    hass: HomeAssistant,
-    mock_citybikes_client: Mock,
-    station: citybikes_model.Station,
-) -> None:
-    """Set up the CityBikes sensor platform."""
-    network = citybikes_model.Network.from_dict(
-        {
-            "id": "mock-network",
-            "name": "Mock Network",
-            "location": {
-                "latitude": 40.0,
-                "longitude": -73.0,
-                "city": "Test City",
-                "country": "US",
-            },
-            "href": "/v2/networks/mock-network",
-            "stations": [station.__dict__],
-        }
-    )
-    mock_citybikes_client.network.return_value.fetch = AsyncMock(return_value=network)
-
-    assert await async_setup_component(
-        hass,
-        "sensor",
-        {
-            "sensor": [
-                {
-                    "platform": "citybikes",
-                    "network": "mock-network",
-                    "stations": ["station-1"],
-                }
-            ]
-        },
-    )
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-
 @pytest.mark.parametrize(
     ("extra", "snapshot_name"),
     [
         pytest.param(
-            {citybikes_sensor.ATTR_UID: "uid-1", "ebikes": 2},
+            {citybikes_sensor.ATTR_UID: "uid-1", citybikes_sensor.EXTRA_EBIKES: 2},
             "with_ebikes",
             id="with_ebikes",
         ),
@@ -97,9 +60,7 @@ async def test_sensor_state(
     snapshot_name: str,
 ) -> None:
     """Test CityBikes sensor state snapshots."""
-    await _async_setup_citybikes_sensor(
-        hass, mock_citybikes_client, station_factory(extra)
-    )
+    await setup_integration(hass, mock_citybikes_client, station_factory(extra))
 
     assert (state := hass.states.get("sensor.mock_network_station_1"))
     assert state == snapshot(name=snapshot_name)

--- a/tests/components/citybikes/test_sensor.py
+++ b/tests/components/citybikes/test_sensor.py
@@ -37,16 +37,14 @@ def mock_citybikes_client_fixture() -> Generator[Mock]:
 
 
 @pytest.mark.parametrize(
-    ("extra", "snapshot_name"),
+    "extra",
     [
         pytest.param(
             {citybikes_sensor.ATTR_UID: "uid-1", citybikes_sensor.EXTRA_EBIKES: 2},
-            "with_ebikes",
             id="with_ebikes",
         ),
         pytest.param(
             {citybikes_sensor.ATTR_UID: "uid-1"},
-            "without_ebikes",
             id="without_ebikes",
         ),
     ],
@@ -57,10 +55,9 @@ async def test_sensor_state(
     mock_citybikes_client: Mock,
     station_factory: Callable[[dict[str, object]], citybikes_model.Station],
     extra: dict[str, object],
-    snapshot_name: str,
 ) -> None:
     """Test CityBikes sensor state snapshots."""
     await setup_integration(hass, mock_citybikes_client, station_factory(extra))
 
     assert (state := hass.states.get("sensor.mock_network_station_1"))
-    assert state == snapshot(name=snapshot_name)
+    assert state == snapshot

--- a/tests/components/citybikes/test_sensor.py
+++ b/tests/components/citybikes/test_sensor.py
@@ -1,0 +1,72 @@
+"""Tests for the CityBikes sensor platform."""
+
+from importlib import import_module
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _import_citybikes_sensor_module():
+    """Import the citybikes sensor module with a stubbed client library."""
+    citybikes_module = SimpleNamespace(__version__="0.0.0")
+    citybikes_asyncio_module = SimpleNamespace(Client=object)
+
+    sys.modules.pop("homeassistant.components.citybikes.sensor", None)
+    with patch.dict(
+        sys.modules,
+        {
+            "citybikes": citybikes_module,
+            "citybikes.asyncio": citybikes_asyncio_module,
+        },
+    ):
+        return import_module("homeassistant.components.citybikes.sensor")
+
+
+async def test_citybikes_station_exposes_ebikes_from_station_extra() -> None:
+    """Test CityBikesStation exposes free ebikes from station.extra."""
+    citybikes_sensor = _import_citybikes_sensor_module()
+    station = SimpleNamespace(
+        id="station-1",
+        name="Station 1",
+        free_bikes=5,
+        empty_slots=8,
+        latitude=40.0,
+        longitude=-73.0,
+        timestamp="2026-03-22T00:00:00Z",
+        extra={citybikes_sensor.ATTR_UID: "uid-1", "ebikes": 2},
+    )
+    network = SimpleNamespace(stations=[station])
+    entity = citybikes_sensor.CityBikesStation(network, "station-1", "sensor.station_1")
+
+    await entity.async_update()
+
+    assert entity.native_value == 5
+    assert entity.extra_state_attributes == {
+        citybikes_sensor.ATTR_UID: "uid-1",
+        citybikes_sensor.ATTR_LATITUDE: 40.0,
+        citybikes_sensor.ATTR_LONGITUDE: -73.0,
+        citybikes_sensor.ATTR_EMPTY_SLOTS: 8,
+        citybikes_sensor.ATTR_FREE_EBIKES: 2,
+        citybikes_sensor.ATTR_TIMESTAMP: "2026-03-22T00:00:00Z",
+    }
+
+
+async def test_citybikes_station_handles_missing_ebikes() -> None:
+    """Test CityBikesStation handles stations without ebike data."""
+    citybikes_sensor = _import_citybikes_sensor_module()
+    station = SimpleNamespace(
+        id="station-1",
+        name="Station 1",
+        free_bikes=5,
+        empty_slots=8,
+        latitude=40.0,
+        longitude=-73.0,
+        timestamp="2026-03-22T00:00:00Z",
+        extra={citybikes_sensor.ATTR_UID: "uid-1"},
+    )
+    network = SimpleNamespace(stations=[station])
+    entity = citybikes_sensor.CityBikesStation(network, "station-1", "sensor.station_1")
+
+    await entity.async_update()
+
+    assert entity.extra_state_attributes[citybikes_sensor.ATTR_FREE_EBIKES] is None


### PR DESCRIPTION
## Proposed change

Adds e-bike support to the CityBikes sensor by exposing `free_ebikes` from `station.extra["ebikes"]`. I'm adding tests to this integration (it had no tests before) so `python -m script.gen_requirements_all` updated the `requirements_test_all.txt` file.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/85279
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%%3Aopen+is%%3Apr+-author%%3A%%40me+-draft%%3Atrue+-label%%3Awaiting-for-upstream+sort%%3Acreated-desc+review%%3Anone+-status%%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
