### PR TITLE
Include port in BSB-LAN configuration URL when non-default

### DIFF
--- a/homeassistant/components/bsblan/entity.py
+++ b/homeassistant/components/bsblan/entity.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from yarl import URL
+
+from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceInfo,
@@ -10,7 +13,7 @@ from homeassistant.helpers.device_registry import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BSBLanData
-from .const import DOMAIN
+from .const import DEFAULT_PORT, DOMAIN
 from .coordinator import BSBLanCoordinator, BSBLanFastCoordinator, BSBLanSlowCoordinator
 
 
@@ -22,7 +25,8 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
     def __init__(self, coordinator: _T, data: BSBLanData) -> None:
         """Initialize BSBLan entity with device info."""
         super().__init__(coordinator)
-        host = coordinator.config_entry.data["host"]
+        host = coordinator.config_entry.data[CONF_HOST]
+        port = coordinator.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
         mac = data.device.MAC
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, mac)},
@@ -44,7 +48,7 @@ class BSBLanEntityBase[_T: BSBLanCoordinator](CoordinatorEntity[_T]):
                 else None
             ),
             sw_version=data.device.version,
-            configuration_url=f"http://{host}",
+            configuration_url=str(URL.build(scheme="http", host=host, port=port)),
         )
 
 

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -6,8 +6,11 @@ from bsblan import BSBLANAuthError, BSBLANConnectionError, BSBLANError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.bsblan.const import CONF_PASSKEY, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -221,3 +224,50 @@ async def test_coordinator_slow_no_dhw_support(
 
     # Verify slow coordinator handled the AttributeError gracefully
     assert mock_bsblan.hot_water_config.called
+
+
+async def test_configuration_url_default_port(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test configuration_url omits port 80 (HTTP default)."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90")}
+    )
+    assert device is not None
+    assert device.configuration_url == "http://127.0.0.1"
+
+
+async def test_configuration_url_non_default_port(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test configuration_url includes port when it differs from the default."""
+    config_entry = MockConfigEntry(
+        title="BSBLAN Setup",
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 8080,
+            CONF_PASSKEY: "1234",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin1234",
+        },
+        unique_id="00:80:41:19:69:90",
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90")}
+    )
+    assert device is not None
+    assert device.configuration_url == "http://192.168.1.100:8080"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The BSB-LAN integration allows configuring a non-default port, but `configuration_url` in the device info was always built as `http://{host}`, ignoring the port. This produces an incorrect configuration URL for devices running on a port other than 80.

This pull request improves how the `configuration_url` is generated for BSBLan devices by ensuring the correct host and port are used, and adds new tests to verify this behavior. The changes enhance flexibility for non-default ports and improve maintainability by using constants.

**Device URL Generation Improvements:**

* Updated `BSBLanEntityBase` in `entity.py` to use `CONF_HOST` and `CONF_PORT` from the configuration, defaulting to `DEFAULT_PORT` if not set, and to construct the `configuration_url` using `yarl.URL` for proper handling of host and port. [[1]](diffhunk://#diff-165306a2f9f11d57d4b9a641c93f3c9034be0d671a20827825a965edb3a32fb7R5-R7) [[2]](diffhunk://#diff-165306a2f9f11d57d4b9a641c93f3c9034be0d671a20827825a965edb3a32fb7L13-R16) [[3]](diffhunk://#diff-165306a2f9f11d57d4b9a641c93f3c9034be0d671a20827825a965edb3a32fb7L25-R29) [[4]](diffhunk://#diff-165306a2f9f11d57d4b9a641c93f3c9034be0d671a20827825a965edb3a32fb7L47-R51)

**Testing Enhancements:**

* Added two new tests in `test_init.py` to verify that the `configuration_url` omits the port when it is the default (80) and includes it when a custom port is specified.
* Updated imports in `test_init.py` to use the relevant constants for host, port, and credentials for consistency and maintainability.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
