### PR TITLE
Add suspend all button Proxmox

### DIFF
--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -82,6 +82,14 @@ NODE_BUTTONS: tuple[ProxmoxNodeButtonNodeEntityDescription, ...] = (
         ).stopall.post(),
         entity_category=EntityCategory.CONFIG,
     ),
+    ProxmoxNodeButtonNodeEntityDescription(
+        key="suspend_all",
+        translation_key="suspend_all",
+        press_action=lambda coordinator, node: coordinator.proxmox.nodes(
+            node
+        ).suspendall.post(),
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 VM_BUTTONS: tuple[ProxmoxVMButtonEntityDescription, ...] = (

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -13,8 +13,17 @@
       "start": {
         "default": "mdi:play"
       },
+      "start_all": {
+        "default": "mdi:play"
+      },
       "stop": {
         "default": "mdi:stop"
+      },
+      "stop_all": {
+        "default": "mdi:stop"
+      },
+      "suspend_all": {
+        "default": "mdi:pause"
       }
     },
     "sensor": {

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -130,6 +130,9 @@
       },
       "stop_all": {
         "name": "Stop all"
+      },
+      "suspend_all": {
+        "name": "Suspend all"
       }
     },
     "sensor": {

--- a/tests/components/proxmoxve/snapshots/test_button.ambr
+++ b/tests/components/proxmoxve/snapshots/test_button.ambr
@@ -502,6 +502,56 @@
     'state': 'unknown',
   })
 # ---
+# name: test_all_button_entities[button.pve1_suspend_all-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.pve1_suspend_all',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Suspend all',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Suspend all',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'suspend_all',
+    'unique_id': '1234_node/pve1_suspend_all',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_button_entities[button.pve1_suspend_all-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'pve1 Suspend all',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.pve1_suspend_all',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_all_button_entities[button.vm_db_hibernate-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -82,9 +82,10 @@ async def test_node_buttons(
     [
         ("button.pve1_start_all", "startall"),
         ("button.pve1_stop_all", "stopall"),
+        ("button.pve1_suspend_all", "suspendall"),
     ],
 )
-async def test_node_startall_stopall_buttons(
+async def test_node_all_actions_buttons(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA - and added extra icons for the start and stop all buttons.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
