### PR TITLE
Minor improvements of cover trigger tests

### DIFF
--- a/tests/components/cover/test_trigger.py
+++ b/tests/components/cover/test_trigger.py
@@ -4,13 +4,12 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID
+from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
-    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -21,11 +20,11 @@ from tests.components.common import (
 )
 
 DEVICE_CLASS_TRIGGERS = [
-    ("awning", "cover.awning_opened", "cover.awning_closed"),
-    ("blind", "cover.blind_opened", "cover.blind_closed"),
-    ("curtain", "cover.curtain_opened", "cover.curtain_closed"),
-    ("shade", "cover.shade_opened", "cover.shade_closed"),
-    ("shutter", "cover.shutter_opened", "cover.shutter_closed"),
+    (CoverDeviceClass.AWNING, "cover.awning_opened", "cover.awning_closed"),
+    (CoverDeviceClass.BLIND, "cover.blind_opened", "cover.blind_closed"),
+    (CoverDeviceClass.CURTAIN, "cover.curtain_opened", "cover.curtain_closed"),
+    (CoverDeviceClass.SHADE, "cover.shade_opened", "cover.shade_closed"),
+    (CoverDeviceClass.SHUTTER, "cover.shutter_opened", "cover.shutter_closed"),
 ]
 
 
@@ -270,106 +269,3 @@ async def test_cover_trigger_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    (
-        "trigger_key",
-        "device_class",
-        "wrong_device_class",
-        "cover_initial",
-        "cover_initial_is_closed",
-        "cover_target",
-        "cover_target_is_closed",
-    ),
-    [
-        (
-            opened_key,
-            device_class,
-            "damper",
-            CoverState.CLOSED,
-            True,
-            CoverState.OPEN,
-            False,
-        )
-        for device_class, opened_key, _ in DEVICE_CLASS_TRIGGERS
-    ]
-    + [
-        (
-            closed_key,
-            device_class,
-            "damper",
-            CoverState.OPEN,
-            False,
-            CoverState.CLOSED,
-            True,
-        )
-        for device_class, _, closed_key in DEVICE_CLASS_TRIGGERS
-    ],
-)
-async def test_cover_trigger_excludes_non_matching_device_class(
-    hass: HomeAssistant,
-    service_calls: list[ServiceCall],
-    trigger_key: str,
-    device_class: str,
-    wrong_device_class: str,
-    cover_initial: str,
-    cover_initial_is_closed: bool,
-    cover_target: str,
-    cover_target_is_closed: bool,
-) -> None:
-    """Test cover trigger does not fire for entities without matching device_class."""
-    entity_id_matching = "cover.test_matching"
-    entity_id_wrong = "cover.test_wrong"
-
-    # Set initial states
-    hass.states.async_set(
-        entity_id_matching,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: device_class, ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    hass.states.async_set(
-        entity_id_wrong,
-        cover_initial,
-        {
-            ATTR_DEVICE_CLASS: wrong_device_class,
-            ATTR_IS_CLOSED: cover_initial_is_closed,
-        },
-    )
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger_key,
-        {},
-        {
-            CONF_ENTITY_ID: [
-                entity_id_matching,
-                entity_id_wrong,
-            ]
-        },
-    )
-
-    # Matching device class changes - should trigger
-    hass.states.async_set(
-        entity_id_matching,
-        cover_target,
-        {ATTR_DEVICE_CLASS: device_class, ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_matching
-    service_calls.clear()
-
-    # Wrong device class changes - should NOT trigger
-    hass.states.async_set(
-        entity_id_wrong,
-        cover_target,
-        {
-            ATTR_DEVICE_CLASS: wrong_device_class,
-            ATTR_IS_CLOSED: cover_target_is_closed,
-        },
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0

--- a/tests/components/door/test_trigger.py
+++ b/tests/components/door/test_trigger.py
@@ -4,13 +4,13 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
-    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -59,14 +59,18 @@ async def test_door_triggers_gated_by_labs_flag(
             trigger="door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -118,7 +122,7 @@ async def test_door_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -136,7 +140,7 @@ async def test_door_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
     ],
@@ -178,14 +182,18 @@ async def test_door_trigger_cover_behavior_any(
             trigger="door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -227,14 +235,18 @@ async def test_door_trigger_binary_sensor_behavior_first(
             trigger="door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -286,7 +298,7 @@ async def test_door_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -304,7 +316,7 @@ async def test_door_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
     ],
@@ -356,7 +368,7 @@ async def test_door_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -374,7 +386,7 @@ async def test_door_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "door"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.DOOR},
             trigger_from_none=False,
         ),
     ],
@@ -402,122 +414,3 @@ async def test_door_trigger_cover_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    (
-        "trigger_key",
-        "binary_sensor_initial",
-        "binary_sensor_target",
-        "cover_initial",
-        "cover_initial_is_closed",
-        "cover_target",
-        "cover_target_is_closed",
-    ),
-    [
-        (
-            "door.opened",
-            STATE_OFF,
-            STATE_ON,
-            CoverState.CLOSED,
-            True,
-            CoverState.OPEN,
-            False,
-        ),
-        (
-            "door.closed",
-            STATE_ON,
-            STATE_OFF,
-            CoverState.OPEN,
-            False,
-            CoverState.CLOSED,
-            True,
-        ),
-    ],
-)
-async def test_door_trigger_excludes_non_door_device_class(
-    hass: HomeAssistant,
-    service_calls: list[ServiceCall],
-    trigger_key: str,
-    binary_sensor_initial: str,
-    binary_sensor_target: str,
-    cover_initial: str,
-    cover_initial_is_closed: bool,
-    cover_target: str,
-    cover_target_is_closed: bool,
-) -> None:
-    """Test door trigger does not fire for entities without device_class door."""
-    entity_id_door = "binary_sensor.test_door"
-    entity_id_window = "binary_sensor.test_window"
-    entity_id_cover_door = "cover.test_door"
-    entity_id_cover_garage = "cover.test_garage"
-
-    # Set initial states
-    hass.states.async_set(
-        entity_id_door, binary_sensor_initial, {ATTR_DEVICE_CLASS: "door"}
-    )
-    hass.states.async_set(
-        entity_id_window, binary_sensor_initial, {ATTR_DEVICE_CLASS: "window"}
-    )
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    hass.states.async_set(
-        entity_id_cover_garage,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger_key,
-        {},
-        {
-            CONF_ENTITY_ID: [
-                entity_id_door,
-                entity_id_window,
-                entity_id_cover_door,
-                entity_id_cover_garage,
-            ]
-        },
-    )
-
-    # Door binary_sensor changes - should trigger
-    hass.states.async_set(
-        entity_id_door, binary_sensor_target, {ATTR_DEVICE_CLASS: "door"}
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_door
-    service_calls.clear()
-
-    # Window binary_sensor changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_window, binary_sensor_target, {ATTR_DEVICE_CLASS: "window"}
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0
-
-    # Cover door changes - should trigger
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_cover_door
-    service_calls.clear()
-
-    # Garage cover changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_cover_garage,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0

--- a/tests/components/garage_door/test_trigger.py
+++ b/tests/components/garage_door/test_trigger.py
@@ -4,13 +4,13 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
-    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -59,14 +59,18 @@ async def test_garage_door_triggers_gated_by_labs_flag(
             trigger="garage_door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="garage_door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -118,7 +122,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -136,7 +140,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
     ],
@@ -178,14 +182,18 @@ async def test_garage_door_trigger_cover_behavior_any(
             trigger="garage_door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="garage_door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -227,14 +235,18 @@ async def test_garage_door_trigger_binary_sensor_behavior_first(
             trigger="garage_door.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="garage_door.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage_door"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.GARAGE_DOOR
+            },
             trigger_from_none=False,
         ),
     ],
@@ -286,7 +298,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -304,7 +316,7 @@ async def test_garage_door_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
     ],
@@ -356,7 +368,7 @@ async def test_garage_door_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -374,7 +386,7 @@ async def test_garage_door_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "garage"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE},
             trigger_from_none=False,
         ),
     ],
@@ -402,126 +414,3 @@ async def test_garage_door_trigger_cover_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    (
-        "trigger_key",
-        "binary_sensor_initial",
-        "binary_sensor_target",
-        "cover_initial",
-        "cover_initial_is_closed",
-        "cover_target",
-        "cover_target_is_closed",
-    ),
-    [
-        (
-            "garage_door.opened",
-            STATE_OFF,
-            STATE_ON,
-            CoverState.CLOSED,
-            True,
-            CoverState.OPEN,
-            False,
-        ),
-        (
-            "garage_door.closed",
-            STATE_ON,
-            STATE_OFF,
-            CoverState.OPEN,
-            False,
-            CoverState.CLOSED,
-            True,
-        ),
-    ],
-)
-async def test_garage_door_trigger_excludes_non_garage_door_device_class(
-    hass: HomeAssistant,
-    service_calls: list[ServiceCall],
-    trigger_key: str,
-    binary_sensor_initial: str,
-    binary_sensor_target: str,
-    cover_initial: str,
-    cover_initial_is_closed: bool,
-    cover_target: str,
-    cover_target_is_closed: bool,
-) -> None:
-    """Test garage door trigger does not fire for entities without device_class garage_door."""
-    entity_id_garage_door = "binary_sensor.test_garage_door"
-    entity_id_door = "binary_sensor.test_door"
-    entity_id_cover_garage_door = "cover.test_garage_door"
-    entity_id_cover_door = "cover.test_door"
-
-    # Set initial states
-    hass.states.async_set(
-        entity_id_garage_door,
-        binary_sensor_initial,
-        {ATTR_DEVICE_CLASS: "garage_door"},
-    )
-    hass.states.async_set(
-        entity_id_door, binary_sensor_initial, {ATTR_DEVICE_CLASS: "door"}
-    )
-    hass.states.async_set(
-        entity_id_cover_garage_door,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger_key,
-        {},
-        {
-            CONF_ENTITY_ID: [
-                entity_id_garage_door,
-                entity_id_door,
-                entity_id_cover_garage_door,
-                entity_id_cover_door,
-            ]
-        },
-    )
-
-    # Garage door binary_sensor changes - should trigger
-    hass.states.async_set(
-        entity_id_garage_door,
-        binary_sensor_target,
-        {ATTR_DEVICE_CLASS: "garage_door"},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_garage_door
-    service_calls.clear()
-
-    # Door binary_sensor changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_door, binary_sensor_target, {ATTR_DEVICE_CLASS: "door"}
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0
-
-    # Cover garage door changes - should trigger
-    hass.states.async_set(
-        entity_id_cover_garage_door,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_cover_garage_door
-    service_calls.clear()
-
-    # Door cover changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0

--- a/tests/components/gate/test_trigger.py
+++ b/tests/components/gate/test_trigger.py
@@ -4,13 +4,12 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID
+from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
-    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -63,7 +62,7 @@ async def test_gate_triggers_gated_by_labs_flag(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -81,7 +80,7 @@ async def test_gate_triggers_gated_by_labs_flag(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
     ],
@@ -133,7 +132,7 @@ async def test_gate_trigger_cover_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -151,7 +150,7 @@ async def test_gate_trigger_cover_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
     ],
@@ -203,7 +202,7 @@ async def test_gate_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -221,7 +220,7 @@ async def test_gate_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "gate"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.GATE},
             trigger_from_none=False,
         ),
     ],
@@ -249,88 +248,3 @@ async def test_gate_trigger_cover_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    (
-        "trigger_key",
-        "cover_initial",
-        "cover_initial_is_closed",
-        "cover_target",
-        "cover_target_is_closed",
-    ),
-    [
-        (
-            "gate.opened",
-            CoverState.CLOSED,
-            True,
-            CoverState.OPEN,
-            False,
-        ),
-        (
-            "gate.closed",
-            CoverState.OPEN,
-            False,
-            CoverState.CLOSED,
-            True,
-        ),
-    ],
-)
-async def test_gate_trigger_excludes_non_gate_device_class(
-    hass: HomeAssistant,
-    service_calls: list[ServiceCall],
-    trigger_key: str,
-    cover_initial: str,
-    cover_initial_is_closed: bool,
-    cover_target: str,
-    cover_target_is_closed: bool,
-) -> None:
-    """Test gate trigger does not fire for entities without device_class gate."""
-    entity_id_cover_gate = "cover.test_gate"
-    entity_id_cover_garage = "cover.test_garage"
-
-    # Set initial states
-    hass.states.async_set(
-        entity_id_cover_gate,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "gate", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    hass.states.async_set(
-        entity_id_cover_garage,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger_key,
-        {},
-        {
-            CONF_ENTITY_ID: [
-                entity_id_cover_gate,
-                entity_id_cover_garage,
-            ]
-        },
-    )
-
-    # Gate cover changes - should trigger
-    hass.states.async_set(
-        entity_id_cover_gate,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "gate", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_cover_gate
-    service_calls.clear()
-
-    # Garage cover changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_cover_garage,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "garage", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0

--- a/tests/components/window/test_trigger.py
+++ b/tests/components/window/test_trigger.py
@@ -4,13 +4,13 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
-from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.components.common import (
     TriggerStateDescription,
-    arm_trigger,
     assert_trigger_behavior_any,
     assert_trigger_behavior_first,
     assert_trigger_behavior_last,
@@ -59,14 +59,18 @@ async def test_window_triggers_gated_by_labs_flag(
             trigger="window.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="window.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
     ],
@@ -118,7 +122,7 @@ async def test_window_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -136,7 +140,7 @@ async def test_window_trigger_binary_sensor_behavior_any(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
     ],
@@ -178,14 +182,18 @@ async def test_window_trigger_cover_behavior_any(
             trigger="window.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="window.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
     ],
@@ -227,14 +235,18 @@ async def test_window_trigger_binary_sensor_behavior_first(
             trigger="window.opened",
             target_states=[STATE_ON],
             other_states=[STATE_OFF],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
             trigger="window.closed",
             target_states=[STATE_OFF],
             other_states=[STATE_ON],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={
+                ATTR_DEVICE_CLASS: BinarySensorDeviceClass.WINDOW
+            },
             trigger_from_none=False,
         ),
     ],
@@ -286,7 +298,7 @@ async def test_window_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -304,7 +316,7 @@ async def test_window_trigger_binary_sensor_behavior_last(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
     ],
@@ -356,7 +368,7 @@ async def test_window_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
         *parametrize_trigger_states(
@@ -374,7 +386,7 @@ async def test_window_trigger_cover_behavior_first(
                 (CoverState.OPEN, {ATTR_IS_CLOSED: None}),
                 (CoverState.OPEN, {}),
             ],
-            required_filter_attributes={ATTR_DEVICE_CLASS: "window"},
+            required_filter_attributes={ATTR_DEVICE_CLASS: CoverDeviceClass.WINDOW},
             trigger_from_none=False,
         ),
     ],
@@ -402,122 +414,3 @@ async def test_window_trigger_cover_behavior_last(
         trigger_options=trigger_options,
         states=states,
     )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    (
-        "trigger_key",
-        "binary_sensor_initial",
-        "binary_sensor_target",
-        "cover_initial",
-        "cover_initial_is_closed",
-        "cover_target",
-        "cover_target_is_closed",
-    ),
-    [
-        (
-            "window.opened",
-            STATE_OFF,
-            STATE_ON,
-            CoverState.CLOSED,
-            True,
-            CoverState.OPEN,
-            False,
-        ),
-        (
-            "window.closed",
-            STATE_ON,
-            STATE_OFF,
-            CoverState.OPEN,
-            False,
-            CoverState.CLOSED,
-            True,
-        ),
-    ],
-)
-async def test_window_trigger_excludes_non_window_device_class(
-    hass: HomeAssistant,
-    service_calls: list[ServiceCall],
-    trigger_key: str,
-    binary_sensor_initial: str,
-    binary_sensor_target: str,
-    cover_initial: str,
-    cover_initial_is_closed: bool,
-    cover_target: str,
-    cover_target_is_closed: bool,
-) -> None:
-    """Test window trigger does not fire for entities without device_class window."""
-    entity_id_window = "binary_sensor.test_window"
-    entity_id_door = "binary_sensor.test_door"
-    entity_id_cover_window = "cover.test_window"
-    entity_id_cover_door = "cover.test_door"
-
-    # Set initial states
-    hass.states.async_set(
-        entity_id_window, binary_sensor_initial, {ATTR_DEVICE_CLASS: "window"}
-    )
-    hass.states.async_set(
-        entity_id_door, binary_sensor_initial, {ATTR_DEVICE_CLASS: "door"}
-    )
-    hass.states.async_set(
-        entity_id_cover_window,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "window", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_initial,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_initial_is_closed},
-    )
-    await hass.async_block_till_done()
-
-    await arm_trigger(
-        hass,
-        trigger_key,
-        {},
-        {
-            CONF_ENTITY_ID: [
-                entity_id_window,
-                entity_id_door,
-                entity_id_cover_window,
-                entity_id_cover_door,
-            ]
-        },
-    )
-
-    # Window binary_sensor changes - should trigger
-    hass.states.async_set(
-        entity_id_window, binary_sensor_target, {ATTR_DEVICE_CLASS: "window"}
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_window
-    service_calls.clear()
-
-    # Door binary_sensor changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_door, binary_sensor_target, {ATTR_DEVICE_CLASS: "door"}
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0
-
-    # Cover window changes - should trigger
-    hass.states.async_set(
-        entity_id_cover_window,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "window", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 1
-    assert service_calls[0].data[CONF_ENTITY_ID] == entity_id_cover_window
-    service_calls.clear()
-
-    # Door cover changes - should NOT trigger (wrong device class)
-    hass.states.async_set(
-        entity_id_cover_door,
-        cover_target,
-        {ATTR_DEVICE_CLASS: "door", ATTR_IS_CLOSED: cover_target_is_closed},
-    )
-    await hass.async_block_till_done()
-    assert len(service_calls) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor improvements of cover trigger tests:
- Use enum instead of magic strings when setting device class
- Remove redundant tests checking the triggers trigger on the correct device class - the `parametrize_trigger_states` helper sets states without the correct device class, and the `assert_trigger_behavior_any` checks those do not cause the trigger to fire.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
