### PR TITLE
Add support for Wearable device status for xiaomi-ble

### DIFF
--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -73,6 +73,12 @@ BINARY_SENSOR_DESCRIPTIONS = {
         key=ExtendedBinarySensorDeviceClass.ARMED,
         icon="mdi:shield-check",
     ),
+    ExtendedBinarySensorDeviceClass.ASLEEP: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.ASLEEP,
+        icon="mdi:sleep",
+        name="Asleep",
+        translation_key="asleep",
+    ),
     ExtendedBinarySensorDeviceClass.CHILDLOCK: BinarySensorEntityDescription(
         key=ExtendedBinarySensorDeviceClass.CHILDLOCK,
     ),
@@ -101,6 +107,12 @@ BINARY_SENSOR_DESCRIPTIONS = {
     ),
     ExtendedBinarySensorDeviceClass.TOOTHBRUSH: BinarySensorEntityDescription(
         key=ExtendedBinarySensorDeviceClass.TOOTHBRUSH,
+    ),
+    ExtendedBinarySensorDeviceClass.WEARING: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.WEARING,
+        icon="mdi:watch-variant",
+        name="Wearing",
+        translation_key="wearing",
     ),
 }
 

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -48,6 +48,14 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Charging state for Wearable device
+    (ExtendedSensorDeviceClass.CHARGING_STATE, None): SensorEntityDescription(
+        key=str(ExtendedSensorDeviceClass.CHARGING_STATE),
+        device_class=SensorDeviceClass.ENUM,
+        icon="mdi:battery-charging",
+        options=["Charging", "Not Charging", "Full", "Unknown"],
+        name="Charging State",
+    ),
     (DeviceClass.CONDUCTIVITY, Units.CONDUCTIVITY): SensorEntityDescription(
         key=str(Units.CONDUCTIVITY),
         device_class=SensorDeviceClass.CONDUCTIVITY,

--- a/homeassistant/components/xiaomi_ble/strings.json
+++ b/homeassistant/components/xiaomi_ble/strings.json
@@ -121,6 +121,20 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "asleep": {
+        "state": {
+          "off": "Awake",
+          "on": "Asleep"
+        }
+      },
+      "wearing": {
+        "state": {
+          "off": "Not Wearing",
+          "on": "Wearing"
+        }
+      }
+    },
     "event": {
       "button": {
         "state_attributes": {

--- a/tests/components/xiaomi_ble/test_binary_sensor.py
+++ b/tests/components/xiaomi_ble/test_binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.components.xiaomi_ble.const import CONF_SLEEPY_DEVICE, DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -463,5 +464,66 @@ async def test_sleepy_device_restore_state(hass: HomeAssistant) -> None:
 
     # Sleepy devices should keep their state over time and restore it
     assert opening_sensor.state == STATE_ON
+
+    assert entry.data[CONF_SLEEPY_DEVICE] is True
+
+
+async def test_xiaomi_m2456b1(hass: HomeAssistant) -> None:
+    """Test Xiaomi M2456B1 multiple advertisements.
+
+    This device has multiple advertisements before all sensors are visible.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="04:34:C3:75:6F:6D",
+        data={"bindkey": "05eecf799ee981b3b73664e114b9373b"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "04:34:C3:75:6F:6D",
+            b"\x48\x59\xfc\x59\xda\x28\xbc\x61\xb4\x02\x00\x00\xd9\x35\xd0\x01",
+        ),
+    )
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "04:34:C3:75:6F:6D",
+            b"\x48\x59\xfc\x59\xbf\x1c\x9f\xd5\x9b\x02\x00\x00\x08\x4a\x47\x40",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 2
+
+    sleep_state = hass.states.get(
+        "binary_sensor.smart_band_10_ceramic_edition_6f6d_asleep"
+    )
+    sleep_state_attr = sleep_state.attributes
+    assert sleep_state.state == STATE_OFF
+    assert (
+        sleep_state_attr[ATTR_FRIENDLY_NAME]
+        == "Smart Band 10 Ceramic Edition 6F6D Asleep"
+    )
+    assert sleep_state_attr[ATTR_ICON] == "mdi:sleep"
+
+    wearing_status = hass.states.get(
+        "binary_sensor.smart_band_10_ceramic_edition_6f6d_wearing"
+    )
+    wearing_status_attr = wearing_status.attributes
+    assert wearing_status.state == STATE_OFF
+    assert (
+        wearing_status_attr[ATTR_FRIENDLY_NAME]
+        == "Smart Band 10 Ceramic Edition 6F6D Wearing"
+    )
+    assert wearing_status_attr[ATTR_ICON] == "mdi:watch-variant"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert entry.data[CONF_SLEEPY_DEVICE] is True

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.xiaomi_ble.const import CONF_SLEEPY_DEVICE, DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
     ATTR_UNIT_OF_MEASUREMENT,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -936,5 +937,45 @@ async def test_sleepy_device_restore_state(hass: HomeAssistant) -> None:
 
     # Sleepy devices should keep their state over time and restore it
     assert mass_non_stabilized_sensor.state == "86.55"
+
+    assert entry.data[CONF_SLEEPY_DEVICE] is True
+
+
+async def test_xiaomi_m2456b1(hass: HomeAssistant) -> None:
+    """Test Xiaomi M2456B1 Charging State."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="04:34:C3:75:6F:6D",
+        data={"bindkey": "05eecf799ee981b3b73664e114b9373b"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+    inject_bluetooth_service_info_bleak(
+        hass,
+        make_advertisement(
+            "04:34:C3:75:6F:6D",
+            b"\x48\x59\xfc\x59\xc3\x27\x05\xff\x45\x02\x00\x00\xd6\xd2\x91\xb3",
+        ),
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 1
+
+    charging_state = hass.states.get(
+        "sensor.smart_band_10_ceramic_edition_6f6d_charging_state"
+    )
+    charging_state_attr = charging_state.attributes
+    assert charging_state.state == "Full"
+    assert (
+        charging_state_attr[ATTR_FRIENDLY_NAME]
+        == "Smart Band 10 Ceramic Edition 6F6D Charging State"
+    )
+    assert charging_state_attr[ATTR_ICON] == "mdi:battery-charging"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert entry.data[CONF_SLEEPY_DEVICE] is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds three `SENSOR_DESCRIPTIONS` for Xiaomi wearable devices, which are required for the Xiaomi MiBand 10.

- `CHARGING_STATE` - Sensor: Not charging, Charging, Full and Unknown
- `ASLEEP` -  Binary sensor: On means Asleep, Off  means Awake
- `WEARING` -  Binary sensor: On means Wearing, Off means Not Wearing,

Depedency bump will be done in a separate PR: #167384

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/Bluetooth-Devices/xiaomi-ble/pull/279
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
