### PR TITLE
Fix `KeyError` for device temperature sensor in Unifi integration

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -300,13 +300,11 @@ def make_wan_latency_sensors() -> tuple[UnifiSensorEntityDescription, ...]:
 @callback
 def async_device_temperatures_value_fn(
     temperature_name: str, hub: UnifiHub, device: Device
-) -> float:
+) -> float | None:
     """Retrieve the temperature of the device."""
-    return_value: float = 0
     if device.temperatures:
-        temperature = _device_temperature(temperature_name, device.temperatures)
-        return_value = temperature if temperature is not None else 0
-    return return_value
+        return _device_temperature(temperature_name, device.temperatures)
+    return None
 
 
 @callback
@@ -315,7 +313,11 @@ def async_device_temperatures_supported_fn(
 ) -> bool:
     """Determine if an device have a temperatures."""
     if (device := hub.api.devices[obj_id]) and device.temperatures:
-        return _device_temperature(temperature_name, device.temperatures) is not None
+        return any(
+            temperature_name in temperature["name"]
+            for temperature in device.temperatures
+        )
+
     return False
 
 
@@ -326,7 +328,8 @@ def _device_temperature(
     """Return the temperature of the device."""
     for temperature in temperatures:
         if temperature_name in temperature["name"]:
-            return temperature["value"]
+            if (value := temperature.get("value")) is not None:
+                return value
     return None
 
 

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -308,6 +308,17 @@ def async_device_temperatures_value_fn(
 
 
 @callback
+def async_device_temperatures_available_fn(
+    temperature_name: str, hub: UnifiHub, obj_id: str
+) -> bool:
+    """Determine if a device temperature has a value."""
+    device = hub.api.devices[obj_id]
+    if not async_device_available_fn(hub, obj_id):
+        return False
+    return _device_temperature(temperature_name, device.temperatures or []) is not None
+
+
+@callback
 def async_device_temperatures_supported_fn(
     temperature_name: str, hub: UnifiHub, obj_id: str
 ) -> bool:
@@ -347,7 +358,7 @@ def make_device_temperatur_sensors() -> tuple[UnifiSensorEntityDescription, ...]
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
             entity_registry_enabled_default=False,
             api_handler_fn=lambda api: api.devices,
-            available_fn=async_device_available_fn,
+            available_fn=partial(async_device_temperatures_available_fn, name),
             device_info_fn=async_device_device_info_fn,
             name_fn=lambda device: f"{device.name} {name} Temperature",
             object_fn=lambda api, obj_id: api.devices[obj_id],

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1779,6 +1779,70 @@ async def test_device_temperatures(
     [
         [
             {
+                "board_rev": 3,
+                "device_id": "mock-id",
+                "has_fan": True,
+                "fan_level": 0,
+                "ip": "10.0.1.1",
+                "last_seen": 1562600145,
+                "mac": "00:00:00:00:01:01",
+                "model": "US16P150",
+                "name": "Device",
+                "next_interval": 20,
+                "overheating": True,
+                "state": 1,
+                "type": "usw",
+                "upgradable": True,
+                "uptime": 60,
+                "version": "4.0.42.10433",
+                "temperatures": [
+                    {"name": "CPU", "type": "cpu", "value": 66.0},
+                ],
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_device_temperature_with_missing_value(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_websocket_message,
+    device_payload: list[dict[str, Any]],
+) -> None:
+    """Verify that device temperatures sensors are working as expected."""
+    entity_id = "sensor.device_device_cpu_temperature"
+
+    temperature_entity = entity_registry.async_get(entity_id)
+    assert temperature_entity.disabled_by == RegistryEntryDisabler.INTEGRATION
+
+    # Enable entity
+    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # Verify sensor state
+    assert hass.states.get(entity_id).state == "66.0"
+
+    # Remove temperature value from payload
+    device = device_payload[0]
+    device["temperatures"][0].pop("value")
+
+    mock_websocket_message(message=MessageKey.DEVICE, data=device)
+
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "device_payload",
+    [
+        [
+            {
                 "board_rev": 2,
                 "device_id": "mock-id",
                 "ip": "10.0.1.1",

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1830,12 +1830,17 @@ async def test_device_temperature_with_missing_value(
     assert hass.states.get(entity_id).state == "66.0"
 
     # Remove temperature value from payload
-    device = device_payload[0]
+    device = deepcopy(device_payload[0])
     device["temperatures"][0].pop("value")
 
     mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # Send original payload again to verify sensor recovers
+    mock_websocket_message(message=MessageKey.DEVICE, data=device_payload[0])
+
+    assert hass.states.get(entity_id).state == "66.0"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1835,7 +1835,7 @@ async def test_device_temperature_with_missing_value(
 
     mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes the payload is missing a `value` for the temperature sensor which causes a `KeyError`.

```
2026-03-24 08:00:52.342 ERROR (MainThread) [homeassistant.helpers.dispatcher] Exception in async_signal_reachable_callback when dispatching 'unifi-reachable-01KJTWKEDZ63EKG8R8F0DR158B': ()
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/unifi/entity.py", line 231, in async_signal_reachable_callback
    self.async_signalling_callback(ItemEvent.ADDED, self._obj_id)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/unifi/entity.py", line 220, in async_signalling_callback
    if not description.supported_fn(self.hub, self._obj_id):
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/unifi/sensor.py", line 318, in async_device_temperatures_supported_fn
    return _device_temperature(temperature_name, device.temperatures) is not None
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/unifi/sensor.py", line 329, in _device_temperature
    return temperature["value"]
           ~~~~~~~~~~~^^^^^^^^^
KeyError: 'value'
```
With this change, in such cases the sensor entity will be marked as `unavailable`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146624
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
