### PR TITLE
Prevent invalid phase count state in nrgkick

### DIFF
--- a/homeassistant/components/nrgkick/number.py
+++ b/homeassistant/components/nrgkick/number.py
@@ -150,7 +150,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
             assert data is not None
         value = self.entity_description.value_fn(data)
         if self.entity_description.key == "phase_count":
-            if value != 0:
+            if value is not None and value != 0:
                 self._last_phase_count = value
             return self._last_phase_count
         return value

--- a/homeassistant/components/nrgkick/number.py
+++ b/homeassistant/components/nrgkick/number.py
@@ -120,6 +120,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
     """Representation of an NRGkick number entity."""
 
     entity_description: NRGkickNumberEntityDescription
+    _last_phase_count: float | None
 
     def __init__(
         self,
@@ -128,6 +129,7 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         self.entity_description = description
+        self._last_phase_count = None
         super().__init__(coordinator, description.key)
 
     @property
@@ -146,10 +148,17 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
         data = self.coordinator.data
         if TYPE_CHECKING:
             assert data is not None
-        return self.entity_description.value_fn(data)
+        value = self.entity_description.value_fn(data)
+        if self.entity_description.key == "phase_count":
+            if value != 0:
+                self._last_phase_count = value
+            return self._last_phase_count
+        return value
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
+        if self.entity_description.key == "phase_count":
+            self._last_phase_count = int(value)
         await self._async_call_api(
             self.entity_description.set_value_fn(self.coordinator, value)
         )

--- a/homeassistant/components/nrgkick/number.py
+++ b/homeassistant/components/nrgkick/number.py
@@ -87,19 +87,18 @@ NUMBERS: tuple[NRGkickNumberEntityDescription, ...] = (
             int(value)
         ),
     ),
-    NRGkickNumberEntityDescription(
-        key="phase_count",
-        translation_key="phase_count",
-        native_min_value=1,
-        native_max_value=3,
-        native_step=1,
-        mode=NumberMode.SLIDER,
-        value_fn=lambda data: data.control.get(CONTROL_KEY_PHASE_COUNT),
-        set_value_fn=lambda coordinator, value: coordinator.api.set_phase_count(
-            int(value)
-        ),
-        max_value_fn=_get_phase_count_max,
-    ),
+)
+
+PHASE_COUNT_DESCRIPTION = NRGkickNumberEntityDescription(
+    key="phase_count",
+    translation_key="phase_count",
+    native_min_value=1,
+    native_max_value=3,
+    native_step=1,
+    mode=NumberMode.SLIDER,
+    value_fn=lambda data: data.control.get(CONTROL_KEY_PHASE_COUNT),
+    set_value_fn=lambda coordinator, value: coordinator.api.set_phase_count(int(value)),
+    max_value_fn=_get_phase_count_max,
 )
 
 
@@ -111,16 +110,17 @@ async def async_setup_entry(
     """Set up NRGkick number entities based on a config entry."""
     coordinator = entry.runtime_data
 
-    async_add_entities(
+    entities: list[NRGkickNumber] = [
         NRGkickNumber(coordinator, description) for description in NUMBERS
-    )
+    ]
+    entities.append(NRGkickPhaseCountNumber(coordinator, PHASE_COUNT_DESCRIPTION))
+    async_add_entities(entities)
 
 
 class NRGkickNumber(NRGkickEntity, NumberEntity):
     """Representation of an NRGkick number entity."""
 
     entity_description: NRGkickNumberEntityDescription
-    _last_phase_count: float | None
 
     def __init__(
         self,
@@ -129,7 +129,6 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
     ) -> None:
         """Initialize the number entity."""
         self.entity_description = description
-        self._last_phase_count = None
         super().__init__(coordinator, description.key)
 
     @property
@@ -148,17 +147,33 @@ class NRGkickNumber(NRGkickEntity, NumberEntity):
         data = self.coordinator.data
         if TYPE_CHECKING:
             assert data is not None
-        value = self.entity_description.value_fn(data)
-        if self.entity_description.key == "phase_count":
-            if value is not None and value != 0:
-                self._last_phase_count = value
-            return self._last_phase_count
-        return value
+        return self.entity_description.value_fn(data)
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
-        if self.entity_description.key == "phase_count":
-            self._last_phase_count = int(value)
         await self._async_call_api(
             self.entity_description.set_value_fn(self.coordinator, value)
         )
+
+
+class NRGkickPhaseCountNumber(NRGkickNumber):
+    """Phase count number entity with optimistic state.
+
+    The device briefly reports 0 phases while switching. This subclass
+    caches the last valid value to avoid exposing the transient state.
+    """
+
+    _last_phase_count: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value, filtering transient zeros."""
+        value = super().native_value
+        if value is not None and value != 0:
+            self._last_phase_count = value
+        return self._last_phase_count
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set phase count with optimistic update."""
+        self._last_phase_count = int(value)
+        await super().async_set_native_value(value)

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -153,6 +153,9 @@ async def test_phase_count_filters_transient_zero_on_poll(
     assert (state := hass.states.get(entity_id))
     assert state.state == "3"
 
+    # One refresh happened during setup.
+    assert mock_nrgkick_api.get_control.call_count == 1
+
     # Device briefly reports 0 during a phase switch.
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 0
@@ -160,6 +163,9 @@ async def test_phase_count_filters_transient_zero_on_poll(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # Verify the coordinator actually polled the device.
+    assert mock_nrgkick_api.get_control.call_count == 2
 
     # The transient 0 must not surface; state stays at the previous value.
     assert (state := hass.states.get(entity_id))
@@ -172,6 +178,9 @@ async def test_phase_count_filters_transient_zero_on_poll(
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # Verify the coordinator polled again.
+    assert mock_nrgkick_api.get_control.call_count == 3
 
     assert (state := hass.states.get(entity_id))
     assert state.state == "1"

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -132,15 +132,15 @@ async def test_set_phase_count(
     mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
 
 
-async def test_phase_count_ignores_transient_zero(
+async def test_phase_count_filters_transient_zero_on_poll(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nrgkick_api: AsyncMock,
 ) -> None:
-    """Test that a transient phase count of 0 is ignored.
+    """Test that a transient phase count of 0 from a poll is filtered.
 
     During a phase-count switch the device briefly reports 0 phases.
-    The entity should keep the optimistic value instead of exposing 0.
+    A coordinator refresh must not expose the transient value.
     """
     await setup_integration(hass, mock_config_entry, platforms=[Platform.NUMBER])
 
@@ -149,15 +149,50 @@ async def test_phase_count_ignores_transient_zero(
     assert (state := hass.states.get(entity_id))
     assert state.state == "3"
 
-    # Simulate the device returning 0 during the phase switch triggered by
-    # the service call below.
+    # Device briefly reports 0 during a phase switch.
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 0
     mock_nrgkick_api.get_control.return_value = control_data
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
 
-    # State is unchanged until the service call triggers a refresh.
+    # The transient 0 must not surface; state stays at the previous value.
     assert (state := hass.states.get(entity_id))
     assert state.state == "3"
+
+    # Once the device settles it reports the real phase count.
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
+    control_data[CONTROL_KEY_PHASE_COUNT] = 1
+    mock_nrgkick_api.get_control.return_value = control_data
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "1"
+
+
+async def test_phase_count_filters_transient_zero_on_service_call(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+) -> None:
+    """Test that a service call keeps the cached value when refreshing returns 0.
+
+    When the user sets a new phase count, the immediate refresh triggered
+    by the service call may still see 0. The entity should keep the
+    requested value instead.
+    """
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.NUMBER])
+
+    entity_id = "number.nrgkick_test_phase_count"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "3"
+
+    # The refresh triggered by the service call will see 0.
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
+    control_data[CONTROL_KEY_PHASE_COUNT] = 0
+    mock_nrgkick_api.get_control.return_value = control_data
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
@@ -167,7 +202,7 @@ async def test_phase_count_ignores_transient_zero(
     )
     mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
 
-    # State must not show 0; the entity keeps the optimistic value.
+    # State must not show 0; the entity keeps the cached value.
     assert (state := hass.states.get(entity_id))
     assert state.state == "1"
 

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -149,10 +149,15 @@ async def test_phase_count_ignores_transient_zero(
     assert (state := hass.states.get(entity_id))
     assert state.state == "3"
 
-    # Simulate the device returning 0 during a phase switch.
+    # Simulate the device returning 0 during the phase switch triggered by
+    # the service call below.
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 0
     mock_nrgkick_api.get_control.return_value = control_data
+
+    # State is unchanged until the service call triggers a refresh.
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "3"
 
     await hass.services.async_call(
         NUMBER_DOMAIN,

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 from nrgkick_api import NRGkickCommandRejectedError
 from nrgkick_api.const import (
     CONTROL_KEY_CURRENT_SET,
@@ -14,6 +15,7 @@ from nrgkick_api.const import (
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.nrgkick.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
@@ -23,11 +25,12 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
 
 pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
 
@@ -136,6 +139,7 @@ async def test_phase_count_filters_transient_zero_on_poll(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nrgkick_api: AsyncMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that a transient phase count of 0 from a poll is filtered.
 
@@ -153,7 +157,8 @@ async def test_phase_count_filters_transient_zero_on_poll(
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 0
     mock_nrgkick_api.get_control.return_value = control_data
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     # The transient 0 must not surface; state stays at the previous value.
@@ -164,7 +169,8 @@ async def test_phase_count_filters_transient_zero_on_poll(
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 1
     mock_nrgkick_api.get_control.return_value = control_data
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=60))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert (state := hass.states.get(entity_id))
@@ -175,6 +181,7 @@ async def test_phase_count_filters_transient_zero_on_service_call(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_nrgkick_api: AsyncMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that a service call keeps the cached value when refreshing returns 0.
 
@@ -210,7 +217,8 @@ async def test_phase_count_filters_transient_zero_on_service_call(
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 1
     mock_nrgkick_api.get_control.return_value = control_data
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert (state := hass.states.get(entity_id))

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -114,7 +114,7 @@ async def test_set_phase_count(
     assert (state := hass.states.get(entity_id))
     assert state.state == "3"
 
-    # Set to 1 phase
+    # Set phase count to 1
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 1
     mock_nrgkick_api.get_control.return_value = control_data
@@ -128,6 +128,40 @@ async def test_set_phase_count(
     assert state.state == "1"
 
     mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
+
+
+async def test_phase_count_ignores_transient_zero(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nrgkick_api: AsyncMock,
+) -> None:
+    """Test that a transient phase count of 0 is ignored.
+
+    During a phase-count switch the device briefly reports 0 phases.
+    The entity should keep the optimistic value instead of exposing 0.
+    """
+    await setup_integration(hass, mock_config_entry, platforms=[Platform.NUMBER])
+
+    entity_id = "number.nrgkick_test_phase_count"
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "3"
+
+    # Simulate the device returning 0 during a phase switch.
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
+    control_data[CONTROL_KEY_PHASE_COUNT] = 0
+    mock_nrgkick_api.get_control.return_value = control_data
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 1},
+        blocking=True,
+    )
+
+    # State must not show 0; the entity keeps the optimistic value.
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "1"
 
 
 async def test_number_command_rejected_by_device(

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -163,6 +163,8 @@ async def test_phase_count_ignores_transient_zero(
     assert (state := hass.states.get(entity_id))
     assert state.state == "1"
 
+    mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
+
 
 async def test_number_command_rejected_by_device(
     hass: HomeAssistant,

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -226,9 +226,13 @@ async def test_phase_count_filters_transient_zero_on_service_call(
     control_data = mock_nrgkick_api.get_control.return_value.copy()
     control_data[CONTROL_KEY_PHASE_COUNT] = 1
     mock_nrgkick_api.get_control.return_value = control_data
+    prior_call_count = mock_nrgkick_api.get_control.call_count
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
+
+    # Verify that a periodic refresh actually occurred.
+    assert mock_nrgkick_api.get_control.call_count > prior_call_count
 
     assert (state := hass.states.get(entity_id))
     assert state.state == "1"

--- a/tests/components/nrgkick/test_number.py
+++ b/tests/components/nrgkick/test_number.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 from nrgkick_api import NRGkickCommandRejectedError
@@ -22,10 +23,11 @@ from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
 
@@ -158,12 +160,21 @@ async def test_phase_count_ignores_transient_zero(
         {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: 1},
         blocking=True,
     )
+    mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
 
     # State must not show 0; the entity keeps the optimistic value.
     assert (state := hass.states.get(entity_id))
     assert state.state == "1"
 
-    mock_nrgkick_api.set_phase_count.assert_awaited_once_with(1)
+    # Once the device settles it reports the real phase count again.
+    control_data = mock_nrgkick_api.get_control.return_value.copy()
+    control_data[CONTROL_KEY_PHASE_COUNT] = 1
+    mock_nrgkick_api.get_control.return_value = control_data
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == "1"
 
 
 async def test_number_command_rejected_by_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After a phase count change, the device first confirms the new phase count with the returned value, but then briefly returns a phase count of 0 for the next 1-2 seconds while it's changing the phase count. With the delayed refresh and entity updates happening only every 30 seconds, this transient phase count is reported for a long time, causing bad UX and confusion.

Therefore, the new approach now takes the confirmed device value and considers a phase count of 0 as illegal and doesn't use this, as charging phases can only be 1 (or 2, 3 depending on the connection). This also reflects the behavior of the official NRGkick app, which also doesn't show a phase count of 0 in the brief transition phase.

This makes the device-confirmed new phase count immediately visible.
(Note: when the device is not charging currently or not connected, the returned phase count is also the configured value, and not 0).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/165039
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
