### PR TITLE
Improve to-do list action naming consistency

### DIFF
--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -41,7 +41,7 @@
           "name": "Item name"
         }
       },
-      "name": "Add item"
+      "name": "Add to-do list item"
     },
     "get_items": {
       "description": "Gets items on a to-do list.",
@@ -51,11 +51,11 @@
           "name": "Status"
         }
       },
-      "name": "Get items"
+      "name": "Get to-do list items"
     },
     "remove_completed_items": {
       "description": "Removes all to-do list items that have been completed.",
-      "name": "Remove completed items"
+      "name": "Remove completed to-do list items"
     },
     "remove_item": {
       "description": "Removes an existing to-do list item by its name or UID.",
@@ -65,7 +65,7 @@
           "name": "[%key:component::todo::services::update_item::fields::item::name%]"
         }
       },
-      "name": "Remove item"
+      "name": "Remove to-do list item"
     },
     "update_item": {
       "description": "Updates an existing to-do list item based on its name or UID.",
@@ -95,7 +95,7 @@
           "name": "Set status"
         }
       },
-      "name": "Update item"
+      "name": "Update to-do list item"
     }
   },
   "title": "To-do list"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Aligns the to-do list integration's action names with the established naming patterns used across Home Assistant.

The action names used generic labels ("Add item", "Get items", "Remove item", "Update item", "Remove completed items") without mentioning the entity type.

This PR updates all action names to include "to-do list" (e.g., "Add to-do list item", "Get to-do list items"). The descriptions were already well-written and consistently reference "a to-do list", so they remain unchanged.

<details>
<summary>Action naming style guide</summary>

# Action/Service Naming & Style Guide

This guide defines the naming patterns for triggers, conditions, and actions (services) in Home Assistant integrations. The trigger and condition patterns are already established and consistent across integrations. The action patterns are derived from those to bring consistency across all three.

## Entity Type

Each integration uses a consistent **entity type** across all its triggers, conditions, and actions. This is the human-friendly name for the type of device.

Examples: "light", "fan", "cover", "lock", "alarm", "media player", "vacuum cleaner", "climate-control device", "lawn mower"

The same entity type must be used consistently within an integration. It should match what is already used in its triggers and conditions.

## Names

### Triggers (established)

Pattern: `[Entity type] [past tense event]`

The entity type comes first, followed by the past tense event description.

Examples:

- "Light turned on"
- "Climate-control device started cooling"
- "Lawn mower started mowing"
- "Lock locked"

### Conditions (established)

Pattern: `[Entity type] is [state]`

The entity type comes first, followed by "is" and the state.

Examples:

- "Light is on"
- "Climate-control device is cooling"
- "Lawn mower is mowing"
- "Lock is locked"

Value-based variant: `[Entity type] [property]`

- "Climate-control device target temperature"

### Actions (proposed)

Pattern: `[Verb] [entity type]` or `[Verb] [entity type] [detail]`

The entity type should always be included. Since actions are imperative commands, the verb comes first (unlike triggers/conditions which are statements and lead with the entity type).

**Power/state actions**: `[Verb] [entity type]`

- "Turn on light"
- "Toggle fan"
- "Pause media player"
- "Lock lock"
- "Disarm alarm"

**Property actions**: `Set [entity type] [property]`

- "Set fan speed"
- "Set cover position"
- "Set media player volume"

**Other actions**: Entity type in the most natural position

- "Open cover"
- "Locate vacuum cleaner"
- "Return lawn mower to dock"
- "Increase fan speed"
- "Select media player source"
- "Send command to vacuum cleaner"

## Descriptions

### Triggers (established)

Pattern: "Triggers after one or more [entity type plural] [present tense verb phrase]."

Examples:

- "Triggers after one or more lights turn on."
- "Triggers after one or more lawn mowers start mowing."
- "Triggers after one or more locks lock."

### Conditions (established)

Pattern: "Tests if one or more [entity type plural] are [state]."

Examples:

- "Tests if one or more lights are on."
- "Tests if one or more climate-control devices are cooling."
- "Tests if one or more locks are locked."

Value-based variant: "Tests the [property] of one or more [entity type plural]."

### Actions (proposed)

Pattern: "[Third person verb phrase] a [entity type]."

Always mention the entity type. Use the indefinite article "a"/"an" (not "the"). No unnecessary filler words.

**Device actions** (the verb directly applies to the device): `[Verb]s a [entity type].`

- "Turns on a light."
- "Toggles a fan on/off."
- "Locks a lock."
- "Locates a vacuum cleaner."

**Task/activity actions** (the verb applies to a task the device performs): `[Verb]s a [entity type]'s [task/activity].`

Some actions control an activity or task that a device performs, rather than the device itself. For example, starting a vacuum cleaner starts its cleaning task — it does not power on the device (that is `turn_on`). In these cases, reference both the entity type and the task to avoid ambiguity.

- "Starts or resumes a vacuum cleaner's cleaning task."
- "Pauses a vacuum cleaner's current task."
- "Stops a vacuum cleaner's current task."
- "Starts a lawn mower's mowing task."
- "Pauses a lawn mower's current task."

**Property actions**: `Sets the [property] of a [entity type].`

- "Sets the speed of a fan."
- "Sets the position of a cover."
- "Sets the volume level of a media player."

**Other actions**: Include "a [entity type]" naturally

- "Opens a cover."
- "Returns a lawn mower to its dock."
- "Sends a command to a vacuum cleaner."

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
