### PR TITLE
Re-discover Z-Wave list sensors when metadata states change

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -761,6 +761,7 @@ class NodeEvents:
         self.value_updates_disc_info: dict[
             int, dict[str, PlatformZwaveDiscoveryInfo]
         ] = {}
+        self._node_locks: dict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     async def async_on_node_ready(self, node: ZwaveNode) -> None:
         """Handle node ready event."""
@@ -910,30 +911,35 @@ class NodeEvents:
         value: Value,
     ) -> None:
         """Fire value updated event."""
-        # If node isn't ready or a device for this node doesn't already exist, we can
-        # let the node ready event handler perform discovery. If a value has already
-        # been processed, we don't need to do it again
-        device_id = get_device_id(
-            self.controller_events.driver_events.driver, value.node
-        )
-        if (
-            not value.node.ready
-            or not (device := self.dev_reg.async_get_device(identifiers={device_id}))
-            or value.value_id in self.controller_events.discovered_value_ids[device.id]
-        ):
-            return
-
-        LOGGER.debug("Processing node %s added value %s", value.node, value)
-        await asyncio.gather(
-            *(
-                self.async_handle_discovery_info(
-                    device, disc_info, value_updates_disc_info
+        async with self._node_locks[value.node.node_id]:
+            # If node isn't ready or a device for this node doesn't already
+            # exist, we can let the node ready event handler perform discovery.
+            # If a value has already been processed, we don't need to do it
+            # again
+            device_id = get_device_id(
+                self.controller_events.driver_events.driver, value.node
+            )
+            if (
+                not value.node.ready
+                or not (
+                    device := self.dev_reg.async_get_device(identifiers={device_id})
                 )
-                for disc_info in async_discover_single_value(
-                    value, device, self.controller_events.discovered_value_ids
+                or value.value_id
+                in self.controller_events.discovered_value_ids[device.id]
+            ):
+                return
+
+            LOGGER.debug("Processing node %s added value %s", value.node, value)
+            await asyncio.gather(
+                *(
+                    self.async_handle_discovery_info(
+                        device, disc_info, value_updates_disc_info
+                    )
+                    for disc_info in async_discover_single_value(
+                        value, device, self.controller_events.discovered_value_ids
+                    )
                 )
             )
-        )
 
     @callback
     def async_on_value_notification(self, notification: ValueNotification) -> None:

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -904,7 +904,7 @@ class NodeEvents:
         value_updates_disc_info: dict[str, PlatformZwaveDiscoveryInfo],
         value: Value,
     ) -> None:
-        """Fire value updated event."""
+        """Run discovery when a value is added, updated or its metadata is changed."""
         # If node isn't ready or a device for this node doesn't already
         # exist, we can let the node ready event handler perform discovery.
         # If a value has already been processed, we don't need to do it

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -108,6 +108,8 @@ from .const import (
     DOMAIN,
     ESPHOME_ADDON_VERSION,
     EVENT_DEVICE_ADDED_TO_REGISTRY,
+    EVENT_METADATA_UPDATED,
+    EVENT_VALUE_ADDED,
     EVENT_VALUE_UPDATED,
     LIB_LOGGER,
     LOGGER,
@@ -781,7 +783,7 @@ class NodeEvents:
         )
 
         # add listeners to handle new values that get added later
-        for event in ("value added", EVENT_VALUE_UPDATED, "metadata updated"):
+        for event in (EVENT_VALUE_ADDED, EVENT_VALUE_UPDATED, EVENT_METADATA_UPDATED):
             self.config_entry.async_on_unload(
                 node.on(
                     event,

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -761,7 +761,6 @@ class NodeEvents:
         self.value_updates_disc_info: dict[
             int, dict[str, PlatformZwaveDiscoveryInfo]
         ] = {}
-        self._node_locks: dict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     async def async_on_node_ready(self, node: ZwaveNode) -> None:
         """Handle node ready event."""

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -758,6 +758,9 @@ class NodeEvents:
         self.dev_reg = controller_events.dev_reg
         self.ent_reg = er.async_get(hass)
         self.hass = hass
+        self.value_updates_disc_info: dict[
+            int, dict[str, PlatformZwaveDiscoveryInfo]
+        ] = {}
 
     async def async_on_node_ready(self, node: ZwaveNode) -> None:
         """Handle node ready event."""
@@ -768,7 +771,9 @@ class NodeEvents:
         # Remove any old value ids if this is a reinterview.
         self.controller_events.discovered_value_ids.pop(device.id, None)
 
+        # Store the discovery info so it can be reused when re-discovering entities
         value_updates_disc_info: dict[str, PlatformZwaveDiscoveryInfo] = {}
+        self.value_updates_disc_info[node.node_id] = value_updates_disc_info
 
         # run discovery on all node values and create/update entities
         await asyncio.gather(

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -601,6 +601,7 @@ class ControllerEvents:
                 f"{DOMAIN}.node_reset_and_removed.{dev_id[1]}",
             )
 
+        self.node_events.value_updates_disc_info.pop(node.node_id, None)
         self.remove_device(device)
 
     @callback

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -777,26 +777,18 @@ class NodeEvents:
         self.value_updates_disc_info[node.node_id] = value_updates_disc_info
 
         # run discovery on all node values and create/update entities
-        await asyncio.gather(
-            *(
-                self.async_handle_discovery_info(
-                    device, disc_info, value_updates_disc_info
-                )
-                for disc_info in async_discover_node_values(
-                    node, device, self.controller_events.discovered_value_ids
-                )
-            )
-        )
+        for disc_info in async_discover_node_values(
+            node, device, self.controller_events.discovered_value_ids
+        ):
+            self.async_handle_discovery_info(device, disc_info, value_updates_disc_info)
 
         # add listeners to handle new values that get added later
         for event in (EVENT_VALUE_ADDED, EVENT_VALUE_UPDATED, EVENT_METADATA_UPDATED):
             self.config_entry.async_on_unload(
                 node.on(
                     event,
-                    lambda event: self.hass.async_create_task(
-                        self.async_on_value_added(
-                            value_updates_disc_info, event["value"]
-                        )
+                    lambda event: self.async_on_value_added(
+                        value_updates_disc_info, event["value"]
                     ),
                 )
             )
@@ -860,7 +852,8 @@ class NodeEvents:
                 # an upstream bug, or the change has been reverted.
                 async_delete_issue(self.hass, DOMAIN, issue_id)
 
-    async def async_handle_discovery_info(
+    @callback
+    def async_handle_discovery_info(
         self,
         device: dr.DeviceEntry,
         disc_info: PlatformZwaveDiscoveryInfo,
@@ -905,41 +898,32 @@ class NodeEvents:
             )
         )
 
-    async def async_on_value_added(
+    @callback
+    def async_on_value_added(
         self,
         value_updates_disc_info: dict[str, PlatformZwaveDiscoveryInfo],
         value: Value,
     ) -> None:
         """Fire value updated event."""
-        async with self._node_locks[value.node.node_id]:
-            # If node isn't ready or a device for this node doesn't already
-            # exist, we can let the node ready event handler perform discovery.
-            # If a value has already been processed, we don't need to do it
-            # again
-            device_id = get_device_id(
-                self.controller_events.driver_events.driver, value.node
-            )
-            if (
-                not value.node.ready
-                or not (
-                    device := self.dev_reg.async_get_device(identifiers={device_id})
-                )
-                or value.value_id
-                in self.controller_events.discovered_value_ids[device.id]
-            ):
-                return
+        # If node isn't ready or a device for this node doesn't already
+        # exist, we can let the node ready event handler perform discovery.
+        # If a value has already been processed, we don't need to do it
+        # again
+        device_id = get_device_id(
+            self.controller_events.driver_events.driver, value.node
+        )
+        if (
+            not value.node.ready
+            or not (device := self.dev_reg.async_get_device(identifiers={device_id}))
+            or value.value_id in self.controller_events.discovered_value_ids[device.id]
+        ):
+            return
 
-            LOGGER.debug("Processing node %s added value %s", value.node, value)
-            await asyncio.gather(
-                *(
-                    self.async_handle_discovery_info(
-                        device, disc_info, value_updates_disc_info
-                    )
-                    for disc_info in async_discover_single_value(
-                        value, device, self.controller_events.discovered_value_ids
-                    )
-                )
-            )
+        LOGGER.debug("Processing node %s added value %s", value.node, value)
+        for disc_info in async_discover_single_value(
+            value, device, self.controller_events.discovered_value_ids
+        ):
+            self.async_handle_discovery_info(device, disc_info, value_updates_disc_info)
 
     @callback
     def async_on_value_notification(self, notification: ValueNotification) -> None:

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -45,6 +45,7 @@ EVENT_DEVICE_ADDED_TO_REGISTRY = f"{DOMAIN}_device_added_to_registry"
 EVENT_VALUE_ADDED = "value added"
 EVENT_VALUE_REMOVED = "value removed"
 EVENT_VALUE_UPDATED = "value updated"
+EVENT_METADATA_UPDATED = "metadata updated"
 
 LOGGER = logging.getLogger(__package__)
 LIB_LOGGER = logging.getLogger("zwave_js_server")

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -353,10 +353,17 @@ class ZWaveBaseEntity(Entity):
         await self.async_remove()
 
         # Now clear from discovered_value_ids and trigger re-discovery
+        # using the existing discovery info dict
         controller_events.discovered_value_ids[self.device_entry.id].discard(
             value.value_id
         )
-        await controller_events.node_events.async_on_value_added({}, value)
+        node_events = controller_events.node_events
+        value_updates_disc_info = (
+            controller_events.node_events.value_updates_disc_info.get(
+                value.node.node_id, {}
+            )
+        )
+        await node_events.async_on_value_added(value_updates_disc_info, value)
 
     @callback
     def get_zwave_value(

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -359,11 +359,9 @@ class ZWaveBaseEntity(Entity):
             value.value_id
         )
         node_events = controller_events.node_events
-        value_updates_disc_info = (
-            controller_events.node_events.value_updates_disc_info.get(
-                value.node.node_id, {}
-            )
-        )
+        value_updates_disc_info = node_events.value_updates_disc_info[
+            value.node.node_id
+        ]
         await node_events.async_on_value_added(value_updates_disc_info, value)
 
     @callback

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -55,6 +55,7 @@ class ZWaveBaseEntity(Entity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    info: ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo
 
     def __init__(
         self,

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -336,11 +336,6 @@ class ZWaveBaseEntity(Entity):
             value.value_id,
         )
 
-        # Do NOT remove from discovered_value_ids here. The "metadata updated"
-        # listener in __init__.py has already scheduled an async_on_value_added
-        # task. By keeping value_id in discovered_value_ids, that task will
-        # return early. We handle removal + re-discovery in the correct order
-        # in our own async task below.
         self.hass.async_create_task(self._async_remove_and_rediscover(value))
 
     async def _async_remove_and_rediscover(self, value: ZwaveValue) -> None:

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -357,7 +357,7 @@ class ZWaveBaseEntity(Entity):
         value_updates_disc_info = node_events.value_updates_disc_info[
             value.node.node_id
         ]
-        await node_events.async_on_value_added(value_updates_disc_info, value)
+        node_events.async_on_value_added(value_updates_disc_info, value)
 
     @callback
     def get_zwave_value(

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -14,7 +14,6 @@ from zwave_js_server.model.value import (
     get_value_id_str,
 )
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -24,6 +23,7 @@ from homeassistant.helpers.typing import UNDEFINED
 
 from .const import (
     DOMAIN,
+    EVENT_METADATA_UPDATED,
     EVENT_VALUE_ADDED,
     EVENT_VALUE_REMOVED,
     EVENT_VALUE_UPDATED,
@@ -31,7 +31,7 @@ from .const import (
 )
 from .discovery_data_template import BaseDiscoverySchemaDataTemplate
 from .helpers import get_device_id, get_unique_id, get_valueless_base_unique_id
-from .models import PlatformZwaveDiscoveryInfo, ZwaveDiscoveryInfo
+from .models import PlatformZwaveDiscoveryInfo, ZwaveDiscoveryInfo, ZwaveJSConfigEntry
 
 
 @dataclass(kw_only=True)
@@ -58,7 +58,7 @@ class ZWaveBaseEntity(Entity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: ZwaveJSConfigEntry,
         driver: Driver,
         info: ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo,
     ) -> None:
@@ -143,6 +143,9 @@ class ZWaveBaseEntity(Entity):
         self.async_on_remove(self.info.node.on(EVENT_VALUE_ADDED, self._value_added))
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_REMOVED, self._value_removed)
+        )
+        self.async_on_remove(
+            self.info.node.on(EVENT_METADATA_UPDATED, self._metadata_updated)
         )
         self.async_on_remove(
             async_dispatcher_connect(
@@ -303,6 +306,57 @@ class ZWaveBaseEntity(Entity):
         self._primary_value_removed = False
         self.on_value_update()
         self.async_write_ha_state()
+
+    @callback
+    def should_rediscover_on_metadata_update(self) -> bool:
+        """Check if a metadata update requires entity rediscovery.
+
+        To be overridden by subclasses that need to detect metadata changes.
+        Return True if the entity needs to be removed and re-discovered.
+        """
+        return False
+
+    @callback
+    def _metadata_updated(self, event_data: dict) -> None:
+        """Handle metadata update requiring entity rediscovery.
+
+        Should not be overridden by subclasses.
+        """
+        value = event_data["value"]
+        if value.value_id != self.info.primary_value.value_id:
+            return
+
+        if not self.should_rediscover_on_metadata_update():
+            return
+
+        LOGGER.debug(
+            "[%s] Metadata options changed for %s, removing for rediscovery",
+            self.entity_id,
+            value.value_id,
+        )
+
+        # Do NOT remove from discovered_value_ids here. The "metadata updated"
+        # listener in __init__.py has already scheduled an async_on_value_added
+        # task. By keeping value_id in discovered_value_ids, that task will
+        # return early. We handle removal + re-discovery in the correct order
+        # in our own async task below.
+        self.hass.async_create_task(self._async_remove_and_rediscover(value))
+
+    async def _async_remove_and_rediscover(self, value: ZwaveValue) -> None:
+        """Remove entity and trigger re-discovery with updated metadata."""
+        assert self.device_entry is not None
+        controller_events = (
+            self.config_entry.runtime_data.driver_events.controller_events
+        )
+
+        # Remove entity first so the unique_id is freed up
+        await self.async_remove()
+
+        # Now clear from discovered_value_ids and trigger re-discovery
+        controller_events.discovered_value_ids[self.device_entry.id].discard(
+            value.value_id
+        )
+        await controller_events.node_events.async_on_value_added({}, value)
 
     @callback
     def get_zwave_value(

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -985,6 +985,13 @@ class ZWaveListSensor(ZwaveSensor):
             self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_options = list(info.primary_value.metadata.states.values())
 
+    @callback
+    def should_rediscover_on_metadata_update(self) -> bool:
+        """Check if metadata states have changed."""
+        return list(self.info.primary_value.metadata.states.values()) != (
+            self._attr_options or []
+        )
+
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -1446,12 +1446,17 @@ async def test_node_removed(
     assert old_device
     assert old_device.id
 
+    node_events = integration.runtime_data.driver_events.controller_events.node_events
+    assert node.node_id in node_events.value_updates_disc_info
+
     event = {"node": node, "reason": 0}
 
     client.driver.controller.emit("node removed", event)
     await hass.async_block_till_done()
     # Assert device has been removed
     assert not device_registry.async_get(old_device.id)
+    # Assert value_updates_disc_info has been cleaned up
+    assert node.node_id not in node_events.value_updates_disc_info
 
 
 async def test_replace_same_node(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -926,6 +926,106 @@ async def test_opening_state_sensor(
         assert hass.states.get(entity_id) is None
 
 
+async def test_opening_state_sensor_metadata_options_change(
+    hass: HomeAssistant,
+    hoppe_ehandle_connectsense: Node,
+    integration,
+) -> None:
+    """Test Opening state sensor is rediscovered when metadata options change."""
+    entity_id = "sensor.ehandle_connectsense_opening_state"
+    node = hoppe_ehandle_connectsense
+
+    # Verify initial state with 2 options
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Closed"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENUM
+    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open"]
+
+    # Simulate metadata update adding "Tilted" state
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Notification",
+                "commandClass": 113,
+                "endpoint": 0,
+                "property": "Access Control",
+                "propertyKey": "Opening state",
+                "propertyName": "Access Control",
+                "propertyKeyName": "Opening state",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Opening state",
+                    "ccSpecific": {"notificationType": 6},
+                    "min": 0,
+                    "max": 255,
+                    "states": {
+                        "0": "Closed",
+                        "1": "Open",
+                        "2": "Tilted",
+                    },
+                    "stateful": True,
+                    "secret": False,
+                },
+            },
+        },
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Entity should be rediscovered with 3 options
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open", "Tilted"]
+
+    # Simulate metadata update removing "Tilted" state
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": node.node_id,
+            "args": {
+                "commandClassName": "Notification",
+                "commandClass": 113,
+                "endpoint": 0,
+                "property": "Access Control",
+                "propertyKey": "Opening state",
+                "propertyName": "Access Control",
+                "propertyKeyName": "Opening state",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Opening state",
+                    "ccSpecific": {"notificationType": 6},
+                    "min": 0,
+                    "max": 255,
+                    "states": {
+                        "0": "Closed",
+                        "1": "Open",
+                    },
+                    "stateful": True,
+                    "secret": False,
+                },
+            },
+        },
+    )
+    node.receive_event(event)
+    await hass.async_block_till_done()
+
+    # Entity should be rediscovered with 2 options again
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_OPTIONS] == ["Closed", "Open"]
+
+
 CONTROLLER_STATISTICS_ENTITY_PREFIX = "sensor.z_stick_gen5_usb_controller_"
 # controller statistics with initial state of 0
 CONTROLLER_STATISTICS_SUFFIXES = {

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -929,7 +929,7 @@ async def test_opening_state_sensor(
 async def test_opening_state_sensor_metadata_options_change(
     hass: HomeAssistant,
     hoppe_ehandle_connectsense: Node,
-    integration,
+    integration: MockConfigEntry,
 ) -> None:
     """Test Opening state sensor is rediscovered when metadata options change."""
     entity_id = "sensor.ehandle_connectsense_opening_state"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Z-Wave JS can update the states of a value dynamically. Particularly, the possible `states` of the "Opening state" notification sensor can gain the `Tilted` state at runtime. Previously this update was not handled at all.

With this PR, we detect when the possible `states` of a list sensor have changed, and remove and re-discover that entity. The mechanism could also be used to update the unit of a temperature sensor without reloading the entire config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
