### PR TITLE
Fix Abode retrofit lock discovery

### DIFF
--- a/homeassistant/components/abode/manifest.json
+++ b/homeassistant/components/abode/manifest.json
@@ -9,6 +9,6 @@
   },
   "iot_class": "cloud_push",
   "loggers": ["jaraco.abode", "lomond"],
-  "requirements": ["jaraco.abode==6.2.1"],
+  "requirements": ["jaraco.abode==6.4.0"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1355,7 +1355,7 @@ ismartgate==5.0.2
 israel-rail-api==0.1.4
 
 # homeassistant.components.abode
-jaraco.abode==6.2.1
+jaraco.abode==6.4.0
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.11.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1201,7 +1201,7 @@ ismartgate==5.0.2
 israel-rail-api==0.1.4
 
 # homeassistant.components.abode
-jaraco.abode==6.2.1
+jaraco.abode==6.4.0
 
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.11.0

--- a/tests/components/abode/test_lock.py
+++ b/tests/components/abode/test_lock.py
@@ -1,6 +1,10 @@
 """Tests for the Abode lock device."""
 
+import json
 from unittest.mock import patch
+
+from jaraco.abode.helpers import urls as URL
+from requests_mock import Mocker
 
 from homeassistant.components.abode import ATTR_DEVICE_ID
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
@@ -14,6 +18,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
+
+from tests.common import async_load_fixture
 
 DEVICE_ID = "lock.test_lock"
 
@@ -63,3 +69,23 @@ async def test_unlock(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         mock_unlock.assert_called_once()
+
+
+async def test_retrofit_lock_discovered(
+    hass: HomeAssistant, requests_mock: Mocker
+) -> None:
+    """Test retrofit locks are discovered as lock entities."""
+    devices = json.loads(await async_load_fixture(hass, "devices.json", "abode"))
+    for device in devices:
+        if device["type_tag"] == "device_type.door_lock":
+            device["type_tag"] = "device_type.retrofit_lock"
+            device["type"] = "Retrofit Lock"
+            break
+
+    requests_mock.get(URL.DEVICES, text=json.dumps(devices))
+
+    await setup_platform(hass, LOCK_DOMAIN)
+
+    state = hass.states.get(DEVICE_ID)
+    assert state is not None
+    assert state.state == LockState.LOCKED


### PR DESCRIPTION
## Proposed change
This fixes Abode retrofit lock discovery by upgrading `jaraco.abode` from `6.2.1` to `6.4.0`.

In `6.2.1`, `device_type.retrofit_lock` is not mapped to the lock device class, so those devices are parsed as unknown and never exposed as lock entities in Home Assistant.

`6.4.0` adds `retrofit_lock` support in the upstream lock device mapping, which allows Home Assistant's existing lock setup logic (`generic_type="lock"`) to discover and create entities for retrofit locks.

This PR also adds a regression test that rewrites the lock fixture to `device_type.retrofit_lock` and verifies a lock entity is still created.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR fixes or closes issue: fixes #160748
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- Submitted from the official Abode account (`@goabodedevops`).

Dependency details:
- Compare `jaraco.abode` `6.2.1...6.4.0`: https://github.com/jaraco/jaraco.abode/compare/v6.2.1...v6.4.0
- Release page: https://github.com/jaraco/jaraco.abode/releases/tag/v6.4.0

Local validation:
- `PATH=".venv/bin:$PATH" .venv/bin/python -m script.hassfest --action validate --integration-path homeassistant/components/abode`
- `.venv/bin/pytest tests/components/abode/test_lock.py -q`
- `.venv/bin/ruff check tests/components/abode/test_lock.py`
- `.venv/bin/pylint --ignore-missing-annotations=y tests/components/abode/test_lock.py`

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

