### PR TITLE
Add create/delete services for input_number helper

### DIFF
--- a/homeassistant/components/input_number/__init__.py
+++ b/homeassistant/components/input_number/__init__.py
@@ -19,7 +19,12 @@ from homeassistant.const import (
     SERVICE_RELOAD,
 )
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import collection, config_validation as cv
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import (
+    collection,
+    config_validation as cv,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.helpers.service
@@ -47,6 +52,8 @@ ATTR_STEP = "step"
 SERVICE_SET_VALUE = "set_value"
 SERVICE_INCREMENT = "increment"
 SERVICE_DECREMENT = "decrement"
+SERVICE_CREATE = "create"
+SERVICE_DELETE = "delete"
 
 
 def _cv_input_number(cfg):
@@ -73,6 +80,19 @@ STORAGE_FIELDS: VolDictType = {
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_MODE, default=MODE_SLIDER): vol.In([MODE_BOX, MODE_SLIDER]),
 }
+
+CREATE_FIELDS: VolDictType = {
+    vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
+    vol.Optional(CONF_ID): cv.slug,
+    vol.Required(CONF_MIN): vol.Coerce(float),
+    vol.Required(CONF_MAX): vol.Coerce(float),
+    vol.Optional(CONF_INITIAL): vol.Coerce(float),
+    vol.Optional(CONF_STEP, default=1): vol.All(vol.Coerce(float), vol.Range(min=1e-9)),
+    vol.Optional(CONF_ICON): cv.icon,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_MODE, default=MODE_SLIDER): vol.In([MODE_SLIDER, MODE_BOX]),
+}
+CREATE_SCHEMA = vol.All(vol.Schema(CREATE_FIELDS), _cv_input_number)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -154,9 +174,67 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         "async_set_value",
     )
 
-    component.async_register_entity_service(SERVICE_INCREMENT, None, "async_increment")
+    component.async_register_entity_service(
+        SERVICE_INCREMENT,
+        None,
+        "async_increment",
+    )
 
-    component.async_register_entity_service(SERVICE_DECREMENT, None, "async_decrement")
+    component.async_register_entity_service(
+        SERVICE_DECREMENT,
+        None,
+        "async_decrement",
+    )
+
+    async def handle_create(call: ServiceCall) -> None:
+        """Create a new helper programmatically."""
+        create_data = {k: v for k, v in call.data.items() if k != CONF_ID}
+        if CONF_ID in call.data:
+            item_id: str = call.data[CONF_ID]
+            if id_manager.has_id(item_id):
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="id_already_exists",
+                    translation_placeholders={"item_id": item_id},
+                )
+        await storage_collection.async_create_item(create_data)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CREATE,
+        handle_create,
+        schema=CREATE_SCHEMA,
+    )
+
+    async def handle_delete(call: ServiceCall) -> None:
+        """Delete a helper."""
+        registry = er.async_get(hass)
+        entity_ids = await homeassistant.helpers.service.async_extract_entity_ids(call)
+        for entity_id in entity_ids:
+            entry = registry.async_get(entity_id)
+            if entry is None:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="entity_not_found",
+                    translation_placeholders={"entity_id": entity_id},
+                )
+            item_id = entry.unique_id
+            if not any(
+                item["id"] == item_id for item in storage_collection.async_items()
+            ):
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="entity_not_storage_based",
+                    translation_placeholders={"entity_id": entity_id},
+                )
+            await storage_collection.async_delete_item(item_id)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DELETE,
+        handle_delete,
+        schema=cv.make_entity_service_schema({}),
+    )
 
     return True
 

--- a/homeassistant/components/input_number/icons.json
+++ b/homeassistant/components/input_number/icons.json
@@ -1,7 +1,13 @@
 {
   "services": {
+    "create": {
+      "service": "mdi:plus"
+    },
     "decrement": {
       "service": "mdi:minus"
+    },
+    "delete": {
+      "service": "mdi:delete"
     },
     "increment": {
       "service": "mdi:plus"

--- a/homeassistant/components/input_number/services.yaml
+++ b/homeassistant/components/input_number/services.yaml
@@ -23,3 +23,51 @@ set_value:
           mode: box
 
 reload:
+
+create:
+  fields:
+    name:
+      required: true
+      selector:
+        text:
+    id:
+      selector:
+        text:
+    min:
+      required: true
+      selector:
+        number:
+          mode: box
+    max:
+      required: true
+      selector:
+        number:
+          mode: box
+    initial:
+      selector:
+        number:
+          mode: box
+    step:
+      default: 1
+      selector:
+        number:
+          min: 0.001
+          mode: box
+    mode:
+      default: "slider"
+      selector:
+        select:
+          options:
+            - "slider"
+            - "box"
+    icon:
+      selector:
+        icon:
+    unit_of_measurement:
+      selector:
+        text:
+
+delete:
+  target:
+    entity:
+      domain: input_number

--- a/homeassistant/components/input_number/strings.json
+++ b/homeassistant/components/input_number/strings.json
@@ -33,10 +33,67 @@
       }
     }
   },
+  "exceptions": {
+    "entity_not_found": {
+      "message": "Entity {entity_id} is not found in the registry."
+    },
+    "entity_not_storage_based": {
+      "message": "Entity {entity_id} is YAML-defined and cannot be deleted."
+    },
+    "id_already_exists": {
+      "message": "A helper with ID {item_id} already exists."
+    }
+  },
   "services": {
+    "create": {
+      "description": "Creates a new input number helper.",
+      "fields": {
+        "icon": {
+          "description": "Icon for the helper.",
+          "name": "Icon"
+        },
+        "id": {
+          "description": "Object ID slug. The entity ID will be input_number.id.",
+          "name": "ID"
+        },
+        "initial": {
+          "description": "Initial value when the helper is created.",
+          "name": "Initial value"
+        },
+        "max": {
+          "description": "Upper bound of the number range.",
+          "name": "Maximum"
+        },
+        "min": {
+          "description": "Lower bound of the number range.",
+          "name": "Minimum"
+        },
+        "mode": {
+          "description": "Display mode of the helper.",
+          "name": "Mode"
+        },
+        "name": {
+          "description": "Friendly name of the helper.",
+          "name": "Name"
+        },
+        "step": {
+          "description": "Step size for incrementing or decrementing.",
+          "name": "Step"
+        },
+        "unit_of_measurement": {
+          "description": "Unit of measurement for the value.",
+          "name": "Unit of measurement"
+        }
+      },
+      "name": "Create"
+    },
     "decrement": {
       "description": "Decrements the value of an input number by 1 step.",
       "name": "Decrement input number"
+    },
+    "delete": {
+      "description": "Deletes an input number helper.",
+      "name": "Delete"
     },
     "increment": {
       "description": "Increments the value of an input number by 1 step.",

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -9,7 +9,9 @@ import voluptuous as vol
 from homeassistant.components.input_number import (
     ATTR_VALUE,
     DOMAIN,
+    SERVICE_CREATE,
     SERVICE_DECREMENT,
+    SERVICE_DELETE,
     SERVICE_INCREMENT,
     SERVICE_RELOAD,
     SERVICE_SET_VALUE,
@@ -21,7 +23,7 @@ from homeassistant.const import (
     ATTR_NAME,
 )
 from homeassistant.core import Context, CoreState, HomeAssistant, State
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import ServiceValidationError, Unauthorized
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -636,3 +638,176 @@ async def test_setup_no_config(hass: HomeAssistant, hass_admin_user: MockUser) -
         await hass.async_block_till_done()
 
     assert count_start == len(hass.states.async_entity_ids())
+
+
+async def test_service_create(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    storage_setup,
+) -> None:
+    """Test creating a helper via the create service."""
+    assert await storage_setup(items=[])
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE,
+        {"name": "New Number", "min": 0, "max": 100},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{DOMAIN}.new_number")
+    assert state is not None
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "New Number"
+    assert state.attributes.get(ATTR_EDITABLE)
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "new_number") is not None
+
+
+async def test_service_create_with_explicit_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    storage_setup,
+) -> None:
+    """Test creating a helper via the create service with an explicit ID."""
+    assert await storage_setup(items=[])
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CREATE,
+        {"name": "My Slider", "id": "my_slider", "min": 5.0, "max": 50.0, "step": 0.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"{DOMAIN}.my_slider")
+    assert state is not None
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "My Slider"
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "my_slider") is not None
+
+
+async def test_service_create_duplicate_id(
+    hass: HomeAssistant,
+    storage_setup,
+) -> None:
+    """Test that creating with a duplicate ID raises an error."""
+    assert await storage_setup()
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE,
+            {"name": "Dupe", "id": "from_storage", "min": 0, "max": 10},
+            blocking=True,
+        )
+
+
+async def test_service_delete(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    storage_setup,
+) -> None:
+    """Test deleting a storage-based helper via the delete service."""
+    assert await storage_setup()
+
+    input_entity_id = f"{DOMAIN}.from_storage"
+    assert hass.states.get(input_entity_id) is not None
+    assert (
+        entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is not None
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DELETE,
+        {"entity_id": input_entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(input_entity_id) is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "from_storage") is None
+
+
+async def test_service_delete_yaml_entity(
+    hass: HomeAssistant,
+    storage_setup,
+) -> None:
+    """Test that deleting a YAML-defined helper raises an error."""
+    assert await storage_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    "min": 1,
+                    "max": 10,
+                    "step": 1,
+                    "mode": "slider",
+                }
+            }
+        }
+    )
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE,
+            {"entity_id": f"{DOMAIN}.from_yaml"},
+            blocking=True,
+        )
+
+
+async def test_service_delete_nonexistent_entity(
+    hass: HomeAssistant,
+    storage_setup,
+) -> None:
+    """Test that deleting a nonexistent entity raises an error."""
+    assert await storage_setup(items=[])
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_DELETE,
+            {"entity_id": f"{DOMAIN}.does_not_exist"},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "match"),
+    [
+        (
+            {"name": "Bad Range", "min": 50.0, "max": 10.0},
+            "Maximum",
+        ),
+        (
+            {"name": "Bad Initial", "min": 0.0, "max": 10.0, "initial": 99.0},
+            "Initial value",
+        ),
+        (
+            {"name": "Bad Step", "min": 0.0, "max": 10.0, "step": 0.0},
+            "step",
+        ),
+        (
+            {"name": "Bad Slug", "id": "has space", "min": 0.0, "max": 10.0},
+            "invalid",
+        ),
+        (
+            {"min": 0.0, "max": 10.0},
+            "required key not provided",
+        ),
+    ],
+)
+async def test_service_create_validation_errors(
+    hass: HomeAssistant,
+    storage_setup,
+    data: dict,
+    match: str,
+) -> None:
+    """Test that create service rejects invalid configurations."""
+    assert await storage_setup(items=[])
+
+    with pytest.raises((ServiceValidationError, vol.Invalid)):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CREATE,
+            data,
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds create and delete services to the input_number integration, enabling helpers to be created and deleted programmatically at runtime without requiring a UI interaction or a configuration reload.

The primary use case (in my situation) is allowing the creation of robust blueprints that can also create their own necessary helpers.  This makes it even easier for users to share their cool setups.

Specifically, I use this in my TagReader automation to create the NFC tag helper and in my Inovelli Global Configuration automation to have a single dashboard that can modify settings for all Inovelli devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
