### PR TITLE
Fix fritzbox coordinator name for readable log messages

### DIFF
--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -46,7 +46,7 @@ class FritzboxDataUpdateCoordinator(DataUpdateCoordinator[FritzboxCoordinatorDat
             hass,
             LOGGER,
             config_entry=config_entry,
-            name=config_entry.entry_id,
+            name=config_entry.title,
             update_interval=timedelta(seconds=30),
         )
 


### PR DESCRIPTION
## Description

The `FritzboxDataUpdateCoordinator` is initialized with `name=config_entry.entry_id`, which causes HA log messages like:

```
Timeout fetching d6db4e72b949d4f3ce820d47da1ac880 data
```

Using `config_entry.title` instead produces:

```
Timeout fetching fritz.box data
```

which is immediately meaningful to the user.

## Changes

- `coordinator.py`: `name=config_entry.entry_id` → `name=config_entry.title`

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)