### PR TITLE
Add binary sensors for PoolDose delay/pump status entities

### DIFF
--- a/homeassistant/components/pooldose/binary_sensor.py
+++ b/homeassistant/components/pooldose/binary_sensor.py
@@ -158,6 +158,24 @@ BINARY_SENSOR_DESCRIPTIONS: tuple[BinarySensorEntityDescription, ...] = (
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    BinarySensorEntityDescription(
+        key="circulation_pump_status",
+        translation_key="circulation_pump_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    BinarySensorEntityDescription(
+        key="power_on_delay_status",
+        translation_key="power_on_delay_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    BinarySensorEntityDescription(
+        key="flow_delay_status",
+        translation_key="flow_delay_status",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
 )
 
 

--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -85,6 +85,18 @@
           "on": "mdi:thermometer-alert"
         }
       },
+      "circulation_pump_status": {
+        "default": "mdi:pump",
+        "state": {
+          "on": "mdi:pump"
+        }
+      },
+      "flow_delay_status": {
+        "default": "mdi:timer-sand",
+        "state": {
+          "on": "mdi:timer-sand"
+        }
+      },
       "flow_rate_alarm": {
         "default": "mdi:autorenew",
         "state": {
@@ -101,6 +113,12 @@
         "default": "mdi:flask",
         "state": {
           "on": "mdi:flask-empty"
+        }
+      },
+      "power_on_delay_status": {
+        "default": "mdi:timer-sand",
+        "state": {
+          "on": "mdi:timer-sand"
         }
       },
       "pump_alarm": {
@@ -131,24 +149,6 @@
         "default": "mdi:electric-switch-closed",
         "state": {
           "on": "mdi:electric-switch"
-        }
-      },
-      "circulation_pump_status": {
-        "default": "mdi:pump",
-        "state": {
-          "on": "mdi:pump"
-        }
-      },
-      "flow_delay_status": {
-        "default": "mdi:timer-sand",
-        "state": {
-          "on": "mdi:timer-sand"
-        }
-      },
-      "power_on_delay_status": {
-        "default": "mdi:timer-sand",
-        "state": {
-          "on": "mdi:timer-sand"
         }
       }
     },

--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -86,16 +86,10 @@
         }
       },
       "circulation_pump_status": {
-        "default": "mdi:pump",
-        "state": {
-          "on": "mdi:pump"
-        }
+        "default": "mdi:pump"
       },
       "flow_delay_status": {
-        "default": "mdi:timer-sand",
-        "state": {
-          "on": "mdi:timer-sand"
-        }
+        "default": "mdi:timer-sand"
       },
       "flow_rate_alarm": {
         "default": "mdi:autorenew",
@@ -116,10 +110,7 @@
         }
       },
       "power_on_delay_status": {
-        "default": "mdi:timer-sand",
-        "state": {
-          "on": "mdi:timer-sand"
-        }
+        "default": "mdi:timer-sand"
       },
       "pump_alarm": {
         "default": "mdi:pump",

--- a/homeassistant/components/pooldose/icons.json
+++ b/homeassistant/components/pooldose/icons.json
@@ -132,6 +132,24 @@
         "state": {
           "on": "mdi:electric-switch"
         }
+      },
+      "circulation_pump_status": {
+        "default": "mdi:pump",
+        "state": {
+          "on": "mdi:pump"
+        }
+      },
+      "flow_delay_status": {
+        "default": "mdi:timer-sand",
+        "state": {
+          "on": "mdi:timer-sand"
+        }
+      },
+      "power_on_delay_status": {
+        "default": "mdi:timer-sand",
+        "state": {
+          "on": "mdi:timer-sand"
+        }
       }
     },
     "number": {

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -109,6 +109,15 @@
       },
       "relay_aux3": {
         "name": "Auxiliary relay 3"
+      },
+      "circulation_pump_status": {
+        "name": "Circulation pump"
+      },
+      "flow_delay_status": {
+        "name": "Flow delay"
+      },
+      "power_on_delay_status": {
+        "name": "Power-on delay"
       }
     },
     "number": {

--- a/homeassistant/components/pooldose/strings.json
+++ b/homeassistant/components/pooldose/strings.json
@@ -86,6 +86,12 @@
       "alarm_water_too_hot": {
         "name": "Water too hot"
       },
+      "circulation_pump_status": {
+        "name": "Circulation pump"
+      },
+      "flow_delay_status": {
+        "name": "Flow delay"
+      },
       "flow_rate_alarm": {
         "name": "Flow rate"
       },
@@ -94,6 +100,9 @@
       },
       "ph_level_alarm": {
         "name": "pH tank level"
+      },
+      "power_on_delay_status": {
+        "name": "Power-on delay"
       },
       "pump_alarm": {
         "name": "Recirculation"
@@ -109,15 +118,6 @@
       },
       "relay_aux3": {
         "name": "Auxiliary relay 3"
-      },
-      "circulation_pump_status": {
-        "name": "Circulation pump"
-      },
-      "flow_delay_status": {
-        "name": "Flow delay"
-      },
-      "power_on_delay_status": {
-        "name": "Power-on delay"
       }
     },
     "number": {

--- a/tests/components/pooldose/fixtures/instantvalues.json
+++ b/tests/components/pooldose/fixtures/instantvalues.json
@@ -2,7 +2,7 @@
   "sensor": {
     "temperature": {
       "value": 25,
-      "unit": "°C"
+      "unit": "\u00b0C"
     },
     "ph": {
       "value": 6.8,
@@ -84,24 +84,12 @@
       "value": 123.45,
       "unit": "m3"
     },
-    "circulation_pump_status": {
-      "value": "disabled",
-      "unit": null
-    },
     "device_config": {
       "value": "ph_orp",
       "unit": null
     },
     "temperature_unit": {
       "value": "celsius",
-      "unit": null
-    },
-    "power_on_delay_status": {
-      "value": "disabled",
-      "unit": null
-    },
-    "flow_delay_status": {
-      "value": "disabled",
       "unit": null
     }
   },
@@ -171,6 +159,15 @@
     },
     "alarm_system_standby": {
       "value": true
+    },
+    "circulation_pump_status": {
+      "value": false
+    },
+    "flow_delay_status": {
+      "value": false
+    },
+    "power_on_delay_status": {
+      "value": false
     }
   },
   "number": {

--- a/tests/components/pooldose/snapshots/test_binary_sensor.ambr
+++ b/tests/components/pooldose/snapshots/test_binary_sensor.ambr
@@ -458,6 +458,106 @@
     'state': 'off',
   })
 # ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_circulation_pump-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_circulation_pump',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Circulation pump',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Circulation pump',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'circulation_pump_status',
+    'unique_id': 'TEST123456789_circulation_pump_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_circulation_pump-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Circulation pump',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_circulation_pump',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_flow_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_flow_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Flow delay',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Flow delay',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'flow_delay_status',
+    'unique_id': 'TEST123456789_flow_delay_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_flow_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Flow delay',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_flow_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_binary_sensors[binary_sensor.pool_device_flow_rate-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -911,6 +1011,56 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.pool_device_ph_too_low',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_power_on_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.pool_device_power_on_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power-on delay',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Power-on delay',
+    'platform': 'pooldose',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_on_delay_status',
+    'unique_id': 'TEST123456789_power_on_delay_status',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_binary_sensors[binary_sensor.pool_device_power_on_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Pool Device Power-on delay',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.pool_device_power_on_delay',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/pooldose/snapshots/test_diagnostics.ambr
+++ b/tests/components/pooldose/snapshots/test_diagnostics.ambr
@@ -45,6 +45,12 @@
         'alarm_water_too_hot': dict({
           'value': False,
         }),
+        'circulation_pump_status': dict({
+          'value': False,
+        }),
+        'flow_delay_status': dict({
+          'value': False,
+        }),
         'flow_rate_alarm': dict({
           'value': False,
         }),
@@ -52,6 +58,9 @@
           'value': False,
         }),
         'ph_level_alarm': dict({
+          'value': False,
+        }),
+        'power_on_delay_status': dict({
           'value': False,
         }),
         'pump_alarm': dict({
@@ -197,10 +206,6 @@
         }),
       }),
       'sensor': dict({
-        'circulation_pump_status': dict({
-          'unit': None,
-          'value': 'disabled',
-        }),
         'cl': dict({
           'unit': 'ppm',
           'value': 1.2,
@@ -212,10 +217,6 @@
         'device_config': dict({
           'unit': None,
           'value': 'ph_orp',
-        }),
-        'flow_delay_status': dict({
-          'unit': None,
-          'value': 'disabled',
         }),
         'flow_rate': dict({
           'unit': 'L/s',
@@ -280,10 +281,6 @@
         'ph_type_dosing': dict({
           'unit': None,
           'value': 'alcalyne',
-        }),
-        'power_on_delay_status': dict({
-          'unit': None,
-          'value': 'disabled',
         }),
         'temperature': dict({
           'unit': '°C',


### PR DESCRIPTION
## Breaking change


## Proposed change

Add `circulation_pump_status`, `power_on_delay_status`, and `flow_delay_status` as binary sensors to the PoolDose integration.

These entities were removed from PR #165608 by @joostlek because they were incorrectly implemented as enum sensors with `disabled`/`enabled` options. They are natively `binary_sensor` types in the python-pooldose device mappings (v0.8.6), returning `true`/`false`.

Follow-up as discussed in [ronaldvdmeer/core#1](https://github.com/ronaldvdmeer/core/issues/1).

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #165608
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr