### PR TITLE
Rename humidity.value condition to humidity.is_value

### DIFF
--- a/homeassistant/components/humidity/condition.py
+++ b/homeassistant/components/humidity/condition.py
@@ -29,7 +29,7 @@ HUMIDITY_DOMAIN_SPECS = {
 }
 
 CONDITIONS: dict[str, type[Condition]] = {
-    "value": make_entity_numerical_condition(HUMIDITY_DOMAIN_SPECS, PERCENTAGE),
+    "is_value": make_entity_numerical_condition(HUMIDITY_DOMAIN_SPECS, PERCENTAGE),
 }
 
 

--- a/homeassistant/components/humidity/conditions.yaml
+++ b/homeassistant/components/humidity/conditions.yaml
@@ -20,7 +20,7 @@
                   device_class: humidity
       translation_key: number_or_entity
 
-value:
+is_value:
   target:
     entity:
       - domain: sensor

--- a/homeassistant/components/humidity/icons.json
+++ b/homeassistant/components/humidity/icons.json
@@ -1,6 +1,6 @@
 {
   "conditions": {
-    "value": {
+    "is_value": {
       "condition": "mdi:water-percent"
     }
   },

--- a/homeassistant/components/humidity/strings.json
+++ b/homeassistant/components/humidity/strings.json
@@ -6,7 +6,7 @@
     "trigger_behavior_name": "Behavior"
   },
   "conditions": {
-    "value": {
+    "is_value": {
       "description": "Tests if a relative humidity value is above a threshold, below a threshold, or in a range of values.",
       "fields": {
         "above": {

--- a/tests/components/humidity/test_condition.py
+++ b/tests/components/humidity/test_condition.py
@@ -57,7 +57,7 @@ async def target_humidifiers(hass: HomeAssistant) -> dict[str, list[str]]:
 @pytest.mark.parametrize(
     "condition",
     [
-        "humidity.value",
+        "humidity.is_value",
     ],
 )
 async def test_humidity_conditions_gated_by_labs_flag(
@@ -75,7 +75,7 @@ async def test_humidity_conditions_gated_by_labs_flag(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_any(
-        "humidity.value",
+        "humidity.is_value",
         device_class="humidity",
         unit_attributes=_HUMIDITY_UNIT_ATTRS,
     ),
@@ -111,7 +111,7 @@ async def test_humidity_sensor_condition_behavior_any(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_all(
-        "humidity.value",
+        "humidity.is_value",
         device_class="humidity",
         unit_attributes=_HUMIDITY_UNIT_ATTRS,
     ),
@@ -147,7 +147,7 @@ async def test_humidity_sensor_condition_behavior_all(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_any(
-        "humidity.value",
+        "humidity.is_value",
         device_class="humidity",
         unit_attributes=_HUMIDITY_UNIT_ATTRS,
     ),
@@ -183,7 +183,7 @@ async def test_humidity_number_condition_behavior_any(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_condition_above_below_all(
-        "humidity.value",
+        "humidity.is_value",
         device_class="humidity",
         unit_attributes=_HUMIDITY_UNIT_ATTRS,
     ),
@@ -219,7 +219,7 @@ async def test_humidity_number_condition_behavior_all(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_attribute_condition_above_below_any(
-        "humidity.value",
+        "humidity.is_value",
         HVACMode.AUTO,
         CLIMATE_ATTR_CURRENT_HUMIDITY,
     ),
@@ -255,7 +255,7 @@ async def test_humidity_climate_condition_behavior_any(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_attribute_condition_above_below_all(
-        "humidity.value",
+        "humidity.is_value",
         HVACMode.AUTO,
         CLIMATE_ATTR_CURRENT_HUMIDITY,
     ),
@@ -291,7 +291,7 @@ async def test_humidity_climate_condition_behavior_all(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_attribute_condition_above_below_any(
-        "humidity.value",
+        "humidity.is_value",
         STATE_ON,
         HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
     ),
@@ -327,7 +327,7 @@ async def test_humidity_humidifier_condition_behavior_any(
 @pytest.mark.parametrize(
     ("condition", "condition_options", "states"),
     parametrize_numerical_attribute_condition_above_below_all(
-        "humidity.value",
+        "humidity.is_value",
         STATE_ON,
         HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
     ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA - after discord discussion, we decided it should be called .is_value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
