### PR TITLE
Rename battery.percentage to battery.is_level

### DIFF
--- a/homeassistant/components/battery/condition.py
+++ b/homeassistant/components/battery/condition.py
@@ -37,7 +37,7 @@ CONDITIONS: dict[str, type[Condition]] = {
     "is_not_charging": make_entity_state_condition(
         BATTERY_CHARGING_DOMAIN_SPECS, STATE_OFF
     ),
-    "percentage": make_entity_numerical_condition(
+    "is_level": make_entity_numerical_condition(
         BATTERY_PERCENTAGE_DOMAIN_SPECS, PERCENTAGE
     ),
 }

--- a/homeassistant/components/battery/conditions.yaml
+++ b/homeassistant/components/battery/conditions.yaml
@@ -53,7 +53,7 @@ is_not_charging:
   fields:
     behavior: *condition_behavior
 
-percentage:
+is_level:
   target:
     entity:
       - domain: sensor

--- a/homeassistant/components/battery/icons.json
+++ b/homeassistant/components/battery/icons.json
@@ -3,6 +3,9 @@
     "is_charging": {
       "condition": "mdi:battery-charging"
     },
+    "is_level": {
+      "condition": "mdi:battery-unknown"
+    },
     "is_low": {
       "condition": "mdi:battery-alert"
     },
@@ -11,9 +14,6 @@
     },
     "is_not_low": {
       "condition": "mdi:battery"
-    },
-    "percentage": {
-      "condition": "mdi:battery-unknown"
     }
   }
 }

--- a/homeassistant/components/battery/strings.json
+++ b/homeassistant/components/battery/strings.json
@@ -14,6 +14,24 @@
       },
       "name": "Battery is charging"
     },
+    "is_level": {
+      "description": "Tests the battery level of one or more batteries.",
+      "fields": {
+        "above": {
+          "description": "Require the battery percentage to be above this value.",
+          "name": "Above"
+        },
+        "behavior": {
+          "description": "[%key:component::battery::common::condition_behavior_description%]",
+          "name": "[%key:component::battery::common::condition_behavior_name%]"
+        },
+        "below": {
+          "description": "Require the battery percentage to be below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Battery level"
+    },
     "is_low": {
       "description": "Tests if one or more batteries are low.",
       "fields": {
@@ -43,24 +61,6 @@
         }
       },
       "name": "Battery is not low"
-    },
-    "percentage": {
-      "description": "Tests the percentage of one or more batteries.",
-      "fields": {
-        "above": {
-          "description": "Require the percentage to be above this value.",
-          "name": "Above"
-        },
-        "behavior": {
-          "description": "[%key:component::battery::common::condition_behavior_description%]",
-          "name": "[%key:component::battery::common::condition_behavior_name%]"
-        },
-        "below": {
-          "description": "Require the percentage to be below this value.",
-          "name": "Below"
-        }
-      },
-      "name": "Battery percentage"
     }
   },
   "selector": {

--- a/tests/components/battery/test_condition.py
+++ b/tests/components/battery/test_condition.py
@@ -53,7 +53,7 @@ async def target_numbers(hass: HomeAssistant) -> dict[str, list[str]]:
         "battery.is_not_low",
         "battery.is_charging",
         "battery.is_not_charging",
-        "battery.percentage",
+        "battery.is_level",
     ],
 )
 async def test_battery_conditions_gated_by_labs_flag(
@@ -185,7 +185,7 @@ async def test_battery_binary_condition_behavior_all(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_any(
-        "battery.percentage",
+        "battery.is_level",
         device_class="battery",
         unit_attributes=_BATTERY_UNIT_ATTRS,
     ),
@@ -221,7 +221,7 @@ async def test_battery_percentage_condition_behavior_any(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_all(
-        "battery.percentage",
+        "battery.is_level",
         device_class="battery",
         unit_attributes=_BATTERY_UNIT_ATTRS,
     ),

--- a/tests/components/battery/test_condition.py
+++ b/tests/components/battery/test_condition.py
@@ -190,7 +190,7 @@ async def test_battery_binary_condition_behavior_all(
         unit_attributes=_BATTERY_UNIT_ATTRS,
     ),
 )
-async def test_battery_percentage_condition_behavior_any(
+async def test_battery_is_level_condition_behavior_any(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     condition_target_config: dict,
@@ -200,7 +200,7 @@ async def test_battery_percentage_condition_behavior_any(
     condition_options: dict[str, Any],
     states: list[ConditionStateDescription],
 ) -> None:
-    """Test the battery percentage condition with 'any' behavior."""
+    """Test the battery is_level condition with 'any' behavior."""
     await assert_condition_behavior_any(
         hass,
         target_entities=target_sensors,
@@ -226,7 +226,7 @@ async def test_battery_percentage_condition_behavior_any(
         unit_attributes=_BATTERY_UNIT_ATTRS,
     ),
 )
-async def test_battery_percentage_condition_behavior_all(
+async def test_battery_is_level_condition_behavior_all(
     hass: HomeAssistant,
     target_sensors: dict[str, list[str]],
     condition_target_config: dict,
@@ -236,7 +236,7 @@ async def test_battery_percentage_condition_behavior_all(
     condition_options: dict[str, Any],
     states: list[ConditionStateDescription],
 ) -> None:
-    """Test the battery percentage condition with 'all' behavior."""
+    """Test the battery is_level condition with 'all' behavior."""
     await assert_condition_behavior_all(
         hass,
         target_entities=target_sensors,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Following up on a comment (https://github.com/home-assistant/core/pull/165208#discussion_r2976279365) on my previous PR, we decided that we should rename `battery.percentage` to `batter.is_level` after a discussion on [discord](https://discord.com/channels/330944238910963714/1351529028112224359/1485937743312846859).

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/164202
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
