### PR TITLE
Add context support for conditions.yaml

### DIFF
--- a/script/hassfest/conditions.py
+++ b/script/hassfest/conditions.py
@@ -26,21 +26,95 @@ def exists(value: Any) -> Any:
     return value
 
 
+def validate_field_schema(condition_schema: dict[str, Any]) -> dict[str, Any]:
+    """Validate a field schema including context references."""
+
+    for field_name, field_schema in condition_schema.get("fields", {}).items():
+        # Validate context if present
+        if "context" in field_schema:
+            if CONF_SELECTOR not in field_schema:
+                raise vol.Invalid(
+                    f"Context defined without a selector in '{field_name}'"
+                )
+
+            context = field_schema["context"]
+            if not isinstance(context, dict):
+                raise vol.Invalid(f"Context must be a dictionary in '{field_name}'")
+
+            # Determine which selector type is being used
+            selector_config = field_schema[CONF_SELECTOR]
+            selector_class = selector.selector(selector_config)
+
+            for context_key, field_ref in context.items():
+                # Check if context key is allowed for this selector type
+                allowed_keys = selector_class.allowed_context_keys
+                if context_key not in allowed_keys:
+                    raise vol.Invalid(
+                        f"Invalid context key '{context_key}' for selector type '{selector_class.selector_type}'. "
+                        f"Allowed keys: {', '.join(sorted(allowed_keys)) if allowed_keys else 'none'}"
+                    )
+
+                # Check if the referenced field exists in condition schema or target
+                if not isinstance(field_ref, str):
+                    raise vol.Invalid(
+                        f"Context value for '{context_key}' must be a string field reference"
+                    )
+
+                # Check if field exists in condition schema fields or target
+                condition_fields = condition_schema["fields"]
+                field_exists = field_ref in condition_fields
+                if field_exists and "selector" in condition_fields[field_ref]:
+                    # Check if the selector type is allowed for this context key
+                    field_selector_config = condition_fields[field_ref][CONF_SELECTOR]
+                    field_selector_class = selector.selector(field_selector_config)
+                    if field_selector_class.selector_type not in allowed_keys.get(
+                        context_key, set()
+                    ):
+                        raise vol.Invalid(
+                            f"The context '{context_key}' for '{field_name}' references '{field_ref}', but '{context_key}' "
+                            f"does not allow selectors of type '{field_selector_class.selector_type}'. Allowed selector types: {', '.join(allowed_keys.get(context_key, set()))}"
+                        )
+                if not field_exists and "target" in condition_schema:
+                    # Target is a special field that always exists when defined
+                    field_exists = field_ref == "target"
+                    if field_exists and "target" not in allowed_keys.get(
+                        context_key, set()
+                    ):
+                        raise vol.Invalid(
+                            f"The context '{context_key}' for '{field_name}' references 'target', but '{context_key}' "
+                            f"does not allow 'target'. Allowed selector types: {', '.join(allowed_keys.get(context_key, set()))}"
+                        )
+
+                if not field_exists:
+                    raise vol.Invalid(
+                        f"Context reference '{field_ref}' for key '{context_key}' does not exist "
+                        f"in condition schema fields or target"
+                    )
+
+    return condition_schema
+
+
 FIELD_SCHEMA = vol.Schema(
     {
         vol.Optional("example"): exists,
         vol.Optional("default"): exists,
         vol.Optional("required"): bool,
         vol.Optional(CONF_SELECTOR): selector.validate_selector,
+        vol.Optional("context"): {
+            str: str  # key is context key, value is field name in the schema which value should be used
+        },  # Will be validated in validate_field_schema
     }
 )
 
 CONDITION_SCHEMA = vol.Any(
-    vol.Schema(
-        {
-            vol.Optional("target"): selector.TargetSelector.CONFIG_SCHEMA,
-            vol.Optional("fields"): vol.Schema({str: FIELD_SCHEMA}),
-        }
+    vol.All(
+        vol.Schema(
+            {
+                vol.Optional("target"): selector.TargetSelector.CONFIG_SCHEMA,
+                vol.Optional("fields"): vol.Schema({str: FIELD_SCHEMA}),
+            }
+        ),
+        validate_field_schema,
     ),
     None,
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support to add a context for some selectors, you specify a specific field, which value will be used as a param for another field, example:

```yaml
turned_on:
  target:
    entity:
      domain: sensor
  fields:
    state:
      selector:
        state:
      context:
        filter_target: target
```

This is the same change as in https://github.com/home-assistant/core/pull/156531, but for conditions

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
