### PR TITLE
Migrate Tuya cover to TuyaCoverDefinition

### DIFF
--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
+from tuya_device_handlers.definition.cover import (
+    TuyaCoverDefinition,
+    get_default_definition,
+)
 from tuya_device_handlers.device_wrapper.cover import (
     ControlBackModePercentageMappingWrapper,
     CoverClosedEnumWrapper,
-    CoverInstructionBooleanWrapper,
     CoverInstructionEnumWrapper,
     CoverInstructionSpecialEnumWrapper,
 )
@@ -153,21 +155,6 @@ COVERS: dict[DeviceCategory, tuple[TuyaCoverEntityDescription, ...]] = {
 }
 
 
-def _get_instruction_wrapper(
-    device: CustomerDevice, description: TuyaCoverEntityDescription
-) -> DeviceWrapper | None:
-    """Get the instruction wrapper for the cover entity."""
-    if enum_wrapper := description.instruction_wrapper.find_dpcode(
-        device, description.key, prefer_function=True
-    ):
-        return enum_wrapper
-
-    # Fallback to a boolean wrapper if available
-    return CoverInstructionBooleanWrapper.find_dpcode(
-        device, description.key, prefer_function=True
-    )
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: TuyaConfigEntry,
@@ -184,32 +171,19 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := COVERS.get(device.category):
                 entities.extend(
-                    TuyaCoverEntity(
-                        device,
-                        manager,
-                        description,
-                        current_position=description.position_wrapper.find_dpcode(
-                            device, description.current_position
-                        ),
-                        current_state_wrapper=description.current_state_wrapper.find_dpcode(
-                            device, description.current_state
-                        ),
-                        instruction_wrapper=_get_instruction_wrapper(
-                            device, description
-                        ),
-                        set_position=description.position_wrapper.find_dpcode(
-                            device, description.set_position, prefer_function=True
-                        ),
-                        tilt_position=description.position_wrapper.find_dpcode(
-                            device,
-                            (DPCode.ANGLE_HORIZONTAL, DPCode.ANGLE_VERTICAL),
-                            prefer_function=True,
-                        ),
-                    )
+                    TuyaCoverEntity(device, manager, description, definition)
                     for description in descriptions
                     if (
-                        description.key in device.function
-                        or description.key in device.status_range
+                        definition := get_default_definition(
+                            device,
+                            current_position_dpcode=description.current_position,
+                            current_state_dpcode=description.current_state,
+                            current_state_wrapper=description.current_state_wrapper,
+                            instruction_dpcode=description.key,
+                            instruction_wrapper=description.instruction_wrapper,
+                            position_wrapper=description.position_wrapper,
+                            set_position_dpcode=description.set_position,
+                        )
                     )
                 )
 
@@ -232,34 +206,31 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: TuyaCoverEntityDescription,
-        *,
-        current_position: DeviceWrapper[int] | None,
-        current_state_wrapper: DeviceWrapper[bool] | None,
-        instruction_wrapper: DeviceWrapper[TuyaCoverAction] | None,
-        set_position: DeviceWrapper[int] | None,
-        tilt_position: DeviceWrapper[int] | None,
+        definition: TuyaCoverDefinition,
     ) -> None:
         """Init Tuya Cover."""
         super().__init__(device, device_manager, description)
         self._attr_supported_features = CoverEntityFeature(0)
 
-        self._current_position = current_position or set_position
-        self._current_state_wrapper = current_state_wrapper
-        self._instruction_wrapper = instruction_wrapper
-        self._set_position = set_position
-        self._tilt_position = tilt_position
+        self._current_position = (
+            definition.current_position_wrapper or definition.set_position_wrapper
+        )
+        self._current_state_wrapper = definition.current_state_wrapper
+        self._instruction_wrapper = definition.instruction_wrapper
+        self._set_position = definition.set_position_wrapper
+        self._tilt_position = definition.tilt_position_wrapper
 
-        if instruction_wrapper:
-            if TuyaCoverAction.OPEN in instruction_wrapper.options:
+        if definition.instruction_wrapper:
+            if TuyaCoverAction.OPEN in definition.instruction_wrapper.options:
                 self._attr_supported_features |= CoverEntityFeature.OPEN
-            if TuyaCoverAction.CLOSE in instruction_wrapper.options:
+            if TuyaCoverAction.CLOSE in definition.instruction_wrapper.options:
                 self._attr_supported_features |= CoverEntityFeature.CLOSE
-            if TuyaCoverAction.STOP in instruction_wrapper.options:
+            if TuyaCoverAction.STOP in definition.instruction_wrapper.options:
                 self._attr_supported_features |= CoverEntityFeature.STOP
 
-        if set_position:
+        if definition.set_position_wrapper:
             self._attr_supported_features |= CoverEntityFeature.SET_POSITION
-        if tilt_position:
+        if definition.tilt_position_wrapper:
             self._attr_supported_features |= CoverEntityFeature.SET_TILT_POSITION
 
     @property


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #166323:
- use library to create `TuyaCoverDefinition`
- pass `TuyaCoverDefinition` to entity construction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
