### PR TITLE
Add humidifier condition

### DIFF
--- a/homeassistant/components/humidifier/condition.py
+++ b/homeassistant/components/humidifier/condition.py
@@ -1,11 +1,15 @@
 """Provides conditions for humidifiers."""
 
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import PERCENTAGE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.automation import DomainSpec
-from homeassistant.helpers.condition import Condition, make_entity_state_condition
+from homeassistant.helpers.automation import DomainSpec, NumericalDomainSpec
+from homeassistant.helpers.condition import (
+    Condition,
+    make_entity_numerical_condition,
+    make_entity_state_condition,
+)
 
-from .const import ATTR_ACTION, DOMAIN, HumidifierAction
+from .const import ATTR_ACTION, ATTR_HUMIDITY, DOMAIN, HumidifierAction
 
 CONDITIONS: dict[str, type[Condition]] = {
     "is_off": make_entity_state_condition(DOMAIN, STATE_OFF),
@@ -15,6 +19,10 @@ CONDITIONS: dict[str, type[Condition]] = {
     ),
     "is_humidifying": make_entity_state_condition(
         {DOMAIN: DomainSpec(value_source=ATTR_ACTION)}, HumidifierAction.HUMIDIFYING
+    ),
+    "is_target_humidity": make_entity_numerical_condition(
+        {DOMAIN: NumericalDomainSpec(value_source=ATTR_HUMIDITY)},
+        valid_unit=PERCENTAGE,
     ),
 }
 

--- a/homeassistant/components/humidifier/conditions.yaml
+++ b/homeassistant/components/humidifier/conditions.yaml
@@ -1,9 +1,9 @@
 .condition_common: &condition_common
-  target:
+  target: &condition_humidifier_target
     entity:
       domain: humidifier
   fields:
-    behavior:
+    behavior: &condition_behavior
       required: true
       default: any
       selector:
@@ -13,7 +13,36 @@
             - all
             - any
 
+.number_or_entity: &number_or_entity
+  required: false
+  selector:
+    choose:
+      choices:
+        number:
+          selector:
+            number:
+              mode: box
+              unit_of_measurement: "%"
+        entity:
+          selector:
+            entity:
+              filter:
+                - domain: input_number
+                  unit_of_measurement: "%"
+                - domain: sensor
+                  device_class: humidity
+                - domain: number
+                  device_class: humidity
+      translation_key: number_or_entity
+
 is_off: *condition_common
 is_on: *condition_common
 is_drying: *condition_common
 is_humidifying: *condition_common
+
+is_target_humidity:
+  target: *condition_humidifier_target
+  fields:
+    behavior: *condition_behavior
+    above: *number_or_entity
+    below: *number_or_entity

--- a/homeassistant/components/humidifier/icons.json
+++ b/homeassistant/components/humidifier/icons.json
@@ -11,6 +11,9 @@
     },
     "is_on": {
       "condition": "mdi:air-humidifier"
+    },
+    "is_target_humidity": {
+      "condition": "mdi:water-percent"
     }
   },
   "entity_component": {

--- a/homeassistant/components/humidifier/strings.json
+++ b/homeassistant/components/humidifier/strings.json
@@ -45,6 +45,24 @@
         }
       },
       "name": "Humidifier is on"
+    },
+    "is_target_humidity": {
+      "description": "Tests the target humidity of one or more humidifiers.",
+      "fields": {
+        "above": {
+          "description": "Require the target humidity to be above this value.",
+          "name": "Above"
+        },
+        "behavior": {
+          "description": "[%key:component::humidifier::common::condition_behavior_description%]",
+          "name": "[%key:component::humidifier::common::condition_behavior_name%]"
+        },
+        "below": {
+          "description": "Require the target humidity to be below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Humidifier target humidity"
     }
   },
   "device_automation": {

--- a/tests/components/humidifier/test_condition.py
+++ b/tests/components/humidifier/test_condition.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.humidifier.const import ATTR_ACTION, HumidifierAction
+from homeassistant.components.humidifier.const import (
+    ATTR_ACTION,
+    ATTR_HUMIDITY,
+    HumidifierAction,
+)
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
@@ -15,6 +19,8 @@ from tests.components.common import (
     assert_condition_gated_by_labs_flag,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
+    parametrize_numerical_attribute_condition_above_below_all,
+    parametrize_numerical_attribute_condition_above_below_any,
     parametrize_target_entities,
     target_entities,
 )
@@ -33,6 +39,7 @@ async def target_humidifiers(hass: HomeAssistant) -> dict[str, list[str]]:
         "humidifier.is_on",
         "humidifier.is_drying",
         "humidifier.is_humidifying",
+        "humidifier.is_target_humidity",
     ],
 )
 async def test_humidifier_conditions_gated_by_labs_flag(
@@ -202,6 +209,78 @@ async def test_humidifier_attribute_condition_behavior_all(
     states: list[ConditionStateDescription],
 ) -> None:
     """Test the humidifier attribute condition with the 'all' behavior."""
+    await assert_condition_behavior_all(
+        hass,
+        target_entities=target_humidifiers,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("humidifier"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_attribute_condition_above_below_any(
+        "humidifier.is_target_humidity",
+        STATE_ON,
+        ATTR_HUMIDITY,
+    ),
+)
+async def test_humidifier_numerical_condition_behavior_any(
+    hass: HomeAssistant,
+    target_humidifiers: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the humidifier numerical condition with the 'any' behavior."""
+    await assert_condition_behavior_any(
+        hass,
+        target_entities=target_humidifiers,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("humidifier"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_attribute_condition_above_below_all(
+        "humidifier.is_target_humidity",
+        STATE_ON,
+        ATTR_HUMIDITY,
+    ),
+)
+async def test_humidifier_numerical_condition_behavior_all(
+    hass: HomeAssistant,
+    target_humidifiers: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the humidifier numerical condition with the 'all' behavior."""
     await assert_condition_behavior_all(
         hass,
         target_entities=target_humidifiers,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a new condition `humidifier.is_target_humidity`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #158637
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
