### PR TITLE
Migrate Tuya humidifier to TuyaHumidifierDefinition

### DIFF
--- a/homeassistant/components/tuya/humidifier.py
+++ b/homeassistant/components/tuya/humidifier.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import (
-    DPCodeBooleanWrapper,
-    DPCodeEnumWrapper,
+from tuya_device_handlers.definition.humidifier import (
+    TuyaHumidifierDefinition,
+    get_default_definition,
 )
-from tuya_device_handlers.device_wrapper.extended import DPCodeRoundedIntegerWrapper
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.humidifier import (
@@ -26,7 +24,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import TuyaConfigEntry
 from .const import TUYA_DISCOVERY_NEW, DeviceCategory, DPCode
 from .entity import TuyaEntity
-from .util import ActionDPCodeNotFoundError, get_dpcode
+from .util import ActionDPCodeNotFoundError
 
 
 @dataclass(frozen=True)
@@ -38,20 +36,6 @@ class TuyaHumidifierEntityDescription(HumidifierEntityDescription):
 
     current_humidity: DPCode | None = None
     humidity: DPCode | None = None
-
-
-def _has_a_valid_dpcode(
-    device: CustomerDevice, description: TuyaHumidifierEntityDescription
-) -> bool:
-    """Check if the device has at least one valid DP code."""
-    properties_to_check: list[str | tuple[str, ...] | None] = [
-        # Main control switch
-        description.dpcode or description.key,
-        # Other humidity properties
-        description.current_humidity,
-        description.humidity,
-    ]
-    return any(get_dpcode(device, code) for code in properties_to_check)
 
 
 HUMIDIFIERS: dict[DeviceCategory, TuyaHumidifierEntityDescription] = {
@@ -86,29 +70,16 @@ async def async_setup_entry(
         entities: list[TuyaHumidifierEntity] = []
         for device_id in device_ids:
             device = manager.device_map[device_id]
-            if (
-                description := HUMIDIFIERS.get(device.category)
-            ) and _has_a_valid_dpcode(device, description):
+            if (description := HUMIDIFIERS.get(device.category)) and (
+                definition := get_default_definition(
+                    device,
+                    switch_dpcode=description.dpcode or description.key,
+                    current_humidity_dpcode=description.current_humidity,
+                    humidity_dpcode=description.humidity,
+                )
+            ):
                 entities.append(
-                    TuyaHumidifierEntity(
-                        device,
-                        manager,
-                        description,
-                        current_humidity_wrapper=DPCodeRoundedIntegerWrapper.find_dpcode(
-                            device, description.current_humidity
-                        ),
-                        mode_wrapper=DPCodeEnumWrapper.find_dpcode(
-                            device, DPCode.MODE, prefer_function=True
-                        ),
-                        switch_wrapper=DPCodeBooleanWrapper.find_dpcode(
-                            device,
-                            description.dpcode or description.key,
-                            prefer_function=True,
-                        ),
-                        target_humidity_wrapper=DPCodeRoundedIntegerWrapper.find_dpcode(
-                            device, description.humidity, prefer_function=True
-                        ),
-                    )
+                    TuyaHumidifierEntity(device, manager, description, definition)
                 )
         async_add_entities(entities)
 
@@ -130,29 +101,29 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: TuyaHumidifierEntityDescription,
-        *,
-        current_humidity_wrapper: DeviceWrapper[int] | None = None,
-        mode_wrapper: DeviceWrapper[str] | None = None,
-        switch_wrapper: DeviceWrapper[bool] | None = None,
-        target_humidity_wrapper: DeviceWrapper[int] | None = None,
+        definition: TuyaHumidifierDefinition,
     ) -> None:
         """Init Tuya (de)humidifier."""
         super().__init__(device, device_manager, description)
 
-        self._current_humidity_wrapper = current_humidity_wrapper
-        self._mode_wrapper = mode_wrapper
-        self._switch_wrapper = switch_wrapper
-        self._target_humidity_wrapper = target_humidity_wrapper
+        self._current_humidity_wrapper = definition.current_humidity_wrapper
+        self._mode_wrapper = definition.mode_wrapper
+        self._switch_wrapper = definition.switch_wrapper
+        self._target_humidity_wrapper = definition.target_humidity_wrapper
 
         # Determine humidity parameters
-        if target_humidity_wrapper:
-            self._attr_min_humidity = round(target_humidity_wrapper.min_value)
-            self._attr_max_humidity = round(target_humidity_wrapper.max_value)
+        if definition.target_humidity_wrapper:
+            self._attr_min_humidity = round(
+                definition.target_humidity_wrapper.min_value
+            )
+            self._attr_max_humidity = round(
+                definition.target_humidity_wrapper.max_value
+            )
 
         # Determine mode support and provided modes
-        if mode_wrapper:
+        if definition.mode_wrapper:
             self._attr_supported_features |= HumidifierEntityFeature.MODES
-            self._attr_available_modes = mode_wrapper.options
+            self._attr_available_modes = definition.mode_wrapper.options
 
     @property
     def is_on(self) -> bool | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #166323:
- use library to create `TuyaHumidifierDefinition`
- pass `TuyaHumidifierDefinition` to entity construction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
