### PR TITLE
Use current track's album thumbnail as our entity_picture for "radio" sources in Music Assistant

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -553,12 +553,14 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
         self, player: Player, queue: PlayerQueue | None
     ) -> None:
         """Update image URL."""
-        if queue and queue.current_item:
-            # image_url is provided by an music-assistant queue
-            image_url = self.mass.get_media_item_image_url(queue.current_item)
-        elif player.current_media and player.current_media.image_url:
-            # image_url is provided by an external source
+        image_url: str | None
+        if player.current_media and player.current_media.image_url:
+            # prefer player.current_media which reflects the live state
+            # (e.g. current track art from radio stream metadata)
             image_url = player.current_media.image_url
+        elif queue and queue.current_item:
+            # fallback to static media item image from queue
+            image_url = self.mass.get_media_item_image_url(queue.current_item)
         else:
             image_url = None
 

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -10,6 +10,7 @@ from music_assistant_models.enums import (
     QueueOption,
 )
 from music_assistant_models.media_items import Track
+from music_assistant_models.player import PlayerMedia
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import paths
@@ -740,3 +741,75 @@ async def test_media_player_supported_features(
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["supported_features"] == expected_features
+
+
+async def test_media_image_prefers_current_media(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that entity_picture uses player.current_media.image_url over static queue image."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "media_player.test_group_player_1"
+    mass_player_id = "test_group_player_1"
+
+    # The group player has a queue with current_item (which has a static image)
+    # and current_media. Set current_media.image_url to a dynamic stream art URL.
+    stream_art_url = "https://img.radioparadise.com/covers/l/19806.jpg"
+    player = music_assistant_client.players._players[mass_player_id]
+    player.current_media = PlayerMedia(
+        uri=player.current_media.uri,
+        title="Lay It Down",
+        artist="Cowboy Junkies",
+        image_url=stream_art_url,
+    )
+
+    # Also set up get_media_item_image_url to return a static logo URL
+    # so we can verify it's NOT used when current_media has an image
+    static_logo_url = "https://example.com/station_logo.png"
+    music_assistant_client.get_media_item_image_url = MagicMock(
+        return_value=static_logo_url
+    )
+
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_UPDATED, mass_player_id
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    # Should use the dynamic stream art, not the static logo
+    assert state.attributes["entity_picture"] == stream_art_url
+    # Static queue image path should not have been consulted
+    music_assistant_client.get_media_item_image_url.assert_not_called()
+
+
+async def test_media_image_falls_back_to_queue_item(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that entity_picture falls back to queue item image when current_media has none."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "media_player.test_group_player_1"
+    mass_player_id = "test_group_player_1"
+
+    # Set current_media with no image_url
+    player = music_assistant_client.players._players[mass_player_id]
+    player.current_media = PlayerMedia(
+        uri=player.current_media.uri,
+        title="Some Track",
+        image_url=None,
+    )
+
+    # Set up get_media_item_image_url to return a static image
+    static_image_url = "https://example.com/album_art.jpg"
+    music_assistant_client.get_media_item_image_url = MagicMock(
+        return_value=static_image_url
+    )
+
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_UPDATED, mass_player_id
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    # Should fall back to the static queue item image
+    assert state.attributes["entity_picture"] == static_image_url
+    # Verify the fallback path was actually taken
+    music_assistant_client.get_media_item_image_url.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I've been using https://github.com/jtenniswood/esphome-media-player on some S3s and a P4 I have, which uses the entity_picture as the background for whatever is currently playing. For 'normal' providers, that works great. But for radio providers which have both a 'stream id' picture as well as the currently playing track's album cover, it has been defaulting to the stream _id and thus never changes. This inverts the test and prioritizes the current track's album art if it exists, falling back to original if not. Also wrote tests to prove all that out.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
