### PR TITLE
Fix AssertionError for Z-Wave opening state value on non-zero endpoint

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -451,7 +451,9 @@ def _async_check_legacy_entity_repair(
             async_delete_issue(hass, DOMAIN, issue_id)
             return
 
-        opening_state_value = get_opening_state_notification_value(entity.info.node)
+        opening_state_value = get_opening_state_notification_value(
+            entity.info.node, entity.info.primary_value.endpoint
+        )
         if opening_state_value is None:
             async_delete_issue(hass, DOMAIN, issue_id)
             return
@@ -700,7 +702,9 @@ class ZWaveLegacyDoorStateBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     ) -> None:
         """Initialize a legacy Door state binary sensor entity."""
         super().__init__(config_entry, driver, info)
-        opening_state_value = get_opening_state_notification_value(self.info.node)
+        opening_state_value = get_opening_state_notification_value(
+            self.info.node, self.info.primary_value.endpoint
+        )
         assert opening_state_value is not None  # guaranteed by required_values schema
         self._opening_state_value_id = opening_state_value.value_id
         self.watched_value_ids.add(opening_state_value.value_id)

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -151,13 +151,15 @@ def is_opening_state_notification_value(value: ZwaveValue) -> bool:
     )
 
 
-def get_opening_state_notification_value(node: ZwaveNode) -> ZwaveValue | None:
+def get_opening_state_notification_value(
+    node: ZwaveNode, endpoint: int | None = None
+) -> ZwaveValue | None:
     """Return the Access Control Opening state value for a node."""
     value_id = get_value_id_str(
         node,
         CommandClass.NOTIFICATION,
         NOTIFICATION_ACCESS_CONTROL_PROPERTY,
-        None,
+        endpoint,
         OPENING_STATE_PROPERTY_KEY,
     )
     return node.values.get(value_id)

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -108,6 +108,27 @@ def _add_barrier_status_value(node_state: dict[str, Any]) -> dict[str, Any]:
     return updated_state
 
 
+def _move_notification_values_to_endpoint(
+    node_state: dict[str, Any], endpoint: int
+) -> dict[str, Any]:
+    """Return a node state with all Notification CC values moved to a different endpoint."""
+    updated_state = copy.deepcopy(node_state)
+    for value_data in updated_state["values"]:
+        if value_data.get("commandClass") == 113:
+            value_data["endpoint"] = endpoint
+    # Add the target endpoint to the endpoints list with the Notification CC.
+    ep0 = updated_state["endpoints"][0]
+    updated_state["endpoints"].append(
+        {
+            "nodeId": ep0["nodeId"],
+            "index": endpoint,
+            "deviceClass": ep0["deviceClass"],
+            "commandClasses": [cc for cc in ep0["commandClasses"] if cc["id"] == 113],
+        }
+    )
+    return updated_state
+
+
 def _add_lock_state_notification_states(node_state: dict[str, Any]) -> dict[str, Any]:
     """Return a node state with Access Control lock state notification states 1-4."""
     updated_state = copy.deepcopy(node_state)
@@ -641,6 +662,63 @@ async def test_legacy_door_state_entities_follow_opening_state(
         assert state, f"{e.entity_id} should have a state"
         assert state.state == STATE_OFF, (
             f"{e.entity_id} ({e.original_name}) should be OFF when Opening state=Open"
+        )
+
+
+async def test_legacy_door_state_non_zero_endpoint(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    hoppe_ehandle_connectsense_state: NodeDataType,
+) -> None:
+    """Test legacy door state entities work when notification values are on endpoint 1.
+
+    Regression test for https://github.com/home-assistant/core/issues/166365.
+    """
+    state = _move_notification_values_to_endpoint(
+        hoppe_ehandle_connectsense_state, endpoint=1
+    )
+    node = Node(client, state)
+    client.driver.controller.nodes[node.node_id] = node
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Legacy door state entities should still be discovered and disabled by default
+    # (because the Opening state value exists on the same endpoint).
+    legacy_names = {
+        "Window/door is open",
+        "Window/door is closed",
+        "Window/door is open in regular position",
+        "Window/door is open in tilt position",
+    }
+    legacy_entries = [
+        e
+        for e in entity_registry.entities.values()
+        if e.domain == "binary_sensor"
+        and e.platform == "zwave_js"
+        and e.original_name in legacy_names
+    ]
+    assert len(legacy_entries) == 6
+
+    # Re-enable them to verify they can be initialized without errors.
+    for legacy_entry in legacy_entries:
+        entity_registry.async_update_entity(legacy_entry.entity_id, disabled_by=None)
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    # All entities should have a valid state (no assertion errors during init).
+    for e in legacy_entries:
+        state = hass.states.get(e.entity_id)
+        assert state is not None, f"{e.entity_id} should have a state"
+        assert state.state != STATE_UNKNOWN, (
+            f"{e.entity_id} ({e.original_name}) should not be unknown"
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

While adding support for the Z-Wave "opening state" value, we overlooked that it can exist on a different endpoint. This caused an `AssertionError` during discovery because the discovery schema would match endpoint 1, but the implementation would look for the value on endpoint 0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/166365
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
