### PR TITLE
Migrate Tuya alarm to TuyaAlarmDefinition

### DIFF
--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -26,18 +26,14 @@ from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
 
-ALARM: dict[DeviceCategory, tuple[AlarmControlPanelEntityDescription, ...]] = {
-    DeviceCategory.MAL: (
-        AlarmControlPanelEntityDescription(
-            key=DPCode.MASTER_MODE,
-            name="Alarm",
-        ),
+ALARM: dict[DeviceCategory, AlarmControlPanelEntityDescription] = {
+    DeviceCategory.MAL: AlarmControlPanelEntityDescription(
+        key=DPCode.MASTER_MODE,
+        name="Alarm",
     ),
-    DeviceCategory.WG2: (
-        AlarmControlPanelEntityDescription(
-            key=DPCode.MASTER_MODE,
-            name="Alarm",
-        ),
+    DeviceCategory.WG2: AlarmControlPanelEntityDescription(
+        key=DPCode.MASTER_MODE,
+        name="Alarm",
     ),
 }
 
@@ -69,11 +65,11 @@ async def async_setup_entry(
         entities: list[TuyaAlarmEntity] = []
         for device_id in device_ids:
             device = manager.device_map[device_id]
-            if descriptions := ALARM.get(device.category):
-                entities.extend(
+            if (description := ALARM.get(device.category)) and (
+                definition := get_default_definition(device)
+            ):
+                entities.append(
                     TuyaAlarmEntity(device, manager, description, definition)
-                    for description in descriptions
-                    if (definition := get_default_definition(device))
                 )
         async_add_entities(entities)
 

--- a/homeassistant/components/tuya/alarm_control_panel.py
+++ b/homeassistant/components/tuya/alarm_control_panel.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers.device_wrapper.alarm_control_panel import (
-    AlarmActionWrapper,
-    AlarmChangedByWrapper,
-    AlarmStateWrapper,
+from tuya_device_handlers.definition.alarm_control_panel import (
+    TuyaAlarmControlPanelDefinition,
+    get_default_definition,
 )
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
 from tuya_device_handlers.helpers.homeassistant import (
     TuyaAlarmControlPanelAction,
     TuyaAlarmControlPanelState,
 )
-from tuya_device_handlers.type_information import EnumTypeInformation
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.alarm_control_panel import (
@@ -74,26 +71,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := ALARM.get(device.category):
                 entities.extend(
-                    TuyaAlarmEntity(
-                        device,
-                        manager,
-                        description,
-                        action_wrapper=AlarmActionWrapper(
-                            master_mode.dpcode, master_mode
-                        ),
-                        changed_by_wrapper=AlarmChangedByWrapper.find_dpcode(
-                            device, DPCode.ALARM_MSG
-                        ),
-                        state_wrapper=AlarmStateWrapper(
-                            master_mode.dpcode, master_mode
-                        ),
-                    )
+                    TuyaAlarmEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        master_mode := EnumTypeInformation.find_dpcode(
-                            device, DPCode.MASTER_MODE, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device))
                 )
         async_add_entities(entities)
 
@@ -115,23 +95,20 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: AlarmControlPanelEntityDescription,
-        *,
-        action_wrapper: DeviceWrapper[TuyaAlarmControlPanelAction],
-        changed_by_wrapper: DeviceWrapper[str] | None,
-        state_wrapper: DeviceWrapper[TuyaAlarmControlPanelState],
+        definition: TuyaAlarmControlPanelDefinition,
     ) -> None:
         """Init Tuya Alarm."""
         super().__init__(device, device_manager, description)
-        self._action_wrapper = action_wrapper
-        self._changed_by_wrapper = changed_by_wrapper
-        self._state_wrapper = state_wrapper
+        self._action_wrapper = definition.action_wrapper
+        self._changed_by_wrapper = definition.changed_by_wrapper
+        self._state_wrapper = definition.state_wrapper
 
         # Determine supported modes
-        if TuyaAlarmControlPanelAction.ARM_HOME in action_wrapper.options:
+        if TuyaAlarmControlPanelAction.ARM_HOME in definition.action_wrapper.options:
             self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_HOME
-        if TuyaAlarmControlPanelAction.ARM_AWAY in action_wrapper.options:
+        if TuyaAlarmControlPanelAction.ARM_AWAY in definition.action_wrapper.options:
             self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
-        if TuyaAlarmControlPanelAction.TRIGGER in action_wrapper.options:
+        if TuyaAlarmControlPanelAction.TRIGGER in definition.action_wrapper.options:
             self._attr_supported_features |= AlarmControlPanelEntityFeature.TRIGGER
 
     @property


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #166323:
- use library to create `TuyaAlarmControlPanelDefinition`
- pass `TuyaAlarmControlPanelDefinition` to entity construction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
