### PR TITLE
Improve vacuum action naming consistency

### DIFF
--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -124,18 +124,18 @@
           "name": "Areas"
         }
       },
-      "name": "Clean vacuum cleaner area"
+      "name": "Clean area with vacuum cleaner"
     },
     "clean_spot": {
       "description": "Tells a vacuum cleaner to do a spot clean-up.",
-      "name": "Spot clean vacuum cleaner"
+      "name": "Spot clean with vacuum cleaner"
     },
     "locate": {
       "description": "Locates a vacuum cleaner.",
       "name": "Locate vacuum cleaner"
     },
     "pause": {
-      "description": "Pauses a vacuum cleaner.",
+      "description": "Pauses a vacuum cleaner's current task.",
       "name": "Pause vacuum cleaner"
     },
     "return_to_base": {
@@ -154,7 +154,7 @@
           "name": "Parameters"
         }
       },
-      "name": "Send vacuum cleaner command"
+      "name": "Send command to vacuum cleaner"
     },
     "set_fan_speed": {
       "description": "Sets the fan speed of a vacuum cleaner.",
@@ -167,15 +167,15 @@
       "name": "Set vacuum cleaner fan speed"
     },
     "start": {
-      "description": "Starts or resumes a vacuum cleaner.",
+      "description": "Starts or resumes a vacuum cleaner's cleaning task.",
       "name": "Start vacuum cleaner"
     },
     "start_pause": {
-      "description": "Starts, pauses, or resumes a vacuum cleaner.",
+      "description": "Starts, pauses, or resumes a vacuum cleaner's cleaning task.",
       "name": "Start/pause vacuum cleaner"
     },
     "stop": {
-      "description": "Stops a vacuum cleaner.",
+      "description": "Stops a vacuum cleaner's current task.",
       "name": "Stop vacuum cleaner"
     },
     "toggle": {

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -124,23 +124,23 @@
           "name": "Areas"
         }
       },
-      "name": "Clean area"
+      "name": "Clean vacuum cleaner area"
     },
     "clean_spot": {
       "description": "Tells a vacuum cleaner to do a spot clean-up.",
-      "name": "Clean spot"
+      "name": "Spot clean vacuum cleaner"
     },
     "locate": {
-      "description": "Locates a vacuum cleaner robot.",
-      "name": "Locate"
+      "description": "Locates a vacuum cleaner.",
+      "name": "Locate vacuum cleaner"
     },
     "pause": {
-      "description": "Pauses the cleaning task.",
-      "name": "[%key:common::action::pause%]"
+      "description": "Pauses a vacuum cleaner.",
+      "name": "Pause vacuum cleaner"
     },
     "return_to_base": {
-      "description": "Tells a vacuum cleaner to return to its dock.",
-      "name": "Return to dock"
+      "description": "Sends a vacuum cleaner back to its dock.",
+      "name": "Return vacuum cleaner to dock"
     },
     "send_command": {
       "description": "Sends a command to a vacuum cleaner.",
@@ -154,7 +154,7 @@
           "name": "Parameters"
         }
       },
-      "name": "Send command"
+      "name": "Send vacuum cleaner command"
     },
     "set_fan_speed": {
       "description": "Sets the fan speed of a vacuum cleaner.",
@@ -164,31 +164,31 @@
           "name": "Fan speed"
         }
       },
-      "name": "Set fan speed"
+      "name": "Set vacuum cleaner fan speed"
     },
     "start": {
-      "description": "Starts or resumes the cleaning task.",
-      "name": "[%key:common::action::start%]"
+      "description": "Starts or resumes a vacuum cleaner.",
+      "name": "Start vacuum cleaner"
     },
     "start_pause": {
-      "description": "Starts, pauses, or resumes the cleaning task.",
-      "name": "Start/pause"
+      "description": "Starts, pauses, or resumes a vacuum cleaner.",
+      "name": "Start/pause vacuum cleaner"
     },
     "stop": {
-      "description": "Stops the current cleaning task.",
-      "name": "[%key:common::action::stop%]"
+      "description": "Stops a vacuum cleaner.",
+      "name": "Stop vacuum cleaner"
     },
     "toggle": {
-      "description": "Toggles the vacuum cleaner on/off.",
-      "name": "[%key:common::action::toggle%]"
+      "description": "Toggles a vacuum cleaner on/off.",
+      "name": "Toggle vacuum cleaner"
     },
     "turn_off": {
-      "description": "Stops the current cleaning task and returns to its dock.",
-      "name": "[%key:common::action::turn_off%]"
+      "description": "Turns off a vacuum cleaner.",
+      "name": "Turn off vacuum cleaner"
     },
     "turn_on": {
-      "description": "Starts a new cleaning task.",
-      "name": "[%key:common::action::turn_on%]"
+      "description": "Turns on a vacuum cleaner.",
+      "name": "Turn on vacuum cleaner"
     }
   },
   "title": "Vacuum",

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -128,7 +128,7 @@
     },
     "clean_spot": {
       "description": "Tells a vacuum cleaner to do a spot clean-up.",
-      "name": "Spot clean with vacuum cleaner"
+      "name": "Clean spot with vacuum cleaner"
     },
     "locate": {
       "description": "Locates a vacuum cleaner.",


### PR DESCRIPTION
## Proposed change

Aligns the vacuum integration's action names and descriptions with the established naming patterns already used by its triggers and conditions.

Triggers and conditions in the vacuum integration consistently include the entity type ("Vacuum cleaner started cleaning", "Vacuum cleaner is docked"), but the actions used generic names ("Start", "Stop", "Toggle") and inconsistent descriptions (some referenced "the cleaning task", others "a vacuum cleaner", one said "vacuum cleaner robot").

This PR updates all vacuum action names to include the entity type and standardizes the descriptions to consistently reference "a vacuum cleaner". For task/activity actions (start, stop, pause), descriptions reference both the entity type and the task being performed (e.g., "Starts or resumes a vacuum cleaner's cleaning task.") to distinguish them from device-level actions like turn_on/turn_off.

<details>
<summary>Action naming style guide</summary>

# Action/Service Naming & Style Guide

This guide defines the naming patterns for triggers, conditions, and actions (services) in Home Assistant integrations. The trigger and condition patterns are already established and consistent across integrations. The action patterns are derived from those to bring consistency across all three.

## Entity Type

Each integration uses a consistent **entity type** across all its triggers, conditions, and actions. This is the human-friendly name for the type of device.

Examples: "light", "fan", "cover", "lock", "alarm", "media player", "vacuum cleaner", "climate-control device", "lawn mower"

The same entity type must be used consistently within an integration. It should match what is already used in its triggers and conditions.

## Names

### Triggers (established)

Pattern: `[Entity type] [past tense event]`

The entity type comes first, followed by the past tense event description.

Examples:

- "Light turned on"
- "Climate-control device started cooling"
- "Lawn mower started mowing"
- "Lock locked"

### Conditions (established)

Pattern: `[Entity type] is [state]`

The entity type comes first, followed by "is" and the state.

Examples:

- "Light is on"
- "Climate-control device is cooling"
- "Lawn mower is mowing"
- "Lock is locked"

Value-based variant: `[Entity type] [property]`

- "Climate-control device target temperature"

### Actions (proposed)

Pattern: `[Verb] [entity type]` or `[Verb] [entity type] [detail]`

The entity type should always be included. Since actions are imperative commands, the verb comes first (unlike triggers/conditions which are statements and lead with the entity type).

**Power/state actions**: `[Verb] [entity type]`

- "Turn on light"
- "Toggle fan"
- "Pause media player"
- "Lock lock"
- "Disarm alarm"

**Property actions**: `Set [entity type] [property]`

- "Set fan speed"
- "Set cover position"
- "Set media player volume"

**Other actions**: Entity type in the most natural position

- "Open cover"
- "Locate vacuum cleaner"
- "Return lawn mower to dock"
- "Increase fan speed"
- "Select media player source"
- "Send command to vacuum cleaner"

## Descriptions

### Triggers (established)

Pattern: "Triggers after one or more [entity type plural] [present tense verb phrase]."

Examples:

- "Triggers after one or more lights turn on."
- "Triggers after one or more lawn mowers start mowing."
- "Triggers after one or more locks lock."

### Conditions (established)

Pattern: "Tests if one or more [entity type plural] are [state]."

Examples:

- "Tests if one or more lights are on."
- "Tests if one or more climate-control devices are cooling."
- "Tests if one or more locks are locked."

Value-based variant: "Tests the [property] of one or more [entity type plural]."

### Actions (proposed)

Pattern: "[Third person verb phrase] a [entity type]."

Always mention the entity type. Use the indefinite article "a"/"an" (not "the"). No unnecessary filler words.

**Device actions** (the verb directly applies to the device): `[Verb]s a [entity type].`

- "Turns on a light."
- "Toggles a fan on/off."
- "Locks a lock."
- "Locates a vacuum cleaner."

**Task/activity actions** (the verb applies to a task the device performs): `[Verb]s a [entity type]'s [task/activity].`

Some actions control an activity or task that a device performs, rather than the device itself. For example, starting a vacuum cleaner starts its cleaning task — it does not power on the device (that is `turn_on`). In these cases, reference both the entity type and the task to avoid ambiguity.

- "Starts or resumes a vacuum cleaner's cleaning task."
- "Pauses a vacuum cleaner's current task."
- "Stops a vacuum cleaner's current task."
- "Starts a lawn mower's mowing task."
- "Pauses a lawn mower's current task."

**Property actions**: `Sets the [property] of a [entity type].`

- "Sets the speed of a fan."
- "Sets the position of a cover."
- "Sets the volume level of a media player."

**Other actions**: Include "a [entity type]" naturally

- "Opens a cover."
- "Returns a lawn mower to its dock."
- "Sends a command to a vacuum cleaner."

</details>

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
