### PR TITLE
Handle Abode runtime auth failures by starting reauth

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -97,7 +97,7 @@ def _start_reauth(
         except Exception as ex:  # noqa: BLE001
             LOGGER.debug("Failed stopping Abode event stream: %s", ex)
 
-    entry.async_start_reauth(hass)
+    hass.loop.call_soon_threadsafe(entry.async_start_reauth, hass)
 
 
 def _is_auth_error(error: Exception) -> bool:
@@ -109,10 +109,18 @@ def _is_auth_error(error: Exception) -> bool:
         return error.response.status_code in AUTH_STATUS_CODES
 
     if isinstance(error, AbodeException):
-        if int(error.errcode) in AUTH_STATUS_CODES:
-            return True
+        errcode: object | None = None
+        try:
+            errcode = getattr(error, "errcode", None)
+            if errcode is not None and int(errcode) in AUTH_STATUS_CODES:
+                return True
+        except TypeError, ValueError:
+            LOGGER.debug("Unexpected Abode errcode value: %r", errcode)
 
-        message = error.message.lower()
+        try:
+            message = str(getattr(error, "message", "") or "").lower()
+        except TypeError, ValueError:
+            message = ""
         return (
             "unauthorized" in message
             or "invalid credentials" in message

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -78,7 +78,7 @@ class AbodeSystem:
 
         self.reauth_started = True
         LOGGER.warning(
-            "Abode authentication failed at runtime: %s. Starting reauthentication.",
+            "Abode authentication failed at runtime: %s. Starting reauthentication",
             error,
         )
 
@@ -160,7 +160,7 @@ def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
     ) -> Any:
         try:
             response = original_send_request(method, path, headers, data)
-        except Exception as ex:  # noqa: BLE001
+        except Exception as ex:
             if _is_auth_error(ex):
                 abode_system.start_reauth(ex)
             raise
@@ -178,7 +178,7 @@ def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
         return response
 
     # This is an instance-level wrapper; avoid changing upstream library behavior globally.
-    abode_system.abode.send_request = wrapped_send_request  # type: ignore[method-assign]
+    abode_system.abode.send_request = wrapped_send_request
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from functools import partial
+from http import HTTPStatus
 from pathlib import Path
+from typing import Any
 
 from jaraco.abode.client import Client as Abode
 import jaraco.abode.config
@@ -63,8 +65,120 @@ class AbodeSystem:
 
     abode: Abode
     polling: bool
+    hass: HomeAssistant
+    entry: ConfigEntry
     entity_ids: set[str | None] = field(default_factory=set)
     logout_listener: CALLBACK_TYPE | None = None
+    reauth_started: bool = False
+
+    def start_reauth(self, error: Exception) -> None:
+        """Start a reauthentication flow once when auth fails at runtime."""
+        if self.reauth_started:
+            return
+
+        self.reauth_started = True
+        LOGGER.warning(
+            "Abode authentication failed at runtime: %s. Starting reauthentication.",
+            error,
+        )
+
+        # Stop event stream first to avoid aggressive retries while user reauthenticates.
+        if not self.polling:
+            try:
+                self.abode.events.stop()
+            except Exception as ex:  # noqa: BLE001
+                LOGGER.debug("Failed stopping Abode event stream: %s", ex)
+
+        self.hass.add_job(self.entry.async_start_reauth, self.hass)
+
+
+AUTH_STATUS_CODES = {
+    HTTPStatus.BAD_REQUEST,
+    HTTPStatus.UNAUTHORIZED,
+    HTTPStatus.FORBIDDEN,
+}
+
+
+def _is_auth_error(error: Exception) -> bool:
+    """Return True if an exception indicates an auth failure."""
+    if isinstance(error, AbodeAuthenticationException):
+        return True
+
+    if isinstance(error, HTTPError) and error.response:
+        return HTTPStatus(error.response.status_code) in AUTH_STATUS_CODES
+
+    if isinstance(error, AbodeException):
+        if error.errcode in AUTH_STATUS_CODES:
+            return True
+
+        message = error.message.lower()
+        return (
+            "unauthorized" in message
+            or "invalid credentials" in message
+            or ("password" in message and "match" in message)
+        )
+
+    return False
+
+
+def _is_auth_like_response(response: Any) -> bool:
+    """Return True if a response payload indicates auth failure despite 200 status."""
+    status_code = getattr(response, "status_code", None)
+    if status_code in AUTH_STATUS_CODES:
+        return True
+    if status_code != HTTPStatus.OK:
+        return False
+
+    try:
+        response_json = response.json()
+    except ValueError:
+        return False
+
+    if not isinstance(response_json, dict):
+        return False
+
+    message = str(response_json.get("message", "")).lower()
+    error_code = response_json.get("errorCode")
+
+    # Abode has returned auth errors in JSON payloads; guard that too.
+    return error_code in {11002, 13027} or (
+        "unauthorized" in message
+        or "invalid credentials" in message
+        or ("password" in message and "match" in message)
+    )
+
+
+def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
+    """Wrap Abode requests to trigger reauth on runtime auth failures."""
+    original_send_request = abode_system.abode.send_request
+
+    def wrapped_send_request(
+        method: str,
+        path: str,
+        headers: dict[str, str] | None = None,
+        data: dict[str, str] | None = None,
+    ) -> Any:
+        try:
+            response = original_send_request(method, path, headers, data)
+        except Exception as ex:  # noqa: BLE001
+            if _is_auth_error(ex):
+                abode_system.start_reauth(ex)
+            raise
+
+        if _is_auth_like_response(response):
+            auth_error = AbodeAuthenticationException(
+                (
+                    HTTPStatus.UNAUTHORIZED,
+                    "Abode returned an authentication error payload",
+                )
+            )
+            abode_system.start_reauth(auth_error)
+            raise auth_error
+
+        return response
+
+    # This is an instance-level wrapper; avoid changing upstream library behavior globally.
+    abode_system.abode.send_request = wrapped_send_request  # type: ignore[method-assign]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -99,7 +213,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except (AbodeException, ConnectTimeout, HTTPError) as ex:
         raise ConfigEntryNotReady(f"Unable to connect to Abode: {ex}") from ex
 
-    hass.data[DOMAIN_DATA] = AbodeSystem(abode, polling)
+    hass.data[DOMAIN_DATA] = AbodeSystem(abode, polling, hass, entry)
+    _install_runtime_auth_guard(hass.data[DOMAIN_DATA])
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -69,6 +69,7 @@ class AbodeSystem:
     entity_ids: set[str | None] = field(default_factory=set)
     logout_listener: CALLBACK_TYPE | None = None
 
+
 AUTH_STATUS_CODES: set[int] = {
     HTTPStatus.BAD_REQUEST,
     HTTPStatus.UNAUTHORIZED,
@@ -165,12 +166,12 @@ def _install_runtime_auth_guard(
         data: dict[str, str] | None = None,
     ) -> Response:
         try:
-            response = cast(Response, original_send_request(method, path, headers, data))
+            response = cast(
+                Response, original_send_request(method, path, headers, data)
+            )
         except Exception as ex:
             if _is_auth_error(ex):
-                _start_reauth(
-                    hass, entry, abode_system.abode, abode_system.polling, ex
-                )
+                _start_reauth(hass, entry, abode_system.abode, abode_system.polling, ex)
             raise
 
         if _is_auth_like_response(response):

--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from jaraco.abode.client import Client as Abode
 import jaraco.abode.config
@@ -15,6 +15,7 @@ from jaraco.abode.exceptions import (
     Exception as AbodeException,
 )
 from jaraco.abode.helpers.timeline import Groups as GROUPS
+from requests import Response
 from requests.exceptions import ConnectTimeout, HTTPError
 
 from homeassistant.config_entries import ConfigEntry
@@ -65,38 +66,37 @@ class AbodeSystem:
 
     abode: Abode
     polling: bool
-    hass: HomeAssistant
-    entry: ConfigEntry
     entity_ids: set[str | None] = field(default_factory=set)
     logout_listener: CALLBACK_TYPE | None = None
-    reauth_started: bool = False
 
-    def start_reauth(self, error: Exception) -> None:
-        """Start a reauthentication flow once when auth fails at runtime."""
-        if self.reauth_started:
-            return
-
-        self.reauth_started = True
-        LOGGER.warning(
-            "Abode authentication failed at runtime: %s. Starting reauthentication",
-            error,
-        )
-
-        # Stop event stream first to avoid aggressive retries while user reauthenticates.
-        if not self.polling:
-            try:
-                self.abode.events.stop()
-            except Exception as ex:  # noqa: BLE001
-                LOGGER.debug("Failed stopping Abode event stream: %s", ex)
-
-        self.hass.add_job(self.entry.async_start_reauth, self.hass)
-
-
-AUTH_STATUS_CODES = {
+AUTH_STATUS_CODES: set[int] = {
     HTTPStatus.BAD_REQUEST,
     HTTPStatus.UNAUTHORIZED,
     HTTPStatus.FORBIDDEN,
 }
+
+
+def _start_reauth(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    abode: Abode,
+    polling: bool,
+    error: Exception,
+) -> None:
+    """Start a reauthentication flow when auth fails at runtime."""
+    LOGGER.warning(
+        "Abode authentication failed at runtime: %s. Starting reauthentication",
+        error,
+    )
+
+    # Stop event stream first to avoid aggressive retries while user reauthenticates.
+    if not polling:
+        try:
+            abode.events.stop()
+        except Exception as ex:  # noqa: BLE001
+            LOGGER.debug("Failed stopping Abode event stream: %s", ex)
+
+    entry.async_start_reauth(hass)
 
 
 def _is_auth_error(error: Exception) -> bool:
@@ -104,11 +104,11 @@ def _is_auth_error(error: Exception) -> bool:
     if isinstance(error, AbodeAuthenticationException):
         return True
 
-    if isinstance(error, HTTPError) and error.response:
-        return HTTPStatus(error.response.status_code) in AUTH_STATUS_CODES
+    if isinstance(error, HTTPError) and error.response is not None:
+        return error.response.status_code in AUTH_STATUS_CODES
 
     if isinstance(error, AbodeException):
-        if error.errcode in AUTH_STATUS_CODES:
+        if int(error.errcode) in AUTH_STATUS_CODES:
             return True
 
         message = error.message.lower()
@@ -121,12 +121,16 @@ def _is_auth_error(error: Exception) -> bool:
     return False
 
 
-def _is_auth_like_response(response: Any) -> bool:
+def _is_auth_like_response(response: Response) -> bool:
     """Return True if a response payload indicates auth failure despite 200 status."""
-    status_code = getattr(response, "status_code", None)
+    status_code = response.status_code
     if status_code in AUTH_STATUS_CODES:
         return True
     if status_code != HTTPStatus.OK:
+        return False
+
+    content_type = response.headers.get("Content-Type", "")
+    if "application/json" not in content_type.lower():
         return False
 
     try:
@@ -148,7 +152,9 @@ def _is_auth_like_response(response: Any) -> bool:
     )
 
 
-def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
+def _install_runtime_auth_guard(
+    abode_system: AbodeSystem, hass: HomeAssistant, entry: ConfigEntry
+) -> None:
     """Wrap Abode requests to trigger reauth on runtime auth failures."""
     original_send_request = abode_system.abode.send_request
 
@@ -157,12 +163,14 @@ def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
         path: str,
         headers: dict[str, str] | None = None,
         data: dict[str, str] | None = None,
-    ) -> Any:
+    ) -> Response:
         try:
-            response = original_send_request(method, path, headers, data)
+            response = cast(Response, original_send_request(method, path, headers, data))
         except Exception as ex:
             if _is_auth_error(ex):
-                abode_system.start_reauth(ex)
+                _start_reauth(
+                    hass, entry, abode_system.abode, abode_system.polling, ex
+                )
             raise
 
         if _is_auth_like_response(response):
@@ -172,7 +180,9 @@ def _install_runtime_auth_guard(abode_system: AbodeSystem) -> None:
                     "Abode returned an authentication error payload",
                 )
             )
-            abode_system.start_reauth(auth_error)
+            _start_reauth(
+                hass, entry, abode_system.abode, abode_system.polling, auth_error
+            )
             raise auth_error
 
         return response
@@ -213,8 +223,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except (AbodeException, ConnectTimeout, HTTPError) as ex:
         raise ConfigEntryNotReady(f"Unable to connect to Abode: {ex}") from ex
 
-    hass.data[DOMAIN_DATA] = AbodeSystem(abode, polling, hass, entry)
-    _install_runtime_auth_guard(hass.data[DOMAIN_DATA])
+    hass.data[DOMAIN_DATA] = AbodeSystem(abode, polling)
+    _install_runtime_auth_guard(hass.data[DOMAIN_DATA], hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -108,24 +108,32 @@ def test_start_reauth_stops_event_stream_and_starts_flow() -> None:
     """Test runtime reauth starts flow and stops event stream for websocket mode."""
     abode_client = Mock()
     hass = Mock()
+    hass.loop = Mock()
     entry = Mock()
 
     _start_reauth(hass, entry, abode_client, False, Exception("auth failed"))
 
     abode_client.events.stop.assert_called_once()
-    entry.async_start_reauth.assert_called_once_with(hass)
+    hass.loop.call_soon_threadsafe.assert_called_once_with(
+        entry.async_start_reauth, hass
+    )
+    entry.async_start_reauth.assert_not_called()
 
 
 def test_start_reauth_polling_does_not_stop_event_stream() -> None:
     """Test runtime reauth does not stop event stream in polling mode."""
     abode_client = Mock()
     hass = Mock()
+    hass.loop = Mock()
     entry = Mock()
 
     _start_reauth(hass, entry, abode_client, True, Exception("auth failed"))
 
     abode_client.events.stop.assert_not_called()
-    entry.async_start_reauth.assert_called_once_with(hass)
+    hass.loop.call_soon_threadsafe.assert_called_once_with(
+        entry.async_start_reauth, hass
+    )
+    entry.async_start_reauth.assert_not_called()
 
 
 def test_start_reauth_handles_event_stop_error() -> None:
@@ -133,11 +141,15 @@ def test_start_reauth_handles_event_stop_error() -> None:
     abode_client = Mock()
     abode_client.events.stop.side_effect = RuntimeError("stop failed")
     hass = Mock()
+    hass.loop = Mock()
     entry = Mock()
 
     _start_reauth(hass, entry, abode_client, False, Exception("auth failed"))
 
-    entry.async_start_reauth.assert_called_once_with(hass)
+    hass.loop.call_soon_threadsafe.assert_called_once_with(
+        entry.async_start_reauth, hass
+    )
+    entry.async_start_reauth.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -152,6 +164,9 @@ def test_start_reauth_handles_event_stop_error() -> None:
             ),
             True,
         ),
+        (AbodeException((None, "Unauthorized token")), True),
+        (AbodeException((None, None)), False),
+        (AbodeException("any"), False),
         (AbodeException((HTTPStatus.FORBIDDEN, "forbidden")), True),
         (AbodeException((HTTPStatus.INTERNAL_SERVER_ERROR, "server error")), False),
         (RuntimeError("boom"), False),

--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -1,13 +1,21 @@
 """Tests for the Abode module."""
 
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from jaraco.abode.exceptions import (
     AuthenticationException as AbodeAuthenticationException,
     Exception as AbodeException,
 )
+import pytest
+from requests.exceptions import HTTPError
 
+from homeassistant.components.abode import (
+    AbodeSystem,
+    _install_runtime_auth_guard,
+    _is_auth_error,
+    _is_auth_like_response,
+)
 from homeassistant.components.abode.const import DOMAIN
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -93,3 +101,148 @@ async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant) ->
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert hass.config_entries.flow.async_progress() == []
+
+
+def test_start_reauth_only_once() -> None:
+    """Test runtime reauth starts once and stops event stream for websocket mode."""
+    abode_client = Mock()
+    hass = Mock()
+    entry = Mock()
+    abode_system = AbodeSystem(abode_client, False, hass, entry)
+
+    abode_system.start_reauth(Exception("auth failed"))
+    abode_system.start_reauth(Exception("auth failed"))
+
+    abode_client.events.stop.assert_called_once()
+    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
+    assert abode_system.reauth_started is True
+
+
+def test_start_reauth_polling_does_not_stop_event_stream() -> None:
+    """Test runtime reauth does not stop event stream in polling mode."""
+    abode_client = Mock()
+    hass = Mock()
+    entry = Mock()
+    abode_system = AbodeSystem(abode_client, True, hass, entry)
+
+    abode_system.start_reauth(Exception("auth failed"))
+
+    abode_client.events.stop.assert_not_called()
+    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
+
+
+def test_start_reauth_handles_event_stop_error() -> None:
+    """Test runtime reauth continues when stopping event stream fails."""
+    abode_client = Mock()
+    abode_client.events.stop.side_effect = RuntimeError("stop failed")
+    hass = Mock()
+    entry = Mock()
+    abode_system = AbodeSystem(abode_client, False, hass, entry)
+
+    abode_system.start_reauth(Exception("auth failed"))
+
+    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
+
+
+@pytest.mark.parametrize(
+    ("error", "is_auth"),
+    [
+        (AbodeAuthenticationException((HTTPStatus.BAD_REQUEST, "auth")), True),
+        (HTTPError(response=Mock(status_code=HTTPStatus.UNAUTHORIZED)), True),
+        (HTTPError(response=Mock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)), False),
+        (
+            AbodeException(
+                (HTTPStatus.INTERNAL_SERVER_ERROR, "Username and password do not match")
+            ),
+            True,
+        ),
+        (AbodeException((HTTPStatus.FORBIDDEN, "forbidden")), True),
+        (AbodeException((HTTPStatus.INTERNAL_SERVER_ERROR, "server error")), False),
+        (RuntimeError("boom"), False),
+    ],
+)
+def test_is_auth_error(error: Exception, is_auth: bool) -> None:
+    """Test auth error detection from exceptions."""
+    assert _is_auth_error(error) is is_auth
+
+
+def test_is_auth_like_response() -> None:
+    """Test auth-like response payload detection."""
+    unauthorized = Mock(status_code=HTTPStatus.UNAUTHORIZED)
+    assert _is_auth_like_response(unauthorized) is True
+
+    server_error = Mock(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert _is_auth_like_response(server_error) is False
+
+    invalid_json = Mock(status_code=HTTPStatus.OK)
+    invalid_json.json.side_effect = ValueError
+    assert _is_auth_like_response(invalid_json) is False
+
+    list_payload = Mock(status_code=HTTPStatus.OK)
+    list_payload.json.return_value = ["not", "dict"]
+    assert _is_auth_like_response(list_payload) is False
+
+    error_code_payload = Mock(status_code=HTTPStatus.OK)
+    error_code_payload.json.return_value = {"errorCode": 11002}
+    assert _is_auth_like_response(error_code_payload) is True
+
+    message_payload = Mock(status_code=HTTPStatus.OK)
+    message_payload.json.return_value = {"message": "Unauthorized token"}
+    assert _is_auth_like_response(message_payload) is True
+
+    ok_payload = Mock(status_code=HTTPStatus.OK)
+    ok_payload.json.return_value = {"message": "ok"}
+    assert _is_auth_like_response(ok_payload) is False
+
+
+def test_runtime_auth_guard_for_exception_and_payload() -> None:
+    """Test send_request wrapper triggers reauth for auth exception and payload."""
+    # Exception path.
+    abode_client = Mock()
+    abode_client.send_request.side_effect = AbodeAuthenticationException(
+        (HTTPStatus.UNAUTHORIZED, "unauthorized")
+    )
+    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
+    abode_system.start_reauth = Mock()
+    _install_runtime_auth_guard(abode_system)
+
+    with pytest.raises(AbodeAuthenticationException):
+        abode_system.abode.send_request("GET", "/api/v1/panel")
+    abode_system.start_reauth.assert_called_once()
+
+    # Payload path.
+    payload_response = Mock(status_code=HTTPStatus.OK)
+    payload_response.json.return_value = {"errorCode": 13027}
+    abode_client = Mock()
+    abode_client.send_request.return_value = payload_response
+    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
+    abode_system.start_reauth = Mock()
+    _install_runtime_auth_guard(abode_system)
+
+    with pytest.raises(AbodeAuthenticationException):
+        abode_system.abode.send_request("GET", "/api/v1/panel")
+    abode_system.start_reauth.assert_called_once()
+
+
+def test_runtime_auth_guard_passthrough_for_non_auth() -> None:
+    """Test send_request wrapper does not trigger reauth for non-auth failures."""
+    abode_client = Mock()
+    abode_client.send_request.side_effect = ValueError("boom")
+    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
+    abode_system.start_reauth = Mock()
+    _install_runtime_auth_guard(abode_system)
+
+    with pytest.raises(ValueError):
+        abode_system.abode.send_request("GET", "/api/v1/panel")
+    abode_system.start_reauth.assert_not_called()
+
+    ok_response = Mock(status_code=HTTPStatus.OK)
+    ok_response.json.return_value = {"message": "ok"}
+    abode_client = Mock()
+    abode_client.send_request.return_value = ok_response
+    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
+    abode_system.start_reauth = Mock()
+    _install_runtime_auth_guard(abode_system)
+
+    assert abode_system.abode.send_request("GET", "/api/v1/panel") is ok_response
+    abode_system.start_reauth.assert_not_called()

--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -15,6 +15,7 @@ from homeassistant.components.abode import (
     _install_runtime_auth_guard,
     _is_auth_error,
     _is_auth_like_response,
+    _start_reauth,
 )
 from homeassistant.components.abode.const import DOMAIN
 from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
@@ -103,19 +104,16 @@ async def test_raise_config_entry_not_ready_when_offline(hass: HomeAssistant) ->
     assert hass.config_entries.flow.async_progress() == []
 
 
-def test_start_reauth_only_once() -> None:
-    """Test runtime reauth starts once and stops event stream for websocket mode."""
+def test_start_reauth_stops_event_stream_and_starts_flow() -> None:
+    """Test runtime reauth starts flow and stops event stream for websocket mode."""
     abode_client = Mock()
     hass = Mock()
     entry = Mock()
-    abode_system = AbodeSystem(abode_client, False, hass, entry)
 
-    abode_system.start_reauth(Exception("auth failed"))
-    abode_system.start_reauth(Exception("auth failed"))
+    _start_reauth(hass, entry, abode_client, False, Exception("auth failed"))
 
     abode_client.events.stop.assert_called_once()
-    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
-    assert abode_system.reauth_started is True
+    entry.async_start_reauth.assert_called_once_with(hass)
 
 
 def test_start_reauth_polling_does_not_stop_event_stream() -> None:
@@ -123,12 +121,11 @@ def test_start_reauth_polling_does_not_stop_event_stream() -> None:
     abode_client = Mock()
     hass = Mock()
     entry = Mock()
-    abode_system = AbodeSystem(abode_client, True, hass, entry)
 
-    abode_system.start_reauth(Exception("auth failed"))
+    _start_reauth(hass, entry, abode_client, True, Exception("auth failed"))
 
     abode_client.events.stop.assert_not_called()
-    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
+    entry.async_start_reauth.assert_called_once_with(hass)
 
 
 def test_start_reauth_handles_event_stop_error() -> None:
@@ -137,11 +134,10 @@ def test_start_reauth_handles_event_stop_error() -> None:
     abode_client.events.stop.side_effect = RuntimeError("stop failed")
     hass = Mock()
     entry = Mock()
-    abode_system = AbodeSystem(abode_client, False, hass, entry)
 
-    abode_system.start_reauth(Exception("auth failed"))
+    _start_reauth(hass, entry, abode_client, False, Exception("auth failed"))
 
-    hass.add_job.assert_called_once_with(entry.async_start_reauth, hass)
+    entry.async_start_reauth.assert_called_once_with(hass)
 
 
 @pytest.mark.parametrize(
@@ -175,24 +171,33 @@ def test_is_auth_like_response() -> None:
     assert _is_auth_like_response(server_error) is False
 
     invalid_json = Mock(status_code=HTTPStatus.OK)
+    invalid_json.headers = {"Content-Type": "application/json"}
     invalid_json.json.side_effect = ValueError
     assert _is_auth_like_response(invalid_json) is False
 
     list_payload = Mock(status_code=HTTPStatus.OK)
+    list_payload.headers = {"Content-Type": "application/json"}
     list_payload.json.return_value = ["not", "dict"]
     assert _is_auth_like_response(list_payload) is False
 
     error_code_payload = Mock(status_code=HTTPStatus.OK)
+    error_code_payload.headers = {"Content-Type": "application/json"}
     error_code_payload.json.return_value = {"errorCode": 11002}
     assert _is_auth_like_response(error_code_payload) is True
 
     message_payload = Mock(status_code=HTTPStatus.OK)
+    message_payload.headers = {"Content-Type": "application/json"}
     message_payload.json.return_value = {"message": "Unauthorized token"}
     assert _is_auth_like_response(message_payload) is True
 
     ok_payload = Mock(status_code=HTTPStatus.OK)
+    ok_payload.headers = {"Content-Type": "application/json"}
     ok_payload.json.return_value = {"message": "ok"}
     assert _is_auth_like_response(ok_payload) is False
+
+    text_payload = Mock(status_code=HTTPStatus.OK)
+    text_payload.headers = {"Content-Type": "text/plain"}
+    assert _is_auth_like_response(text_payload) is False
 
 
 def test_runtime_auth_guard_for_exception_and_payload() -> None:
@@ -202,47 +207,49 @@ def test_runtime_auth_guard_for_exception_and_payload() -> None:
     abode_client.send_request.side_effect = AbodeAuthenticationException(
         (HTTPStatus.UNAUTHORIZED, "unauthorized")
     )
-    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
-    abode_system.start_reauth = Mock()
-    _install_runtime_auth_guard(abode_system)
+    abode_system = AbodeSystem(abode_client, False)
+    hass = Mock()
+    entry = Mock()
+    with patch("homeassistant.components.abode._start_reauth") as mock_start_reauth:
+        _install_runtime_auth_guard(abode_system, hass, entry)
 
-    with pytest.raises(AbodeAuthenticationException):
-        abode_system.abode.send_request("GET", "/api/v1/panel")
-    abode_system.start_reauth.assert_called_once()
+        with pytest.raises(AbodeAuthenticationException):
+            abode_system.abode.send_request("GET", "/api/v1/panel")
+        mock_start_reauth.assert_called_once()
 
     # Payload path.
     payload_response = Mock(status_code=HTTPStatus.OK)
+    payload_response.headers = {"Content-Type": "application/json"}
     payload_response.json.return_value = {"errorCode": 13027}
     abode_client = Mock()
     abode_client.send_request.return_value = payload_response
-    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
-    abode_system.start_reauth = Mock()
-    _install_runtime_auth_guard(abode_system)
+    abode_system = AbodeSystem(abode_client, False)
+    hass = Mock()
+    entry = Mock()
+    with patch("homeassistant.components.abode._start_reauth") as mock_start_reauth:
+        _install_runtime_auth_guard(abode_system, hass, entry)
 
-    with pytest.raises(AbodeAuthenticationException):
-        abode_system.abode.send_request("GET", "/api/v1/panel")
-    abode_system.start_reauth.assert_called_once()
+        with pytest.raises(AbodeAuthenticationException):
+            abode_system.abode.send_request("GET", "/api/v1/panel")
+        mock_start_reauth.assert_called_once()
 
 
 def test_runtime_auth_guard_passthrough_for_non_auth() -> None:
     """Test send_request wrapper does not trigger reauth for non-auth failures."""
     abode_client = Mock()
     abode_client.send_request.side_effect = ValueError("boom")
-    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
-    abode_system.start_reauth = Mock()
-    _install_runtime_auth_guard(abode_system)
+    abode_system = AbodeSystem(abode_client, False)
+    _install_runtime_auth_guard(abode_system, Mock(), Mock())
 
     with pytest.raises(ValueError):
         abode_system.abode.send_request("GET", "/api/v1/panel")
-    abode_system.start_reauth.assert_not_called()
 
     ok_response = Mock(status_code=HTTPStatus.OK)
+    ok_response.headers = {"Content-Type": "application/json"}
     ok_response.json.return_value = {"message": "ok"}
     abode_client = Mock()
     abode_client.send_request.return_value = ok_response
-    abode_system = AbodeSystem(abode_client, False, Mock(), Mock())
-    abode_system.start_reauth = Mock()
-    _install_runtime_auth_guard(abode_system)
+    abode_system = AbodeSystem(abode_client, False)
+    _install_runtime_auth_guard(abode_system, Mock(), Mock())
 
     assert abode_system.abode.send_request("GET", "/api/v1/panel") is ok_response
-    abode_system.start_reauth.assert_not_called()


### PR DESCRIPTION
## Proposed change
This bugfix improves how the Abode integration handles runtime authentication failures after setup.

When Abode credentials/token become invalid at runtime, the integration could continue retrying API calls and keep the event stream active. This change installs an instance-level runtime auth guard around `abode.send_request(...)` so auth failures now trigger `entry.async_start_reauth(...)` once and stop the Abode event stream first (for websocket mode), reducing repeated traffic until the user reauthenticates.

The guard treats these as auth failures:
- HTTP status errors for `400/401/403`
- `AbodeAuthenticationException`
- `AbodeException` auth-like messages/codes
- auth-like JSON payloads even when HTTP is `200` (to cover provider responses that encode auth failure in-body)

This PR is intentionally small (single file, focused behavior change) to make review faster.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR fixes or closes issue: #152205
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- Submitted from the official Abode account (`@goabodedevops`).
- Local verification run: `python -m compileall homeassistant/components/abode/__init__.py`.
- `pytest` is not installed in this local venv, so integration tests were not run in this environment.

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Fixes #152205