### PR TITLE
Migrate remaning Tuya entities to TuyaDefinition

### DIFF
--- a/homeassistant/components/tuya/button.py
+++ b/homeassistant/components/tuya/button.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.definition.button import (
+    TuyaButtonDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
@@ -82,13 +84,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := BUTTONS.get(device.category):
                 entities.extend(
-                    TuyaButtonEntity(device, manager, description, dpcode_wrapper)
+                    TuyaButtonEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeBooleanWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -108,11 +106,11 @@ class TuyaButtonEntity(TuyaEntity, ButtonEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: ButtonEntityDescription,
-        dpcode_wrapper: DeviceWrapper[bool],
+        definition: TuyaButtonDefinition,
     ) -> None:
         """Init Tuya button."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
+        self._dpcode_wrapper = definition.button_wrapper
 
     async def async_press(self) -> None:
         """Press the button."""

--- a/homeassistant/components/tuya/event.py
+++ b/homeassistant/components/tuya/event.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
+from tuya_device_handlers.definition.event import (
+    TuyaEventDefinition,
+    get_default_definition,
+)
 from tuya_device_handlers.device_wrapper.common import DPCodeTypeInformationWrapper
 from tuya_device_handlers.device_wrapper.event import (
     Base64Utf8RawEventWrapper,
@@ -128,13 +130,11 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := EVENTS.get(device.category):
                 entities.extend(
-                    TuyaEventEntity(
-                        device, manager, description, dpcode_wrapper=dpcode_wrapper
-                    )
+                    TuyaEventEntity(device, manager, description, definition)
                     for description in descriptions
                     if (
-                        dpcode_wrapper := description.wrapper_class.find_dpcode(
-                            device, description.key
+                        definition := get_default_definition(
+                            device, description.key, description.wrapper_class
                         )
                     )
                 )
@@ -158,12 +158,12 @@ class TuyaEventEntity(TuyaEntity, EventEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: EventEntityDescription,
-        dpcode_wrapper: DeviceWrapper[tuple[str, dict[str, Any] | None]],
+        definition: TuyaEventDefinition,
     ) -> None:
         """Init Tuya event entity."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
-        self._attr_event_types = dpcode_wrapper.options
+        self._dpcode_wrapper = definition.event_wrapper
+        self._attr_event_types = definition.event_wrapper.options
 
     async def _process_device_update(
         self,

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeIntegerWrapper
+from tuya_device_handlers.definition.number import (
+    TuyaNumberDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.number import (
@@ -463,13 +465,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := NUMBERS.get(device.category):
                 entities.extend(
-                    TuyaNumberEntity(device, manager, description, dpcode_wrapper)
+                    TuyaNumberEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeIntegerWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -489,17 +487,19 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: NumberEntityDescription,
-        dpcode_wrapper: DeviceWrapper[float],
+        definition: TuyaNumberDefinition,
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
+        self._dpcode_wrapper = definition.number_wrapper
 
-        self._attr_native_max_value = dpcode_wrapper.max_value
-        self._attr_native_min_value = dpcode_wrapper.min_value
-        self._attr_native_step = dpcode_wrapper.value_step
+        self._attr_native_max_value = definition.number_wrapper.max_value
+        self._attr_native_min_value = definition.number_wrapper.min_value
+        self._attr_native_step = definition.number_wrapper.value_step
         if description.native_unit_of_measurement is None:
-            self._attr_native_unit_of_measurement = dpcode_wrapper.native_unit
+            self._attr_native_unit_of_measurement = (
+                definition.number_wrapper.native_unit
+            )
 
         self._validate_device_class_unit()
 

--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -489,7 +489,7 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
         description: NumberEntityDescription,
         definition: TuyaNumberDefinition,
     ) -> None:
-        """Init Tuya sensor."""
+        """Initialize a Tuya number entity."""
         super().__init__(device, device_manager, description)
         self._dpcode_wrapper = definition.number_wrapper
 

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -392,7 +392,7 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         description: SelectEntityDescription,
         definition: TuyaSelectDefinition,
     ) -> None:
-        """Init Tuya sensor."""
+        """Initialize a Tuya select entity."""
         super().__init__(device, device_manager, description)
         self._dpcode_wrapper = definition.select_wrapper
         self._attr_options = definition.select_wrapper.options

--- a/homeassistant/components/tuya/select.py
+++ b/homeassistant/components/tuya/select.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeEnumWrapper
+from tuya_device_handlers.definition.select import (
+    TuyaSelectDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
@@ -366,15 +368,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := SELECTS.get(device.category):
                 entities.extend(
-                    TuyaSelectEntity(
-                        device, manager, description, dpcode_wrapper=dpcode_wrapper
-                    )
+                    TuyaSelectEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeEnumWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -394,12 +390,12 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SelectEntityDescription,
-        dpcode_wrapper: DeviceWrapper[str],
+        definition: TuyaSelectDefinition,
     ) -> None:
         """Init Tuya sensor."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
-        self._attr_options = dpcode_wrapper.options
+        self._dpcode_wrapper = definition.select_wrapper
+        self._attr_options = definition.select_wrapper.options
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/tuya/siren.py
+++ b/homeassistant/components/tuya/siren.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.definition.siren import (
+    TuyaSirenDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.siren import (
@@ -66,13 +68,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := SIRENS.get(device.category):
                 entities.extend(
-                    TuyaSirenEntity(device, manager, description, dpcode_wrapper)
+                    TuyaSirenEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeBooleanWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -95,11 +93,11 @@ class TuyaSirenEntity(TuyaEntity, SirenEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SirenEntityDescription,
-        dpcode_wrapper: DeviceWrapper[bool],
+        definition: TuyaSirenDefinition,
     ) -> None:
         """Init Tuya Siren."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
+        self._dpcode_wrapper = definition.siren_wrapper
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.definition.switch import (
+    TuyaSwitchDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.switch import (
@@ -921,13 +923,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := SWITCHES.get(device.category):
                 entities.extend(
-                    TuyaSwitchEntity(device, manager, description, dpcode_wrapper)
+                    TuyaSwitchEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeBooleanWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -947,11 +945,11 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: SwitchEntityDescription,
-        dpcode_wrapper: DeviceWrapper[bool],
+        definition: TuyaSwitchDefinition,
     ) -> None:
         """Init TuyaHaSwitch."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
+        self._dpcode_wrapper = definition.switch_wrapper
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/tuya/valve.py
+++ b/homeassistant/components/tuya/valve.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from tuya_device_handlers.device_wrapper.base import DeviceWrapper
-from tuya_device_handlers.device_wrapper.common import DPCodeBooleanWrapper
+from tuya_device_handlers.definition.valve import (
+    TuyaValveDefinition,
+    get_default_definition,
+)
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.valve import (
@@ -95,13 +97,9 @@ async def async_setup_entry(
             device = manager.device_map[device_id]
             if descriptions := VALVES.get(device.category):
                 entities.extend(
-                    TuyaValveEntity(device, manager, description, dpcode_wrapper)
+                    TuyaValveEntity(device, manager, description, definition)
                     for description in descriptions
-                    if (
-                        dpcode_wrapper := DPCodeBooleanWrapper.find_dpcode(
-                            device, description.key, prefer_function=True
-                        )
-                    )
+                    if (definition := get_default_definition(device, description.key))
                 )
 
         async_add_entities(entities)
@@ -123,11 +121,11 @@ class TuyaValveEntity(TuyaEntity, ValveEntity):
         device: CustomerDevice,
         device_manager: Manager,
         description: ValveEntityDescription,
-        dpcode_wrapper: DeviceWrapper[bool],
+        definition: TuyaValveDefinition,
     ) -> None:
         """Init TuyaValveEntity."""
         super().__init__(device, device_manager, description)
-        self._dpcode_wrapper = dpcode_wrapper
+        self._dpcode_wrapper = definition.control_wrapper
 
     @property
     def is_closed(self) -> bool | None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow-up to #166323:
- use library to create `TuyaXXXDefinition`
- pass `TuyaXXXDefinition` to entity construction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
