### PR TITLE
Migrate Tessie to tesla-fleet-api 1.4.5

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -9,11 +9,11 @@ from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
     InvalidToken,
+    MissingToken,
     SubscriptionRequired,
     TeslaFleetError,
 )
 from tesla_fleet_api.tessie import Tessie
-from tessie_api import get_state_of_all_vehicles
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
@@ -33,6 +33,7 @@ from .coordinator import (
     TessieEnergySiteLiveCoordinator,
     TessieStateUpdateCoordinator,
 )
+from .helpers import fetch_state_of_all_vehicles
 from .models import TessieData, TessieEnergyData, TessieVehicleData
 
 PLATFORMS = [
@@ -59,52 +60,58 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     """Set up Tessie config."""
     api_key = entry.data[CONF_ACCESS_TOKEN]
     session = async_get_clientsession(hass)
+    tessie = Tessie(session, api_key)
 
     try:
-        state_of_all_vehicles = await get_state_of_all_vehicles(
-            session=session,
-            api_key=api_key,
-            only_active=True,
+        state_of_all_vehicles = await fetch_state_of_all_vehicles(
+            tessie, only_active=True
         )
     except ClientResponseError as e:
         if e.status == HTTPStatus.UNAUTHORIZED:
             raise ConfigEntryAuthFailed from e
         raise ConfigEntryError("Setup failed, unable to connect to Tessie") from e
+    except (InvalidToken, MissingToken) as e:
+        raise ConfigEntryAuthFailed from e
+    except TeslaFleetError as e:
+        raise ConfigEntryError("Setup failed, unable to connect to Tessie") from e
     except ClientError as e:
         raise ConfigEntryNotReady from e
 
-    vehicles = [
-        TessieVehicleData(
-            vin=vehicle["vin"],
-            data_coordinator=TessieStateUpdateCoordinator(
-                hass,
-                entry,
-                api_key=api_key,
+    vehicles = []
+    for vehicle in state_of_all_vehicles["results"]:
+        if vehicle["last_state"] is None:
+            continue
+
+        vehicle_api = tessie.vehicles.create(vehicle["vin"])
+        vehicles.append(
+            TessieVehicleData(
+                api=vehicle_api,
                 vin=vehicle["vin"],
-                data=vehicle["last_state"],
-            ),
-            device=DeviceInfo(
-                identifiers={(DOMAIN, vehicle["vin"])},
-                manufacturer="Tesla",
-                configuration_url="https://my.tessie.com/",
-                name=vehicle["last_state"]["display_name"],
-                model=MODELS.get(
-                    vehicle["last_state"]["vehicle_config"]["car_type"],
-                    vehicle["last_state"]["vehicle_config"]["car_type"],
+                data_coordinator=TessieStateUpdateCoordinator(
+                    hass,
+                    entry,
+                    api=vehicle_api,
+                    data=vehicle["last_state"],
                 ),
-                sw_version=vehicle["last_state"]["vehicle_state"]["car_version"].split(
-                    " "
-                )[0],
-                hw_version=vehicle["last_state"]["vehicle_config"]["driver_assist"],
-                serial_number=vehicle["vin"],
-            ),
+                device=DeviceInfo(
+                    identifiers={(DOMAIN, vehicle["vin"])},
+                    manufacturer="Tesla",
+                    configuration_url="https://my.tessie.com/",
+                    name=vehicle["last_state"]["display_name"],
+                    model=MODELS.get(
+                        vehicle["last_state"]["vehicle_config"]["car_type"],
+                        vehicle["last_state"]["vehicle_config"]["car_type"],
+                    ),
+                    sw_version=vehicle["last_state"]["vehicle_state"][
+                        "car_version"
+                    ].split(" ")[0],
+                    hw_version=vehicle["last_state"]["vehicle_config"]["driver_assist"],
+                    serial_number=vehicle["vin"],
+                ),
+            )
         )
-        for vehicle in state_of_all_vehicles["results"]
-        if vehicle["last_state"] is not None
-    ]
 
     # Energy Sites
-    tessie = Tessie(session, api_key)
     energysites: list[TessieEnergyData] = []
 
     try:
@@ -119,58 +126,56 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
             raise ConfigEntryNotReady from e
 
         for product in products:
-            if "energy_site_id" in product:
-                site_id = product["energy_site_id"]
-                if not (
-                    product["components"]["battery"]
-                    or product["components"]["solar"]
-                    or "wall_connectors" in product["components"]
-                ):
-                    _LOGGER.debug(
-                        "Skipping Energy Site %s as it has no components",
-                        site_id,
-                    )
-                    continue
+            if "energy_site_id" not in product:
+                continue
 
-                api = tessie.energySites.create(site_id)
-
-                try:
-                    live_status = (await api.live_status())["response"]
-                except (InvalidToken, Forbidden, SubscriptionRequired) as e:
-                    raise ConfigEntryAuthFailed from e
-                except TeslaFleetError as e:
-                    raise ConfigEntryNotReady(e.message) from e
-
-                powerwall = (
-                    product["components"]["battery"] or product["components"]["solar"]
+            site_id = product["energy_site_id"]
+            if not (
+                product["components"]["battery"]
+                or product["components"]["solar"]
+                or "wall_connectors" in product["components"]
+            ):
+                _LOGGER.debug(
+                    "Skipping Energy Site %s as it has no components",
+                    site_id,
                 )
+                continue
 
-                energysites.append(
-                    TessieEnergyData(
-                        api=api,
-                        id=site_id,
-                        live_coordinator=(
-                            TessieEnergySiteLiveCoordinator(
-                                hass, entry, api, live_status
-                            )
-                            if isinstance(live_status, dict)
-                            else None
-                        ),
-                        info_coordinator=TessieEnergySiteInfoCoordinator(
-                            hass, entry, api
-                        ),
-                        history_coordinator=(
-                            TessieEnergyHistoryCoordinator(hass, entry, api)
-                            if powerwall
-                            else None
-                        ),
-                        device=DeviceInfo(
-                            identifiers={(DOMAIN, str(site_id))},
-                            manufacturer="Tesla",
-                            name=product.get("site_name", "Energy Site"),
-                        ),
-                    )
+            api = tessie.energySites.create(site_id)
+
+            try:
+                live_status = (await api.live_status())["response"]
+            except (InvalidToken, Forbidden, SubscriptionRequired) as e:
+                raise ConfigEntryAuthFailed from e
+            except TeslaFleetError as e:
+                raise ConfigEntryNotReady(e.message) from e
+
+            powerwall = (
+                product["components"]["battery"] or product["components"]["solar"]
+            )
+
+            energysites.append(
+                TessieEnergyData(
+                    api=api,
+                    id=site_id,
+                    live_coordinator=(
+                        TessieEnergySiteLiveCoordinator(hass, entry, api, live_status)
+                        if isinstance(live_status, dict)
+                        else None
+                    ),
+                    info_coordinator=TessieEnergySiteInfoCoordinator(hass, entry, api),
+                    history_coordinator=(
+                        TessieEnergyHistoryCoordinator(hass, entry, api)
+                        if powerwall
+                        else None
+                    ),
+                    device=DeviceInfo(
+                        identifiers={(DOMAIN, str(site_id))},
+                        manufacturer="Tesla",
+                        name=product.get("site_name", "Energy Site"),
+                    ),
                 )
+            )
 
         # Populate coordinator data before forwarding to platforms
         await asyncio.gather(

--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -2,17 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-from tessie_api import (
-    boombox,
-    enable_keyless_driving,
-    flash_lights,
-    honk,
-    trigger_homelink,
-    wake,
-)
+from tesla_fleet_api.tessie import Vehicle
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
@@ -29,21 +22,21 @@ PARALLEL_UPDATES = 0
 class TessieButtonEntityDescription(ButtonEntityDescription):
     """Describes a Tessie Button entity."""
 
-    func: Callable
+    func: Callable[[Vehicle], Awaitable[dict]]
 
 
 DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
-    TessieButtonEntityDescription(key="wake", func=lambda: wake),
-    TessieButtonEntityDescription(key="flash_lights", func=lambda: flash_lights),
-    TessieButtonEntityDescription(key="honk", func=lambda: honk),
+    TessieButtonEntityDescription(key="wake", func=lambda api: api.wake()),
+    TessieButtonEntityDescription(key="flash_lights", func=lambda api: api.flash()),
+    TessieButtonEntityDescription(key="honk", func=lambda api: api.honk()),
     TessieButtonEntityDescription(
-        key="trigger_homelink", func=lambda: trigger_homelink
+        key="trigger_homelink", func=lambda api: api.tessie_trigger_homelink()
     ),
     TessieButtonEntityDescription(
         key="enable_keyless_driving",
-        func=lambda: enable_keyless_driving,
+        func=lambda api: api.remote_start(),
     ),
-    TessieButtonEntityDescription(key="boombox", func=lambda: boombox),
+    TessieButtonEntityDescription(key="boombox", func=lambda api: api.remote_boombox()),
 )
 
 
@@ -78,4 +71,4 @@ class TessieButtonEntity(TessieEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Press the button."""
-        await self.run(self.entity_description.func())
+        await self.run(self.entity_description.func(self.api))

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -4,13 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from tessie_api import (
-    set_climate_keeper_mode,
-    set_temperature,
-    start_climate_preconditioning,
-    stop_climate,
-)
-
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
     ClimateEntity,
@@ -102,12 +95,12 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
 
     async def async_turn_on(self) -> None:
         """Set the climate state to on."""
-        await self.run(start_climate_preconditioning)
+        await self.run(self.api.start_climate())
         self.set(("climate_state_is_climate_on", True))
 
     async def async_turn_off(self) -> None:
         """Set the climate state to off."""
-        await self.run(stop_climate)
+        await self.run(self.api.stop_climate())
         self.set(
             ("climate_state_is_climate_on", False),
             ("climate_state_climate_keeper_mode", "off"),
@@ -119,7 +112,7 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
             await self.async_set_hvac_mode(mode)
 
         if temp := kwargs.get(ATTR_TEMPERATURE):
-            await self.run(set_temperature, temperature=temp)
+            await self.run(self.api.set_temperatures(temp))
             self.set(("climate_state_driver_temp_setting", temp))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
@@ -132,7 +125,9 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the climate preset mode."""
         await self.run(
-            set_climate_keeper_mode, mode=self._attr_preset_modes.index(preset_mode)
+            self.api.tessie_set_climate_keeper_mode(
+                self._attr_preset_modes.index(preset_mode)
+            )
         )
         self.set(
             (

--- a/homeassistant/components/tessie/config_flow.py
+++ b/homeassistant/components/tessie/config_flow.py
@@ -7,7 +7,8 @@ from http import HTTPStatus
 from typing import Any
 
 from aiohttp import ClientConnectionError, ClientResponseError
-from tessie_api import get_state_of_all_vehicles
+from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
+from tesla_fleet_api.tessie import Tessie
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -15,6 +16,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
+from .helpers import fetch_state_of_all_vehicles
 
 TESSIE_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
 DESCRIPTION_PLACEHOLDERS = {
@@ -36,9 +38,11 @@ class TessieConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             self._async_abort_entries_match(dict(user_input))
             try:
-                await get_state_of_all_vehicles(
-                    session=async_get_clientsession(self.hass),
-                    api_key=user_input[CONF_ACCESS_TOKEN],
+                await fetch_state_of_all_vehicles(
+                    Tessie(
+                        async_get_clientsession(self.hass),
+                        user_input[CONF_ACCESS_TOKEN],
+                    ),
                     only_active=True,
                 )
             except ClientResponseError as e:
@@ -46,8 +50,12 @@ class TessieConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors[CONF_ACCESS_TOKEN] = "invalid_access_token"
                 else:
                     errors["base"] = "unknown"
+            except InvalidToken, MissingToken:
+                errors[CONF_ACCESS_TOKEN] = "invalid_access_token"
             except ClientConnectionError:
                 errors["base"] = "cannot_connect"
+            except TeslaFleetError:
+                errors["base"] = "unknown"
             else:
                 return self.async_create_entry(
                     title="Tessie",
@@ -75,17 +83,23 @@ class TessieConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input:
             try:
-                await get_state_of_all_vehicles(
-                    session=async_get_clientsession(self.hass),
-                    api_key=user_input[CONF_ACCESS_TOKEN],
+                await fetch_state_of_all_vehicles(
+                    Tessie(
+                        async_get_clientsession(self.hass),
+                        user_input[CONF_ACCESS_TOKEN],
+                    )
                 )
             except ClientResponseError as e:
                 if e.status == HTTPStatus.UNAUTHORIZED:
                     errors[CONF_ACCESS_TOKEN] = "invalid_access_token"
                 else:
                     errors["base"] = "unknown"
+            except InvalidToken, MissingToken:
+                errors[CONF_ACCESS_TOKEN] = "invalid_access_token"
             except ClientConnectionError:
                 errors["base"] = "cannot_connect"
+            except TeslaFleetError:
+                errors["base"] = "unknown"
             else:
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(), data=user_input

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -10,12 +10,10 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import TeslaEnergyPeriod
 from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
-from tesla_fleet_api.tessie import EnergySite
-from tessie_api import get_state
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -54,8 +52,7 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         hass: HomeAssistant,
         config_entry: TessieConfigEntry,
-        api_key: str,
-        vin: str,
+        api: Vehicle,
         data: dict[str, Any],
     ) -> None:
         """Initialize Tessie Data Update Coordinator."""
@@ -66,20 +63,13 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             name="Tessie",
             update_interval=timedelta(seconds=TESSIE_SYNC_INTERVAL),
         )
-        self.api_key = api_key
-        self.vin = vin
-        self.session = async_get_clientsession(hass)
+        self.api = api
         self.data = flatten(data)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using Tessie API."""
         try:
-            vehicle = await get_state(
-                session=self.session,
-                api_key=self.api_key,
-                vin=self.vin,
-                use_cache=True,
-            )
+            vehicle = await self.api.state(use_cache=True)
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
                 raise ConfigEntryAuthFailed from e
@@ -87,7 +77,14 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
             ) from e
+        except (InvalidToken, MissingToken) as e:
+            raise ConfigEntryAuthFailed from e
         except ClientError as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
+        except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
@@ -125,7 +122,6 @@ class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update energy site data using Tessie API."""
-
         try:
             data = (await self.api.live_status())["response"]
         except (InvalidToken, MissingToken) as e:
@@ -164,7 +160,6 @@ class TessieEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update energy site data using Tessie API."""
-
         try:
             data = (await self.api.site_info())["response"]
         except (InvalidToken, MissingToken) as e:
@@ -202,7 +197,6 @@ class TessieEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update energy history data using Tessie API."""
-
         try:
             data = (await self.api.energy_history(TeslaEnergyPeriod.DAY))["response"]
         except (InvalidToken, MissingToken) as e:

--- a/homeassistant/components/tessie/cover.py
+++ b/homeassistant/components/tessie/cover.py
@@ -5,17 +5,6 @@ from __future__ import annotations
 from itertools import chain
 from typing import Any
 
-from tessie_api import (
-    close_charge_port,
-    close_sunroof,
-    close_windows,
-    open_close_rear_trunk,
-    open_front_trunk,
-    open_unlock_charge_port,
-    vent_sunroof,
-    vent_windows,
-)
-
 from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntity,
@@ -85,7 +74,7 @@ class TessieWindowEntity(TessieEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open windows."""
-        await self.run(vent_windows)
+        await self.run(self.api.vent_windows())
         self.set(
             ("vehicle_state_fd_window", TessieCoverStates.OPEN),
             ("vehicle_state_fp_window", TessieCoverStates.OPEN),
@@ -95,7 +84,7 @@ class TessieWindowEntity(TessieEntity, CoverEntity):
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close windows."""
-        await self.run(close_windows)
+        await self.run(self.api.close_windows())
         self.set(
             ("vehicle_state_fd_window", TessieCoverStates.CLOSED),
             ("vehicle_state_fp_window", TessieCoverStates.CLOSED),
@@ -121,12 +110,12 @@ class TessieChargePortEntity(TessieEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open windows."""
-        await self.run(open_unlock_charge_port)
+        await self.run(self.api.open_charge_port())
         self.set((self.key, True))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close windows."""
-        await self.run(close_charge_port)
+        await self.run(self.api.close_charge_port())
         self.set((self.key, False))
 
 
@@ -147,7 +136,7 @@ class TessieFrontTrunkEntity(TessieEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open front trunk."""
-        await self.run(open_front_trunk)
+        await self.run(self.api.activate_front_trunk())
         self.set((self.key, TessieCoverStates.OPEN))
 
 
@@ -169,13 +158,13 @@ class TessieRearTrunkEntity(TessieEntity, CoverEntity):
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open rear trunk."""
         if self.is_closed:
-            await self.run(open_close_rear_trunk)
+            await self.run(self.api.activate_rear_trunk())
             self.set((self.key, TessieCoverStates.OPEN))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close rear trunk."""
         if not self.is_closed:
-            await self.run(open_close_rear_trunk)
+            await self.run(self.api.activate_rear_trunk())
             self.set((self.key, TessieCoverStates.CLOSED))
 
 
@@ -201,10 +190,10 @@ class TessieSunroofEntity(TessieEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open sunroof."""
-        await self.run(vent_sunroof)
+        await self.run(self.api.vent_sunroof())
         self.set((self.key, TessieCoverStates.OPEN))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close sunroof."""
-        await self.run(close_sunroof)
+        await self.run(self.api.close_sunroof())
         self.set((self.key, TessieCoverStates.CLOSED))

--- a/homeassistant/components/tessie/entity.py
+++ b/homeassistant/components/tessie/entity.py
@@ -1,22 +1,20 @@
 """Tessie parent entity class."""
 
 from abc import abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable
 from typing import Any
 
-from aiohttp import ClientError
-
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, TRANSLATED_ERRORS
+from .const import DOMAIN
 from .coordinator import (
     TessieEnergyHistoryCoordinator,
     TessieEnergySiteInfoCoordinator,
     TessieEnergySiteLiveCoordinator,
     TessieStateUpdateCoordinator,
 )
+from .helpers import handle_command
 from .models import TessieEnergyData, TessieVehicleData
 
 
@@ -42,7 +40,6 @@ class TessieBaseEntity(
         data_key: str | None = None,
     ) -> None:
         """Initialize common aspects of a Tessie entity."""
-
         self.key = key
         self.data_key = data_key or key
         self._attr_translation_key = key
@@ -79,8 +76,7 @@ class TessieEntity(TessieBaseEntity):
     ) -> None:
         """Initialize common aspects of a Tessie vehicle entity."""
         self.vin = vehicle.vin
-        self._session = vehicle.data_coordinator.session
-        self._api_key = vehicle.data_coordinator.api_key
+        self.api = vehicle.api
         self._attr_unique_id = f"{vehicle.vin}-{key}"
         self._attr_device_info = vehicle.device
 
@@ -92,31 +88,9 @@ class TessieEntity(TessieBaseEntity):
             self.coordinator.data[key] = value
         self.async_write_ha_state()
 
-    async def run(
-        self, func: Callable[..., Awaitable[dict[str, Any]]], **kargs: Any
-    ) -> None:
-        """Run a tessie_api function and handle exceptions."""
-        try:
-            response = await func(
-                session=self._session,
-                vin=self.vin,
-                api_key=self._api_key,
-                **kargs,
-            )
-        except ClientError as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="cannot_connect",
-            ) from e
-        if response["result"] is False:
-            name: str = getattr(self, "name", self.entity_id)
-            reason: str = response.get("reason", "unknown")
-            translation_key = TRANSLATED_ERRORS.get(reason, "command_failed")
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key=translation_key,
-                translation_placeholders={"name": name, "message": reason},
-            )
+    async def run(self, command: Awaitable[dict[str, Any]]) -> None:
+        """Run a Tesla Fleet API command and handle exceptions."""
+        await handle_command(command, getattr(self, "name", self.entity_id))
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""

--- a/homeassistant/components/tessie/helpers.py
+++ b/homeassistant/components/tessie/helpers.py
@@ -1,24 +1,54 @@
 """Tessie helper functions."""
 
+import logging
 from typing import Any
 
+from aiohttp import ClientError
 from tesla_fleet_api.exceptions import TeslaFleetError
+from tesla_fleet_api.tessie import Tessie
 
 from homeassistant.exceptions import HomeAssistantError
 
-from . import _LOGGER
-from .const import DOMAIN
+from .const import DOMAIN, TRANSLATED_ERRORS
+
+_LOGGER = logging.getLogger(__name__)
 
 
-async def handle_command(command) -> dict[str, Any]:
+async def fetch_state_of_all_vehicles(
+    api: Tessie, only_active: bool = True
+) -> dict[str, Any]:
+    """Fetch the latest state for all vehicles."""
+    return await api.list_vehicles(only_active=only_active)
+
+
+async def handle_command(command, name: str | None = None) -> dict[str, Any]:
     """Handle a command."""
     try:
         result = await command
-    except TeslaFleetError as e:
+    except ClientError as e:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
-            translation_key="command_failed",
-            translation_placeholders={"message": e.message},
+            translation_key="cannot_connect",
         ) from e
+    except TeslaFleetError as e:
+        key = getattr(e, "key", None)
+        error_key: str = key if isinstance(key, str) else "unknown"
+        translation_key = TRANSLATED_ERRORS.get(error_key, "command_failed")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={"message": e.message, "name": name or "Entity"},
+        ) from e
+
+    response = result.get("response", result)
+    if response.get("result") is False:
+        reason = response.get("reason", "unknown")
+        translation_key = TRANSLATED_ERRORS.get(reason, "command_failed")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={"message": reason, "name": name or "Entity"},
+        )
+
     _LOGGER.debug("Command result: %s", result)
     return result

--- a/homeassistant/components/tessie/lock.py
+++ b/homeassistant/components/tessie/lock.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from tessie_api import lock, open_unlock_charge_port, unlock
-
 from homeassistant.components.lock import LockEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
@@ -51,12 +49,12 @@ class TessieLockEntity(TessieEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Set new value."""
-        await self.run(lock)
+        await self.run(self.api.lock())
         self.set((self.key, True))
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Set new value."""
-        await self.run(unlock)
+        await self.run(self.api.unlock())
         self.set((self.key, False))
 
 
@@ -84,5 +82,5 @@ class TessieCableLockEntity(TessieEntity, LockEntity):
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock charge cable lock."""
-        await self.run(open_unlock_charge_port)
+        await self.run(self.api.open_charge_port())
         self.set((self.key, TessieChargeCableLockStates.DISENGAGED))

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
   "quality_scale": "silver",
-  "requirements": ["tessie-api==0.1.1", "tesla-fleet-api==1.4.5"]
+  "requirements": ["tesla-fleet-api==1.4.5"]
 }

--- a/homeassistant/components/tessie/models.py
+++ b/homeassistant/components/tessie/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tesla_fleet_api.tessie import EnergySite
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -26,7 +26,7 @@ class TessieData:
 
 @dataclass
 class TessieEnergyData:
-    """Data for a Energy Site in the Tessie integration."""
+    """Data for an energy site in the Tessie integration."""
 
     api: EnergySite
     live_coordinator: TessieEnergySiteLiveCoordinator | None
@@ -40,6 +40,7 @@ class TessieEnergyData:
 class TessieVehicleData:
     """Data for a Tessie vehicle."""
 
+    api: Vehicle
     data_coordinator: TessieStateUpdateCoordinator
     device: DeviceInfo
     vin: str

--- a/homeassistant/components/tessie/number.py
+++ b/homeassistant/components/tessie/number.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import Any
 
-from tesla_fleet_api.tessie import EnergySite
-from tessie_api import set_charge_limit, set_charging_amps, set_speed_limit
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -38,8 +37,7 @@ PARALLEL_UPDATES = 0
 class TessieNumberEntityDescription(NumberEntityDescription):
     """Describes Tessie Number entity."""
 
-    func: Callable
-    arg: str
+    func: Callable[[Vehicle, float], Awaitable[Any]]
     native_min_value: float
     native_max_value: float
     min_key: str | None = None
@@ -55,8 +53,7 @@ VEHICLE_DESCRIPTIONS: tuple[TessieNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=NumberDeviceClass.CURRENT,
         max_key="charge_state_charge_current_request_max",
-        func=lambda: set_charging_amps,
-        arg="amps",
+        func=lambda api, value: api.tessie_set_charging_amps(int(value)),
     ),
     TessieNumberEntityDescription(
         key="charge_state_charge_limit_soc",
@@ -67,8 +64,7 @@ VEHICLE_DESCRIPTIONS: tuple[TessieNumberEntityDescription, ...] = (
         device_class=NumberDeviceClass.BATTERY,
         min_key="charge_state_charge_limit_soc_min",
         max_key="charge_state_charge_limit_soc_max",
-        func=lambda: set_charge_limit,
-        arg="percent",
+        func=lambda api, value: api.set_charge_limit(int(value)),
     ),
     TessieNumberEntityDescription(
         key="vehicle_state_speed_limit_mode_current_limit_mph",
@@ -80,8 +76,7 @@ VEHICLE_DESCRIPTIONS: tuple[TessieNumberEntityDescription, ...] = (
         mode=NumberMode.BOX,
         min_key="vehicle_state_speed_limit_mode_min_limit_mph",
         max_key="vehicle_state_speed_limit_mode_max_limit_mph",
-        func=lambda: set_speed_limit,
-        arg="mph",
+        func=lambda api, value: api.set_speed_limit(int(value)),
     ),
 )
 
@@ -171,9 +166,8 @@ class TessieNumberEntity(TessieEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        await self.run(
-            self.entity_description.func(), **{self.entity_description.arg: value}
-        )
+        value = int(value)
+        await self.run(self.entity_description.func(self.api, value))
         self.set((self.key, value))
 
 

--- a/homeassistant/components/tessie/select.py
+++ b/homeassistant/components/tessie/select.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from itertools import chain
 
 from tesla_fleet_api.const import EnergyExportMode, EnergyOperationMode
-from tessie_api import set_seat_cool, set_seat_heat
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
@@ -91,7 +90,7 @@ class TessieSeatHeaterSelectEntity(TessieEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         level = self._attr_options.index(option)
-        await self.run(set_seat_heat, seat=SEAT_HEATERS[self.key], level=level)
+        await self.run(self.api.set_seat_heat(SEAT_HEATERS[self.key], level))
         self.set((self.key, level))
 
 
@@ -113,7 +112,7 @@ class TessieSeatCoolerSelectEntity(TessieEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         level = self._attr_options.index(option)
-        await self.run(set_seat_cool, seat=SEAT_COOLERS[self.key], level=level)
+        await self.run(self.api.set_seat_cool(SEAT_COOLERS[self.key], level))
         self.set((self.key, level))
 
 

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -2,23 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from itertools import chain
 from typing import Any
 
-from tessie_api import (
-    disable_sentry_mode,
-    disable_valet_mode,
-    enable_sentry_mode,
-    enable_valet_mode,
-    start_charging,
-    start_defrost,
-    start_steering_wheel_heater,
-    stop_charging,
-    stop_defrost,
-    stop_steering_wheel_heater,
-)
+from tesla_fleet_api.tessie import Vehicle
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -39,8 +28,8 @@ from .models import TessieEnergyData, TessieVehicleData
 class TessieSwitchEntityDescription(SwitchEntityDescription):
     """Describes Tessie Switch entity."""
 
-    on_func: Callable
-    off_func: Callable
+    on_func: Callable[[Vehicle], Awaitable[dict]]
+    off_func: Callable[[Vehicle], Awaitable[dict]]
     value_func: Callable[[StateType], bool] = bool
     unique_id: str | None = None
 
@@ -48,29 +37,29 @@ class TessieSwitchEntityDescription(SwitchEntityDescription):
 DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
     TessieSwitchEntityDescription(
         key="climate_state_defrost_mode",
-        on_func=lambda: start_defrost,
-        off_func=lambda: stop_defrost,
+        on_func=lambda api: api.start_max_defrost(),
+        off_func=lambda api: api.stop_max_defrost(),
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_sentry_mode",
-        on_func=lambda: enable_sentry_mode,
-        off_func=lambda: disable_sentry_mode,
+        on_func=lambda api: api.enable_sentry(),
+        off_func=lambda api: api.disable_sentry(),
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_valet_mode",
-        on_func=lambda: enable_valet_mode,
-        off_func=lambda: disable_valet_mode,
+        on_func=lambda api: api.enable_valet(),
+        off_func=lambda api: api.disable_valet(),
     ),
     TessieSwitchEntityDescription(
         key="climate_state_steering_wheel_heater",
-        on_func=lambda: start_steering_wheel_heater,
-        off_func=lambda: stop_steering_wheel_heater,
+        on_func=lambda api: api.start_steering_wheel_heater(),
+        off_func=lambda api: api.stop_steering_wheel_heater(),
     ),
     TessieSwitchEntityDescription(
         key="charge_state_charging_state",
         unique_id="charge_state_charge_enable_request",
-        on_func=lambda: start_charging,
-        off_func=lambda: stop_charging,
+        on_func=lambda api: api.start_charging(),
+        off_func=lambda api: api.stop_charging(),
         value_func=lambda state: state in {"Starting", "Charging"},
     ),
 )
@@ -132,12 +121,12 @@ class TessieSwitchEntity(TessieEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Switch."""
-        await self.run(self.entity_description.on_func())
+        await self.run(self.entity_description.on_func(self.api))
         self.set((self.entity_description.key, True))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Switch."""
-        await self.run(self.entity_description.off_func())
+        await self.run(self.entity_description.off_func(self.api))
         self.set((self.entity_description.key, False))
 
 

--- a/homeassistant/components/tessie/update.py
+++ b/homeassistant/components/tessie/update.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from tessie_api import schedule_software_update
-
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -99,7 +97,7 @@ class TessieUpdateEntity(TessieEntity, UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Install an update."""
-        await self.run(schedule_software_update, in_seconds=0)
+        await self.run(self.api.tessie_schedule_software_update(in_seconds=0))
         self.set(
             ("vehicle_state_software_update_status", TessieUpdateStatus.INSTALLING)
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3096,9 +3096,6 @@ tesla-wall-connector==1.1.0
 # homeassistant.components.teslemetry
 teslemetry-stream==0.9.0
 
-# homeassistant.components.tessie
-tessie-api==0.1.1
-
 # homeassistant.components.thermobeacon
 thermobeacon-ble==0.10.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2614,9 +2614,6 @@ tesla-wall-connector==1.1.0
 # homeassistant.components.teslemetry
 teslemetry-stream==0.9.0
 
-# homeassistant.components.tessie
-tessie-api==0.1.1
-
 # homeassistant.components.thermobeacon
 thermobeacon-ble==0.10.0
 

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -18,14 +18,12 @@ from .common import (
     TEST_VEHICLE_STATE_ONLINE,
 )
 
-# Tessie
-
 
 @pytest.fixture(autouse=True)
 def mock_get_state():
-    """Mock get_state function."""
+    """Mock vehicle state fetches."""
     with patch(
-        "homeassistant.components.tessie.coordinator.get_state",
+        "tesla_fleet_api.tessie.Vehicle.state",
         return_value=TEST_VEHICLE_STATE_ONLINE,
     ) as mock_get_state:
         yield mock_get_state
@@ -34,14 +32,19 @@ def mock_get_state():
 @pytest.fixture(autouse=True)
 def mock_get_state_of_all_vehicles():
     """Mock get_state_of_all_vehicles function."""
-    with patch(
-        "homeassistant.components.tessie.get_state_of_all_vehicles",
-        return_value=TEST_STATE_OF_ALL_VEHICLES,
-    ) as mock_get_state_of_all_vehicles:
+    with (
+        patch(
+            "homeassistant.components.tessie.fetch_state_of_all_vehicles",
+            return_value=TEST_STATE_OF_ALL_VEHICLES,
+        ) as mock_get_state_of_all_vehicles,
+        patch(
+            "homeassistant.components.tessie.config_flow.fetch_state_of_all_vehicles",
+            new=mock_get_state_of_all_vehicles,
+        ),
+    ):
         yield mock_get_state_of_all_vehicles
 
 
-# Fleet API
 @pytest.fixture(autouse=True)
 def mock_scopes():
     """Mock scopes function."""
@@ -54,7 +57,7 @@ def mock_scopes():
 
 @pytest.fixture(autouse=True)
 def mock_products():
-    """Mock Tesla Fleet Api products method."""
+    """Mock Tesla Fleet API products method."""
     with patch(
         "homeassistant.components.tessie.Tessie.products", return_value=PRODUCTS
     ) as mock_products:
@@ -73,7 +76,7 @@ def mock_request():
 
 @pytest.fixture(autouse=True)
 def mock_live_status():
-    """Mock Tesla Fleet API EnergySpecific live_status method."""
+    """Mock Tesla Fleet API EnergySite live_status method."""
     with patch(
         "tesla_fleet_api.tessie.EnergySite.live_status",
         side_effect=lambda: deepcopy(LIVE_STATUS),
@@ -83,12 +86,12 @@ def mock_live_status():
 
 @pytest.fixture(autouse=True)
 def mock_site_info():
-    """Mock Tesla Fleet API EnergySpecific site_info method."""
+    """Mock Tesla Fleet API EnergySite site_info method."""
     with patch(
         "tesla_fleet_api.tessie.EnergySite.site_info",
         side_effect=lambda: deepcopy(SITE_INFO),
-    ) as mock_live_status:
-        yield mock_live_status
+    ) as mock_site_info:
+        yield mock_site_info
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -9,7 +9,7 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_buttons(
@@ -21,16 +21,23 @@ async def test_buttons(
 
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
 
-    for entity_id, func in (
-        ("button.test_wake", "wake"),
-        ("button.test_flash_lights", "flash_lights"),
-        ("button.test_honk_horn", "honk"),
-        ("button.test_homelink", "trigger_homelink"),
-        ("button.test_keyless_driving", "enable_keyless_driving"),
-        ("button.test_play_fart", "boombox"),
+    for entity_id, path in (
+        ("button.test_wake", "tesla_fleet_api.tessie.Vehicle.wake"),
+        ("button.test_flash_lights", "tesla_fleet_api.tessie.Vehicle.flash"),
+        ("button.test_honk_horn", "tesla_fleet_api.tessie.Vehicle.honk"),
+        (
+            "button.test_homelink",
+            "tesla_fleet_api.tessie.Vehicle.tessie_trigger_homelink",
+        ),
+        (
+            "button.test_keyless_driving",
+            "tesla_fleet_api.tessie.Vehicle.remote_start",
+        ),
+        ("button.test_play_fart", "tesla_fleet_api.tessie.Vehicle.remote_boombox"),
     ):
         with patch(
-            f"homeassistant.components.tessie.button.{func}",
+            path,
+            return_value=TEST_RESPONSE,
         ) as mock_press:
             await hass.services.async_call(
                 BUTTON_DOMAIN,

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import TeslaFleetError
 
 from homeassistant.components.climate import (
     ATTR_HVAC_MODE,
@@ -22,13 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import (
-    ERROR_CONNECTION,
-    ERROR_UNKNOWN,
-    TEST_RESPONSE,
-    assert_entities,
-    setup_platform,
-)
+from .common import TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_climate(
@@ -42,9 +37,8 @@ async def test_climate(
 
     entity_id = "climate.test_climate"
 
-    # Test setting climate on
     with patch(
-        "homeassistant.components.tessie.climate.start_climate_preconditioning",
+        "tesla_fleet_api.tessie.Vehicle.start_climate",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -54,17 +48,15 @@ async def test_climate(
             blocking=True,
         )
         mock_set.assert_called_once()
-    state = hass.states.get(entity_id)
-    assert state.state == HVACMode.HEAT_COOL
+    assert hass.states.get(entity_id).state == HVACMode.HEAT_COOL
 
-    # Test setting climate temp
     with (
         patch(
-            "homeassistant.components.tessie.climate.set_temperature",
+            "tesla_fleet_api.tessie.Vehicle.set_temperatures",
             return_value=TEST_RESPONSE,
         ) as mock_set,
         patch(
-            "homeassistant.components.tessie.climate.start_climate_preconditioning",
+            "tesla_fleet_api.tessie.Vehicle.start_climate",
             return_value=TEST_RESPONSE,
         ) as mock_set2,
     ):
@@ -80,12 +72,10 @@ async def test_climate(
         )
         mock_set.assert_called_once()
         mock_set2.assert_called_once()
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_TEMPERATURE] == 20
+    assert hass.states.get(entity_id).attributes[ATTR_TEMPERATURE] == 20
 
-    # Test setting climate preset
     with patch(
-        "homeassistant.components.tessie.climate.set_climate_keeper_mode",
+        "tesla_fleet_api.tessie.Vehicle.tessie_set_climate_keeper_mode",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -95,12 +85,13 @@ async def test_climate(
             blocking=True,
         )
         mock_set.assert_called_once()
-    state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_PRESET_MODE] == TessieClimateKeeper.ON
+    assert (
+        hass.states.get(entity_id).attributes[ATTR_PRESET_MODE]
+        == TessieClimateKeeper.ON
+    )
 
-    # Test setting climate off
     with patch(
-        "homeassistant.components.tessie.climate.stop_climate",
+        "tesla_fleet_api.tessie.Vehicle.stop_climate",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -110,8 +101,7 @@ async def test_climate(
             blocking=True,
         )
         mock_set.assert_called_once()
-    state = hass.states.get(entity_id)
-    assert state.state == HVACMode.OFF
+    assert hass.states.get(entity_id).state == HVACMode.OFF
 
 
 async def test_errors(hass: HomeAssistant) -> None:
@@ -120,11 +110,10 @@ async def test_errors(hass: HomeAssistant) -> None:
     await setup_platform(hass, [Platform.CLIMATE])
     entity_id = "climate.test_climate"
 
-    # Test setting climate on with unknown error
     with (
         patch(
-            "homeassistant.components.tessie.climate.stop_climate",
-            side_effect=ERROR_UNKNOWN,
+            "tesla_fleet_api.tessie.Vehicle.stop_climate",
+            side_effect=TeslaFleetError,
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
     ):
@@ -135,34 +124,12 @@ async def test_errors(hass: HomeAssistant) -> None:
             blocking=True,
         )
     mock_set.assert_called_once()
-    assert error.value.__cause__ == ERROR_UNKNOWN
-    assert error.value.translation_domain == "tessie"
-    assert error.value.translation_key == "cannot_connect"
+    assert isinstance(error.value.__cause__, TeslaFleetError)
 
-    # Test setting climate on with connection error
     with (
         patch(
-            "homeassistant.components.tessie.climate.stop_climate",
-            side_effect=ERROR_CONNECTION,
-        ) as mock_set,
-        pytest.raises(HomeAssistantError) as error,
-    ):
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: [entity_id]},
-            blocking=True,
-        )
-    mock_set.assert_called_once()
-    assert error.value.__cause__ == ERROR_CONNECTION
-    assert error.value.translation_domain == "tessie"
-    assert error.value.translation_key == "cannot_connect"
-
-    # Test setting climate with child presence detection error
-    with (
-        patch(
-            "homeassistant.components.tessie.climate.start_climate_preconditioning",
-            return_value={"result": False, "reason": "cpd_enabled"},
+            "tesla_fleet_api.tessie.Vehicle.start_climate",
+            return_value={"response": {"result": False, "reason": "cpd_enabled"}},
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
     ):

--- a/tests/components/tessie/test_config_flow.py
+++ b/tests/components/tessie/test_config_flow.py
@@ -25,7 +25,7 @@ from tests.common import MockConfigEntry
 def mock_config_flow_get_state_of_all_vehicles():
     """Mock get_state_of_all_vehicles in config flow."""
     with patch(
-        "homeassistant.components.tessie.config_flow.get_state_of_all_vehicles",
+        "homeassistant.components.tessie.config_flow.fetch_state_of_all_vehicles",
         return_value=TEST_STATE_OF_ALL_VEHICLES,
     ) as mock_config_flow_get_state_of_all_vehicles:
         yield mock_config_flow_get_state_of_all_vehicles

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api.exceptions import TeslaFleetError
 
 from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
@@ -16,13 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import (
-    ERROR_UNKNOWN,
-    TEST_RESPONSE,
-    TEST_RESPONSE_ERROR,
-    assert_entities,
-    setup_platform,
-)
+from .common import TEST_RESPONSE, TEST_RESPONSE_ERROR, assert_entities, setup_platform
 
 
 async def test_covers(
@@ -37,18 +32,34 @@ async def test_covers(
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
 
     for entity_id, openfunc, closefunc in (
-        ("cover.test_vent_windows", "vent_windows", "close_windows"),
-        ("cover.test_charge_port_door", "open_unlock_charge_port", "close_charge_port"),
-        ("cover.test_frunk", "open_front_trunk", False),
-        ("cover.test_trunk", "open_close_rear_trunk", "open_close_rear_trunk"),
-        ("cover.test_sunroof", "vent_sunroof", "close_sunroof"),
+        (
+            "cover.test_vent_windows",
+            "tesla_fleet_api.tessie.Vehicle.vent_windows",
+            "tesla_fleet_api.tessie.Vehicle.close_windows",
+        ),
+        (
+            "cover.test_charge_port_door",
+            "tesla_fleet_api.tessie.Vehicle.open_charge_port",
+            "tesla_fleet_api.tessie.Vehicle.close_charge_port",
+        ),
+        (
+            "cover.test_frunk",
+            "tesla_fleet_api.tessie.Vehicle.activate_front_trunk",
+            False,
+        ),
+        (
+            "cover.test_trunk",
+            "tesla_fleet_api.tessie.Vehicle.activate_rear_trunk",
+            "tesla_fleet_api.tessie.Vehicle.activate_rear_trunk",
+        ),
+        (
+            "cover.test_sunroof",
+            "tesla_fleet_api.tessie.Vehicle.vent_sunroof",
+            "tesla_fleet_api.tessie.Vehicle.close_sunroof",
+        ),
     ):
-        # Test open windows
         if openfunc:
-            with patch(
-                f"homeassistant.components.tessie.cover.{openfunc}",
-                return_value=TEST_RESPONSE,
-            ) as mock_open:
+            with patch(openfunc, return_value=TEST_RESPONSE) as mock_open:
                 await hass.services.async_call(
                     COVER_DOMAIN,
                     SERVICE_OPEN_COVER,
@@ -58,12 +69,8 @@ async def test_covers(
                 mock_open.assert_called_once()
             assert hass.states.get(entity_id).state == CoverState.OPEN
 
-        # Test close windows
         if closefunc:
-            with patch(
-                f"homeassistant.components.tessie.cover.{closefunc}",
-                return_value=TEST_RESPONSE,
-            ) as mock_close:
+            with patch(closefunc, return_value=TEST_RESPONSE) as mock_close:
                 await hass.services.async_call(
                     COVER_DOMAIN,
                     SERVICE_CLOSE_COVER,
@@ -80,11 +87,10 @@ async def test_errors(hass: HomeAssistant) -> None:
     await setup_platform(hass, [Platform.COVER])
     entity_id = "cover.test_charge_port_door"
 
-    # Test setting cover open with unknown error
     with (
         patch(
-            "homeassistant.components.tessie.cover.open_unlock_charge_port",
-            side_effect=ERROR_UNKNOWN,
+            "tesla_fleet_api.tessie.Vehicle.open_charge_port",
+            side_effect=TeslaFleetError,
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
     ):
@@ -95,15 +101,12 @@ async def test_errors(hass: HomeAssistant) -> None:
             blocking=True,
         )
     mock_set.assert_called_once()
-    assert error.value.__cause__ == ERROR_UNKNOWN
-    assert error.value.translation_domain == "tessie"
-    assert error.value.translation_key == "cannot_connect"
+    assert isinstance(error.value.__cause__, TeslaFleetError)
 
-    # Test setting cover open with unknown error
     with (
         patch(
-            "homeassistant.components.tessie.cover.open_unlock_charge_port",
-            return_value=TEST_RESPONSE_ERROR,
+            "tesla_fleet_api.tessie.Vehicle.open_charge_port",
+            return_value={"response": TEST_RESPONSE_ERROR},
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
     ):

--- a/tests/components/tessie/test_lock.py
+++ b/tests/components/tessie/test_lock.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_locks(
@@ -30,7 +30,9 @@ async def test_locks(
 
     # Test lock set value functions
     entity_id = "lock.test_lock"
-    with patch("homeassistant.components.tessie.lock.lock") as mock_run:
+    with patch(
+        "tesla_fleet_api.tessie.Vehicle.lock", return_value=TEST_RESPONSE
+    ) as mock_run:
         await hass.services.async_call(
             LOCK_DOMAIN,
             SERVICE_LOCK,
@@ -40,7 +42,9 @@ async def test_locks(
         mock_run.assert_called_once()
     assert hass.states.get(entity_id).state == LockState.LOCKED
 
-    with patch("homeassistant.components.tessie.lock.unlock") as mock_run:
+    with patch(
+        "tesla_fleet_api.tessie.Vehicle.unlock", return_value=TEST_RESPONSE
+    ) as mock_run:
         await hass.services.async_call(
             LOCK_DOMAIN,
             SERVICE_UNLOCK,
@@ -61,7 +65,8 @@ async def test_locks(
         )
 
     with patch(
-        "homeassistant.components.tessie.lock.open_unlock_charge_port"
+        "tesla_fleet_api.tessie.Vehicle.open_charge_port",
+        return_value=TEST_RESPONSE,
     ) as mock_run:
         await hass.services.async_call(
             LOCK_DOMAIN,

--- a/tests/components/tessie/test_number.py
+++ b/tests/components/tessie/test_number.py
@@ -28,7 +28,8 @@ async def test_numbers(
     # Test number set value functions
     entity_id = "number.test_charge_current"
     with patch(
-        "homeassistant.components.tessie.number.set_charging_amps",
+        "tesla_fleet_api.tessie.Vehicle.tessie_set_charging_amps",
+        return_value=TEST_RESPONSE,
     ) as mock_set_charging_amps:
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -37,11 +38,12 @@ async def test_numbers(
             blocking=True,
         )
         mock_set_charging_amps.assert_called_once()
-    assert hass.states.get(entity_id).state == "16.0"
+    assert hass.states.get(entity_id).state == "16"
 
     entity_id = "number.test_charge_limit"
     with patch(
-        "homeassistant.components.tessie.number.set_charge_limit",
+        "tesla_fleet_api.tessie.Vehicle.set_charge_limit",
+        return_value=TEST_RESPONSE,
     ) as mock_set_charge_limit:
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -50,11 +52,12 @@ async def test_numbers(
             blocking=True,
         )
         mock_set_charge_limit.assert_called_once()
-    assert hass.states.get(entity_id).state == "80.0"
+    assert hass.states.get(entity_id).state == "80"
 
     entity_id = "number.test_speed_limit"
     with patch(
-        "homeassistant.components.tessie.number.set_speed_limit",
+        "tesla_fleet_api.tessie.Vehicle.set_speed_limit",
+        return_value=TEST_RESPONSE,
     ) as mock_set_speed_limit:
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -63,7 +66,7 @@ async def test_numbers(
             blocking=True,
         )
         mock_set_speed_limit.assert_called_once()
-    assert hass.states.get(entity_id).state == "60.0"
+    assert hass.states.get(entity_id).state == "60"
 
     entity_id = "number.energy_site_backup_reserve"
     with patch(

--- a/tests/components/tessie/test_select.py
+++ b/tests/components/tessie/test_select.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tesla_fleet_api.const import EnergyExportMode, EnergyOperationMode
-from tesla_fleet_api.exceptions import UnsupportedVehicle
+from tesla_fleet_api.exceptions import TeslaFleetError, UnsupportedVehicle
 
 from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .common import ERROR_UNKNOWN, TEST_RESPONSE, assert_entities, setup_platform
+from .common import TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_select(
@@ -32,10 +32,9 @@ async def test_select(
 
     assert_entities(hass, entry.entry_id, entity_registry, snapshot)
 
-    # Test changing select
     entity_id = "select.test_seat_heater_left"
     with patch(
-        "homeassistant.components.tessie.select.set_seat_heat",
+        "tesla_fleet_api.tessie.Vehicle.set_seat_heat",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -45,11 +44,9 @@ async def test_select(
             blocking=True,
         )
         mock_set.assert_called_once()
-    assert mock_set.call_args[1]["seat"] == "front_left"
-    assert mock_set.call_args[1]["level"] == 1
+    assert mock_set.call_args.args[-2:] == ("front_left", 1)
     assert hass.states.get(entity_id) == snapshot(name=SERVICE_SELECT_OPTION)
 
-    # Test site operation mode
     entity_id = "select.energy_site_operation_mode"
     with patch(
         "tesla_fleet_api.tessie.EnergySite.operation",
@@ -68,7 +65,6 @@ async def test_select(
         assert state.state == EnergyOperationMode.AUTONOMOUS.value
         call.assert_called_once()
 
-    # Test site export mode
     entity_id = "select.energy_site_allow_export"
     with patch(
         "tesla_fleet_api.tessie.EnergySite.grid_import_export",
@@ -84,10 +80,9 @@ async def test_select(
         assert state.state == EnergyExportMode.BATTERY_OK.value
         call.assert_called_once()
 
-    # Test changing select
     entity_id = "select.test_seat_cooler_left"
     with patch(
-        "homeassistant.components.tessie.select.set_seat_cool",
+        "tesla_fleet_api.tessie.Vehicle.set_seat_cool",
         return_value=TEST_RESPONSE,
     ) as mock_set:
         await hass.services.async_call(
@@ -97,8 +92,7 @@ async def test_select(
             blocking=True,
         )
         mock_set.assert_called_once()
-    assert mock_set.call_args[1]["seat"] == "front_left"
-    assert mock_set.call_args[1]["level"] == 1
+    assert mock_set.call_args.args[-2:] == ("front_left", 1)
 
 
 async def test_errors(hass: HomeAssistant) -> None:
@@ -106,11 +100,10 @@ async def test_errors(hass: HomeAssistant) -> None:
 
     await setup_platform(hass, [Platform.SELECT])
 
-    # Test changing vehicle select with unknown error
     with (
         patch(
-            "homeassistant.components.tessie.select.set_seat_heat",
-            side_effect=ERROR_UNKNOWN,
+            "tesla_fleet_api.tessie.Vehicle.set_seat_heat",
+            side_effect=TeslaFleetError,
         ) as mock_set,
         pytest.raises(HomeAssistantError) as error,
     ):
@@ -124,11 +117,8 @@ async def test_errors(hass: HomeAssistant) -> None:
             blocking=True,
         )
     mock_set.assert_called_once()
-    assert error.value.__cause__ == ERROR_UNKNOWN
-    assert error.value.translation_domain == "tessie"
-    assert error.value.translation_key == "cannot_connect"
+    assert isinstance(error.value.__cause__, TeslaFleetError)
 
-    # Test changing energy select with unknown error
     with (
         patch(
             "tesla_fleet_api.tessie.EnergySite.operation",

--- a/tests/components/tessie/test_switch.py
+++ b/tests/components/tessie/test_switch.py
@@ -14,7 +14,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import RESPONSE_OK, assert_entities, setup_platform
+from .common import RESPONSE_OK, TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_switches(
@@ -28,7 +28,8 @@ async def test_switches(
 
     entity_id = "switch.test_charge"
     with patch(
-        "homeassistant.components.tessie.switch.start_charging",
+        "tesla_fleet_api.tessie.Vehicle.start_charging",
+        return_value=TEST_RESPONSE,
     ) as mock_start_charging:
         # Test Switch On
         await hass.services.async_call(
@@ -41,7 +42,8 @@ async def test_switches(
     assert hass.states.get(entity_id) == snapshot(name=SERVICE_TURN_ON)
 
     with patch(
-        "homeassistant.components.tessie.switch.stop_charging",
+        "tesla_fleet_api.tessie.Vehicle.stop_charging",
+        return_value=TEST_RESPONSE,
     ) as mock_stop_charging:
         # Test Switch Off
         await hass.services.async_call(

--- a/tests/components/tessie/test_update.py
+++ b/tests/components/tessie/test_update.py
@@ -13,7 +13,7 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import assert_entities, setup_platform
+from .common import TEST_RESPONSE, assert_entities, setup_platform
 
 
 async def test_updates(
@@ -28,7 +28,8 @@ async def test_updates(
     entity_id = "update.test_update"
 
     with patch(
-        "homeassistant.components.tessie.update.schedule_software_update"
+        "tesla_fleet_api.tessie.Vehicle.tessie_schedule_software_update",
+        return_value=TEST_RESPONSE,
     ) as mock_update:
         await hass.services.async_call(
             UPDATE_DOMAIN,


### PR DESCRIPTION
## Proposed change
Migrate the Tessie integration off `tessie-api` and fully onto `tesla-fleet-api`, updating the coordinator, config flow, and entity commands to match the current `TessieVehicle` API while keeping the integration feature complete.
Refresh the Tessie tests for the new client behavior and remove the old dependency from the integration.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:
- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
