### PR TITLE
Add a missing regression test for airq config flow

### DIFF
--- a/homeassistant/components/airq/strings.json
+++ b/homeassistant/components/airq/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "incomplete_discovery": "The discovered air-Q device did not provide a device ID. Ensure the firmware is up to date."
     },
     "error": {

--- a/tests/components/airq/test_config_flow.py
+++ b/tests/components/airq/test_config_flow.py
@@ -258,6 +258,63 @@ async def test_zeroconf_updates_ip_on_already_configured(
     assert entry.data[CONF_IP_ADDRESS] == "192.168.0.123"
 
 
+async def test_user_flow_succeeds_during_zeroconf_discovery(
+    hass: HomeAssistant, mock_airq: AsyncMock
+) -> None:
+    """Test manual user flow does not abort when a zeroconf flow is in progress.
+
+    Regression test: before raise_on_progress=False, initiating a manual
+    setup while zeroconf discovery was pending for the same device would
+    abort with ``already_in_progress``.
+    """
+    # 1. Start a zeroconf discovery flow — this sets unique_id and waits
+    #    for the user to confirm (enter password).
+    zeroconf_result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=IPv4Address("192.168.0.123"),
+            ip_addresses=[IPv4Address("192.168.0.123")],
+            port=80,
+            hostname="airq.local.",
+            type="_http._tcp.local.",
+            name="air-Q._http._tcp.local.",
+            # Use the same ID as TEST_DEVICE_INFO so both flows share
+            # the unique_id.
+            properties={
+                "device": "air-q",
+                "devicename": "My air-Q",
+                "id": TEST_DEVICE_INFO["id"],
+            },
+        ),
+    )
+    assert zeroconf_result["type"] is FlowResultType.FORM
+    assert zeroconf_result["step_id"] == "discovery_confirm"
+
+    # 2. While the zeroconf flow is pending, start a manual user flow.
+    user_result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert user_result["type"] is FlowResultType.FORM
+
+    # 3. Complete the manual flow — this should NOT abort with
+    #    "already_in_progress".
+    user_result2 = await hass.config_entries.flow.async_configure(
+        user_result["flow_id"], TEST_USER_DATA
+    )
+    await hass.async_block_till_done()
+
+    assert user_result2["type"] is FlowResultType.CREATE_ENTRY
+    assert user_result2["title"] == TEST_DEVICE_INFO["name"]
+    assert user_result2["data"] == TEST_USER_DATA
+
+    # 4. The zeroconf discovery flow should now be aborted: completing
+    #    the user flow created a config entry for this unique_id, so
+    #    the pending discovery flow is no longer valid.
+    ongoing_flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert not ongoing_flows, f"Expected no remaining flows, but found: {ongoing_flows}"
+
+
 async def test_zeroconf_discovery_missing_id(
     hass: HomeAssistant, mock_airq: AsyncMock
 ) -> None:


### PR DESCRIPTION
A little follow-up for #166459.

The test starts a zeroconf flow for a unique_id and then completes the manual user flow, asserting the user flow no longer aborts with `already_in_progress` and that the discovery flow is aborted/cleaned up when the entry is created.

`already_in_progress` must be specified in `strings.json` for the test to fail properly _without_ the `raise_on_progress=False` kwarg.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
