### PR TITLE
Bump ZHA to 1.1.0

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==1.0.2", "serialx==0.6.2"],
+  "requirements": ["zha==1.1.0", "serialx==0.6.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -294,8 +294,14 @@
       "ias_zone": {
         "name": "IAS zone"
       },
+      "interconnectable": {
+        "name": "Interconnectable"
+      },
       "led_indicator": {
         "name": "LED indicator"
+      },
+      "lifecycle": {
+        "name": "Lifecycle"
       },
       "linkage_alarm_state": {
         "name": "Linkage alarm state"
@@ -303,8 +309,14 @@
       "mounting_mode_active": {
         "name": "Mounting mode active"
       },
+      "muted": {
+        "name": "Muted"
+      },
       "open_window_detection_status": {
         "name": "Open window detection status"
+      },
+      "preheat": {
+        "name": "Preheat"
       },
       "preheat_active": {
         "name": "Preheat active"
@@ -312,11 +324,20 @@
       "preheat_status": {
         "name": "Pre-heat status"
       },
+      "rain_detected": {
+        "name": "Rain detected"
+      },
       "replace_filter": {
         "name": "Replace filter"
       },
+      "self_test_state": {
+        "name": "Self-test"
+      },
       "silence_alarm": {
         "name": "Silence alarm"
+      },
+      "test": {
+        "name": "Test"
       },
       "valve_alarm": {
         "name": "Valve alarm"
@@ -335,14 +356,26 @@
       }
     },
     "button": {
+      "allow_remote_binding": {
+        "name": "Allow remote binding"
+      },
       "boost_mode": {
         "name": "Boost mode"
+      },
+      "calibrate_sensor": {
+        "name": "Calibrate sensor"
+      },
+      "calibrate_tvoc_sensor": {
+        "name": "Calibrate TVOC sensor"
       },
       "calibrate_valve": {
         "name": "Calibrate valve"
       },
       "calibrate_z_axis": {
         "name": "Calibrate Z axis"
+      },
+      "configure_limits": {
+        "name": "Configure cover limits"
       },
       "delete_all_limits": {
         "name": "Delete all limits"
@@ -367,6 +400,9 @@
       },
       "prepare_manual_calibration": {
         "name": "Prepare manual calibration"
+      },
+      "remote_test": {
+        "name": "Remote test"
       },
       "reset_alarm": {
         "name": "Reset alarm"
@@ -460,6 +496,9 @@
     "number": {
       "additional_steps": {
         "name": "Additional steps"
+      },
+      "air_threshold": {
+        "name": "Air threshold"
       },
       "alarm_duration": {
         "name": "Alarm duration"
@@ -677,6 +716,9 @@
       "installation_height": {
         "name": "Height from sensor to tank bottom"
       },
+      "integral_factor": {
+        "name": "Integral factor"
+      },
       "interval_time": {
         "name": "Interval time"
       },
@@ -706,6 +748,9 @@
       },
       "led_intensity_when_on": {
         "name": "Default all LED on intensity"
+      },
+      "length": {
+        "name": "Length"
       },
       "lift_drive_down_time": {
         "name": "Lift drive down time"
@@ -869,8 +914,17 @@
       "presence_sensitivity": {
         "name": "Presence sensitivity"
       },
+      "presence_sensor_sensitivity": {
+        "name": "Presence sensor sensitivity"
+      },
       "presence_timeout": {
         "name": "Fade time"
+      },
+      "proportional_gain": {
+        "name": "Proportional gain (Kp)"
+      },
+      "proportional_shift": {
+        "name": "Proportional shift (N)"
       },
       "pulse_configuration": {
         "name": "Pulse configuration"
@@ -911,6 +965,9 @@
       "sensitivity_level": {
         "name": "Sensitivity level"
       },
+      "sensor_sensitivity": {
+        "name": "Sensor sensitivity"
+      },
       "serving_size": {
         "name": "Serving to dispense"
       },
@@ -938,6 +995,9 @@
       "sound_volume": {
         "name": "Sound volume"
       },
+      "speed": {
+        "name": "Speed"
+      },
       "start_up_color_temperature": {
         "name": "Start-up color temperature"
       },
@@ -955,6 +1015,9 @@
       },
       "static_detection_sensitivity": {
         "name": "Static detection sensitivity"
+      },
+      "summer_backup_heating_demand": {
+        "name": "Summer backup heating demand"
       },
       "sustain_time": {
         "name": "Sustain time"
@@ -997,6 +1060,9 @@
       },
       "timer_time_left": {
         "name": "Timer time left"
+      },
+      "total_cycle_times": {
+        "name": "Total cycle times"
       },
       "transmit_power": {
         "name": "Transmit power"
@@ -1060,6 +1126,9 @@
       },
       "water_interval": {
         "name": "Water interval"
+      },
+      "winter_backup_heating_demand": {
+        "name": "Winter backup heating demand"
       }
     },
     "select": {
@@ -1086,6 +1155,15 @@
       },
       "approach_distance": {
         "name": "Approach distance"
+      },
+      "audio": {
+        "name": "Audio"
+      },
+      "audio_effect": {
+        "name": "Audio effect"
+      },
+      "audio_sensitivity": {
+        "name": "Audio sensitivity"
       },
       "backlight_mode": {
         "name": "Backlight mode"
@@ -1125,6 +1203,9 @@
       },
       "default_strobe_level": {
         "name": "Default strobe level"
+      },
+      "detach_relay": {
+        "name": "Detach relay"
       },
       "detection_distance": {
         "name": "Detection distance"
@@ -1401,6 +1482,12 @@
       "brightness_level": {
         "name": "Brightness level"
       },
+      "calibrated": {
+        "name": "Calibrated"
+      },
+      "chamber_contamination": {
+        "name": "Chamber contamination"
+      },
       "control_status": {
         "name": "Control status"
       },
@@ -1463,6 +1550,9 @@
       },
       "formaldehyde": {
         "name": "Formaldehyde concentration"
+      },
+      "gust_speed": {
+        "name": "Gust speed"
       },
       "heating_demand": {
         "name": "Heating demand"
@@ -1532,6 +1622,9 @@
       "last_pin_code": {
         "name": "Last PIN code"
       },
+      "last_remaining_battery_percentage": {
+        "name": "Last remaining battery percentage"
+      },
       "last_valve_open_duration": {
         "name": "Last valve open duration"
       },
@@ -1543,6 +1636,9 @@
       },
       "lifetime": {
         "name": "Lifetime"
+      },
+      "light_level": {
+        "name": "Light level"
       },
       "liquid_depth": {
         "name": "Liquid depth"
@@ -1607,8 +1703,17 @@
       "preheat_time": {
         "name": "Pre-heat time"
       },
+      "rebooted_count": {
+        "name": "Rebooted count"
+      },
+      "rejoined_count": {
+        "name": "Rejoined count"
+      },
       "remaining_watering_time": {
         "name": "Remaining watering time"
+      },
+      "reported_packages": {
+        "name": "Reported packages"
       },
       "rms_current_ph_b": {
         "name": "Current phase B"
@@ -1645,6 +1750,9 @@
       },
       "smoke_density": {
         "name": "Smoke density"
+      },
+      "smoke_level": {
+        "name": "Smoke level"
       },
       "software_error": {
         "name": "Software error",
@@ -1742,6 +1850,12 @@
       "total_power_factor": {
         "name": "Total power factor"
       },
+      "total_volatile_organic_compounds": {
+        "name": "Total volatile organic compounds"
+      },
+      "uv_index": {
+        "name": "UV index"
+      },
       "valve_adapt_status": {
         "name": "Valve adaptation status"
       },
@@ -1771,6 +1885,9 @@
       },
       "window_covering_type": {
         "name": "Window covering type"
+      },
+      "work_mode": {
+        "name": "Work mode"
       }
     },
     "switch": {
@@ -1779,6 +1896,9 @@
       },
       "adaptive_mode": {
         "name": "Adaptive mode"
+      },
+      "alarm_switch": {
+        "name": "Alarm switch"
       },
       "auto_clean": {
         "name": "Autoclean"
@@ -1810,6 +1930,9 @@
       "detach_relay": {
         "name": "Detach relay"
       },
+      "detach_relay_id": {
+        "name": "Detach relay {id}"
+      },
       "detached": {
         "name": "Detached mode"
       },
@@ -1821,6 +1944,9 @@
       },
       "disable_clear_notifications_double_tap": {
         "name": "Disable config 2x tap to clear notifications"
+      },
+      "disable_double_click": {
+        "name": "Disable double click"
       },
       "disable_led": {
         "name": "Disable LED"
@@ -1921,6 +2047,9 @@
       "mute_siren": {
         "name": "Mute siren"
       },
+      "network_led": {
+        "name": "Network LED"
+      },
       "on_only_when_dark": {
         "name": "On only when dark"
       },
@@ -1971,6 +2100,9 @@
       },
       "sound_enabled": {
         "name": "Sound enabled"
+      },
+      "summer_mode": {
+        "name": "Summer mode"
       },
       "switch": {
         "name": "[%key:component::switch::title%]"

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1183,6 +1183,9 @@
       "click_mode": {
         "name": "Click mode"
       },
+      "color_temperature_channel": {
+        "name": "Color temperature channel"
+      },
       "control_type": {
         "name": "Control type"
       },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3389,7 +3389,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.0.2
+zha==1.1.0
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2865,7 +2865,7 @@ zeroconf==0.148.0
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha==1.0.2
+zha==1.1.0
 
 # homeassistant.components.zinvolt
 zinvolt==0.3.0

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -404,6 +404,7 @@ async def test_firmware_update_success(
                 # After a successful OTA, zigpy sends a post-OTA image_notify
                 # which triggers a query_next_image -> NO_IMAGE_AVAILABLE exchange
                 if cmd.status == foundation.Status.NO_IMAGE_AVAILABLE:
+                    assert ota_completed
                     return
 
                 assert cmd.status == foundation.Status.SUCCESS

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -375,10 +375,17 @@ async def test_firmware_update_success(
         attrs[ATTR_LATEST_VERSION] == f"0x{fw_image.firmware.header.file_version:08x}"
     )
 
+    ota_completed = False
+
     async def endpoint_reply(cluster, sequence, data, **kwargs):
+        nonlocal ota_completed
         if cluster == general.Ota.cluster_id:
             _hdr, cmd = ota_cluster.deserialize(data)
             if isinstance(cmd, general.Ota.ImageNotifyCommand):
+                if ota_completed:
+                    # Post-OTA image_notify: ignore or don't respond
+                    return
+
                 zha_device.device.device.packet_received(
                     make_packet(
                         zha_device.device.device,
@@ -394,6 +401,11 @@ async def test_firmware_update_success(
             elif isinstance(
                 cmd, general.Ota.ClientCommandDefs.query_next_image_response.schema
             ):
+                # After a successful OTA, zigpy sends a post-OTA image_notify
+                # which triggers a query_next_image -> NO_IMAGE_AVAILABLE exchange
+                if cmd.status == foundation.Status.NO_IMAGE_AVAILABLE:
+                    return
+
                 assert cmd.status == foundation.Status.SUCCESS
                 assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
                 assert cmd.image_type == fw_image.firmware.header.image_type
@@ -485,6 +497,8 @@ async def test_firmware_update_success(
                 assert cmd.file_version == fw_image.firmware.header.file_version
                 assert cmd.current_time == 0
                 assert cmd.upgrade_time == 0
+
+                ota_completed = True
 
                 def read_new_fw_version(*args, **kwargs):
                     ota_cluster.update_attribute(
@@ -590,6 +604,9 @@ async def test_firmware_update_raises(
             elif isinstance(
                 cmd, general.Ota.ClientCommandDefs.query_next_image_response.schema
             ):
+                if cmd.status == foundation.Status.NO_IMAGE_AVAILABLE:
+                    return
+
                 assert cmd.status == foundation.Status.SUCCESS
                 assert cmd.manufacturer_code == fw_image.firmware.header.manufacturer_id
                 assert cmd.image_type == fw_image.firmware.header.image_type


### PR DESCRIPTION
## Proposed change

This bumps ZHA to [1.1.0](https://github.com/zigpy/zha/releases/tag/1.1.0) (full diff: https://github.com/zigpy/zha/compare/1.0.2...1.1.0).
These dependency upgrades are bundled with it: 

- `zigpy` [1.2.1](https://github.com/zigpy/zigpy/releases/tag/1.2.1), including [1.2.0](https://github.com/zigpy/zigpy/releases/tag/1.2.0)
full diff: https://github.com/zigpy/zigpy/compare/1.1.1...1.2.1

- `zha-quirks` [1.1.0](https://github.com/zigpy/zha-device-handlers/releases/tag/1.1.0)
full diff: https://github.com/zigpy/zha-device-handlers/compare/1.0.1...1.1.0

New strings for ZHA and quirks v2 entities have also been added.

Tests needed to be slightly modified as zigpy now sends an "image notify" command when a device joins and after an update has finished. This allows for a better user-experience with chained OTA upgrades. We want to ignore this "image notify" command during our OTA updates, so that's what the test is modified for. All new functionality is handled in the libraries and thus also tested there.

A quick overview of the changes in this ZHA release:
- Lots of quirks were added and existing ones improved
- OTA update entities now show if an update is available or if they're up-to-date after startup
  - Previously, we required devices to check-in with an image query command. This command is cached now 
  - Due to needing to cache OTA image query cmds from all devices, this may only work properly after a day or so
- New features were added for BEGA devices
- New features were added for Frient devices
- New features were added for Heiman devices
- New features were added for Third Reality devices
- Time synchronization during DST is improved
- Configuring attribute reporting with colliding ZCL attribute IDs is improved
- Other small fixes and improvements...

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
