### PR TITLE
Add moisture conditions

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -136,6 +136,7 @@ _EXPERIMENTAL_CONDITION_PLATFORMS = {
     "light",
     "lock",
     "media_player",
+    "moisture",
     "motion",
     "occupancy",
     "person",

--- a/homeassistant/components/moisture/__init__.py
+++ b/homeassistant/components/moisture/__init__.py
@@ -1,4 +1,4 @@
-"""Integration for moisture triggers."""
+"""Integration for moisture triggers and conditions."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/moisture/condition.py
+++ b/homeassistant/components/moisture/condition.py
@@ -1,0 +1,44 @@
+"""Provides conditions for moisture."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+    BinarySensorDeviceClass,
+)
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberDeviceClass
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
+from homeassistant.const import PERCENTAGE, STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.condition import (
+    Condition,
+    make_entity_numerical_condition,
+    make_entity_state_condition,
+)
+
+_MOISTURE_BINARY_DOMAIN_SPECS = {
+    BINARY_SENSOR_DOMAIN: DomainSpec(
+        device_class=BinarySensorDeviceClass.MOISTURE,
+    )
+}
+
+_MOISTURE_NUMERICAL_DOMAIN_SPECS = {
+    SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.MOISTURE),
+    NUMBER_DOMAIN: DomainSpec(device_class=NumberDeviceClass.MOISTURE),
+}
+
+CONDITIONS: dict[str, type[Condition]] = {
+    "is_detected": make_entity_state_condition(_MOISTURE_BINARY_DOMAIN_SPECS, STATE_ON),
+    "is_not_detected": make_entity_state_condition(
+        _MOISTURE_BINARY_DOMAIN_SPECS, STATE_OFF
+    ),
+    "is_value": make_entity_numerical_condition(
+        _MOISTURE_NUMERICAL_DOMAIN_SPECS, PERCENTAGE
+    ),
+}
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+    """Return the conditions for moisture."""
+    return CONDITIONS

--- a/homeassistant/components/moisture/conditions.yaml
+++ b/homeassistant/components/moisture/conditions.yaml
@@ -1,0 +1,52 @@
+.detected_condition_common: &detected_condition_common
+  target:
+    entity:
+      - domain: binary_sensor
+        device_class: moisture
+  fields:
+    behavior: &condition_behavior
+      required: true
+      default: any
+      selector:
+        select:
+          translation_key: condition_behavior
+          options:
+            - all
+            - any
+
+.number_or_entity: &number_or_entity
+  required: false
+  selector:
+    choose:
+      choices:
+        number:
+          selector:
+            number:
+              unit_of_measurement: "%"
+        entity:
+          selector:
+            entity:
+              filter:
+                - domain: input_number
+                  unit_of_measurement: "%"
+                - domain: number
+                  device_class: moisture
+                - domain: sensor
+                  device_class: moisture
+      translation_key: number_or_entity
+
+is_detected: *detected_condition_common
+
+is_not_detected: *detected_condition_common
+
+is_value:
+  target:
+    entity:
+      - domain: sensor
+        device_class: moisture
+      - domain: number
+        device_class: moisture
+  fields:
+    behavior: *condition_behavior
+    above: *number_or_entity
+    below: *number_or_entity

--- a/homeassistant/components/moisture/icons.json
+++ b/homeassistant/components/moisture/icons.json
@@ -1,4 +1,15 @@
 {
+  "conditions": {
+    "is_detected": {
+      "condition": "mdi:water"
+    },
+    "is_not_detected": {
+      "condition": "mdi:water-off"
+    },
+    "is_value": {
+      "condition": "mdi:water-percent"
+    }
+  },
   "triggers": {
     "changed": {
       "trigger": "mdi:water-percent"

--- a/homeassistant/components/moisture/strings.json
+++ b/homeassistant/components/moisture/strings.json
@@ -1,9 +1,57 @@
 {
   "common": {
+    "condition_behavior_description": "How the state should match on the targeted moisture sensors.",
+    "condition_behavior_name": "Behavior",
     "trigger_behavior_description": "The behavior of the targeted entities to trigger on.",
     "trigger_behavior_name": "Behavior"
   },
+  "conditions": {
+    "is_detected": {
+      "description": "Tests if moisture is currently detected.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::moisture::common::condition_behavior_description%]",
+          "name": "[%key:component::moisture::common::condition_behavior_name%]"
+        }
+      },
+      "name": "Moisture is detected"
+    },
+    "is_not_detected": {
+      "description": "Tests if moisture is currently not detected.",
+      "fields": {
+        "behavior": {
+          "description": "[%key:component::moisture::common::condition_behavior_description%]",
+          "name": "[%key:component::moisture::common::condition_behavior_name%]"
+        }
+      },
+      "name": "Moisture is not detected"
+    },
+    "is_value": {
+      "description": "Tests the moisture level value.",
+      "fields": {
+        "above": {
+          "description": "Require the moisture level to be above this value.",
+          "name": "Above"
+        },
+        "behavior": {
+          "description": "[%key:component::moisture::common::condition_behavior_description%]",
+          "name": "[%key:component::moisture::common::condition_behavior_name%]"
+        },
+        "below": {
+          "description": "Require the moisture level to be below this value.",
+          "name": "Below"
+        }
+      },
+      "name": "Moisture level"
+    }
+  },
   "selector": {
+    "condition_behavior": {
+      "options": {
+        "all": "All",
+        "any": "Any"
+      }
+    },
     "number_or_entity": {
       "choices": {
         "entity": "Entity",

--- a/homeassistant/components/moisture/strings.json
+++ b/homeassistant/components/moisture/strings.json
@@ -27,7 +27,7 @@
       "name": "Moisture is not detected"
     },
     "is_value": {
-      "description": "Tests the moisture level value.",
+      "description": "Tests the moisture level of one or more entities.",
       "fields": {
         "above": {
           "description": "Require the moisture level to be above this value.",

--- a/homeassistant/components/moisture/strings.json
+++ b/homeassistant/components/moisture/strings.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "condition_behavior_description": "How the state should match on the targeted moisture sensors.",
+    "condition_behavior_description": "How the state should match on the targeted entities.",
     "condition_behavior_name": "Behavior",
     "trigger_behavior_description": "The behavior of the targeted entities to trigger on.",
     "trigger_behavior_name": "Behavior"

--- a/homeassistant/components/moisture/strings.json
+++ b/homeassistant/components/moisture/strings.json
@@ -7,7 +7,7 @@
   },
   "conditions": {
     "is_detected": {
-      "description": "Tests if moisture is currently detected.",
+      "description": "Tests if one or more moisture sensors are detecting moisture.",
       "fields": {
         "behavior": {
           "description": "[%key:component::moisture::common::condition_behavior_description%]",
@@ -17,7 +17,7 @@
       "name": "Moisture is detected"
     },
     "is_not_detected": {
-      "description": "Tests if moisture is currently not detected.",
+      "description": "Tests if one or more moisture sensors are not detecting moisture.",
       "fields": {
         "behavior": {
           "description": "[%key:component::moisture::common::condition_behavior_description%]",

--- a/tests/components/moisture/test_condition.py
+++ b/tests/components/moisture/test_condition.py
@@ -1,0 +1,295 @@
+"""Test moisture conditions."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.components.common import (
+    ConditionStateDescription,
+    assert_condition_behavior_all,
+    assert_condition_behavior_any,
+    assert_condition_gated_by_labs_flag,
+    parametrize_condition_states_all,
+    parametrize_condition_states_any,
+    parametrize_numerical_condition_above_below_all,
+    parametrize_numerical_condition_above_below_any,
+    parametrize_target_entities,
+    target_entities,
+)
+
+_MOISTURE_UNIT_ATTRS = {ATTR_UNIT_OF_MEASUREMENT: "%"}
+
+
+@pytest.fixture
+async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple binary sensor entities associated with different targets."""
+    return await target_entities(hass, "binary_sensor")
+
+
+@pytest.fixture
+async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple sensor entities associated with different targets."""
+    return await target_entities(hass, "sensor")
+
+
+@pytest.fixture
+async def target_numbers(hass: HomeAssistant) -> dict[str, list[str]]:
+    """Create multiple number entities associated with different targets."""
+    return await target_entities(hass, "number")
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "moisture.is_detected",
+        "moisture.is_not_detected",
+        "moisture.is_value",
+    ],
+)
+async def test_moisture_conditions_gated_by_labs_flag(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, condition: str
+) -> None:
+    """Test the moisture conditions are gated by the labs flag."""
+    await assert_condition_gated_by_labs_flag(hass, caplog, condition)
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("binary_sensor"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    [
+        *parametrize_condition_states_any(
+            condition="moisture.is_detected",
+            target_states=[STATE_ON],
+            other_states=[STATE_OFF],
+            required_filter_attributes={ATTR_DEVICE_CLASS: "moisture"},
+        ),
+        *parametrize_condition_states_any(
+            condition="moisture.is_not_detected",
+            target_states=[STATE_OFF],
+            other_states=[STATE_ON],
+            required_filter_attributes={ATTR_DEVICE_CLASS: "moisture"},
+        ),
+    ],
+)
+async def test_moisture_binary_sensor_condition_behavior_any(
+    hass: HomeAssistant,
+    target_binary_sensors: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test moisture condition for binary_sensor with 'any' behavior."""
+    await assert_condition_behavior_any(
+        hass,
+        target_entities=target_binary_sensors,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("binary_sensor"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    [
+        *parametrize_condition_states_all(
+            condition="moisture.is_detected",
+            target_states=[STATE_ON],
+            other_states=[STATE_OFF],
+            required_filter_attributes={ATTR_DEVICE_CLASS: "moisture"},
+        ),
+        *parametrize_condition_states_all(
+            condition="moisture.is_not_detected",
+            target_states=[STATE_OFF],
+            other_states=[STATE_ON],
+            required_filter_attributes={ATTR_DEVICE_CLASS: "moisture"},
+        ),
+    ],
+)
+async def test_moisture_binary_sensor_condition_behavior_all(
+    hass: HomeAssistant,
+    target_binary_sensors: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test moisture condition for binary_sensor with 'all' behavior."""
+    await assert_condition_behavior_all(
+        hass,
+        target_entities=target_binary_sensors,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("sensor"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_condition_above_below_any(
+        "moisture.is_value",
+        device_class="moisture",
+        unit_attributes=_MOISTURE_UNIT_ATTRS,
+    ),
+)
+async def test_moisture_sensor_condition_behavior_any(
+    hass: HomeAssistant,
+    target_sensors: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the moisture sensor condition with 'any' behavior."""
+    await assert_condition_behavior_any(
+        hass,
+        target_entities=target_sensors,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("sensor"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_condition_above_below_all(
+        "moisture.is_value",
+        device_class="moisture",
+        unit_attributes=_MOISTURE_UNIT_ATTRS,
+    ),
+)
+async def test_moisture_sensor_condition_behavior_all(
+    hass: HomeAssistant,
+    target_sensors: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the moisture sensor condition with 'all' behavior."""
+    await assert_condition_behavior_all(
+        hass,
+        target_entities=target_sensors,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("number"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_condition_above_below_any(
+        "moisture.is_value",
+        device_class="moisture",
+        unit_attributes=_MOISTURE_UNIT_ATTRS,
+    ),
+)
+async def test_moisture_number_condition_behavior_any(
+    hass: HomeAssistant,
+    target_numbers: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the moisture number condition with 'any' behavior."""
+    await assert_condition_behavior_any(
+        hass,
+        target_entities=target_numbers,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )
+
+
+@pytest.mark.usefixtures("enable_labs_preview_features")
+@pytest.mark.parametrize(
+    ("condition_target_config", "entity_id", "entities_in_target"),
+    parametrize_target_entities("number"),
+)
+@pytest.mark.parametrize(
+    ("condition", "condition_options", "states"),
+    parametrize_numerical_condition_above_below_all(
+        "moisture.is_value",
+        device_class="moisture",
+        unit_attributes=_MOISTURE_UNIT_ATTRS,
+    ),
+)
+async def test_moisture_number_condition_behavior_all(
+    hass: HomeAssistant,
+    target_numbers: dict[str, list[str]],
+    condition_target_config: dict,
+    entity_id: str,
+    entities_in_target: int,
+    condition: str,
+    condition_options: dict[str, Any],
+    states: list[ConditionStateDescription],
+) -> None:
+    """Test the moisture number condition with 'all' behavior."""
+    await assert_condition_behavior_all(
+        hass,
+        target_entities=target_numbers,
+        condition_target_config=condition_target_config,
+        entity_id=entity_id,
+        entities_in_target=entities_in_target,
+        condition=condition,
+        condition_options=condition_options,
+        states=states,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the moisture conditions `moisture.is_detected`, `moisture.is_not_detected` and `moisture.is_value`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
	- closes #164163
	- closes #164228
	- closes #164229
	- closes #164230
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
