### PR TITLE
EZVIZ: A3 hub sensors, load_devices, polling options & burst service

### DIFF
--- a/homeassistant/components/ezviz/__init__.py
+++ b/homeassistant/components/ezviz/__init__.py
@@ -10,20 +10,25 @@ from pyezvizapi.exceptions import (
     InvalidURL,
     PyEzvizError,
 )
+import voluptuous as vol
 
 from homeassistant.const import CONF_TIMEOUT, CONF_TYPE, CONF_URL, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     ATTR_TYPE_CAMERA,
     ATTR_TYPE_CLOUD,
     CONF_FFMPEG_ARGUMENTS,
     CONF_RFSESSION_ID,
+    CONF_SCAN_INTERVAL,
     CONF_SESSION_ID,
     DEFAULT_FFMPEG_ARGUMENTS,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     DOMAIN,
+    SERVICE_SET_POLLING_INTERVAL,
 )
 from .coordinator import EzvizConfigEntry, EzvizDataUpdateCoordinator
 
@@ -87,12 +92,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: EzvizConfigEntry) -> boo
             raise ConfigEntryNotReady from error
 
         coordinator = EzvizDataUpdateCoordinator(
-            hass, entry, api=ezviz_client, api_timeout=entry.options[CONF_TIMEOUT]
+            hass,
+            entry,
+            api=ezviz_client,
+            api_timeout=entry.options[CONF_TIMEOUT],
+            scan_interval=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
         )
 
         await coordinator.async_config_entry_first_refresh()
 
         entry.runtime_data = coordinator
+
+        await coordinator.start_mqtt()
 
     # Check EZVIZ cloud account entity is present, reload cloud account entities for camera entity change to take effect.
     # Cameras are accessed via local RTSP stream with unique credentials per camera.
@@ -108,12 +119,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: EzvizConfigEntry) -> boo
         entry, PLATFORMS_BY_TYPE[sensor_type]
     )
 
+    if sensor_type == ATTR_TYPE_CLOUD and not hass.services.has_service(
+        DOMAIN, SERVICE_SET_POLLING_INTERVAL
+    ):
+        async def _handle_set_polling_interval(call: ServiceCall) -> None:
+            interval = call.data["interval"]
+            duration = call.data["duration"]
+            for item in hass.config_entries.async_loaded_entries(domain=DOMAIN):
+                if item.data.get(CONF_TYPE) == ATTR_TYPE_CLOUD:
+                    coord: EzvizDataUpdateCoordinator = item.runtime_data
+                    await coord.set_burst_interval(interval, duration)
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_POLLING_INTERVAL,
+            _handle_set_polling_interval,
+            schema=vol.Schema(
+                {
+                    vol.Required("interval", default=1): vol.All(
+                        cv.positive_int, vol.Range(min=1, max=15)
+                    ),
+                    vol.Required("duration", default=60): vol.All(
+                        cv.positive_int, vol.Range(min=1, max=240)
+                    ),
+                }
+            ),
+        )
+
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: EzvizConfigEntry) -> bool:
     """Unload a config entry."""
     sensor_type = entry.data[CONF_TYPE]
+
+    if sensor_type == ATTR_TYPE_CLOUD and hasattr(entry, "runtime_data"):
+        coordinator: EzvizDataUpdateCoordinator = entry.runtime_data
+        await coordinator.stop_mqtt()
 
     return await hass.config_entries.async_unload_platforms(
         entry, PLATFORMS_BY_TYPE[sensor_type]

--- a/homeassistant/components/ezviz/binary_sensor.py
+++ b/homeassistant/components/ezviz/binary_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -10,8 +12,14 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .contact_device_class import (
+    async_ensure_contact_window_i18n,
+    infer_contact_sensor_device_class,
+)
 from .coordinator import EzvizConfigEntry, EzvizDataUpdateCoordinator
 from .entity import EzvizEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
@@ -28,6 +36,15 @@ BINARY_SENSOR_TYPES: dict[str, BinarySensorEntityDescription] = {
         key="encrypted",
         translation_key="encrypted",
     ),
+    # device_class overridden per entity from device name (see EzvizBinarySensor.device_class).
+    "door_status": BinarySensorEntityDescription(
+        key="door_status",
+        device_class=BinarySensorDeviceClass.DOOR,
+    ),
+    "water_leak_status": BinarySensorEntityDescription(
+        key="water_leak_status",
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    ),
 }
 
 
@@ -37,7 +54,24 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up EZVIZ sensors based on a config entry."""
+    await async_ensure_contact_window_i18n(hass)
     coordinator = entry.runtime_data
+
+    _LOGGER.debug(
+        "binary_sensor setup: %d devices in coordinator.data, keys per device:",
+        len(coordinator.data),
+    )
+    for camera in coordinator.data:
+        matching = {
+            k: v for k, v in coordinator.data[camera].items()
+            if k in BINARY_SENSOR_TYPES
+        }
+        _LOGGER.debug(
+            "  %s (%s): matching keys=%s",
+            camera,
+            coordinator.data[camera].get("device_category"),
+            {k: v for k, v in matching.items()},
+        )
 
     async_add_entities(
         [
@@ -64,8 +98,29 @@ class EzvizBinarySensor(EzvizEntity, BinarySensorEntity):
         self._sensor_name = binary_sensor
         self._attr_unique_id = f"{serial}_{self._camera_name}.{binary_sensor}"
         self.entity_description = BINARY_SENSOR_TYPES[binary_sensor]
+        if binary_sensor == "door_status":
+            _LOGGER.debug(
+                "door_status device %s: inferred device_class=%s from name=%r",
+                serial,
+                infer_contact_sensor_device_class(
+                    coordinator.hass, self.data.get("name")
+                ),
+                self.data.get("name"),
+            )
+
+    @property
+    def device_class(self) -> BinarySensorDeviceClass | None:
+        """Use WINDOW when the EZVIZ device name suggests a window contact."""
+        if self._sensor_name == "door_status":
+            return infer_contact_sensor_device_class(
+                self.coordinator.hass, self.data.get("name")
+            )
+        return self.entity_description.device_class
 
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        return self.data[self._sensor_name]
+        value = self.data[self._sensor_name]
+        if self._sensor_name == "water_leak_status":
+            return value != 2
+        return bool(value)

--- a/homeassistant/components/ezviz/camera.py
+++ b/homeassistant/components/ezviz/camera.py
@@ -42,9 +42,13 @@ async def async_setup_entry(
 
     coordinator = entry.runtime_data
 
+    CAMERA_DEVICE_CATEGORIES = {"IPC", "BatteryCamera", "BDoorBell", "CatEye", "XVR", "COMMON"}
+
     camera_entities = []
 
     for camera, value in coordinator.data.items():
+        if value.get("device_category") not in CAMERA_DEVICE_CATEGORIES:
+            continue
         camera_rtsp_entry = [
             item
             for item in hass.config_entries.async_entries(DOMAIN)

--- a/homeassistant/components/ezviz/config_flow.py
+++ b/homeassistant/components/ezviz/config_flow.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     ATTR_SERIAL,
@@ -39,9 +40,11 @@ from .const import (
     ATTR_TYPE_CLOUD,
     CONF_FFMPEG_ARGUMENTS,
     CONF_RFSESSION_ID,
+    CONF_SCAN_INTERVAL,
     CONF_SESSION_ID,
     DEFAULT_CAMERA_USERNAME,
     DEFAULT_FFMPEG_ARGUMENTS,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_TIMEOUT,
     DOMAIN,
     EU_URL,
@@ -296,13 +299,13 @@ class EzvizConfigFlow(ConfigFlow, domain=DOMAIN):
             try:
                 return await self._validate_and_create_camera_rtsp(user_input)
 
-            except InvalidHost, InvalidURL:
+            except (InvalidHost, InvalidURL):
                 errors["base"] = "invalid_host"
 
             except EzvizAuthVerificationCode:
                 errors["base"] = "mfa_required"
 
-            except PyEzvizError, AuthTestResultFailed:
+            except (PyEzvizError, AuthTestResultFailed):
                 errors["base"] = "invalid_auth"
 
             except Exception:
@@ -357,13 +360,13 @@ class EzvizConfigFlow(ConfigFlow, domain=DOMAIN):
                     _validate_and_create_auth, user_input
                 )
 
-            except InvalidHost, InvalidURL:
+            except (InvalidHost, InvalidURL):
                 errors["base"] = "invalid_host"
 
             except EzvizAuthVerificationCode:
                 errors["base"] = "mfa_required"
 
-            except PyEzvizError, AuthTestResultFailed:
+            except (PyEzvizError, AuthTestResultFailed):
                 errors["base"] = "invalid_auth"
 
             except Exception:
@@ -402,6 +405,12 @@ class EzvizOptionsFlowHandler(OptionsFlowWithReload):
 
         options = vol.Schema(
             {
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.options.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=5, max=300)),
                 vol.Optional(
                     CONF_TIMEOUT,
                     default=self.config_entry.options.get(

--- a/homeassistant/components/ezviz/const.py
+++ b/homeassistant/components/ezviz/const.py
@@ -26,6 +26,7 @@ ATTR_TYPE = "type_value"
 # Service names
 SERVICE_WAKE_DEVICE = "wake_device"
 SERVICE_DETECTION_SENSITIVITY = "set_alarm_detection_sensibility"
+SERVICE_SET_POLLING_INTERVAL = "set_polling_interval"
 
 # Defaults
 EU_URL = "apiieu.ezvizlife.com"
@@ -33,3 +34,7 @@ RUSSIA_URL = "apirus.ezvizru.com"
 DEFAULT_CAMERA_USERNAME = "admin"
 DEFAULT_TIMEOUT = 25
 DEFAULT_FFMPEG_ARGUMENTS = "/Streaming/Channels/102"
+DEFAULT_SCAN_INTERVAL = 30
+CONF_SCAN_INTERVAL = "scan_interval"
+
+NON_CAMERA_DEVICE_CATEGORIES = {"Detector", "lighting", "Socket"}

--- a/homeassistant/components/ezviz/contact_device_class.py
+++ b/homeassistant/components/ezviz/contact_device_class.py
@@ -1,0 +1,135 @@
+"""Map EZVIZ contact sensor names to WINDOW using Home Assistant core i18n.
+
+Reads ``entity_component.window.name`` from every shipped locale under
+``homeassistant.components.binary_sensor`` — the same strings the frontend uses for
+the *Window* device class — instead of maintaining a custom synonym list.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import re
+import unicodedata
+from typing import TYPE_CHECKING
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+)
+import homeassistant.components.binary_sensor as binary_sensor_component
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_CONTACT_WINDOW_I18N = "contact_window_i18n"
+
+# Normalized Latin window labels → one regex each (deduped).
+_LATIN_LABEL_PATTERN = re.compile(r"^[a-z\s\-']+$")
+ContactWindowI18n = tuple[tuple[re.Pattern[str], ...], frozenset[str]]
+
+
+def _normalize_for_latin_match(text: str) -> str:
+    """Lowercase and strip combining marks (fenêtre → fenetre)."""
+    decomposed = unicodedata.normalize("NFKD", text.casefold())
+    return "".join(c for c in decomposed if unicodedata.category(c) != "Mn")
+
+
+def _load_window_labels_from_core_translations() -> ContactWindowI18n:
+    """Collect *window* device-class names from core binary_sensor translations."""
+    trans_dir = pathlib.Path(binary_sensor_component.__file__).parent / "translations"
+    seen_latin_norms: set[str] = set()
+    patterns: list[re.Pattern[str]] = []
+    unicode_substrings: set[str] = set()
+
+    paths = sorted(trans_dir.glob("*.json"))
+    for path in paths:
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            continue
+        ec = data.get("entity_component") or {}
+        win = ec.get("window") or {}
+        name = win.get("name")
+        if not isinstance(name, str):
+            continue
+        name = name.strip()
+        if not name:
+            continue
+
+        norm = _normalize_for_latin_match(name)
+        if norm and _LATIN_LABEL_PATTERN.fullmatch(norm):
+            if norm in seen_latin_norms:
+                continue
+            seen_latin_norms.add(norm)
+            parts = norm.split()
+            if len(parts) == 1:
+                patterns.append(
+                    re.compile(rf"\b{re.escape(parts[0])}\b", re.IGNORECASE)
+                )
+            else:
+                patterns.append(
+                    re.compile(
+                        r"\b" + r"\s+".join(re.escape(p) for p in parts) + r"\b",
+                        re.IGNORECASE,
+                    )
+                )
+        else:
+            unicode_substrings.add(name)
+
+    _LOGGER.debug(
+        "EZVIZ contact WINDOW i18n: %d Latin patterns, %d unicode phrases from %d files",
+        len(patterns),
+        len(unicode_substrings),
+        len(paths),
+    )
+    return (tuple(patterns), frozenset(unicode_substrings))
+
+
+async def async_ensure_contact_window_i18n(hass: HomeAssistant) -> None:
+    """Load and cache core translation-derived window labels (once per HA instance)."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    if DATA_CONTACT_WINDOW_I18N in domain_data:
+        return
+    domain_data[DATA_CONTACT_WINDOW_I18N] = await hass.async_add_executor_job(
+        _load_window_labels_from_core_translations
+    )
+
+
+def infer_contact_sensor_device_class(
+    hass: HomeAssistant | None, name: str | None
+) -> BinarySensorDeviceClass:
+    """Return WINDOW if ``name`` matches a core *window* label in any locale; else DOOR."""
+    if not name or not name.strip():
+        return BinarySensorDeviceClass.DOOR
+    # Entity.__init__ runs before ``self.hass`` is bound; callers must pass coordinator.hass.
+    if hass is None:
+        return BinarySensorDeviceClass.DOOR
+
+    i18n: ContactWindowI18n | None = hass.data.get(DOMAIN, {}).get(
+        DATA_CONTACT_WINDOW_I18N
+    )
+    if i18n is None:
+        _LOGGER.warning(
+            "Contact window i18n not loaded; defaulting door_status to DOOR. "
+            "Ensure async_ensure_contact_window_i18n ran during binary_sensor setup."
+        )
+        return BinarySensorDeviceClass.DOOR
+
+    patterns, unicode_substrings = i18n
+    name_cf = name.casefold()
+    for phrase in unicode_substrings:
+        if phrase.casefold() in name_cf:
+            return BinarySensorDeviceClass.WINDOW
+
+    normalized_device = _normalize_for_latin_match(name)
+    for pattern in patterns:
+        if pattern.search(normalized_device):
+            return BinarySensorDeviceClass.WINDOW
+
+    return BinarySensorDeviceClass.DOOR

--- a/homeassistant/components/ezviz/coordinator.py
+++ b/homeassistant/components/ezviz/coordinator.py
@@ -1,8 +1,11 @@
 """Provides the ezviz DataUpdateCoordinator."""
 
+from __future__ import annotations
+
 import asyncio
 from datetime import timedelta
 import logging
+from typing import Any
 
 from pyezvizapi.client import EzvizClient
 from pyezvizapi.exceptions import (
@@ -18,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,26 +38,101 @@ class EzvizDataUpdateCoordinator(DataUpdateCoordinator):
         *,
         api: EzvizClient,
         api_timeout: int,
+        scan_interval: int = DEFAULT_SCAN_INTERVAL,
     ) -> None:
         """Initialize global EZVIZ data updater."""
         self.ezviz_client = api
         self._api_timeout = api_timeout
-        update_interval = timedelta(seconds=30)
+        self._mqtt_started = False
+        self._default_interval = timedelta(seconds=scan_interval)
+        self._burst_restore_task: asyncio.Task | None = None
 
         super().__init__(
             hass,
             _LOGGER,
             config_entry=entry,
             name=DOMAIN,
-            update_interval=update_interval,
+            update_interval=self._default_interval,
         )
+
+    async def set_burst_interval(
+        self, interval_seconds: int, duration_seconds: int
+    ) -> None:
+        """Temporarily set a fast polling interval, then restore the default."""
+        if self._burst_restore_task and not self._burst_restore_task.done():
+            self._burst_restore_task.cancel()
+
+        self.update_interval = timedelta(seconds=interval_seconds)
+        _LOGGER.info(
+            "EZVIZ burst polling: %ds for %ds", interval_seconds, duration_seconds
+        )
+        await self.async_request_refresh()
+        self._burst_restore_task = self.hass.async_create_task(
+            self._restore_interval_after(duration_seconds)
+        )
+
+    async def _restore_interval_after(self, duration_seconds: int) -> None:
+        """Wait then restore the default polling interval."""
+        try:
+            await asyncio.sleep(duration_seconds)
+        except asyncio.CancelledError:
+            return
+        self.update_interval = self._default_interval
+        _LOGGER.info(
+            "EZVIZ burst polling ended, restored to %ss", self._default_interval
+        )
+
+    async def start_mqtt(self) -> None:
+        """Start the EZVIZ MQTT push listener in the background."""
+        if self._mqtt_started:
+            return
+        try:
+            await self.hass.async_add_executor_job(self._setup_mqtt)
+            self._mqtt_started = True
+            _LOGGER.debug("EZVIZ MQTT push listener started")
+        except Exception:
+            _LOGGER.warning(
+                "Could not start EZVIZ MQTT push listener, "
+                "falling back to polling only",
+                exc_info=True,
+            )
+
+    def _setup_mqtt(self) -> None:
+        """Set up and connect the MQTT client (runs in executor)."""
+        mqtt_client = self.ezviz_client.get_mqtt_client(
+            on_message_callback=self._on_mqtt_message,
+        )
+        mqtt_client.connect(clean_session=True)
+
+    def _on_mqtt_message(self, message: dict[str, Any]) -> None:
+        """Handle incoming MQTT push and request a coordinator refresh."""
+        ext = message.get("ext", {}) if isinstance(message.get("ext"), dict) else {}
+        device_serial = ext.get("device_serial", "unknown")
+        _LOGGER.debug("MQTT push received for %s, requesting refresh", device_serial)
+        self.hass.loop.call_soon_threadsafe(
+            self.hass.async_create_task,
+            self.async_request_refresh(),
+        )
+
+    async def stop_mqtt(self) -> None:
+        """Stop the MQTT push listener."""
+        if not self._mqtt_started:
+            return
+        try:
+            mqtt_client = self.ezviz_client.mqtt_client
+            if mqtt_client:
+                await self.hass.async_add_executor_job(mqtt_client.stop)
+            self._mqtt_started = False
+            _LOGGER.debug("EZVIZ MQTT push listener stopped")
+        except Exception:
+            _LOGGER.debug("Error stopping MQTT listener", exc_info=True)
 
     async def _async_update_data(self) -> dict:
         """Fetch data from EZVIZ."""
         try:
             async with asyncio.timeout(self._api_timeout):
                 return await self.hass.async_add_executor_job(
-                    self.ezviz_client.load_cameras
+                    self.ezviz_client.load_devices
                 )
 
         except (EzvizAuthTokenExpired, EzvizAuthVerificationCode) as error:

--- a/homeassistant/components/ezviz/entity.py
+++ b/homeassistant/components/ezviz/entity.py
@@ -25,19 +25,21 @@ class EzvizEntity(CoordinatorEntity[EzvizDataUpdateCoordinator], Entity):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._serial = serial
-        self._camera_name = self.data["name"]
+        self._camera_name = self.data.get("name") or serial
 
         connections = set()
-        if mac_address := self.data["mac_address"]:
+        if mac_address := self.data.get("mac_address"):
             connections.add((CONNECTION_NETWORK_MAC, mac_address))
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
             connections=connections,
             manufacturer=MANUFACTURER,
-            model=self.data["device_sub_category"],
-            name=self.data["name"],
-            sw_version=self.data["version"],
+            model=self.data.get("device_sub_category")
+            or self.data.get("device_category")
+            or "EZVIZ",
+            name=self.data.get("name") or serial,
+            sw_version=self.data.get("version"),
         )
 
     @property
@@ -48,7 +50,7 @@ class EzvizEntity(CoordinatorEntity[EzvizDataUpdateCoordinator], Entity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.data["status"] != 2
+        return self.data.get("status") != 2
 
 
 class EzvizBaseEntity(Entity):
@@ -64,19 +66,21 @@ class EzvizBaseEntity(Entity):
         """Initialize the entity."""
         self._serial = serial
         self.coordinator = coordinator
-        self._camera_name = self.data["name"]
+        self._camera_name = self.data.get("name") or serial
 
         connections = set()
-        if mac_address := self.data["mac_address"]:
+        if mac_address := self.data.get("mac_address"):
             connections.add((CONNECTION_NETWORK_MAC, mac_address))
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
             connections=connections,
             manufacturer=MANUFACTURER,
-            model=self.data["device_sub_category"],
-            name=self.data["name"],
-            sw_version=self.data["version"],
+            model=self.data.get("device_sub_category")
+            or self.data.get("device_category")
+            or "EZVIZ",
+            name=self.data.get("name") or serial,
+            sw_version=self.data.get("version"),
         )
 
     @property
@@ -87,4 +91,4 @@ class EzvizBaseEntity(Entity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self.data["status"] != 2
+        return self.data.get("status") != 2

--- a/homeassistant/components/ezviz/icons.json
+++ b/homeassistant/components/ezviz/icons.json
@@ -46,6 +46,9 @@
     "set_alarm_detection_sensibility": {
       "service": "mdi:motion-sensor"
     },
+    "set_polling_interval": {
+      "service": "mdi:timer-refresh"
+    },
     "wake_device": {
       "service": "mdi:sleep-off"
     }

--- a/homeassistant/components/ezviz/image.py
+++ b/homeassistant/components/ezviz/image.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import DOMAIN, NON_CAMERA_DEVICE_CATEGORIES
 from .coordinator import EzvizConfigEntry, EzvizDataUpdateCoordinator
 from .entity import EzvizEntity
 
@@ -37,7 +37,9 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     async_add_entities(
-        EzvizLastMotion(hass, coordinator, camera) for camera in coordinator.data
+        EzvizLastMotion(hass, coordinator, camera)
+        for camera in coordinator.data
+        if coordinator.data[camera].get("device_category") not in NON_CAMERA_DEVICE_CATEGORIES
     )
 
 

--- a/homeassistant/components/ezviz/manifest.json
+++ b/homeassistant/components/ezviz/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ezviz",
   "iot_class": "cloud_polling",
   "loggers": ["paho_mqtt", "pyezvizapi"],
-  "requirements": ["pyezvizapi==1.0.0.7"]
+  "requirements": ["pyezvizapi==1.0.4.5"]
 }

--- a/homeassistant/components/ezviz/manifest.json
+++ b/homeassistant/components/ezviz/manifest.json
@@ -7,5 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/ezviz",
   "iot_class": "cloud_polling",
   "loggers": ["paho_mqtt", "pyezvizapi"],
-  "requirements": ["pyezvizapi==1.0.4.5"]
+  "requirements": [
+    "pyezvizapi @ git+https://github.com/srescio/pyEzvizApi.git@feature/detector-device-support"
+  ]
 }

--- a/homeassistant/components/ezviz/number.py
+++ b/homeassistant/components/ezviz/number.py
@@ -121,7 +121,7 @@ class EzvizNumber(EzvizBaseEntity, NumberEntity):
                 str(self.sensitivity_type),
             )
 
-        except EzvizAuthTokenExpired, EzvizAuthVerificationCode:
+        except (EzvizAuthTokenExpired, EzvizAuthVerificationCode):
             _LOGGER.debug("Failed to login to EZVIZ API")
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(self.config_entry_id)

--- a/homeassistant/components/ezviz/select.py
+++ b/homeassistant/components/ezviz/select.py
@@ -68,11 +68,18 @@ ALARM_SOUND_MODE_SELECT_TYPE = EzvizSelectEntityDescription(
 
 def battery_work_mode_current_option(ezvizSelect: EzvizSelect) -> str | None:
     """Return the selected entity option to represent the entity state."""
-    battery_work_mode = getattr(
-        BatteryCameraWorkMode,
-        ezvizSelect.data[ezvizSelect.entity_description.key],
-        BatteryCameraWorkMode.UNKNOWN,
-    )
+    raw = ezvizSelect.data[ezvizSelect.entity_description.key]
+    if isinstance(raw, int):
+        try:
+            battery_work_mode = BatteryCameraWorkMode(raw)
+        except ValueError:
+            battery_work_mode = BatteryCameraWorkMode.UNKNOWN
+    else:
+        battery_work_mode = getattr(
+            BatteryCameraWorkMode,
+            str(raw),
+            BatteryCameraWorkMode.UNKNOWN,
+        )
     if battery_work_mode == BatteryCameraWorkMode.UNKNOWN:
         return None
 

--- a/homeassistant/components/ezviz/sensor.py
+++ b/homeassistant/components/ezviz/sensor.py
@@ -11,8 +11,12 @@ from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+import logging
+
 from .coordinator import EzvizConfigEntry, EzvizDataUpdateCoordinator
 from .entity import EzvizEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 
@@ -66,6 +70,17 @@ SENSOR_TYPES: dict[str, SensorEntityDescription] = {
         key="last_alarm_type_name",
         translation_key="last_alarm_type_name",
     ),
+    "zigbee_signal": SensorEntityDescription(
+        key="zigbee_signal",
+        translation_key="zigbee_signal",
+        entity_registry_enabled_default=False,
+    ),
+    "siren_alarm_volume": SensorEntityDescription(
+        key="siren_alarm_volume",
+        translation_key="siren_alarm_volume",
+        native_unit_of_measurement=PERCENTAGE,
+        entity_registry_enabled_default=False,
+    ),
 }
 
 
@@ -76,6 +91,22 @@ async def async_setup_entry(
 ) -> None:
     """Set up EZVIZ sensors based on a config entry."""
     coordinator = entry.runtime_data
+
+    _LOGGER.debug(
+        "sensor setup: %d devices in coordinator.data, keys per device:",
+        len(coordinator.data),
+    )
+    for camera in coordinator.data:
+        matching = {
+            k: v for k, v in coordinator.data[camera].items()
+            if k in SENSOR_TYPES
+        }
+        _LOGGER.debug(
+            "  %s (%s): matching sensor keys=%s",
+            camera,
+            coordinator.data[camera].get("device_category"),
+            {k: v for k, v in matching.items()},
+        )
 
     async_add_entities(
         [

--- a/homeassistant/components/ezviz/services.yaml
+++ b/homeassistant/components/ezviz/services.yaml
@@ -29,3 +29,28 @@ wake_device:
     entity:
       integration: ezviz
       domain: camera
+
+set_polling_interval:
+  fields:
+    interval:
+      required: true
+      example: 1
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 15
+          step: 1
+          unit_of_measurement: seconds
+          mode: box
+    duration:
+      required: true
+      example: 60
+      default: 60
+      selector:
+        number:
+          min: 1
+          max: 240
+          step: 1
+          unit_of_measurement: seconds
+          mode: box

--- a/homeassistant/components/ezviz/strings.json
+++ b/homeassistant/components/ezviz/strings.json
@@ -137,6 +137,12 @@
       },
       "wan_ip": {
         "name": "WAN IP"
+      },
+      "zigbee_signal": {
+        "name": "Zigbee signal"
+      },
+      "siren_alarm_volume": {
+        "name": "Siren alarm volume"
       }
     },
     "siren": {
@@ -187,6 +193,7 @@
     "step": {
       "init": {
         "data": {
+          "scan_interval": "Polling interval (seconds)",
           "ffmpeg_arguments": "Arguments passed to FFmpeg for cameras",
           "timeout": "Request timeout (seconds)"
         }
@@ -211,6 +218,20 @@
     "wake_device": {
       "description": "Wakes a camera from sleep mode. Especially useful for battery cameras.",
       "name": "Wake camera"
+    },
+    "set_polling_interval": {
+      "description": "Temporarily sets a fast polling interval for near-real-time sensor updates, then automatically restores the default interval after the specified duration.",
+      "fields": {
+        "interval": {
+          "description": "Polling interval in seconds during the burst window (1–15 s).",
+          "name": "Interval"
+        },
+        "duration": {
+          "description": "How long (in seconds) to keep the fast polling interval before reverting to the default (1–240 s, max 4 min).",
+          "name": "Duration"
+        }
+      },
+      "name": "Set polling interval"
     }
   }
 }

--- a/homeassistant/components/ezviz/switch.py
+++ b/homeassistant/components/ezviz/switch.py
@@ -69,7 +69,7 @@ SWITCH_TYPES: dict[int, EzvizSwitchEntityDescription] = {
         key="29",
         translation_key="all_day_video_recording",
         device_class=SwitchDeviceClass.SWITCH,
-        supported_ext=str(SupportExt.SupportFulldayRecord.value),
+        supported_ext=str(SupportExt.SupportFullDayRecord.value),
     ),
     32: EzvizSwitchEntityDescription(
         key="32",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2104,7 +2104,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezvizapi==1.0.0.7
+pyezvizapi==1.0.4.5
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2104,7 +2104,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezvizapi==1.0.4.5
+pyezvizapi @ git+https://github.com/srescio/pyEzvizApi.git@feature/detector-device-support
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1802,7 +1802,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezvizapi==1.0.4.5
+pyezvizapi @ git+https://github.com/srescio/pyEzvizApi.git@feature/detector-device-support
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1802,7 +1802,7 @@ pyeverlights==0.1.0
 pyevilgenius==2.0.0
 
 # homeassistant.components.ezviz
-pyezvizapi==1.0.0.7
+pyezvizapi==1.0.4.5
 
 # homeassistant.components.fibaro
 pyfibaro==0.8.3


### PR DESCRIPTION
## Blocker / dependency

**This PR must not merge until [RenierM26/pyEzvizApi#99](https://github.com/RenierM26/pyEzvizApi/pull/99)** (detector / hub device support) **is merged** and the dependency is switched to a **published PyPI** `pyezvizapi` version (Core does not ship with permanent git pins).

Until then, `manifest.json` / `requirements_*.txt` use the same **VCS requirement** as [ezviz-patched](https://github.com/srescio/ezviz-patched):

`pyezvizapi @ git+https://github.com/srescio/pyEzvizApi.git@feature/detector-device-support`

## Changes

- **Dependency:** `pyezvizapi` from **`feature/detector-device-support`** (see above); updates `manifest.json`, `requirements_all.txt`, `requirements_test_all.txt`.
- **Coordinator:** use `load_devices` instead of `load_cameras`; configurable default poll interval; optional **burst polling** (`set_burst_interval`) with automatic restore; optional MQTT listener requesting refresh on push.
- **Options:** `scan_interval` (5–300 s) in the integration options flow.
- **Service:** `ezviz.set_polling_interval` (temporary fast polling window) with `services.yaml` / `strings.json` / `icons.json` entries.
- **Binary sensors:** `door_status`, `water_leak_status`; **`contact_device_class`** maps contact names to door vs window using core i18n.
- **Sensors:** optional `zigbee_signal`, `siren_alarm_volume` for supported detectors (disabled by default).
- **Entity base:** safer `.get()` access for detector payloads missing some camera-only keys.
- **Debug:** extra logging in binary_sensor / sensor setup when matching coordinator keys.

Refs #166295