### PR TITLE
Add support for input_boolean to switch triggers

### DIFF
--- a/homeassistant/components/switch/trigger.py
+++ b/homeassistant/components/switch/trigger.py
@@ -1,14 +1,18 @@
 """Provides triggers for switch platform."""
 
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import Trigger, make_entity_target_state_trigger
 
 from .const import DOMAIN
 
+SWITCH_DOMAIN_SPECS = {DOMAIN: DomainSpec(), INPUT_BOOLEAN_DOMAIN: DomainSpec()}
+
 TRIGGERS: dict[str, type[Trigger]] = {
-    "turned_on": make_entity_target_state_trigger(DOMAIN, STATE_ON),
-    "turned_off": make_entity_target_state_trigger(DOMAIN, STATE_OFF),
+    "turned_on": make_entity_target_state_trigger(SWITCH_DOMAIN_SPECS, STATE_ON),
+    "turned_off": make_entity_target_state_trigger(SWITCH_DOMAIN_SPECS, STATE_OFF),
 }
 
 

--- a/homeassistant/components/switch/triggers.yaml
+++ b/homeassistant/components/switch/triggers.yaml
@@ -1,7 +1,8 @@
 .trigger_common: &trigger_common
   target:
     entity:
-      domain: switch
+      - domain: switch
+      - domain: input_boolean
   fields:
     behavior:
       required: true

--- a/tests/components/switch/test_trigger.py
+++ b/tests/components/switch/test_trigger.py
@@ -5,11 +5,12 @@ from typing import Any
 import pytest
 
 from homeassistant.components.switch import DOMAIN
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
+    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -19,11 +20,30 @@ from tests.components.common import (
     target_entities,
 )
 
+TRIGGER_STATES = [
+    *parametrize_trigger_states(
+        trigger="switch.turned_off",
+        target_states=[STATE_OFF],
+        other_states=[STATE_ON],
+    ),
+    *parametrize_trigger_states(
+        trigger="switch.turned_on",
+        target_states=[STATE_ON],
+        other_states=[STATE_OFF],
+    ),
+]
+
 
 @pytest.fixture
 async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple switch entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+@pytest.fixture
+async def target_input_booleans(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple input_boolean entities associated with different targets."""
+    return await target_entities(hass, "input_boolean")
 
 
 @pytest.mark.parametrize(
@@ -40,6 +60,9 @@ async def test_switch_triggers_gated_by_labs_flag(
     await assert_trigger_gated_by_labs_flag(hass, caplog, trigger_key)
 
 
+# --- Switch domain tests ---
+
+
 @pytest.mark.usefixtures("enable_labs_preview_features")
 @pytest.mark.parametrize(
     ("trigger_target_config", "entity_id", "entities_in_target"),
@@ -47,18 +70,7 @@ async def test_switch_triggers_gated_by_labs_flag(
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="switch.turned_off",
-            target_states=[STATE_OFF],
-            other_states=[STATE_ON],
-        ),
-        *parametrize_trigger_states(
-            trigger="switch.turned_on",
-            target_states=[STATE_ON],
-            other_states=[STATE_OFF],
-        ),
-    ],
+    TRIGGER_STATES,
 )
 async def test_switch_state_trigger_behavior_any(
     hass: HomeAssistant,
@@ -92,18 +104,7 @@ async def test_switch_state_trigger_behavior_any(
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="switch.turned_off",
-            target_states=[STATE_OFF],
-            other_states=[STATE_ON],
-        ),
-        *parametrize_trigger_states(
-            trigger="switch.turned_on",
-            target_states=[STATE_ON],
-            other_states=[STATE_OFF],
-        ),
-    ],
+    TRIGGER_STATES,
 )
 async def test_switch_state_trigger_behavior_first(
     hass: HomeAssistant,
@@ -137,18 +138,7 @@ async def test_switch_state_trigger_behavior_first(
 )
 @pytest.mark.parametrize(
     ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_trigger_states(
-            trigger="switch.turned_off",
-            target_states=[STATE_OFF],
-            other_states=[STATE_ON],
-        ),
-        *parametrize_trigger_states(
-            trigger="switch.turned_on",
-            target_states=[STATE_ON],
-            other_states=[STATE_OFF],
-        ),
-    ],
+    TRIGGER_STATES,
 )
 async def test_switch_state_trigger_behavior_last(
     hass: HomeAssistant,
@@ -173,3 +163,146 @@ async def test_switch_state_trigger_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
+
+
+# --- Input boolean domain tests ---
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("input_boolean"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    TRIGGER_STATES,
+)
+async def test_input_boolean_state_trigger_behavior_any(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_input_booleans: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the switch trigger fires when any input_boolean state changes."""
+    await assert_trigger_behavior_any(
+        hass,
+        service_calls=service_calls,
+        target_entities=target_input_booleans,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("input_boolean"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    TRIGGER_STATES,
+)
+async def test_input_boolean_state_trigger_behavior_first(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_input_booleans: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the switch trigger fires when the first input_boolean changes."""
+    await assert_trigger_behavior_first(
+        hass,
+        service_calls=service_calls,
+        target_entities=target_input_booleans,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("trigger_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("input_boolean"),
+)
+@pytest.mark.parametrize(
+    ("trigger", "trigger_options", "states"),
+    TRIGGER_STATES,
+)
+async def test_input_boolean_state_trigger_behavior_last(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+    target_input_booleans: dict[str, list[str]],
+    trigger_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    trigger: str,
+    trigger_options: dict[str, Any],
+    states: list[TriggerStateDescription],
+) -> None:
+    """Test that the switch trigger fires when the last input_boolean changes."""
+    await assert_trigger_behavior_last(
+        hass,
+        service_calls=service_calls,
+        target_entities=target_input_booleans,
+        trigger_target_config=trigger_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        trigger=trigger,
+        trigger_options=trigger_options,
+        states=states,
+    )
+
+
+# --- Cross-domain test ---
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+async def test_switch_trigger_fires_for_both_domains(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test that the switch trigger fires for both switch and input_boolean entities."""
+    entity_id_switch = "switch.test_switch"
+    entity_id_input_boolean = "input_boolean.test_input_boolean"
+
+    hass.states.async_set(entity_id_switch, STATE_OFF)
+    hass.states.async_set(entity_id_input_boolean, STATE_OFF)
+    await hass.async_block_till_done()
+
+    await arm_trigger(
+        hass,
+        "switch.turned_on",
+        {},
+        {CONF_ENTITY_ID: [entity_id_switch, entity_id_input_boolean]},
+    )
+
+    # switch entity changes - should trigger
+    hass.states.async_set(entity_id_switch, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_switch
+    service_calls.clear()
+
+    # input_boolean entity changes - should also trigger
+    hass.states.async_set(entity_id_input_boolean, STATE_ON)
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_input_boolean
+    service_calls.clear()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for `input_boolean` to `switch` triggers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
  - fixes https://github.com/home-assistant/core/issues/165763
  - fixes https://github.com/home-assistant/core/issues/165764
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
