### PR TITLE
Add schedule management services to switcher_kis

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -12,7 +12,14 @@ from homeassistant.const import CONF_TOKEN, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import DOMAIN, SwitcherEntityFeature
+
+# SwitcherEntityFeature must be re-exported here (not just in const.py) so that
+# hassfest can resolve "switcher_kis.SwitcherEntityFeature.SCHEDULES" in services.yaml
+# target filters. hassfest resolves supported_features strings by importing from the
+# integration's package root (__init__.py), following the same pattern as e.g.
+# alarm_control_panel.AlarmControlPanelEntityFeature.
+__all__ = ["DOMAIN", "SwitcherEntityFeature"]
 from .coordinator import SwitcherDataUpdateCoordinator
 
 PLATFORMS = [

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -1,6 +1,15 @@
 """Constants for the Switcher integration."""
 
+from enum import IntFlag
+
 DOMAIN = "switcher_kis"
+
+
+class SwitcherEntityFeature(IntFlag):
+    """Supported features of Switcher entities."""
+
+    SCHEDULES = 1
+
 
 API_CONTROL_BREEZE_DEVICE = "control_breeze_device"
 

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -13,6 +13,15 @@ CONF_AUTO_OFF = "auto_off"
 CONF_TIMER_MINUTES = "timer_minutes"
 SERVICE_SET_AUTO_OFF_NAME = "set_auto_off"
 SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"
+SERVICE_GET_SCHEDULES_NAME = "get_schedules"
+SERVICE_CREATE_SCHEDULE_NAME = "create_schedule"
+SERVICE_DELETE_SCHEDULE_NAME = "delete_schedule"
+
+# Schedule service fields
+CONF_SCHEDULE_START_TIME = "start_time"
+CONF_SCHEDULE_END_TIME = "end_time"
+CONF_SCHEDULE_DAYS = "days"
+CONF_SCHEDULE_ID = "schedule_id"
 
 # Defines the maximum interval device must send an update before it marked unavailable
 MAX_UPDATE_INTERVAL_SEC = 30

--- a/homeassistant/components/switcher_kis/entity.py
+++ b/homeassistant/components/switcher_kis/entity.py
@@ -38,8 +38,10 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
     def _update_data(self) -> None:
         """Update data from device."""
 
-    async def _async_call_api(self, api: str, *args: Any, **kwargs: Any) -> None:
-        """Call Switcher API."""
+    async def _async_call_api(
+        self, api: str, *args: Any, **kwargs: Any
+    ) -> SwitcherBaseResponse:
+        """Call Switcher API and return the response."""
         _LOGGER.debug("Calling api for %s, api: '%s', args: %s", self.name, api, args)
         response: SwitcherBaseResponse | None = None
         error = None
@@ -63,3 +65,5 @@ class SwitcherEntity(CoordinatorEntity[SwitcherDataUpdateCoordinator]):
                 f"Call api for {self.name} failed, api: '{api}', "
                 f"args: {args}, response/error: {response or error}"
             )
+
+        return response

--- a/homeassistant/components/switcher_kis/icons.json
+++ b/homeassistant/components/switcher_kis/icons.json
@@ -24,6 +24,15 @@
     }
   },
   "services": {
+    "create_schedule": {
+      "service": "mdi:calendar-plus"
+    },
+    "delete_schedule": {
+      "service": "mdi:calendar-remove"
+    },
+    "get_schedules": {
+      "service": "mdi:calendar-clock"
+    },
     "set_auto_off": {
       "service": "mdi:progress-clock"
     },

--- a/homeassistant/components/switcher_kis/services.yaml
+++ b/homeassistant/components/switcher_kis/services.yaml
@@ -31,14 +31,16 @@ get_schedules:
     entity:
       integration: switcher_kis
       domain: switch
-      device_class: switch
+      supported_features:
+        - switcher_kis.SwitcherEntityFeature.SCHEDULES
 
 create_schedule:
   target:
     entity:
       integration: switcher_kis
       domain: switch
-      device_class: switch
+      supported_features:
+        - switcher_kis.SwitcherEntityFeature.SCHEDULES
   fields:
     start_time:
       required: true
@@ -70,7 +72,8 @@ delete_schedule:
     entity:
       integration: switcher_kis
       domain: switch
-      device_class: switch
+      supported_features:
+        - switcher_kis.SwitcherEntityFeature.SCHEDULES
   fields:
     schedule_id:
       required: true

--- a/homeassistant/components/switcher_kis/services.yaml
+++ b/homeassistant/components/switcher_kis/services.yaml
@@ -25,3 +25,63 @@ turn_on_with_timer:
           min: 1
           max: 150
           unit_of_measurement: minutes
+
+get_schedules:
+  target:
+    entity:
+      integration: switcher_kis
+      domain: switch
+      device_class: switch
+
+create_schedule:
+  target:
+    entity:
+      integration: switcher_kis
+      domain: switch
+      device_class: switch
+  fields:
+    start_time:
+      required: true
+      example: '"07:00"'
+      selector:
+        time:
+    end_time:
+      required: true
+      example: '"07:30"'
+      selector:
+        time:
+    days:
+      required: false
+      selector:
+        select:
+          multiple: true
+          translation_key: days
+          options:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+            - saturday
+            - sunday
+
+delete_schedule:
+  target:
+    entity:
+      integration: switcher_kis
+      domain: switch
+      device_class: switch
+  fields:
+    schedule_id:
+      required: true
+      selector:
+        select:
+          options:
+            - "0"
+            - "1"
+            - "2"
+            - "3"
+            - "4"
+            - "5"
+            - "6"
+            - "7"

--- a/homeassistant/components/switcher_kis/strings.json
+++ b/homeassistant/components/switcher_kis/strings.json
@@ -78,7 +78,57 @@
       }
     }
   },
+  "exceptions": {
+    "schedule_end_time_not_after_start_time": {
+      "message": "The schedule end time must be after the start time."
+    }
+  },
+  "selector": {
+    "days": {
+      "options": {
+        "friday": "[%key:common::time::friday%]",
+        "monday": "[%key:common::time::monday%]",
+        "saturday": "[%key:common::time::saturday%]",
+        "sunday": "[%key:common::time::sunday%]",
+        "thursday": "[%key:common::time::thursday%]",
+        "tuesday": "[%key:common::time::tuesday%]",
+        "wednesday": "[%key:common::time::wednesday%]"
+      }
+    }
+  },
   "services": {
+    "create_schedule": {
+      "description": "Creates a new schedule on the Switcher device.",
+      "fields": {
+        "days": {
+          "description": "Days for a recurring schedule. Leave empty for a one-time schedule.",
+          "name": "Days"
+        },
+        "end_time": {
+          "description": "Schedule end time in HH:MM format.",
+          "name": "End time"
+        },
+        "start_time": {
+          "description": "Schedule start time in HH:MM format.",
+          "name": "Start time"
+        }
+      },
+      "name": "Create schedule"
+    },
+    "delete_schedule": {
+      "description": "Deletes a schedule from the Switcher device.",
+      "fields": {
+        "schedule_id": {
+          "description": "ID of the schedule to delete (0–7). Use Get schedules to find existing IDs.",
+          "name": "Schedule ID"
+        }
+      },
+      "name": "Delete schedule"
+    },
+    "get_schedules": {
+      "description": "Retrieves all schedules configured on the Switcher device.",
+      "name": "Get schedules"
+    },
     "set_auto_off": {
       "description": "Updates Switcher device auto-off setting.",
       "fields": {

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -233,7 +233,9 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
                 {
                     "schedule_id": s.schedule_id,
                     "recurring": s.recurring,
-                    "days": [d.name.lower() for d in sorted(s.days, key=lambda d: d.name)],
+                    "days": [
+                        d.name.lower() for d in sorted(s.days, key=lambda d: d.name)
+                    ],
                     "start_time": s.start_time,
                     "end_time": s.end_time,
                     "duration": s.duration,

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -2,21 +2,29 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import time, timedelta
 from typing import Any, cast
 
 from aioswitcher.api import Command
+from aioswitcher.api.messages import SwitcherGetSchedulesResponse
 from aioswitcher.device import (
     DeviceCategory,
     DeviceState,
     ShutterChildLock,
     SwitcherShutter,
 )
+from aioswitcher.schedule import Days
 import voluptuous as vol
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceResponse,
+    SupportsResponse,
+    callback,
+)
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -25,7 +33,15 @@ from homeassistant.helpers.typing import VolDictType
 from . import SwitcherConfigEntry
 from .const import (
     CONF_AUTO_OFF,
+    CONF_SCHEDULE_DAYS,
+    CONF_SCHEDULE_END_TIME,
+    CONF_SCHEDULE_ID,
+    CONF_SCHEDULE_START_TIME,
     CONF_TIMER_MINUTES,
+    DOMAIN,
+    SERVICE_CREATE_SCHEDULE_NAME,
+    SERVICE_DELETE_SCHEDULE_NAME,
+    SERVICE_GET_SCHEDULES_NAME,
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
     SIGNAL_DEVICE_ADD,
@@ -49,6 +65,28 @@ SERVICE_TURN_ON_WITH_TIMER_SCHEMA: VolDictType = {
     ),
 }
 
+DAYS_MAPPING: dict[str, Days] = {
+    "monday": Days.MONDAY,
+    "tuesday": Days.TUESDAY,
+    "wednesday": Days.WEDNESDAY,
+    "thursday": Days.THURSDAY,
+    "friday": Days.FRIDAY,
+    "saturday": Days.SATURDAY,
+    "sunday": Days.SUNDAY,
+}
+
+SERVICE_CREATE_SCHEDULE_SCHEMA: VolDictType = {
+    vol.Required(CONF_SCHEDULE_START_TIME): cv.time,
+    vol.Required(CONF_SCHEDULE_END_TIME): cv.time,
+    vol.Optional(CONF_SCHEDULE_DAYS, default=[]): vol.All(
+        cv.ensure_list, [vol.In(DAYS_MAPPING)]
+    ),
+}
+
+SERVICE_DELETE_SCHEDULE_SCHEMA: VolDictType = {
+    vol.Required(CONF_SCHEDULE_ID): vol.All(str, vol.In([str(i) for i in range(8)])),
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -69,6 +107,28 @@ async def async_setup_entry(
         SERVICE_TURN_ON_WITH_TIMER_NAME,
         SERVICE_TURN_ON_WITH_TIMER_SCHEMA,
         "async_turn_on_with_timer_service",
+        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_GET_SCHEDULES_NAME,
+        {},
+        "async_get_schedules_service",
+        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_CREATE_SCHEDULE_NAME,
+        SERVICE_CREATE_SCHEDULE_SCHEMA,
+        "async_create_schedule_service",
+        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_DELETE_SCHEDULE_NAME,
+        SERVICE_DELETE_SCHEDULE_SCHEMA,
+        "async_delete_schedule_service",
         entity_device_classes=(SwitchDeviceClass.SWITCH,),
     )
 
@@ -161,6 +221,46 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
         await self._async_call_api(API_CONTROL_DEVICE, Command.ON, timer_minutes)
         self._attr_is_on = self.control_result = True
         self.async_write_ha_state()
+
+    async def async_get_schedules_service(self) -> ServiceResponse:
+        """Return all schedules configured on the device."""
+        response = cast(
+            SwitcherGetSchedulesResponse,
+            await self._async_call_api("get_schedules"),
+        )
+        return {
+            "schedules": [
+                {
+                    "schedule_id": s.schedule_id,
+                    "recurring": s.recurring,
+                    "days": [d.name.lower() for d in s.days],
+                    "start_time": s.start_time,
+                    "end_time": s.end_time,
+                    "duration": s.duration,
+                }
+                for s in response.schedules
+            ]
+        }
+
+    async def async_create_schedule_service(
+        self, start_time: time, end_time: time, days: list[str]
+    ) -> None:
+        """Create a new schedule on the device."""
+        if end_time <= start_time:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="schedule_end_time_not_after_start_time",
+            )
+        await self._async_call_api(
+            "create_schedule",
+            start_time.strftime("%H:%M"),
+            end_time.strftime("%H:%M"),
+            {DAYS_MAPPING[d] for d in days},
+        )
+
+    async def async_delete_schedule_service(self, schedule_id: str) -> None:
+        """Delete a schedule from the device by its ID."""
+        await self._async_call_api("delete_schedule", schedule_id)
 
 
 class SwitcherShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -45,6 +45,7 @@ from .const import (
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
     SIGNAL_DEVICE_ADD,
+    SwitcherEntityFeature,
 )
 from .coordinator import SwitcherDataUpdateCoordinator
 from .entity import SwitcherEntity
@@ -117,7 +118,7 @@ async def async_setup_entry(
         SERVICE_GET_SCHEDULES_NAME,
         {},
         "async_get_schedules_service",
-        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+        required_features=[SwitcherEntityFeature.SCHEDULES],
         supports_response=SupportsResponse.ONLY,
     )
 
@@ -125,14 +126,14 @@ async def async_setup_entry(
         SERVICE_CREATE_SCHEDULE_NAME,
         SERVICE_CREATE_SCHEDULE_SCHEMA,
         "async_create_schedule_service",
-        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+        required_features=[SwitcherEntityFeature.SCHEDULES],
     )
 
     platform.async_register_entity_service(
         SERVICE_DELETE_SCHEDULE_NAME,
         SERVICE_DELETE_SCHEDULE_SCHEMA,
         "async_delete_schedule_service",
-        entity_device_classes=(SwitchDeviceClass.SWITCH,),
+        required_features=[SwitcherEntityFeature.SCHEDULES],
     )
 
     @callback
@@ -213,6 +214,12 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
     """Representation of a Switcher heater switch entity."""
 
     _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(self, coordinator: SwitcherDataUpdateCoordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        if coordinator.data.device_type.category == DeviceCategory.WATER_HEATER:
+            self._attr_supported_features = SwitcherEntityFeature.SCHEDULES
 
     async def async_set_auto_off_service(self, auto_off: timedelta) -> None:
         """Use for handling setting device auto-off service calls."""

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -54,6 +54,9 @@ PARALLEL_UPDATES = 1
 API_CONTROL_DEVICE = "control_device"
 API_SET_AUTO_SHUTDOWN = "set_auto_shutdown"
 API_SET_CHILD_LOCK = "set_shutter_child_lock"
+API_GET_SCHEDULES = "get_schedules"
+API_CREATE_SCHEDULE = "create_schedule"
+API_DELETE_SCHEDULE = "delete_schedule"
 
 SERVICE_SET_AUTO_OFF_SCHEMA: VolDictType = {
     vol.Required(CONF_AUTO_OFF): cv.time_period_str,
@@ -226,7 +229,7 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
         """Return all schedules configured on the device."""
         response = cast(
             SwitcherGetSchedulesResponse,
-            await self._async_call_api("get_schedules"),
+            await self._async_call_api(API_GET_SCHEDULES),
         )
         return {
             "schedules": [
@@ -254,7 +257,7 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
                 translation_key="schedule_end_time_not_after_start_time",
             )
         await self._async_call_api(
-            "create_schedule",
+            API_CREATE_SCHEDULE,
             start_time.strftime("%H:%M"),
             end_time.strftime("%H:%M"),
             {DAYS_MAPPING[d] for d in days},
@@ -262,7 +265,7 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
 
     async def async_delete_schedule_service(self, schedule_id: str) -> None:
         """Delete a schedule from the device by its ID."""
-        await self._async_call_api("delete_schedule", schedule_id)
+        await self._async_call_api(API_DELETE_SCHEDULE, schedule_id)
 
 
 class SwitcherShutterChildLockBaseSwitchEntity(SwitcherEntity, SwitchEntity):

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -233,12 +233,12 @@ class SwitcherHeaterSwitchEntity(SwitcherBaseSwitchEntity):
                 {
                     "schedule_id": s.schedule_id,
                     "recurring": s.recurring,
-                    "days": [d.name.lower() for d in s.days],
+                    "days": [d.name.lower() for d in sorted(s.days, key=lambda d: d.name)],
                     "start_time": s.start_time,
                     "end_time": s.end_time,
                     "duration": s.duration,
                 }
-                for s in response.schedules
+                for s in sorted(response.schedules, key=lambda s: s.schedule_id)
             ]
         }
 

--- a/tests/components/switcher_kis/snapshots/test_services.ambr
+++ b/tests/components/switcher_kis/snapshots/test_services.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: test_get_schedules_service[mock_bridge0]
+  dict({
+    'switch.waterheater_fe12': dict({
+      'schedules': list([
+        dict({
+          'days': list([
+            'friday',
+            'monday',
+          ]),
+          'duration': '0:30:00',
+          'end_time': '07:30',
+          'recurring': True,
+          'schedule_id': '0',
+          'start_time': '07:00',
+        }),
+      ]),
+    }),
+  })
+# ---

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -1,22 +1,35 @@
 """Test the services for the Switcher integration."""
 
-from unittest.mock import patch
+from datetime import time
+from unittest.mock import MagicMock, patch
 
 from aioswitcher.api import Command
 from aioswitcher.device import DeviceState
+from aioswitcher.schedule import Days
 import pytest
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switcher_kis.const import (
     CONF_AUTO_OFF,
+    CONF_SCHEDULE_DAYS,
+    CONF_SCHEDULE_END_TIME,
+    CONF_SCHEDULE_ID,
+    CONF_SCHEDULE_START_TIME,
     CONF_TIMER_MINUTES,
     DOMAIN,
+    SERVICE_CREATE_SCHEDULE_NAME,
+    SERVICE_DELETE_SCHEDULE_NAME,
+    SERVICE_GET_SCHEDULES_NAME,
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceNotSupported
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotSupported,
+    ServiceValidationError,
+)
 from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.util import slugify
 
@@ -259,3 +272,301 @@ async def test_plug_unsupported_services(
         )
 
     assert mock_api.call_count == 0
+
+    # Get schedules
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SCHEDULES_NAME,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert mock_api.call_count == 0
+
+    # Create schedule
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 0),
+                CONF_SCHEDULE_END_TIME: time(7, 30),
+            },
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 0
+
+    # Delete schedule
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SCHEDULE_NAME,
+            {ATTR_ENTITY_ID: entity_id, CONF_SCHEDULE_ID: "0"},
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 0
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_get_schedules_service(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test the get schedules service."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    dummy_schedule = MagicMock()
+    dummy_schedule.schedule_id = "0"
+    dummy_schedule.recurring = True
+    dummy_schedule.days = {Days.MONDAY, Days.FRIDAY}
+    dummy_schedule.start_time = "07:00"
+    dummy_schedule.end_time = "07:30"
+    dummy_schedule.duration = "0:30:00"
+
+    mock_response = MagicMock()
+    mock_response.successful = True
+    mock_response.schedules = {dummy_schedule}
+
+    with patch(
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.get_schedules",
+        return_value=mock_response,
+    ) as mock_get_schedules:
+        result = await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SCHEDULES_NAME,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )
+
+        assert mock_api.call_count == 2
+        mock_get_schedules.assert_called_once_with()
+
+    assert result is not None
+    entity_result = result[entity_id]
+    assert len(entity_result["schedules"]) == 1
+    schedule = entity_result["schedules"][0]
+    assert schedule["schedule_id"] == "0"
+    assert schedule["recurring"] is True
+    assert set(schedule["days"]) == {"monday", "friday"}
+    assert schedule["start_time"] == "07:00"
+    assert schedule["end_time"] == "07:30"
+    assert schedule["duration"] == "0:30:00"
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_get_schedules_service_fail(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test the get schedules service when API call fails."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with (
+        patch(
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.get_schedules",
+            return_value=None,
+        ) as mock_get_schedules,
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SCHEDULES_NAME,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )
+
+    assert mock_api.call_count == 2
+    mock_get_schedules.assert_called_once_with()
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_create_schedule_service(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test the create schedule service (one-time schedule)."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with patch(
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.create_schedule"
+    ) as mock_create_schedule:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 0),
+                CONF_SCHEDULE_END_TIME: time(7, 30),
+            },
+            blocking=True,
+        )
+
+        assert mock_api.call_count == 2
+        mock_create_schedule.assert_called_once_with("07:00", "07:30", set())
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_create_schedule_service_recurring(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test the create schedule service with recurring days."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with patch(
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.create_schedule"
+    ) as mock_create_schedule:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 0),
+                CONF_SCHEDULE_END_TIME: time(7, 30),
+                CONF_SCHEDULE_DAYS: ["monday", "friday"],
+            },
+            blocking=True,
+        )
+
+        assert mock_api.call_count == 2
+        mock_create_schedule.assert_called_once_with(
+            "07:00", "07:30", {Days.MONDAY, Days.FRIDAY}
+        )
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_create_schedule_service_end_before_start(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test create schedule raises ServiceValidationError when end_time <= start_time."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 30),
+                CONF_SCHEDULE_END_TIME: time(7, 0),
+            },
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 0
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_create_schedule_service_fail(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test create schedule service when API call fails."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with (
+        patch(
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.create_schedule",
+            return_value=None,
+        ) as mock_create_schedule,
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 0),
+                CONF_SCHEDULE_END_TIME: time(7, 30),
+            },
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 2
+    mock_create_schedule.assert_called_once_with("07:00", "07:30", set())
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_delete_schedule_service(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test the delete schedule service."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with patch(
+        "homeassistant.components.switcher_kis.entity.SwitcherApi.delete_schedule"
+    ) as mock_delete_schedule:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SCHEDULE_NAME,
+            {ATTR_ENTITY_ID: entity_id, CONF_SCHEDULE_ID: "0"},
+            blocking=True,
+        )
+
+        assert mock_api.call_count == 2
+        mock_delete_schedule.assert_called_once_with("0")
+
+
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
+async def test_delete_schedule_service_fail(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test delete schedule service when API call fails."""
+    await init_integration(hass)
+    assert mock_bridge
+
+    device = DUMMY_WATER_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with (
+        patch(
+            "homeassistant.components.switcher_kis.entity.SwitcherApi.delete_schedule",
+            return_value=None,
+        ) as mock_delete_schedule,
+        pytest.raises(HomeAssistantError),
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SCHEDULE_NAME,
+            {ATTR_ENTITY_ID: entity_id, CONF_SCHEDULE_ID: "0"},
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 2
+    mock_delete_schedule.assert_called_once_with("0")
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -7,6 +7,7 @@ from aioswitcher.api import Command
 from aioswitcher.device import DeviceState
 from aioswitcher.schedule import Days
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switcher_kis.const import (
@@ -314,7 +315,10 @@ async def test_plug_unsupported_services(
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
 async def test_get_schedules_service(
-    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+    hass: HomeAssistant,
+    mock_bridge: MagicMock,
+    mock_api: MagicMock,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the get schedules service."""
     await init_integration(hass)
@@ -350,16 +354,7 @@ async def test_get_schedules_service(
         assert mock_api.call_count == 2
         mock_get_schedules.assert_called_once_with()
 
-    assert result is not None
-    entity_result = result[entity_id]
-    assert len(entity_result["schedules"]) == 1
-    schedule = entity_result["schedules"][0]
-    assert schedule["schedule_id"] == "0"
-    assert schedule["recurring"] is True
-    assert set(schedule["days"]) == {"monday", "friday"}
-    assert schedule["start_time"] == "07:00"
-    assert schedule["end_time"] == "07:30"
-    assert schedule["duration"] == "0:30:00"
+    assert result == snapshot
 
 
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -541,6 +541,49 @@ async def test_delete_schedule_service(
         mock_delete_schedule.assert_called_once_with("0")
 
 
+@pytest.mark.parametrize("mock_bridge", [[DUMMY_HEATER_DEVICE]], indirect=True)
+async def test_heater_unsupported_schedule_services(
+    hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock
+) -> None:
+    """Test that schedule services are not supported on Switcher Heater devices (DeviceCategory.HEATER), only on water heater boiler devices (DeviceCategory.WATER_HEATER)."""
+    await init_integration(hass, USERNAME, TOKEN)
+    assert mock_bridge
+
+    device = DUMMY_HEATER_DEVICE
+    entity_id = f"{SWITCH_DOMAIN}.{slugify(device.name)}"
+
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_GET_SCHEDULES_NAME,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            return_response=True,
+        )
+
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE_SCHEDULE_NAME,
+            {
+                ATTR_ENTITY_ID: entity_id,
+                CONF_SCHEDULE_START_TIME: time(7, 0),
+                CONF_SCHEDULE_END_TIME: time(7, 30),
+            },
+            blocking=True,
+        )
+
+    with pytest.raises(ServiceNotSupported):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE_SCHEDULE_NAME,
+            {ATTR_ENTITY_ID: entity_id, CONF_SCHEDULE_ID: "0"},
+            blocking=True,
+        )
+
+    assert mock_api.call_count == 0
+
+
 @pytest.mark.parametrize("mock_bridge", [[DUMMY_WATER_HEATER_DEVICE]], indirect=True)
 async def test_delete_schedule_service_fail(
     hass: HomeAssistant, mock_bridge: MagicMock, mock_api: MagicMock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds three new entity services for Switcher water heater switch entities (Switcher Touch, V2, V4, Mini):

- `switcher_kis.get_schedules` — retrieves all schedules configured on the device, returned as service response data
- `switcher_kis.create_schedule` — creates a one-time or recurring schedule; raises `ServiceValidationError` if `end_time` is not after `start_time`
- `switcher_kis.delete_schedule` — removes a schedule by slot ID (0–7)

`_async_call_api` (in `entity.py`) now returns `SwitcherBaseResponse` so response data can be consumed by callers; existing callers are unaffected.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44275
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr