### PR TITLE
Improve error handling in the Tractive config flow

### DIFF
--- a/homeassistant/components/tractive/config_flow.py
+++ b/homeassistant/components/tractive/config_flow.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from http import HTTPStatus
 import logging
 from typing import Any
 
+import aiohttp
 import aiotractive
 import voluptuous as vol
 
@@ -34,6 +36,13 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         user_id = await client.user_id()
     except aiotractive.exceptions.UnauthorizedError as error:
         raise InvalidAuth from error
+    except aiotractive.exceptions.TractiveError as error:
+        if (
+            isinstance(error.__cause__, aiohttp.ClientResponseError)
+            and error.__cause__.status == HTTPStatus.TOO_MANY_REQUESTS
+        ):
+            raise RateLimitExceeded from error
+        raise CannotConnect from error
     finally:
         await client.close()
 
@@ -56,6 +65,10 @@ class TractiveConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             info = await validate_input(self.hass, user_input)
+        except RateLimitExceeded:
+            errors["base"] = "rate_limit_exceeded"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
         except Exception:
@@ -86,6 +99,10 @@ class TractiveConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
+            except RateLimitExceeded:
+                errors["base"] = "rate_limit_exceeded"
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except Exception:
@@ -105,5 +122,13 @@ class TractiveConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
 
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
 class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class RateLimitExceeded(HomeAssistantError):
+    """Error to indicate the API rate limit has been exceeded."""

--- a/homeassistant/components/tractive/strings.json
+++ b/homeassistant/components/tractive/strings.json
@@ -6,7 +6,9 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "rate_limit_exceeded": "Too many requests. Please try again later.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {

--- a/tests/components/tractive/test_config_flow.py
+++ b/tests/components/tractive/test_config_flow.py
@@ -208,7 +208,7 @@ async def test_reauthentication_failure(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["step_id"] == "reauth_confirm"
-    assert result["type"] is FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "invalid_auth"
 
 
@@ -238,7 +238,7 @@ async def test_reauthentication_cannot_connect(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["step_id"] == "reauth_confirm"
-    assert result["type"] is FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "cannot_connect"
 
 
@@ -273,7 +273,7 @@ async def test_reauthentication_rate_limit_exceeded(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
     assert result2["step_id"] == "reauth_confirm"
-    assert result["type"] is FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "rate_limit_exceeded"
 
 
@@ -303,7 +303,7 @@ async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result2["step_id"] == "reauth_confirm"
-    assert result["type"] is FlowResultType.FORM
+    assert result2["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "unknown"
 
 

--- a/tests/components/tractive/test_config_flow.py
+++ b/tests/components/tractive/test_config_flow.py
@@ -1,7 +1,9 @@
 """Test the tractive config flow."""
 
+from http import HTTPStatus
 from unittest.mock import patch
 
+import aiohttp
 import aiotractive
 
 from homeassistant import config_entries
@@ -64,8 +66,54 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "aiotractive.api.API.user_id",
+        side_effect=aiotractive.exceptions.TractiveError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            USER_INPUT,
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_rate_limit_exceeded(hass: HomeAssistant) -> None:
+    """Test we handle rate limit error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    cause = aiohttp.ClientResponseError(
+        None,
+        (),
+        status=HTTPStatus.TOO_MANY_REQUESTS,
+    )
+    error = aiotractive.exceptions.TractiveError()
+    error.__cause__ = cause
+
+    with patch(
+        "aiotractive.api.API.user_id",
+        side_effect=error,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            USER_INPUT,
+        )
+
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "rate_limit_exceeded"}
+
+
 async def test_form_unknown_error(hass: HomeAssistant) -> None:
-    """Test we handle invalid auth."""
+    """Test we handle unknown error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -162,6 +210,71 @@ async def test_reauthentication_failure(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "reauth_confirm"
     assert result["type"] is FlowResultType.FORM
     assert result2["errors"]["base"] == "invalid_auth"
+
+
+async def test_reauthentication_cannot_connect(hass: HomeAssistant) -> None:
+    """Test Tractive reauthentication with connection error."""
+    old_entry = MockConfigEntry(
+        domain="tractive",
+        data=USER_INPUT,
+        unique_id="USERID",
+    )
+    old_entry.add_to_hass(hass)
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(
+        "aiotractive.api.API.user_id",
+        side_effect=aiotractive.exceptions.TractiveError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["step_id"] == "reauth_confirm"
+    assert result["type"] is FlowResultType.FORM
+    assert result2["errors"]["base"] == "cannot_connect"
+
+
+async def test_reauthentication_rate_limit_exceeded(hass: HomeAssistant) -> None:
+    """Test Tractive reauthentication with rate limit error."""
+    old_entry = MockConfigEntry(
+        domain="tractive",
+        data=USER_INPUT,
+        unique_id="USERID",
+    )
+    old_entry.add_to_hass(hass)
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "reauth_confirm"
+
+    cause = aiohttp.ClientResponseError(
+        None,
+        (),
+        status=HTTPStatus.TOO_MANY_REQUESTS,
+    )
+    error = aiotractive.exceptions.TractiveError()
+    error.__cause__ = cause
+
+    with patch("aiotractive.api.API.user_id", side_effect=error):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["step_id"] == "reauth_confirm"
+    assert result["type"] is FlowResultType.FORM
+    assert result2["errors"]["base"] == "rate_limit_exceeded"
 
 
 async def test_reauthentication_unknown_failure(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves error handling in the config flow.

Waiting for https://github.com/home-assistant/core/pull/166288

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #166143
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
