### PR TITLE
Fix Tesla Fleet partner_login to not require vehicle scope.

### DIFF
--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 
 import jwt
 from tesla_fleet_api import TeslaFleetApi
-from tesla_fleet_api.const import SERVERS
+from tesla_fleet_api.const import SERVERS, Scope
 from tesla_fleet_api.exceptions import PreconditionFailed, TeslaFleetError
 import voluptuous as vol
 
@@ -85,7 +85,7 @@ class OAuth2FlowHandler(
             )
             await api.get_private_key(self.hass.config.path("tesla_fleet.key"))
             await api.partner_login(
-                implementation.client_id, implementation.client_secret
+                implementation.client_id, implementation.client_secret, [Scope.OPENID]
             )
             self.apis.append(api)
 

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -10,7 +10,13 @@ from typing import Any, cast
 import jwt
 from tesla_fleet_api import TeslaFleetApi
 from tesla_fleet_api.const import SERVERS, Scope
-from tesla_fleet_api.exceptions import PreconditionFailed, TeslaFleetError
+from tesla_fleet_api.exceptions import (
+    InvalidToken,
+    LoginRequired,
+    OAuthExpired,
+    PreconditionFailed,
+    TeslaFleetError,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
@@ -69,6 +75,7 @@ class OAuth2FlowHandler(
         # OAuth done, setup Partner API connections for all regions
         implementation = cast(TeslaUserImplementation, self.flow_impl)
         session = async_get_clientsession(self.hass)
+        failed_regions: list[str] = []
 
         for region, server_url in SERVERS.items():
             if region == "cn":
@@ -84,10 +91,36 @@ class OAuth2FlowHandler(
                 vehicle_scope=False,
             )
             await api.get_private_key(self.hass.config.path("tesla_fleet.key"))
-            await api.partner_login(
-                implementation.client_id, implementation.client_secret, [Scope.OPENID]
-            )
+            try:
+                await api.partner_login(
+                    implementation.client_id,
+                    implementation.client_secret,
+                    [Scope.OPENID],
+                )
+            except (InvalidToken, OAuthExpired, LoginRequired) as err:
+                LOGGER.warning(
+                    "Partner login failed for %s due to an authentication error: %s",
+                    server_url,
+                    err,
+                )
+                return self.async_abort(reason="oauth_error")
+            except TeslaFleetError as err:
+                LOGGER.warning("Partner login failed for %s: %s", server_url, err)
+                failed_regions.append(server_url)
+                continue
             self.apis.append(api)
+
+        if not self.apis:
+            LOGGER.warning(
+                "Partner login failed for all regions: %s", ", ".join(failed_regions)
+            )
+            return self.async_abort(reason="oauth_error")
+
+        if failed_regions:
+            LOGGER.warning(
+                "Partner login succeeded on some regions but failed on: %s",
+                ", ".join(failed_regions),
+            )
 
         return await self.async_step_domain_input()
 

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from tesla_fleet_api.exceptions import (
     InvalidResponse,
+    LoginRequired,
     PreconditionFailed,
     TeslaFleetError,
 )
@@ -85,6 +86,121 @@ def mock_private_key():
         ),
     ]
     return private_key
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_partner_login_auth_error(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key,
+) -> None:
+    """Test partner login auth errors abort the flow cleanly."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi"
+    ) as mock_api_class:
+        mock_api = AsyncMock()
+        mock_api.private_key = mock_private_key
+        mock_api.get_private_key = AsyncMock()
+        mock_api.partner_login = AsyncMock(side_effect=LoginRequired)
+        mock_api_class.return_value = mock_api
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "oauth_error"
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_partner_login_partial_failure(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    access_token: str,
+    mock_private_key,
+) -> None:
+    """Test partner login succeeds when one region fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT,
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": access_token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    public_key = "0404112233445566778899aabbccddeeff112233445566778899aabbccddeeff112233445566778899aabbccddeeff112233445566778899aabbccddeeff1122"
+
+    mock_api_na = AsyncMock()
+    mock_api_na.private_key = mock_private_key
+    mock_api_na.get_private_key = AsyncMock()
+    mock_api_na.partner_login = AsyncMock()
+    mock_api_na.public_uncompressed_point = public_key
+    mock_api_na.partner.register.return_value = {"response": {"public_key": public_key}}
+
+    mock_api_eu = AsyncMock()
+    mock_api_eu.private_key = mock_private_key
+    mock_api_eu.get_private_key = AsyncMock()
+    mock_api_eu.partner_login = AsyncMock(
+        side_effect=TeslaFleetError("EU partner login failed")
+    )
+
+    with patch(
+        "homeassistant.components.tesla_fleet.config_flow.TeslaFleetApi",
+        side_effect=[mock_api_na, mock_api_eu],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "domain_input"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_DOMAIN: "example.com"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "registration_complete"
 
 
 @pytest.mark.usefixtures("current_request_with_host")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The library defaults to using a vehicle data scope for partner logins, but its not required for what we do in Home Assistant, so this PR forces a scope that will work for all users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/166397
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
