### PR TITLE
Don't return remote/cloudhook URLs while registering a local user

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -124,9 +124,8 @@ async def _async_setup_cloudhook(
             hass.config_entries.async_update_entry(entry, data=data)
 
     if local_only:
-        if CONF_CLOUDHOOK_URL in entry.data:
-            # Local-only user should not have a cloudhook
-            clean_cloudhook()
+        # Local-only user should not have a cloudhook
+        clean_cloudhook()
         return
 
     def on_cloudhook_change(cloudhook: dict[str, Any] | None) -> None:

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -125,6 +125,9 @@ async def _async_setup_cloudhook(
 
     if local_only:
         # Local-only user should not have a cloudhook
+        if cloud.async_is_logged_in(hass) and CONF_CLOUDHOOK_URL in entry.data:
+            with suppress(cloud.CloudNotAvailable, ValueError):
+                await cloud.async_delete_cloudhook(hass, webhook_id)
         clean_cloudhook()
         return
 

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -49,7 +49,7 @@ from .const import (
     STORAGE_KEY,
     STORAGE_VERSION,
 )
-from .helpers import savable_state
+from .helpers import async_is_local_only_user, savable_state
 from .http_api import RegistrationsView
 from .timers import async_handle_timer_event
 from .util import async_create_cloud_hook, supports_push
@@ -107,29 +107,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up a mobile_app entry."""
-    registration = entry.data
-
-    webhook_id = registration[CONF_WEBHOOK_ID]
-
-    hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id] = entry
-
-    device_registry = dr.async_get(hass)
-
-    device = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, registration[ATTR_DEVICE_ID])},
-        manufacturer=registration[ATTR_MANUFACTURER],
-        model=registration[ATTR_MODEL],
-        name=registration[ATTR_DEVICE_NAME],
-        sw_version=registration[ATTR_OS_VERSION],
-    )
-
-    hass.data[DOMAIN][DATA_DEVICES][webhook_id] = device
-
-    registration_name = f"Mobile App: {registration[ATTR_DEVICE_NAME]}"
-    webhook_register(hass, DOMAIN, registration_name, webhook_id, handle_webhook)
+async def _async_setup_cloudhook(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    user_id: str,
+    webhook_id: str,
+) -> None:
+    """Set up cloudhook forwarding for a mobile_app entry."""
+    local_only = await async_is_local_only_user(hass, user_id)
 
     def clean_cloudhook() -> None:
         """Clean up cloudhook from config entry."""
@@ -137,6 +122,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             data = dict(entry.data)
             data.pop(CONF_CLOUDHOOK_URL)
             hass.config_entries.async_update_entry(entry, data=data)
+
+    if local_only:
+        if CONF_CLOUDHOOK_URL in entry.data:
+            # Local-only user should not have a cloudhook
+            clean_cloudhook()
+        return
 
     def on_cloudhook_change(cloudhook: dict[str, Any] | None) -> None:
         """Handle cloudhook changes."""
@@ -179,6 +170,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         clean_cloudhook()
 
     entry.async_on_unload(cloud.async_listen_connection_change(hass, manage_cloudhook))
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a mobile_app entry."""
+    registration = entry.data
+
+    webhook_id = registration[CONF_WEBHOOK_ID]
+
+    hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id] = entry
+
+    device_registry = dr.async_get(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, registration[ATTR_DEVICE_ID])},
+        manufacturer=registration[ATTR_MANUFACTURER],
+        model=registration[ATTR_MODEL],
+        name=registration[ATTR_DEVICE_NAME],
+        sw_version=registration[ATTR_OS_VERSION],
+    )
+
+    hass.data[DOMAIN][DATA_DEVICES][webhook_id] = device
+
+    registration_name = f"Mobile App: {registration[ATTR_DEVICE_NAME]}"
+    webhook_register(hass, DOMAIN, registration_name, webhook_id, handle_webhook)
+
+    await _async_setup_cloudhook(hass, entry, registration[CONF_USER_ID], webhook_id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/mobile_app/helpers.py
+++ b/homeassistant/components/mobile_app/helpers.py
@@ -114,6 +114,12 @@ def decrypt_payload_legacy(key: str, ciphertext: bytes) -> JsonValueType | None:
     )
 
 
+async def async_is_local_only_user(hass: HomeAssistant, user_id: str) -> bool:
+    """Return True if the user is local only."""
+    user = await hass.auth.async_get_user(user_id)
+    return user is not None and user.local_only
+
+
 def registration_context(registration: Mapping[str, Any]) -> Context:
     """Generate a context from a request."""
     return Context(user_id=registration[CONF_USER_ID])

--- a/homeassistant/components/mobile_app/helpers.py
+++ b/homeassistant/components/mobile_app/helpers.py
@@ -117,7 +117,10 @@ def decrypt_payload_legacy(key: str, ciphertext: bytes) -> JsonValueType | None:
 async def async_is_local_only_user(hass: HomeAssistant, user_id: str) -> bool:
     """Return True if the user is local only."""
     user = await hass.auth.async_get_user(user_id)
-    return user is not None and user.local_only
+    if user is None:
+        # Treat unknown/missing users as local-only to avoid exposing cloud URLs
+        return True
+    return user.local_only
 
 
 def registration_context(registration: Mapping[str, Any]) -> Context:

--- a/homeassistant/components/mobile_app/http_api.py
+++ b/homeassistant/components/mobile_app/http_api.py
@@ -68,8 +68,13 @@ class RegistrationsView(HomeAssistantView):
         hass = request.app[KEY_HASS]
 
         webhook_id = secrets.token_hex()
+        user = request["hass_user"]
 
-        if cloud.async_active_subscription(hass) and cloud.async_is_connected(hass):
+        if (
+            not user.local_only
+            and cloud.async_active_subscription(hass)
+            and cloud.async_is_connected(hass)
+        ):
             data[CONF_CLOUDHOOK_URL] = await async_create_cloud_hook(
                 hass, webhook_id, None
             )
@@ -79,7 +84,7 @@ class RegistrationsView(HomeAssistantView):
         if data[ATTR_SUPPORTS_ENCRYPTION]:
             data[CONF_SECRET] = secrets.token_hex(SecretBox.KEY_SIZE)
 
-        data[CONF_USER_ID] = request["hass_user"].id
+        data[CONF_USER_ID] = user.id
 
         # Fallback to DEVICE_ID if slug is empty.
         if not slugify(data[ATTR_DEVICE_NAME], separator=""):
@@ -92,7 +97,7 @@ class RegistrationsView(HomeAssistantView):
         )
 
         remote_ui_url = None
-        if cloud.async_active_subscription(hass):
+        if not user.local_only and cloud.async_active_subscription(hass):
             with suppress(cloud.CloudNotAvailable):
                 remote_ui_url = cloud.async_remote_ui_url(hass)
 

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -94,6 +94,7 @@ from .const import (
     CONF_CLOUDHOOK_URL,
     CONF_REMOTE_UI_URL,
     CONF_SECRET,
+    CONF_USER_ID,
     DATA_CONFIG_ENTRIES,
     DATA_DELETED_IDS,
     DATA_DEVICES,
@@ -109,6 +110,7 @@ from .const import (
     SIGNAL_SENSOR_UPDATE,
 )
 from .helpers import (
+    async_is_local_only_user,
     decrypt_payload,
     decrypt_payload_legacy,
     empty_okay_response,
@@ -756,7 +758,9 @@ async def webhook_get_config(
         "theme_color": MANIFEST_JSON["theme_color"],
     }
 
-    if cloud.async_active_subscription(hass):
+    if cloud.async_active_subscription(hass) and not await async_is_local_only_user(
+        hass, config_entry.data[CONF_USER_ID]
+    ):
         if CONF_CLOUDHOOK_URL in config_entry.data:
             resp[CONF_CLOUDHOOK_URL] = config_entry.data[CONF_CLOUDHOOK_URL]
         with suppress(cloud.CloudNotAvailable):

--- a/tests/components/mobile_app/test_http_api.py
+++ b/tests/components/mobile_app/test_http_api.py
@@ -11,6 +11,7 @@ import pytest
 
 from homeassistant.components.mobile_app.const import (
     CONF_CLOUDHOOK_URL,
+    CONF_REMOTE_UI_URL,
     CONF_SECRET,
     DOMAIN,
 )
@@ -159,6 +160,50 @@ async def test_registration_with_cloud(
     assert register_json.get(CONF_CLOUDHOOK_URL) == (
         cloudhook_url if cloud_is_connected else None
     )
+
+
+async def test_registration_with_cloud_local_only_user(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that cloudhook_url and remote_ui_url are not returned for local_only users."""
+    hass_admin_user.local_only = True
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    api_client = await hass_client()
+
+    with (
+        patch(
+            "homeassistant.components.mobile_app.http_api.cloud.async_active_subscription",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.mobile_app.http_api.cloud.async_is_connected",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.mobile_app.http_api.async_create_cloud_hook",
+            return_value="https://hooks.nabu.casa/test123",
+        ) as mock_create_cloud_hook,
+        patch(
+            "homeassistant.components.mobile_app.http_api.cloud.async_remote_ui_url",
+            return_value="https://remote.ui",
+        ),
+        patch(
+            "homeassistant.components.person.async_add_user_device_tracker",
+            spec=True,
+        ),
+    ):
+        resp = await api_client.post(
+            "/api/mobile_app/registrations", json=REGISTER_CLEARTEXT
+        )
+
+    assert resp.status == HTTPStatus.CREATED
+    register_json = await resp.json()
+    assert register_json.get(CONF_CLOUDHOOK_URL) is None
+    assert register_json.get(CONF_REMOTE_UI_URL) is None
+    mock_create_cloud_hook.assert_not_called()
 
 
 async def test_registration_encryption_legacy(

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -319,10 +319,11 @@ async def test_setup_entry_local_only_user_cleans_existing_cloudhook(
     """Test that existing cloudhook is cleaned up for local_only users during setup."""
     hass_admin_user.local_only = True
 
+    webhook_id = "test-webhook-id"
     config_entry = MockConfigEntry(
         data={
             **REGISTER_CLEARTEXT,
-            CONF_WEBHOOK_ID: "test-webhook-id",
+            CONF_WEBHOOK_ID: webhook_id,
             ATTR_DEVICE_NAME: "Test",
             ATTR_DEVICE_ID: "Test",
             CONF_USER_ID: hass_admin_user.id,
@@ -333,12 +334,20 @@ async def test_setup_entry_local_only_user_cleans_existing_cloudhook(
     )
     config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    with (
+        patch("homeassistant.components.cloud.async_is_logged_in", return_value=True),
+        patch(
+            "homeassistant.components.cloud.async_delete_cloudhook",
+        ) as delete_cloudhook,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
     assert config_entry.state is ConfigEntryState.LOADED
 
     # Existing cloudhook should be removed for local_only user
     assert CONF_CLOUDHOOK_URL not in config_entry.data
+    delete_cloudhook.assert_called_once_with(hass, webhook_id)
 
 
 async def test_remove_entry_on_user_remove(

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -272,6 +272,75 @@ async def test_delete_cloud_hook(
         assert (CONF_CLOUDHOOK_URL in config_entry.data) == should_cloudhook_exist
 
 
+async def test_setup_entry_local_only_user_no_cloudhook(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that cloudhook is not created for local_only users during setup."""
+    hass_admin_user.local_only = True
+
+    config_entry = MockConfigEntry(
+        data={
+            **REGISTER_CLEARTEXT,
+            CONF_WEBHOOK_ID: "test-webhook-id",
+            ATTR_DEVICE_NAME: "Test",
+            ATTR_DEVICE_ID: "Test",
+            CONF_USER_ID: hass_admin_user.id,
+        },
+        domain=DOMAIN,
+        title="Test",
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.cloud.async_active_subscription",
+            return_value=True,
+        ),
+        patch("homeassistant.components.cloud.async_is_logged_in", return_value=True),
+        patch("homeassistant.components.cloud.async_is_connected", return_value=True),
+        patch(
+            "homeassistant.components.cloud.async_get_or_create_cloudhook",
+        ) as mock_create_cloudhook,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        assert config_entry.state is ConfigEntryState.LOADED
+
+        # Cloudhook should not be created for local_only user
+        assert CONF_CLOUDHOOK_URL not in config_entry.data
+        mock_create_cloudhook.assert_not_called()
+
+
+async def test_setup_entry_local_only_user_cleans_existing_cloudhook(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+) -> None:
+    """Test that existing cloudhook is cleaned up for local_only users during setup."""
+    hass_admin_user.local_only = True
+
+    config_entry = MockConfigEntry(
+        data={
+            **REGISTER_CLEARTEXT,
+            CONF_WEBHOOK_ID: "test-webhook-id",
+            ATTR_DEVICE_NAME: "Test",
+            ATTR_DEVICE_ID: "Test",
+            CONF_USER_ID: hass_admin_user.id,
+            CONF_CLOUDHOOK_URL: "https://hooks.nabu.casa/stale",
+        },
+        domain=DOMAIN,
+        title="Test",
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Existing cloudhook should be removed for local_only user
+    assert CONF_CLOUDHOOK_URL not in config_entry.data
+
+
 async def test_remove_entry_on_user_remove(
     hass: HomeAssistant,
     hass_admin_user: MockUser,

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -29,7 +29,7 @@ from homeassistant.setup import async_setup_component
 
 from .const import CALL_SERVICE, FIRE_EVENT, REGISTER_CLEARTEXT, RENDER_TEMPLATE, UPDATE
 
-from tests.common import async_capture_events, async_mock_service
+from tests.common import MockUser, async_capture_events, async_mock_service
 from tests.components.conversation import MockAgent
 
 
@@ -374,6 +374,43 @@ async def test_webhook_handle_get_config_with_cloudhook_no_subscription(
         # Cloudhook should NOT be in response even though it exists in config entry
         assert "cloudhook_url" not in json_resp
         # Remote UI should also not be in response
+        assert "remote_ui_url" not in json_resp
+
+
+async def test_webhook_handle_get_config_with_cloudhook_local_only_user(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+) -> None:
+    """Test get_config doesn't return cloudhook_url or remote_ui_url for local_only users."""
+    hass_admin_user.local_only = True
+
+    webhook_id = create_registrations[1]["webhook_id"]
+    webhook_url = f"/api/webhook/{webhook_id}"
+
+    # Get the config entry and add cloudhook_url to it
+    config_entry = hass.config_entries.async_entries(DOMAIN)[1]
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={**config_entry.data, "cloudhook_url": "https://hooks.nabu.casa/test"},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.cloud.async_active_subscription",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.cloud.async_remote_ui_url",
+            return_value="https://remote.ui.url",
+        ),
+    ):
+        resp = await webhook_client.post(webhook_url, json={"type": "get_config"})
+        assert resp.status == HTTPStatus.OK
+        json_resp = await resp.json()
+
+        assert "cloudhook_url" not in json_resp
         assert "remote_ui_url" not in json_resp
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following https://github.com/home-assistant/core/pull/161891 we should not return a cloud URL or a cloudhook when the current user is a local_only user and registering a new device. Otherwise the mobile_app could use it, since they don't check this local_only state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
