### PR TITLE
Adjust Thread network diagnostics prefixes to include double colon

### DIFF
--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -151,8 +151,8 @@ async def async_get_config_entry_diagnostics(
             # We know that it is indeed a /64 mesh-local IPv6 NETWORK because Thread spec;
             # However, the "prefixes" field contains no /XX (prefix length) in their entries ATM,
             # so we use a IPv6Address in order to get a "prefixes" entry with no prefix length.
-            prefix_network = IPv6Address(mlp_item.data.ljust(16, b"\x00"))
-            network["prefixes"].add(str(prefix_network))
+            prefix_address = IPv6Address(mlp_item.data.ljust(16, b"\x00"))
+            network["prefixes"].add(str(prefix_address))
 
     # Find all routes currently act that might be thread related, so we can match them to
     # border routers as we process the zeroconf data.

--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -17,6 +17,7 @@ some of their thread accessories can't be pinged, but it's still a thread proble
 
 from __future__ import annotations
 
+from ipaddress import IPv6Address
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from python_otbr_api.tlv_parser import MeshcopTLVType
@@ -147,8 +148,11 @@ async def async_get_config_entry_diagnostics(
             },
         )
         if mlp_item := record.dataset.get(MeshcopTLVType.MESHLOCALPREFIX):
-            mlp = str(mlp_item)
-            network["prefixes"].add(f"{mlp[0:4]}:{mlp[4:8]}:{mlp[8:12]}:{mlp[12:16]}::")
+            # We know that it is indeed a /64 mesh-local IPv6 NETWORK because Thread spec;
+            # However, the "prefixes" field contains no /XX (prefix length) in their entries ATM,
+            # so we use a IPv6Address in order to get a "prefixes" entry with no prefix length.
+            prefix_network = IPv6Address(mlp_item.data.ljust(16, b"\x00"))
+            network["prefixes"].add(str(prefix_network))
 
     # Find all routes currently act that might be thread related, so we can match them to
     # border routers as we process the zeroconf data.

--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -148,7 +148,7 @@ async def async_get_config_entry_diagnostics(
         )
         if mlp_item := record.dataset.get(MeshcopTLVType.MESHLOCALPREFIX):
             mlp = str(mlp_item)
-            network["prefixes"].add(f"{mlp[0:4]}:{mlp[4:8]}:{mlp[8:12]}:{mlp[12:16]}")
+            network["prefixes"].add(f"{mlp[0:4]}:{mlp[4:8]}:{mlp[8:12]}:{mlp[12:16]}::")
 
     # Find all routes currently act that might be thread related, so we can match them to
     # border routers as we process the zeroconf data.

--- a/homeassistant/components/thread/diagnostics.py
+++ b/homeassistant/components/thread/diagnostics.py
@@ -150,7 +150,7 @@ async def async_get_config_entry_diagnostics(
         if mlp_item := record.dataset.get(MeshcopTLVType.MESHLOCALPREFIX):
             # We know that it is indeed a /64 mesh-local IPv6 NETWORK because Thread spec;
             # However, the "prefixes" field contains no /XX (prefix length) in their entries ATM,
-            # so we use a IPv6Address in order to get a "prefixes" entry with no prefix length.
+            # so we use an IPv6Address in order to get a "prefixes" entry with no prefix length.
             prefix_address = IPv6Address(mlp_item.data.ljust(16, b"\x00"))
             network["prefixes"].add(str(prefix_address))
 

--- a/tests/components/thread/snapshots/test_diagnostics.ambr
+++ b/tests/components/thread/snapshots/test_diagnostics.ambr
@@ -5,7 +5,7 @@
       '1111111122222222': dict({
         'name': 'OpenThreadDemo',
         'prefixes': list([
-          'fdad:70bf:e5aa:15dd',
+          'fdad:70bf:e5aa:15dd::',
         ]),
         'routers': dict({
         }),


### PR DESCRIPTION
A network prefix should be a network prefix. And 4 words of IPv6 is not a syntactically valid prefix without the trailing :: (double colon).

MESHLOCALPREFIX is not used anywhere else AFAICT, so this is purely semantical/aesthetic fix for diagnostics.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve correctness of thread diagnostics. A bit syntax-lawyery, I concede.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
