### PR TITLE
Allow TODO entity listeners to handle None state

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -240,7 +240,7 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     """An entity that represents a To-do list."""
 
     _attr_todo_items: list[TodoItem] | None = None
-    _update_listeners: list[Callable[[list[TodoItem]], None]] | None = None
+    _update_listeners: list[Callable[[list[TodoItem] | None], None]] | None = None
 
     @property
     def state(self) -> int | None:
@@ -281,7 +281,7 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @final
     @callback
     def async_subscribe_updates(
-        self, listener: Callable[[list[TodoItem]], None]
+        self, listener: Callable[[list[TodoItem] | None], None]
     ) -> CALLBACK_TYPE:
         """Subscribe to To-do list item updates."""
         if self._update_listeners is None:
@@ -302,7 +302,12 @@ class TodoListEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         if not self._update_listeners:
             return
 
-        todo_items = [copy.copy(item) for item in self.todo_items or []]
+        todo_items = (
+            [copy.copy(item) for item in self.todo_items]
+            if self.todo_items is not None
+            else None
+        )
+
         for listener in self._update_listeners:
             listener(todo_items)
 
@@ -335,14 +340,13 @@ async def websocket_handle_subscribe_todo_items(
         return
 
     @callback
-    def todo_item_listener(todo_items: list[TodoItem]) -> None:
+    def todo_item_listener(todo_items: list[TodoItem] | None) -> None:
         """Push updated To-do list items to websocket."""
+        items = [dataclasses.asdict(item) for item in todo_items or []]
         connection.send_message(
             websocket_api.event_message(
                 msg["id"],
-                {
-                    "items": [dataclasses.asdict(item) for item in todo_items],
-                },
+                {"items": items},
             )
         )
 

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -1239,9 +1239,9 @@ async def test_async_subscribe_updates(
     """Test async_subscribe_updates delivers list updates to listeners."""
     await create_mock_platform(hass, [test_entity])
 
-    received_updates: list[list[TodoItem]] = []
+    received_updates: list[list[TodoItem] | None] = []
 
-    def listener(items: list[TodoItem]) -> None:
+    def listener(items: list[TodoItem] | None) -> None:
         received_updates.append(items)
 
     unsub = test_entity.async_subscribe_updates(listener)
@@ -1277,7 +1277,25 @@ async def test_async_subscribe_updates(
     assert len(items) == 3
     assert items[2].summary == "Item #3"
 
+    # Set items to None and trigger update
+    test_entity._attr_todo_items = None
+    test_entity.async_write_ha_state()
+    assert len(received_updates) == 3
+    assert received_updates[2] is None
+
+    # Add a new item to make it available again and trigger update
+    test_entity._attr_todo_items = [
+        TodoItem(summary="New item", uid="4", status=TodoItemStatus.NEEDS_ACTION)
+    ]
+    test_entity.async_write_ha_state()
+    assert len(received_updates) == 4
+    items = received_updates[3]
+    assert len(items) == 1
+    assert items[0].summary == "New item"
+    assert items[0].uid == "4"
+    assert items[0].status == TodoItemStatus.NEEDS_ACTION
+
     # Unsubscribe and verify no more updates
     unsub()
     test_entity.async_write_ha_state()
-    assert len(received_updates) == 2
+    assert len(received_updates) == 4


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is needed to have proper state update tracking by listeners.

This API was changed last week by https://github.com/home-assistant/core/pull/165802 and it was not identified as breaking at that time.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
