### PR TITLE
Filter artificial zero values at UTC midnight from Forecast.Solar data

### DIFF
--- a/homeassistant/components/forecast_solar/energy.py
+++ b/homeassistant/components/forecast_solar/energy.py
@@ -20,5 +20,7 @@ async def async_get_solar_forecast(
         "wh_hours": {
             timestamp.isoformat(): val
             for timestamp, val in entry.runtime_data.data.wh_period.items()
+            if val != 0
+            or (timestamp.hour, timestamp.minute, timestamp.second) != (0, 0, 0)
         }
     }

--- a/tests/components/forecast_solar/test_energy.py
+++ b/tests/components/forecast_solar/test_energy.py
@@ -33,3 +33,35 @@ async def test_energy_solar_forecast(
             "2021-06-27T14:00:00+00:00": 8,
         }
     }
+
+
+async def test_energy_solar_forecast_filters_midnight_utc_zeros(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_forecast_solar: MagicMock,
+) -> None:
+    """Test that artificial zero values at UTC midnight boundaries are filtered out."""
+    mock_forecast_solar.estimate.return_value.wh_period = {
+        datetime(2021, 6, 27, 0, 0, tzinfo=UTC): 0,
+        datetime(2021, 6, 27, 1, 0, tzinfo=UTC): 1388,
+        datetime(2021, 6, 27, 2, 0, tzinfo=UTC): 830,
+        datetime(2021, 6, 27, 14, 0, tzinfo=UTC): 0,
+        datetime(2021, 6, 27, 15, 0, tzinfo=UTC): 292,
+        datetime(2021, 6, 28, 0, 0, tzinfo=UTC): 0,
+    }
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    result = await energy.async_get_solar_forecast(hass, mock_config_entry.entry_id)
+    assert result == {
+        "wh_hours": {
+            "2021-06-27T01:00:00+00:00": 1388,
+            "2021-06-27T02:00:00+00:00": 830,
+            "2021-06-27T14:00:00+00:00": 0,
+            "2021-06-27T15:00:00+00:00": 292,
+        }
+    }


### PR DESCRIPTION
## Proposed change

The Forecast.Solar API inserts zero `wh_period` values at UTC midnight day boundaries. For locations where UTC midnight falls during daytime (e.g. Sydney at UTC+11), this causes a visible glitch/dip in the Energy Dashboard solar production chart.

This filters out the artificial zero entries at exactly midnight UTC when preparing forecast data for the energy dashboard. Legitimate zero values at other times (sunrise/sunset boundaries) are preserved.

Tested with this script for Sydney
```
import asyncio
import aiohttp
import json

async def main():
    # Sydney, Australia - UTC+10/+11, solar day spans UTC midnight
    lat, lon = -33.87, 151.21
    declination, azimuth, kwp = 30, 0, 5
    
    url = f'https://api.forecast.solar/estimate/{lat}/{lon}/{declination}/{azimuth}/{kwp}'
    params = {'time': 'utc'}
    
    async with aiohttp.ClientSession() as session:
        async with session.get(url, params=params) as resp:
            data = await resp.json()
            
            print('=== watt_hours_period (full) ===')
            for ts, val in data['result']['watt_hours_period'].items():
                marker = ' <<<< MIDNIGHT UTC' if 'T00:00:00' in ts else ''
                print(f'  {ts}: {val}{marker}')

asyncio.run(main())
```

Result was
```
=== watt_hours_period (full) ===
  2026-03-25T00:00:00+00:00: 0 <<<< MIDNIGHT UTC
  2026-03-25T01:00:00+00:00: 2035
  2026-03-25T02:00:00+00:00: 2078
  2026-03-25T03:00:00+00:00: 1858
  2026-03-25T04:00:00+00:00: 1461
  2026-03-25T05:00:00+00:00: 1056
  2026-03-25T06:00:00+00:00: 735
  2026-03-25T07:00:00+00:00: 450
  2026-03-25T08:00:00+00:00: 194
  2026-03-25T08:00:36+00:00: 0
  2026-03-25T20:02:38+00:00: 0
  2026-03-25T21:00:00+00:00: 123
  2026-03-25T22:00:00+00:00: 346
  2026-03-25T23:00:00+00:00: 502
  2026-03-26T00:00:00+00:00: 0 <<<< MIDNIGHT UTC
  2026-03-26T01:00:00+00:00: 718
  2026-03-26T02:00:00+00:00: 766
  2026-03-26T03:00:00+00:00: 762
  2026-03-26T04:00:00+00:00: 707
  2026-03-26T05:00:00+00:00: 606
  2026-03-26T06:00:00+00:00: 466
  2026-03-26T07:00:00+00:00: 313
  2026-03-26T07:59:15+00:00: 117
```

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #166443
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr