### PR TITLE
Warn about *.pth files in dependencies

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -235,3 +235,12 @@ auth0-python<5.0
 
 # Setuptools >=82.0.0 doesn't contain pkg_resources anymore
 setuptools<82.0.0
+
+# Pin dependencies with '.pth' files to exact versions, only update manually!
+# https://github.com/Azure/azure-kusto-python/ -> '.pth' files removed with >=5.0.5
+# https://github.com/xolox/python-coloredlogs -> unmaintained
+# https://github.com/pypa/setuptools
+azure-kusto-data==4.5.1
+azure-kusto-ingest==4.5.1
+coloredlogs==15.0.1
+setuptools==81.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -225,6 +225,15 @@ auth0-python<5.0
 
 # Setuptools >=82.0.0 doesn't contain pkg_resources anymore
 setuptools<82.0.0
+
+# Pin dependencies with '.pth' files to exact versions, only update manually!
+# https://github.com/Azure/azure-kusto-python/ -> '.pth' files removed with >=5.0.5
+# https://github.com/xolox/python-coloredlogs -> unmaintained
+# https://github.com/pypa/setuptools
+azure-kusto-data==4.5.1
+azure-kusto-ingest==4.5.1
+coloredlogs==15.0.1
+setuptools==81.0.0
 """
 
 GENERATED_MESSAGE = (

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -247,6 +247,7 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
         # azure_kusto_data-*-nspkg.pth
         # azure_kusto_ingest-*-nspkg.pth
         "homeassistant": {"azure-kusto-data", "azure-kusto-ingest"},
+        "azure-kusto-ingest": {"azure-kusto-data"},
     },
     # https://github.com/coinbase/coinbase-advanced-py
     "cmus": {

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -236,16 +236,41 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     # - reasonX should be the name of the invalid dependency
     # https://github.com/jaraco/jaraco.net
     "abode": {"jaraco-abode": {"jaraco-net"}},
+    # https://github.com/Azure/azure-kusto-python/
+    "azure_data_explorer": {
+        # Legacy namespace packages, resolved with >=5.0.5
+        # azure_kusto_data-*-nspkg.pth
+        # azure_kusto_ingest-*-nspkg.pth
+        "homeassistant": {"azure-kusto-data", "azure-kusto-ingest"},
+    },
     # https://github.com/coinbase/coinbase-advanced-py
+    "cmus": {
+        # Setuptools - distutils-precedence.pth
+        "pbr": {"setuptools"}
+    },
     "coinbase": {"homeassistant": {"coinbase-advanced-py"}},
     # https://github.com/u9n/dlms-cosem
     "dsmr": {"dsmr-parser": {"dlms-cosem"}},
     # https://github.com/ChrisMandich/PyFlume  # Fixed with >=0.7.1
+    "fitbit": {
+        # Setuptools - distutils-precedence.pth
+        "fitbit": {"setuptools"}
+    },
     "flume": {"homeassistant": {"pyflume"}},
     # https://github.com/fortinet-solutions-cse/fortiosapi
     "fortios": {"homeassistant": {"fortiosapi"}},
     # https://github.com/manzanotti/geniushub-client
     "geniushub": {"homeassistant": {"geniushub-client"}},
+    # https://github.com/costastf/locationsharinglib
+    "google_maps": {
+        # Coloredlogs, unmaintained - coloredlogs.pth
+        "locationsharinglib": {"coloredlogs"},
+    },
+    # https://github.com/NabuCasa/universal-silabs-flasher
+    "homeassistant_hardware": {
+        # Coloredlogs, unmaintained - coloredlogs.pth
+        "universal-silabs-flasher": {"coloredlogs"},
+    },
     # https://github.com/basnijholt/aiokef
     "kef": {"homeassistant": {"aiokef"}},
     # https://github.com/danifus/pyzipper
@@ -257,11 +282,26 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     # https://github.com/timmo001/aiolyric
     "lyric": {"homeassistant": {"aiolyric"}},
     # https://github.com/microBeesTech/pythonSDK/
-    "microbees": {"homeassistant": {"microbeespy"}},
+    "microbees": {
+        "homeassistant": {"microbeespy"},
+        "microbeespy": {"setuptools"},
+    },
+    "mochad": {
+        # Setuptools - distutils-precedence.pth
+        "pbr": {"setuptools"}
+    },
     # https://github.com/ejpenney/pyobihai
     "obihai": {"homeassistant": {"pyobihai"}},
+    "opnsense": {
+        # Setuptools - distutils-precedence.pth
+        "pbr": {"setuptools"}
+    },
     # https://github.com/iamkubi/pydactyl
     "pterodactyl": {"homeassistant": {"py-dactyl"}},
+    "remote_rpi_gpio": {
+        # Setuptools - distutils-precedence.pth
+        "colorzero": {"setuptools"}
+    },
     # https://github.com/sstallion/sensorpush-api
     "sensorpush_cloud": {
         "homeassistant": {"sensorpush-api"},
@@ -273,6 +313,14 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     "watergate": {"homeassistant": {"watergate-local-api"}},
     # https://github.com/markusressel/xs1-api-client
     "xs1": {"homeassistant": {"xs1-api-client"}},
+    # https://github.com/zigpy/zigpy-znp
+    "zha": {
+        # Setuptools - distutils-precedence.pth
+        "colorzero": {"setuptools"},
+        # Coloredlogs, unmaintained - coloredlogs.pth
+        # https://github.com/xolox/python-coloredlogs/blob/15.0.1/coloredlogs.pth
+        "zigpy-znp": {"coloredlogs"},
+    },
 }
 
 PYTHON_VERSION_CHECK_EXCEPTIONS: dict[str, dict[str, set[str]]] = {

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -724,10 +724,10 @@ def check_dependency_files(
         for file in files(pkg) or ():
             if not (top := file.parts[0].lower()).endswith((".dist-info", ".py")):
                 top_level.add(top)
-            if (name := str(file)).lower() in FORBIDDEN_FILE_NAMES or (
+            if (name := str(file).lower()) in FORBIDDEN_FILE_NAMES or (
                 name.endswith(".pth") and len(file.parts) == 1
             ):
-                file_names.add(name)
+                file_names.add(str(file))
         results = _PackageFilesCheckResult(
             top_level=FORBIDDEN_PACKAGE_NAMES & top_level,
             file_names=file_names,

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -670,7 +670,9 @@ def check_dependency_files(
         for file in files(pkg) or ():
             if not (top := file.parts[0].lower()).endswith((".dist-info", ".py")):
                 top_level.add(top)
-            if (name := str(file)).lower() in FORBIDDEN_FILE_NAMES:
+            if (name := str(file)).lower() in FORBIDDEN_FILE_NAMES or name.endswith(
+                ".pth"
+            ):
                 file_names.add(name)
         results = _PackageFilesCheckResult(
             top_level=FORBIDDEN_PACKAGE_NAMES & top_level,
@@ -687,7 +689,8 @@ def check_dependency_files(
             f"Package {pkg} has a forbidden top level directory '{dir_name}' in {package}",
         )
     for file_name in results["file_names"]:
-        integration.add_error(
+        integration.add_warning_or_error(
+            pkg in package_exceptions,
             "requirements",
             f"Package {pkg} has a forbidden file '{file_name}' in {package}",
         )

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -95,6 +95,8 @@ FORBIDDEN_PACKAGES = {
     "async-timeout": "be replaced by asyncio.timeout (Python 3.11+)",
     # Only needed for tests
     "codecov": "not be a runtime dependency",
+    # Coloredlogs is unmaintained and contains a '.pth' file
+    "coloredlogs": "be replaced with colorlog",
     # Only needed for docs
     "mkdocs": "not be a runtime dependency",
     # Does blocking I/O and should be replaced by pyserial-asyncio-fast
@@ -149,11 +151,13 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     },
     "flux_led": {"flux-led": {"async-timeout"}},
     "foobot": {"foobot-async": {"async-timeout"}},
+    "google_maps": {"locationsharinglib": {"coloredlogs"}},
     "harmony": {"aioharmony": {"async-timeout"}},
     "here_travel_time": {
         "here-routing": {"async-timeout"},
         "here-transit": {"async-timeout"},
     },
+    "homeassistant_hardware": {"universal-silabs-flasher": {"coloredlogs"}},
     "homewizard": {"python-homewizard-energy": {"async-timeout"}},
     "imeon_inverter": {"imeon-inverter-api": {"async-timeout"}},
     "izone": {"python-izone": {"async-timeout"}},
@@ -217,6 +221,7 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
         # https://github.com/waveform80/colorzero/issues/9
         # zha > zigpy-zigate > gpiozero > colorzero > setuptools
         "colorzero": {"setuptools"},
+        "zigpy-znp": {"coloredlogs"},
     },
 }
 

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -723,8 +723,8 @@ def check_dependency_files(
         for file in files(pkg) or ():
             if not (top := file.parts[0].lower()).endswith((".dist-info", ".py")):
                 top_level.add(top)
-            if (name := str(file)).lower() in FORBIDDEN_FILE_NAMES or name.endswith(
-                ".pth"
+            if (name := str(file)).lower() in FORBIDDEN_FILE_NAMES or (
+                name.endswith(".pth") and len(file.parts) == 1
             ):
                 file_names.add(name)
         results = _PackageFilesCheckResult(

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -275,6 +275,7 @@ def test_check_dependency_file_names(integration: Integration) -> None:
     pkg_files = [
         PackagePath("py.typed"),
         PackagePath("my_package.py"),
+        PackagePath("some_script.pth"),
         PackagePath("my_package-1.0.0.dist-info/METADATA"),
     ]
     with (
@@ -285,9 +286,15 @@ def test_check_dependency_file_names(integration: Integration) -> None:
     ):
         assert not _packages_checked_files_cache
         assert check_dependency_files(integration, package, pkg, ()) is False
-        assert _packages_checked_files_cache[pkg]["file_names"] == {"py.typed"}
-        assert len(integration.errors) == 1
+        assert _packages_checked_files_cache[pkg]["file_names"] == {
+            "py.typed",
+            "some_script.pth",
+        }
+        assert len(integration.errors) == 2
         assert f"Package {pkg} has a forbidden file 'py.typed' in {package}" in [
+            x.error for x in integration.errors
+        ]
+        assert f"Package {pkg} has a forbidden file 'some_script.pth' in {package}" in [
             x.error for x in integration.errors
         ]
         integration.errors.clear()
@@ -295,7 +302,7 @@ def test_check_dependency_file_names(integration: Integration) -> None:
         # Repeated call should use cache
         assert check_dependency_files(integration, package, pkg, ()) is False
         assert mock_files.call_count == 1
-        assert len(integration.errors) == 1
+        assert len(integration.errors) == 2
         integration.errors.clear()
 
     # All good

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -275,7 +275,7 @@ def test_check_dependency_file_names(integration: Integration) -> None:
     pkg_files = [
         PackagePath("py.typed"),
         PackagePath("my_package.py"),
-        PackagePath("some_script.pth"),
+        PackagePath("some_script.Pth"),
         PackagePath("my_package-1.0.0.dist-info/METADATA"),
     ]
     with (
@@ -288,13 +288,13 @@ def test_check_dependency_file_names(integration: Integration) -> None:
         assert check_dependency_files(integration, package, pkg, ()) is False
         assert _packages_checked_files_cache[pkg]["file_names"] == {
             "py.typed",
-            "some_script.pth",
+            "some_script.Pth",
         }
         assert len(integration.errors) == 2
         assert f"Package {pkg} has a forbidden file 'py.typed' in {package}" in [
             x.error for x in integration.errors
         ]
-        assert f"Package {pkg} has a forbidden file 'some_script.pth' in {package}" in [
+        assert f"Package {pkg} has a forbidden file 'some_script.Pth' in {package}" in [
             x.error for x in integration.errors
         ]
         integration.errors.clear()


### PR DESCRIPTION
## Proposed change
In response to the litellm hack [today](https://github.com/BerriAI/litellm/issues/24512) which installed a malicious `.pth` file. Detect these with `hassfest`.

At the moment, four dependencies install `.pth` files:
- `setuptools` with `distutils-precedence.pth`. _A compatibility layer to file distutils files._
https://github.com/pypa/setuptools/blob/v81.0.0/setup.py#L30-L35
- `coloredlogs` with `coloredlogs.pth`. _Unmaintained, last commit 5 years ago._
https://github.com/xolox/python-coloredlogs/blob/15.0.1/coloredlogs.pth
- `azure-kusto-data` and `azure-kusto-ingest`. _Both old style namespace packages, `.pth` created by setuptools._
https://github.com/Azure/azure-kusto-python/
Removed / resolved with `>=5.0.5`.

Added `coloredlogs` to the list of forbidden packages. `colorlog` is a equivalent / better (and maintained) replacement. It's also used by Home Assistant already.

Also added exact pins for these four dependencies to `package_constraints.txt`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
