### PR TITLE
Migrate Tuya vacuum to TuyaVacuumDefinition

### DIFF
--- a/homeassistant/components/tuya/vacuum.py
+++ b/homeassistant/components/tuya/vacuum.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeEnumWrapper
-from tuya_device_handlers.device_wrapper.vacuum import (
-    VacuumActionWrapper,
-    VacuumActivityWrapper,
+from tuya_device_handlers.definition.vacuum import (
+    TuyaVacuumDefinition,
+    get_default_definition,
 )
 from tuya_device_handlers.helpers.homeassistant import (
     TuyaVacuumAction,
@@ -26,7 +24,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TuyaConfigEntry
-from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
+from .const import TUYA_DISCOVERY_NEW, DeviceCategory
 from .entity import TuyaEntity
 
 _TUYA_TO_HA_ACTIVITY_MAPPINGS = {
@@ -55,15 +53,7 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if device.category == DeviceCategory.SD:
                 entities.append(
-                    TuyaVacuumEntity(
-                        device,
-                        manager,
-                        action_wrapper=VacuumActionWrapper.find_dpcode(device),
-                        activity_wrapper=VacuumActivityWrapper.find_dpcode(device),
-                        fan_speed_wrapper=DPCodeEnumWrapper.find_dpcode(
-                            device, DPCode.SUCTION, prefer_function=True
-                        ),
-                    )
+                    TuyaVacuumEntity(device, manager, get_default_definition(device))
                 )
         async_add_entities(entities)
 
@@ -83,37 +73,34 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         self,
         device: CustomerDevice,
         device_manager: Manager,
-        *,
-        action_wrapper: DeviceWrapper[TuyaVacuumAction] | None,
-        activity_wrapper: DeviceWrapper[TuyaVacuumActivity] | None,
-        fan_speed_wrapper: DeviceWrapper[str] | None,
+        definition: TuyaVacuumDefinition,
     ) -> None:
         """Init Tuya vacuum."""
         super().__init__(device, device_manager)
-        self._action_wrapper = action_wrapper
-        self._activity_wrapper = activity_wrapper
-        self._fan_speed_wrapper = fan_speed_wrapper
+        self._action_wrapper = definition.action_wrapper
+        self._activity_wrapper = definition.activity_wrapper
+        self._fan_speed_wrapper = definition.fan_speed_wrapper
 
         self._attr_fan_speed_list = []
         self._attr_supported_features = VacuumEntityFeature.SEND_COMMAND
 
-        if action_wrapper:
-            if TuyaVacuumAction.PAUSE in action_wrapper.options:
+        if definition.action_wrapper:
+            if TuyaVacuumAction.PAUSE in definition.action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.PAUSE
-            if TuyaVacuumAction.RETURN_TO_BASE in action_wrapper.options:
+            if TuyaVacuumAction.RETURN_TO_BASE in definition.action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.RETURN_HOME
-            if TuyaVacuumAction.LOCATE in action_wrapper.options:
+            if TuyaVacuumAction.LOCATE in definition.action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.LOCATE
-            if TuyaVacuumAction.START in action_wrapper.options:
+            if TuyaVacuumAction.START in definition.action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.START
-            if TuyaVacuumAction.STOP in action_wrapper.options:
+            if TuyaVacuumAction.STOP in definition.action_wrapper.options:
                 self._attr_supported_features |= VacuumEntityFeature.STOP
 
-        if activity_wrapper:
+        if definition.activity_wrapper:
             self._attr_supported_features |= VacuumEntityFeature.STATE
 
-        if fan_speed_wrapper:
-            self._attr_fan_speed_list = fan_speed_wrapper.options
+        if definition.fan_speed_wrapper:
+            self._attr_fan_speed_list = definition.fan_speed_wrapper.options
             self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
 
     @property


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #166323:
- use library to create `TuyaVacuumDefinition`
- pass `TuyaVacuumDefinition` to entity construction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
