### PR TITLE
Add support for LetPot ISE06 watering system device

### DIFF
--- a/homeassistant/components/letpot/binary_sensor.py
+++ b/homeassistant/components/letpot/binary_sensor.py
@@ -77,6 +77,20 @@ BINARY_SENSORS: tuple[LetPotBinarySensorEntityDescription, ...] = (
         ),
     ),
     LetPotBinarySensorEntityDescription(
+        key="pump_watering",
+        translation_key="pump",
+        is_on_fn=lambda status: bool(getattr(status, "pump_on", False)),
+        device_class=BinarySensorDeviceClass.RUNNING,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_WATERING_SYSTEM
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
+    ),
+    LetPotBinarySensorEntityDescription(
         key="refill_error",
         translation_key="refill_error",
         is_on_fn=lambda status: bool(status.errors.refill_error),

--- a/homeassistant/components/letpot/manifest.json
+++ b/homeassistant/components/letpot/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_push",
   "loggers": ["letpot"],
   "quality_scale": "silver",
-  "requirements": ["letpot==0.6.4"]
+  "requirements": ["letpot==0.7.0"]
 }

--- a/homeassistant/components/letpot/number.py
+++ b/homeassistant/components/letpot/number.py
@@ -83,6 +83,14 @@ NUMBERS: tuple[LetPotNumberEntityDescription, ...] = (
                 serial, int(value)
             )
         ),
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
         native_min_value=float(0),
         max_value_fn=lambda _: float(999),
         native_step=PRECISION_WHOLE,

--- a/homeassistant/components/letpot/select.py
+++ b/homeassistant/components/letpot/select.py
@@ -121,6 +121,14 @@ SELECTORS: tuple[LetPotSelectEntityDescription, ...] = (
                 serial, LightMode[option.upper()]
             )
         ),
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
         entity_category=EntityCategory.CONFIG,
     ),
 )

--- a/homeassistant/components/letpot/strings.json
+++ b/homeassistant/components/letpot/strings.json
@@ -92,6 +92,9 @@
       "auto_mode": {
         "name": "Auto mode"
       },
+      "manual_watering": {
+        "name": "Manual watering"
+      },
       "power": {
         "name": "Power"
       },

--- a/homeassistant/components/letpot/switch.py
+++ b/homeassistant/components/letpot/switch.py
@@ -37,7 +37,15 @@ SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
             lambda device_client, serial, value: device_client.set_sound(serial, value)
         ),
         entity_category=EntityCategory.CONFIG,
-        supported_fn=lambda coordinator: coordinator.data.system_sound is not None,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+                and coordinator.data.system_sound is not None
+            )
+        ),
     ),
     LetPotSwitchEntityDescription(
         key="auto_mode",
@@ -59,6 +67,22 @@ SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
         ),
     ),
     LetPotSwitchEntityDescription(
+        key="manual_watering",
+        translation_key="manual_watering",
+        value_fn=lambda status: status.pump_mode == 1,
+        set_value_fn=lambda device_client, serial, value: device_client.set_pump_mode(
+            serial, value
+        ),
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_WATERING_SYSTEM
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
+    ),
+    LetPotSwitchEntityDescription(
         key="power",
         translation_key="power",
         value_fn=lambda status: status.system_on,
@@ -66,6 +90,14 @@ SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
             serial, value
         ),
         entity_category=EntityCategory.CONFIG,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
     ),
     LetPotSwitchEntityDescription(
         key="pump_cycling",
@@ -75,6 +107,14 @@ SWITCHES: tuple[LetPotSwitchEntityDescription, ...] = (
             serial, value
         ),
         entity_category=EntityCategory.CONFIG,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
     ),
 )
 

--- a/homeassistant/components/letpot/time.py
+++ b/homeassistant/components/letpot/time.py
@@ -6,7 +6,7 @@ from datetime import time
 from typing import Any
 
 from letpot.deviceclient import LetPotDeviceClient
-from letpot.models import LetPotDeviceStatus
+from letpot.models import DeviceFeature, LetPotDeviceStatus
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.const import EntityCategory
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import LetPotConfigEntry, LetPotDeviceCoordinator
-from .entity import LetPotEntity, exception_handler
+from .entity import LetPotEntity, LetPotEntityDescription, exception_handler
 
 # Each change pushes a 'full' device status with the change. The library will cache
 # pending changes to avoid overwriting, but try to avoid a lot of parallelism.
@@ -22,7 +22,7 @@ PARALLEL_UPDATES = 1
 
 
 @dataclass(frozen=True, kw_only=True)
-class LetPotTimeEntityDescription(TimeEntityDescription):
+class LetPotTimeEntityDescription(LetPotEntityDescription, TimeEntityDescription):
     """Describes a LetPot time entity."""
 
     value_fn: Callable[[LetPotDeviceStatus], time | None]
@@ -40,6 +40,14 @@ TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
             )
         ),
         entity_category=EntityCategory.CONFIG,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
     ),
     LetPotTimeEntityDescription(
         key="light_schedule_start",
@@ -51,6 +59,14 @@ TIME_SENSORS: tuple[LetPotTimeEntityDescription, ...] = (
             )
         ),
         entity_category=EntityCategory.CONFIG,
+        supported_fn=(
+            lambda coordinator: (
+                DeviceFeature.CATEGORY_HYDROPONIC_GARDEN
+                in coordinator.device_client.device_info(
+                    coordinator.device.serial_number
+                ).features
+            )
+        ),
     ),
 )
 
@@ -66,6 +82,7 @@ async def async_setup_entry(
         LetPotTimeEntity(coordinator, description)
         for description in TIME_SENSORS
         for coordinator in coordinators
+        if description.supported_fn(coordinator)
     )
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1407,7 +1407,7 @@ led-ble==1.1.7
 lektricowifi==0.1
 
 # homeassistant.components.letpot
-letpot==0.6.4
+letpot==0.7.0
 
 # homeassistant.components.foscam
 libpyfoscamcgi==0.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1241,7 +1241,7 @@ led-ble==1.1.7
 lektricowifi==0.1
 
 # homeassistant.components.letpot
-letpot==0.6.4
+letpot==0.7.0
 
 # homeassistant.components.foscam
 libpyfoscamcgi==0.0.9

--- a/tests/components/letpot/__init__.py
+++ b/tests/components/letpot/__init__.py
@@ -4,8 +4,10 @@ import datetime
 
 from letpot.models import (
     AuthenticationInfo,
+    CycleWateringMode,
     LetPotDeviceErrors,
-    LetPotDeviceStatus,
+    LetPotGardenStatus,
+    LetPotWateringSystemStatus,
     LightMode,
     TemperatureUnit,
 )
@@ -31,7 +33,7 @@ AUTHENTICATION = AuthenticationInfo(
     email="email@example.com",
 )
 
-MAX_STATUS = LetPotDeviceStatus(
+MAX_STATUS = LetPotGardenStatus(
     errors=LetPotDeviceErrors(low_water=True, low_nutrients=False, refill_error=False),
     light_brightness=750,
     light_mode=LightMode.VEGETABLE,
@@ -51,7 +53,7 @@ MAX_STATUS = LetPotDeviceStatus(
     water_level=100,
 )
 
-SE_STATUS = LetPotDeviceStatus(
+SE_STATUS = LetPotGardenStatus(
     errors=LetPotDeviceErrors(low_water=True, pump_malfunction=True),
     light_brightness=500,
     light_mode=LightMode.VEGETABLE,
@@ -65,4 +67,24 @@ SE_STATUS = LetPotDeviceStatus(
     raw=[],  # Not used by integration, and it requires a real device to get
     system_on=True,
     system_sound=False,
+)
+
+WATERING_STATUS = LetPotWateringSystemStatus(
+    errors=LetPotDeviceErrors(low_water=False),
+    raw=[],  # Not used by integration, and it requires a real device to get
+    pump_mode=0,
+    wifi_state=0,
+    pump_on=False,
+    pump_countdown=[0, 0, 0, 0],
+    pump_manual_duration=5,
+    pump_cycle_on=True,
+    pump_cycle_frequency=24,
+    pump_cycle_duration=10,
+    pump_cycle_mode=CycleWateringMode.CONTINUOUS,
+    pump_cycle_workinginterval=0,
+    pump_cycle_restinterval=0,
+    pump_cycle_skip_water=None,
+    pump_works_latest_reason=0,
+    pump_works_latest_time=[0, 0, 0, 0],
+    pump_works_next_time=[0, 0, 0, 0],
 )

--- a/tests/components/letpot/conftest.py
+++ b/tests/components/letpot/conftest.py
@@ -20,7 +20,7 @@ from homeassistant.components.letpot.const import (
 )
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL
 
-from . import AUTHENTICATION, MAX_STATUS, SE_STATUS
+from . import AUTHENTICATION, MAX_STATUS, SE_STATUS, WATERING_STATUS
 
 from tests.common import MockConfigEntry
 
@@ -33,10 +33,16 @@ def device_type() -> str:
 
 def _mock_device_info(device_type: str) -> LetPotDeviceInfo:
     """Return mock device info for the given type."""
+    if device_type == "ISE06":
+        model_name = "LetPot Automatic Watering System"
+        model_code = "DI"
+    else:
+        model_name = f"LetPot {device_type}"
+        model_code = device_type
     return LetPotDeviceInfo(
         model=device_type,
-        model_name=f"LetPot {device_type}",
-        model_code=device_type,
+        model_name=model_name,
+        model_code=model_code,
         features=_mock_device_features(device_type),
     )
 
@@ -69,6 +75,8 @@ def _mock_device_features(device_type: str) -> DeviceFeature:
             | DeviceFeature.TEMPERATURE
             | DeviceFeature.WATER_LEVEL
         )
+    if device_type == "ISE06":
+        return DeviceFeature.CATEGORY_WATERING_SYSTEM
     raise ValueError(f"No mock data for device type {device_type}")
 
 
@@ -78,6 +86,8 @@ def _mock_device_status(device_type: str) -> LetPotDeviceStatus:
         return SE_STATUS
     if device_type in {"LPH62", "LPH63"}:
         return MAX_STATUS
+    if device_type == "ISE06":
+        return WATERING_STATUS
     raise ValueError(f"No mock data for device type {device_type}")
 
 
@@ -87,6 +97,8 @@ def _mock_light_brightness_levels(device_type: str) -> list[int]:
         return [500, 1000]
     if device_type in {"LPH62", "LPH63"}:
         return [125, 250, 375, 500, 625, 750, 875, 1000]
+    if device_type == "ISE06":
+        return []
     raise ValueError(f"No mock data for device type {device_type}")
 
 
@@ -115,10 +127,15 @@ def mock_client(device_type: str) -> Generator[AsyncMock]:
         client = mock_client.return_value
         client.login.return_value = AUTHENTICATION
         client.refresh_token.return_value = AUTHENTICATION
+        device_name = (
+            "Watering System"
+            if device_type.startswith("ISE")
+            else "Garden"
+        )
         client.get_devices.return_value = [
             LetPotDevice(
                 serial_number=f"{device_type}ABCD",
-                name="Garden",
+                name=device_name,
                 device_type=device_type,
                 is_online=True,
                 is_remote=False,

--- a/tests/components/letpot/snapshots/test_binary_sensor.ambr
+++ b/tests/components/letpot/snapshots/test_binary_sensor.ambr
@@ -349,3 +349,103 @@
     'state': 'off',
   })
 # ---
+# name: test_all_entities[ISE06][binary_sensor.watering_system_low_water-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.watering_system_low_water',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Low water',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Low water',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'low_water',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_ISE06ABCD_low_water',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[ISE06][binary_sensor.watering_system_low_water-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'problem',
+      'friendly_name': 'Watering System Low water',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.watering_system_low_water',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[ISE06][binary_sensor.watering_system_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.watering_system_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Pump',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Pump',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'pump',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_ISE06ABCD_pump_watering',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[ISE06][binary_sensor.watering_system_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Watering System Pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.watering_system_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/letpot/snapshots/test_switch.ambr
+++ b/tests/components/letpot/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[switch.garden_alarm_sound-entry]
+# name: test_all_entities[LPH63][switch.garden_alarm_sound-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -35,7 +35,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.garden_alarm_sound-state]
+# name: test_all_entities[LPH63][switch.garden_alarm_sound-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Alarm sound',
@@ -48,7 +48,7 @@
     'state': 'off',
   })
 # ---
-# name: test_all_entities[switch.garden_auto_mode-entry]
+# name: test_all_entities[LPH63][switch.garden_auto_mode-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -84,7 +84,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.garden_auto_mode-state]
+# name: test_all_entities[LPH63][switch.garden_auto_mode-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Auto mode',
@@ -97,7 +97,7 @@
     'state': 'on',
   })
 # ---
-# name: test_all_entities[switch.garden_power-entry]
+# name: test_all_entities[LPH63][switch.garden_power-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -133,7 +133,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.garden_power-state]
+# name: test_all_entities[LPH63][switch.garden_power-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Power',
@@ -146,7 +146,7 @@
     'state': 'on',
   })
 # ---
-# name: test_all_entities[switch.garden_pump_cycling-entry]
+# name: test_all_entities[LPH63][switch.garden_pump_cycling-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
     }),
@@ -182,7 +182,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[switch.garden_pump_cycling-state]
+# name: test_all_entities[LPH63][switch.garden_pump_cycling-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Garden Pump cycling',
@@ -193,5 +193,54 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
+  })
+# ---
+# name: test_all_entities[ISE06][switch.watering_system_manual_watering-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.watering_system_manual_watering',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Manual watering',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Manual watering',
+    'platform': 'letpot',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'manual_watering',
+    'unique_id': 'a1b2c3d4e5f6a1b2c3d4e5f6_ISE06ABCD_manual_watering',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[ISE06][switch.watering_system_manual_watering-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Watering System Manual watering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.watering_system_manual_watering',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---

--- a/tests/components/letpot/test_binary_sensor.py
+++ b/tests/components/letpot/test_binary_sensor.py
@@ -14,7 +14,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.mark.parametrize("device_type", ["LPH63", "LPH31"])
+@pytest.mark.parametrize("device_type", ["LPH63", "LPH31", "ISE06"])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_all_entities(
     hass: HomeAssistant,

--- a/tests/components/letpot/test_switch.py
+++ b/tests/components/letpot/test_switch.py
@@ -21,6 +21,7 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.parametrize("device_type", ["LPH63", "ISE06"])
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -28,6 +29,7 @@ async def test_all_entities(
     mock_device_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    device_type: str,
 ) -> None:
     """Test switch entities."""
     with patch("homeassistant.components.letpot.PLATFORMS", [Platform.SWITCH]):
@@ -73,6 +75,38 @@ async def test_set_switch(
     )
 
     mock_device_client.set_power.assert_awaited_once_with(
+        f"{device_type}ABCD", parameter_value
+    )
+
+
+@pytest.mark.parametrize("device_type", ["ISE06"])
+@pytest.mark.parametrize(
+    ("service", "parameter_value"),
+    [
+        (SERVICE_TURN_ON, True),
+        (SERVICE_TURN_OFF, False),
+    ],
+)
+async def test_set_manual_watering_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    mock_device_client: MagicMock,
+    device_type: str,
+    service: str,
+    parameter_value: bool,
+) -> None:
+    """Test manual watering switch entity turned on/turned off."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        "switch",
+        service,
+        blocking=True,
+        target={"entity_id": "switch.watering_system_manual_watering"},
+    )
+
+    mock_device_client.set_pump_mode.assert_awaited_once_with(
         f"{device_type}ABCD", parameter_value
     )
 


### PR DESCRIPTION
## Proposed change

This PR adds support for the LetPot ISE06 Automatic Watering System device to the LetPot integration. The ISE06 is a different device category from the existing hydroponic garden devices (LPH series), with its own set of features and capabilities.

### Key changes:

1. **Device feature filtering**: Added `supported_fn` checks to existing entities to ensure they only appear for compatible device types. Hydroponic garden entities (light, temperature, water level controls) now check for `CATEGORY_HYDROPONIC_GARDEN` feature, while new watering system entities check for `CATEGORY_WATERING_SYSTEM`.

2. **New entities for ISE06**:
   - `switch.manual_watering`: Toggle manual watering mode via `set_pump_mode()`
   - `binary_sensor.pump`: Monitor pump running status
   - `binary_sensor.low_water`: Diagnostic sensor for low water condition

3. **Updated library dependency**: Bumped `letpot` from 0.6.4 to 0.7.0 to support the new device type and status models (`LetPotWateringSystemStatus`, `LetPotGardenStatus`).

4. **Test infrastructure**: Updated test fixtures to support parameterized testing across device types (LPH63, LPH31, ISE06) with appropriate mock data for each device category.

## Type of change

- [x] Dependency upgrade
- [x] New feature (which adds functionality to an existing integration)

## Additional information

- Updated `letpot` library requirement from 0.6.4 to 0.7.0
- All existing tests pass with the new parameterization
- New test cases added for ISE06-specific functionality (`test_set_manual_watering_switch`)
- Snapshot tests updated to reflect new entities and device-specific filtering

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist.
- [x] The code has been formatted using Ruff.
- [x] Tests have been added to verify that the new code works.
- [x] The manifest file has been updated with the new dependency version.
- [x] New dependencies have been added to `requirements_all.txt` and `requirements_test_all.txt`.

https://claude.ai/code/session_01EotHEBRU5qsNrXtTevmSZQ