### PR TITLE
Add command compatibility scaffold for Tessie migration

### DIFF
--- a/homeassistant/components/tessie/entity.py
+++ b/homeassistant/components/tessie/entity.py
@@ -2,21 +2,20 @@
 
 from abc import abstractmethod
 from collections.abc import Awaitable, Callable
+from inspect import isawaitable
 from typing import Any
 
-from aiohttp import ClientError
-
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, TRANSLATED_ERRORS
+from .const import DOMAIN
 from .coordinator import (
     TessieEnergyHistoryCoordinator,
     TessieEnergySiteInfoCoordinator,
     TessieEnergySiteLiveCoordinator,
     TessieStateUpdateCoordinator,
 )
+from .helpers import handle_command, handle_legacy_command
 from .models import TessieEnergyData, TessieVehicleData
 
 
@@ -93,30 +92,24 @@ class TessieEntity(TessieBaseEntity):
         self.async_write_ha_state()
 
     async def run(
-        self, func: Callable[..., Awaitable[dict[str, Any]]], **kargs: Any
+        self,
+        command: Callable[..., Awaitable[dict[str, Any]]] | Awaitable[dict[str, Any]],
+        **kargs: Any,
     ) -> None:
-        """Run a tessie_api function and handle exceptions."""
-        try:
-            response = await func(
+        """Run a legacy tessie_api command function or awaitable Vehicle command."""
+        if isawaitable(command):
+            await handle_command(command)
+            return
+
+        await handle_legacy_command(
+            command(
                 session=self._session,
                 vin=self.vin,
                 api_key=self._api_key,
                 **kargs,
-            )
-        except ClientError as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="cannot_connect",
-            ) from e
-        if response["result"] is False:
-            name: str = getattr(self, "name", self.entity_id)
-            reason: str = response.get("reason", "unknown")
-            translation_key = TRANSLATED_ERRORS.get(reason, "command_failed")
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key=translation_key,
-                translation_placeholders={"name": name, "message": reason},
-            )
+            ),
+            name=getattr(self, "name", self.entity_id),
+        )
 
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""

--- a/homeassistant/components/tessie/helpers.py
+++ b/homeassistant/components/tessie/helpers.py
@@ -1,17 +1,19 @@
 """Tessie helper functions."""
 
+from collections.abc import Awaitable
 from typing import Any
 
+from aiohttp import ClientError
 from tesla_fleet_api.exceptions import TeslaFleetError
 
 from homeassistant.exceptions import HomeAssistantError
 
 from . import _LOGGER
-from .const import DOMAIN
+from .const import DOMAIN, TRANSLATED_ERRORS
 
 
-async def handle_command(command) -> dict[str, Any]:
-    """Handle a command."""
+async def handle_command(command: Awaitable[dict[str, Any]]) -> dict[str, Any]:
+    """Handle an awaitable Vehicle/EnergySite command."""
     try:
         result = await command
     except TeslaFleetError as e:
@@ -22,3 +24,22 @@ async def handle_command(command) -> dict[str, Any]:
         ) from e
     _LOGGER.debug("Command result: %s", result)
     return result
+
+
+async def handle_legacy_command(command: Awaitable[dict[str, Any]], name: str) -> None:
+    """Handle a legacy tessie_api command result."""
+    try:
+        response = await command
+    except ClientError as e:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
+    if response["result"] is False:
+        reason: str = response.get("reason", "unknown")
+        translation_key = TRANSLATED_ERRORS.get(reason, "command_failed")
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={"name": name, "message": reason},
+        )

--- a/homeassistant/components/tessie/models.py
+++ b/homeassistant/components/tessie/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tesla_fleet_api.tessie import EnergySite
+from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -43,3 +43,4 @@ class TessieVehicleData:
     data_coordinator: TessieStateUpdateCoordinator
     device: DeviceInfo
     vin: str
+    api: Vehicle | None = None

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -74,4 +74,7 @@ async def test_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
     """Test runtime vehicle API handle defaults to None during scaffold stage."""
 
     entry = await setup_platform(hass)
-    assert all(vehicle.api is None for vehicle in entry.runtime_data.vehicles)
+    assert entry.state is ConfigEntryState.LOADED
+    vehicles = entry.runtime_data.vehicles
+    assert vehicles
+    assert all(vehicle.api is None for vehicle in vehicles)

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -68,3 +68,10 @@ async def test_scopes_error(hass: HomeAssistant) -> None:
     ):
         entry = await setup_platform(hass)
         assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_vehicle_api_handle_is_optional(hass: HomeAssistant) -> None:
+    """Test runtime vehicle API handle defaults to None during scaffold stage."""
+
+    entry = await setup_platform(hass)
+    assert all(vehicle.api is None for vehicle in entry.runtime_data.vehicles)


### PR DESCRIPTION
## Proposed change
This PR adds a compatibility scaffold for the Tessie integration so legacy `tessie_api` command calls and new awaitable command style can coexist during migration. It centralizes command handling in `helpers.py`, updates the vehicle entity `run` path to support both call styles, and adds an optional `Vehicle` API handle on `TessieVehicleData`. A targeted init test was added to verify the optional API handle defaults to `None` in this scaffold stage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr