### PR TITLE
homematicip_cloud: migrate entity unique IDs to stable format

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -23,8 +21,6 @@ from .const import (
 from .hap import HomematicIPConfigEntry, HomematicipHAP
 from .migration import async_migrate_entry  # noqa: F401
 from .services import async_setup_services
-
-_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
-import re
 
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import (
-    config_validation as cv,
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -27,234 +21,10 @@ from .const import (
     HMIPC_NAME,
 )
 from .hap import HomematicIPConfigEntry, HomematicipHAP
+from .migration import async_migrate_entry  # noqa: F401
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class _MigrationConfig:
-    """Configuration for migrating a single entity class to the new unique_id format."""
-
-    feature_id: str
-    channel: int | None = None
-    is_group: bool = False
-
-
-UNIQUE_ID_MIGRATION_MAP: dict[str, _MigrationConfig] = {
-    # binary_sensor
-    "HomematicipCloudConnectionSensor": _MigrationConfig(
-        "cloud_connection", is_group=True
-    ),
-    "HomematicipAccelerationSensor": _MigrationConfig("acceleration", channel=1),
-    "HomematicipTiltVibrationSensor": _MigrationConfig("tilt_vibration", channel=1),
-    "HomematicipMultiContactInterface": _MigrationConfig("contact"),
-    "HomematicipContactInterface": _MigrationConfig("contact", channel=1),
-    "HomematicipShutterContact": _MigrationConfig("shutter_contact", channel=1),
-    "HomematicipMotionDetector": _MigrationConfig("motion", channel=1),
-    "HomematicipPresenceDetector": _MigrationConfig("presence", channel=1),
-    "HomematicipSmokeDetector": _MigrationConfig("smoke", channel=1),
-    "HomematicipWaterDetector": _MigrationConfig("water", channel=1),
-    "HomematicipStormSensor": _MigrationConfig("storm", channel=1),
-    "HomematicipRainSensor": _MigrationConfig("rain", channel=1),
-    "HomematicipSunshineSensor": _MigrationConfig("sunshine", channel=1),
-    "HomematicipBatterySensor": _MigrationConfig("battery", channel=0),
-    "HomematicipPluggableMainsFailureSurveillanceSensor": _MigrationConfig(
-        "mains_failure", channel=1
-    ),
-    "HomematicipSecurityZoneSensorGroup": _MigrationConfig(
-        "security_zone", is_group=True
-    ),
-    "HomematicipSecuritySensorGroup": _MigrationConfig("security", is_group=True),
-    "HomematicipFullFlushLockControllerLocked": _MigrationConfig(
-        "lock_locked", channel=1
-    ),
-    "HomematicipFullFlushLockControllerGlassBreak": _MigrationConfig(
-        "glass_break", channel=1
-    ),
-    "HomematicipSmokeDetectorChamberDegraded": _MigrationConfig(
-        "chamber_degraded", channel=1
-    ),
-    # sensor
-    "HomematicipAccesspointDutyCycle": _MigrationConfig("duty_cycle", channel=0),
-    "HomematicipHeatingThermostat": _MigrationConfig("valve_position", channel=1),
-    "HomematicipHumiditySensor": _MigrationConfig("humidity", channel=1),
-    "HomematicipTemperatureSensor": _MigrationConfig("temperature", channel=1),
-    "HomematicipAbsoluteHumiditySensor": _MigrationConfig(
-        "absolute_humidity", channel=1
-    ),
-    "HomematicipIlluminanceSensor": _MigrationConfig("illuminance", channel=1),
-    "HomematicipPowerSensor": _MigrationConfig("power", channel=1),
-    "HomematicipEnergySensor": _MigrationConfig("energy", channel=1),
-    "HomematicipWindspeedSensor": _MigrationConfig("wind_speed", channel=1),
-    "HomematicipTodayRainSensor": _MigrationConfig("today_rain", channel=1),
-    "HomematicipPassageDetectorDeltaCounter": _MigrationConfig(
-        "passage_counter", channel=1
-    ),
-    "HomematicipWaterFlowSensor": _MigrationConfig("water_flow"),
-    "HomematicipWaterVolumeSensor": _MigrationConfig("water_volume"),
-    "HomematicipWaterVolumeSinceOpenSensor": _MigrationConfig(
-        "water_volume_since_open"
-    ),
-    "HomematicipTiltAngleSensor": _MigrationConfig("tilt_angle", channel=1),
-    "HomematicipTiltStateSensor": _MigrationConfig("tilt_state", channel=1),
-    "HomematicipFloorTerminalBlockMechanicChannelValve": _MigrationConfig(
-        "ftb_valve_position"
-    ),
-    "HomematicpTemperatureExternalSensorCh1": _MigrationConfig(
-        "temperature_external_ch1", channel=1
-    ),
-    "HomematicpTemperatureExternalSensorCh2": _MigrationConfig(
-        "temperature_external_ch2", channel=1
-    ),
-    "HomematicpTemperatureExternalSensorDelta": _MigrationConfig(
-        "temperature_external_delta", channel=1
-    ),
-    "HmipEsiIecPowerConsumption": _MigrationConfig("esi_iec_power", channel=1),
-    "HmipEsiIecEnergyCounterHighTariff": _MigrationConfig(
-        "esi_iec_energy_high", channel=1
-    ),
-    "HmipEsiIecEnergyCounterLowTariff": _MigrationConfig(
-        "esi_iec_energy_low", channel=1
-    ),
-    "HmipEsiIecEnergyCounterInputSingleTariff": _MigrationConfig(
-        "esi_iec_energy_input", channel=1
-    ),
-    "HmipEsiGasCurrentGasFlow": _MigrationConfig("esi_gas_flow", channel=1),
-    "HmipEsiGasGasVolume": _MigrationConfig("esi_gas_volume", channel=1),
-    "HmipEsiLedCurrentPowerConsumption": _MigrationConfig("esi_led_power", channel=1),
-    "HmipEsiLedEnergyCounterHighTariff": _MigrationConfig(
-        "esi_led_energy_high", channel=1
-    ),
-    "HomematicipSoilMoistureSensor": _MigrationConfig("soil_moisture", channel=1),
-    "HomematicipSoilTemperatureSensor": _MigrationConfig("soil_temperature", channel=1),
-    # light
-    "HomematicipLight": _MigrationConfig("light", channel=1),
-    "HomematicipLightHS": _MigrationConfig("light"),
-    "HomematicipLightMeasuring": _MigrationConfig("light", channel=1),
-    "HomematicipMultiDimmer": _MigrationConfig("dimmer"),
-    "HomematicipDimmer": _MigrationConfig("dimmer", channel=1),
-    "HomematicipNotificationLight": _MigrationConfig("notification_light"),
-    "HomematicipNotificationLightV2": _MigrationConfig("notification_light"),
-    "HomematicipColorLight": _MigrationConfig("color_light", channel=1),
-    "HomematicipOpticalSignalLight": _MigrationConfig(
-        "optical_signal_light", channel=1
-    ),
-    "HomematicipCombinationSignallingLight": _MigrationConfig(
-        "combination_signalling_light", channel=1
-    ),
-    # switch
-    "HomematicipMultiSwitch": _MigrationConfig("switch"),
-    "HomematicipSwitch": _MigrationConfig("switch", channel=1),
-    "HomematicipGroupSwitch": _MigrationConfig("switch", is_group=True),
-    "HomematicipSwitchMeasuring": _MigrationConfig("switch", channel=1),
-    # cover
-    "HomematicipBlindModule": _MigrationConfig("blind", channel=1),
-    "HomematicipMultiCoverShutter": _MigrationConfig("shutter"),
-    "HomematicipCoverShutter": _MigrationConfig("shutter", channel=1),
-    "HomematicipMultiCoverSlats": _MigrationConfig("slats"),
-    "HomematicipCoverSlats": _MigrationConfig("slats", channel=1),
-    "HomematicipGarageDoorModule": _MigrationConfig("garage_door", channel=1),
-    "HomematicipCoverShutterGroup": _MigrationConfig("shutter", is_group=True),
-    # climate
-    "HomematicipHeatingGroup": _MigrationConfig("climate", is_group=True),
-    # weather
-    "HomematicipWeatherSensor": _MigrationConfig("weather", channel=1),
-    "HomematicipWeatherSensorPro": _MigrationConfig("weather", channel=1),
-    "HomematicipHomeWeather": _MigrationConfig("home_weather", is_group=True),
-    # valve
-    "HomematicipWateringValve": _MigrationConfig("watering"),
-    # lock
-    "HomematicipDoorLockDrive": _MigrationConfig("lock", channel=1),
-    # button
-    "HomematicipGarageDoorControllerButton": _MigrationConfig(
-        "garage_button", channel=1
-    ),
-    "HomematicipFullFlushLockControllerButton": _MigrationConfig(
-        "lock_opener_button", channel=1
-    ),
-    # event
-    "HomematicipDoorBellEvent": _MigrationConfig("doorbell", channel=1),
-    # alarm_control_panel
-    "HomematicipAlarmControlPanelEntity": _MigrationConfig("alarm", is_group=True),
-    # siren
-    "HomematicipMP3Siren": _MigrationConfig("siren", channel=1),
-}
-
-# Sorted by length descending so longer class names match before shorter ones
-# (e.g., "HomematicipSwitchMeasuring" before "HomematicipSwitch")
-_SORTED_CLASS_NAMES = sorted(UNIQUE_ID_MIGRATION_MAP, key=len, reverse=True)
-
-_CHANNEL_RE = re.compile(r"^Channel(\d+)_(.+)$")
-_NOTIFICATION_LIGHT_RE = re.compile(r"^(Top|Bottom)_(.+)$")
-
-_NOTIFICATION_LIGHT_CHANNEL_MAP = {"Top": 2, "Bottom": 3}
-
-
-def _migrate_unique_id(old_unique_id: str) -> str | None:
-    """Convert an old-format unique_id to the new format.
-
-    Old formats:
-      {ClassName}_{device_id}
-      {ClassName}_Channel{N}_{device_id}
-      {ClassName}_{Top|Bottom}_{device_id}  (NotificationLight only)
-
-    New format:
-      {device_id}_{channel}_{feature_id}    (device entities)
-      {device_id}_{feature_id}              (group/home entities)
-    """
-    # Find the matching class name (longest first)
-    matched_class: str | None = None
-    for class_name in _SORTED_CLASS_NAMES:
-        prefix = class_name + "_"
-        if old_unique_id.startswith(prefix):
-            matched_class = class_name
-            break
-
-    if matched_class is None:
-        return None
-
-    config = UNIQUE_ID_MIGRATION_MAP[matched_class]
-    remainder = old_unique_id[len(matched_class) + 1 :]
-
-    # Parse remainder to extract channel and device_id
-    channel: int | None = None
-    device_id: str
-
-    # Check for Channel{N}_{rest} pattern
-    channel_match = _CHANNEL_RE.match(remainder)
-    if channel_match:
-        channel = int(channel_match.group(1))
-        device_id = channel_match.group(2)
-    elif matched_class in (
-        "HomematicipNotificationLight",
-        "HomematicipNotificationLightV2",
-    ):
-        # Check for Top/Bottom pattern
-        notif_match = _NOTIFICATION_LIGHT_RE.match(remainder)
-        if notif_match:
-            channel = _NOTIFICATION_LIGHT_CHANNEL_MAP[notif_match.group(1)]
-            device_id = notif_match.group(2)
-        else:
-            device_id = remainder
-            channel = config.channel
-    else:
-        device_id = remainder
-        channel = config.channel
-
-    # Build new unique_id
-    if config.is_group:
-        return f"{device_id}_{config.feature_id}"
-
-    if channel is not None:
-        return f"{device_id}_{channel}_{config.feature_id}"
-
-    _LOGGER.warning(
-        "Cannot determine channel for unique_id: %s",
-        old_unique_id,
-    )
-    return None
-
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -273,86 +43,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-
-async def async_migrate_entry(
-    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
-) -> bool:
-    """Migrate the config entry from version 1 to version 2."""
-    if config_entry.version > 2:
-        return False
-
-    if config_entry.version == 1:
-        _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")
-
-        # Remove obsolete entities before the bulk unique_id rewrite.
-        # After rewrite, old-format patterns would no longer be matchable.
-        # HomematicipAccesspointStatus* entities are always obsolete (removed
-        # in firmware 2.2.12+). HomematicipBatterySensor_{hapid} entities for
-        # access points are also obsolete. Those legacy access point battery
-        # entities do not belong to a device registry device, unlike real
-        # device battery sensors, so we can safely remove them before rewrite.
-        entity_registry = er.async_get(hass)
-        entries = er.async_entries_for_config_entry(
-            entity_registry, config_entry.entry_id
-        )
-        for entry in entries:
-            if entry.unique_id.startswith("HomematicipAccesspointStatus"):
-                _LOGGER.debug(
-                    "Removing obsolete access point status entity: %s",
-                    entry.entity_id,
-                )
-                entity_registry.async_remove(entry.entity_id)
-                continue
-
-            if (
-                entry.unique_id.startswith("HomematicipBatterySensor_")
-                and entry.device_id is None
-            ):
-                _LOGGER.debug(
-                    "Removing obsolete access point battery entity: %s",
-                    entry.entity_id,
-                )
-                entity_registry.async_remove(entry.entity_id)
-
-        @callback
-        def _update_unique_id(
-            entity_entry: er.RegistryEntry,
-        ) -> dict[str, str] | None:
-            new_unique_id = _migrate_unique_id(entity_entry.unique_id)
-            if new_unique_id is None:
-                # Some entities (e.g. HmipSmokeDetectorSensor) already use
-                # stable non-class-name unique_ids and don't need migration.
-                # Only warn if the ID looks like an old class-name format.
-                if any(
-                    entity_entry.unique_id.startswith(cls + "_")
-                    for cls in _SORTED_CLASS_NAMES
-                ):
-                    _LOGGER.warning(
-                        "Could not migrate unique_id for %s: %s",
-                        entity_entry.entity_id,
-                        entity_entry.unique_id,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Skipping unique_id %s (already stable format)",
-                        entity_entry.unique_id,
-                    )
-                return None
-            _LOGGER.debug(
-                "Migrating %s: %s -> %s",
-                entity_entry.entity_id,
-                entity_entry.unique_id,
-                new_unique_id,
-            )
-            return {"new_unique_id": new_unique_id}
-
-        await er.async_migrate_entries(hass, config_entry.entry_id, _update_unique_id)
-
-        hass.config_entries.async_update_entry(config_entry, version=2)
-        _LOGGER.info("Migration to version 2 successful")
-
-    return True
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -398,8 +88,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicIPConfigEntry) 
     if not await hap.async_setup():
         return False
 
-    _async_remove_obsolete_entities(hass, entry, hap)
-
     # Register on HA stop event to gracefully shutdown HomematicIP Cloud connection
     hap.reset_connection_listener = hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, hap.shutdown
@@ -430,27 +118,3 @@ async def async_unload_entry(
     hap.reset_connection_listener()
 
     return await hap.async_reset()
-
-
-@callback
-def _async_remove_obsolete_entities(
-    hass: HomeAssistant, entry: HomematicIPConfigEntry, hap: HomematicipHAP
-):
-    """Remove obsolete entities from entity registry."""
-
-    if hap.home.currentAPVersion < "2.2.12":
-        return
-
-    entity_registry = er.async_get(hass)
-    er_entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    for er_entry in er_entries:
-        if er_entry.unique_id.startswith("HomematicipAccesspointStatus"):
-            entity_registry.async_remove(er_entry.entity_id)
-            continue
-
-        # For v2+ config entries, battery sensor cleanup already happened
-        # during migration in async_migrate_entry. This is a safety net for
-        # any edge case where the migration didn't run.
-        for hapid in hap.home.accessPointUpdateStates:
-            if er_entry.unique_id == f"HomematicipBatterySensor_{hapid}":
-                entity_registry.async_remove(er_entry.entity_id)

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -19,8 +25,10 @@ from .const import (
     HMIPC_NAME,
 )
 from .hap import HomematicIPConfigEntry, HomematicipHAP
-from .migration import async_migrate_entry  # noqa: F401
+from .migration import _SORTED_CLASS_NAMES, _migrate_unique_id
 from .services import async_setup_services
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -114,3 +122,76 @@ async def async_unload_entry(
     hap.reset_connection_listener()
 
     return await hap.async_reset()
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+) -> bool:
+    """Migrate the config entry from version 1 to version 2."""
+    if config_entry.version > 2:
+        return False
+
+    if config_entry.version == 1:
+        _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")
+
+        # Remove obsolete entities before the bulk unique_id rewrite.
+        # After rewrite, old-format patterns would no longer be matchable.
+        # HomematicipAccesspointStatus* entities are always obsolete (removed
+        # in firmware 2.2.12+). HomematicipBatterySensor_{hapid} entities for
+        # access points are also obsolete. Those legacy access point battery
+        # entities do not belong to a device registry device, unlike real
+        # device battery sensors, so we can safely remove them before rewrite.
+        entity_registry = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        for entry in entries:
+            if entry.unique_id.startswith("HomematicipAccesspointStatus") or (
+                entry.unique_id.startswith("HomematicipBatterySensor_")
+                and entry.device_id is None
+            ):
+                _LOGGER.debug(
+                    "Removing obsolete entity: %s (%s)",
+                    entry.entity_id,
+                    entry.unique_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+
+        @callback
+        def _update_unique_id(
+            entity_entry: er.RegistryEntry,
+        ) -> dict[str, str] | None:
+            new_unique_id = _migrate_unique_id(entity_entry.unique_id)
+            if new_unique_id is None:
+                # Some entities (e.g. HmipSmokeDetectorSensor) already use
+                # stable non-class-name unique_ids and don't need migration.
+                # Only warn if the ID looks like an old class-name format.
+                if any(
+                    entity_entry.unique_id.startswith(cls + "_")
+                    for cls in _SORTED_CLASS_NAMES
+                ):
+                    _LOGGER.warning(
+                        "Could not migrate unique_id for %s: %s",
+                        entity_entry.entity_id,
+                        entity_entry.unique_id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Skipping unique_id %s (already stable format)",
+                        entity_entry.unique_id,
+                    )
+                return None
+            _LOGGER.debug(
+                "Migrating %s: %s -> %s",
+                entity_entry.entity_id,
+                entity_entry.unique_id,
+                new_unique_id,
+            )
+            return {"new_unique_id": new_unique_id}
+
+        await er.async_migrate_entries(hass, config_entry.entry_id, _update_unique_id)
+
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        _LOGGER.info("Migration to version 2 successful")
+
+    return True

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -1,5 +1,11 @@
 """Support for HomematicIP Cloud devices."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -23,6 +29,233 @@ from .const import (
 from .hap import HomematicIPConfigEntry, HomematicipHAP
 from .services import async_setup_services
 
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _MigrationConfig:
+    """Configuration for migrating a single entity class to the new unique_id format."""
+
+    feature_id: str
+    channel: int | None = None
+    is_group: bool = False
+
+
+UNIQUE_ID_MIGRATION_MAP: dict[str, _MigrationConfig] = {
+    # binary_sensor
+    "HomematicipCloudConnectionSensor": _MigrationConfig(
+        "cloud_connection", is_group=True
+    ),
+    "HomematicipAccelerationSensor": _MigrationConfig("acceleration", channel=1),
+    "HomematicipTiltVibrationSensor": _MigrationConfig("tilt_vibration", channel=1),
+    "HomematicipMultiContactInterface": _MigrationConfig("contact"),
+    "HomematicipContactInterface": _MigrationConfig("contact", channel=1),
+    "HomematicipShutterContact": _MigrationConfig("shutter_contact", channel=1),
+    "HomematicipMotionDetector": _MigrationConfig("motion", channel=1),
+    "HomematicipPresenceDetector": _MigrationConfig("presence", channel=1),
+    "HomematicipSmokeDetector": _MigrationConfig("smoke", channel=1),
+    "HomematicipWaterDetector": _MigrationConfig("water", channel=1),
+    "HomematicipStormSensor": _MigrationConfig("storm", channel=1),
+    "HomematicipRainSensor": _MigrationConfig("rain", channel=1),
+    "HomematicipSunshineSensor": _MigrationConfig("sunshine", channel=1),
+    "HomematicipBatterySensor": _MigrationConfig("battery", channel=0),
+    "HomematicipPluggableMainsFailureSurveillanceSensor": _MigrationConfig(
+        "mains_failure", channel=1
+    ),
+    "HomematicipSecurityZoneSensorGroup": _MigrationConfig(
+        "security_zone", is_group=True
+    ),
+    "HomematicipSecuritySensorGroup": _MigrationConfig("security", is_group=True),
+    "HomematicipFullFlushLockControllerLocked": _MigrationConfig(
+        "lock_locked", channel=1
+    ),
+    "HomematicipFullFlushLockControllerGlassBreak": _MigrationConfig(
+        "glass_break", channel=1
+    ),
+    "HomematicipSmokeDetectorChamberDegraded": _MigrationConfig(
+        "chamber_degraded", channel=1
+    ),
+    # sensor
+    "HomematicipAccesspointDutyCycle": _MigrationConfig("duty_cycle", channel=0),
+    "HomematicipHeatingThermostat": _MigrationConfig("valve_position", channel=1),
+    "HomematicipHumiditySensor": _MigrationConfig("humidity", channel=1),
+    "HomematicipTemperatureSensor": _MigrationConfig("temperature", channel=1),
+    "HomematicipAbsoluteHumiditySensor": _MigrationConfig(
+        "absolute_humidity", channel=1
+    ),
+    "HomematicipIlluminanceSensor": _MigrationConfig("illuminance", channel=1),
+    "HomematicipPowerSensor": _MigrationConfig("power", channel=1),
+    "HomematicipEnergySensor": _MigrationConfig("energy", channel=1),
+    "HomematicipWindspeedSensor": _MigrationConfig("wind_speed", channel=1),
+    "HomematicipTodayRainSensor": _MigrationConfig("today_rain", channel=1),
+    "HomematicipPassageDetectorDeltaCounter": _MigrationConfig(
+        "passage_counter", channel=1
+    ),
+    "HomematicipWaterFlowSensor": _MigrationConfig("water_flow"),
+    "HomematicipWaterVolumeSensor": _MigrationConfig("water_volume"),
+    "HomematicipWaterVolumeSinceOpenSensor": _MigrationConfig(
+        "water_volume_since_open"
+    ),
+    "HomematicipTiltAngleSensor": _MigrationConfig("tilt_angle", channel=1),
+    "HomematicipTiltStateSensor": _MigrationConfig("tilt_state", channel=1),
+    "HomematicipFloorTerminalBlockMechanicChannelValve": _MigrationConfig(
+        "ftb_valve_position"
+    ),
+    "HomematicpTemperatureExternalSensorCh1": _MigrationConfig(
+        "temperature_external_ch1", channel=1
+    ),
+    "HomematicpTemperatureExternalSensorCh2": _MigrationConfig(
+        "temperature_external_ch2", channel=1
+    ),
+    "HomematicpTemperatureExternalSensorDelta": _MigrationConfig(
+        "temperature_external_delta", channel=1
+    ),
+    "HmipEsiIecPowerConsumption": _MigrationConfig("esi_iec_power", channel=1),
+    "HmipEsiIecEnergyCounterHighTariff": _MigrationConfig(
+        "esi_iec_energy_high", channel=1
+    ),
+    "HmipEsiIecEnergyCounterLowTariff": _MigrationConfig(
+        "esi_iec_energy_low", channel=1
+    ),
+    "HmipEsiIecEnergyCounterInputSingleTariff": _MigrationConfig(
+        "esi_iec_energy_input", channel=1
+    ),
+    "HmipEsiGasCurrentGasFlow": _MigrationConfig("esi_gas_flow", channel=1),
+    "HmipEsiGasGasVolume": _MigrationConfig("esi_gas_volume", channel=1),
+    "HmipEsiLedCurrentPowerConsumption": _MigrationConfig("esi_led_power", channel=1),
+    "HmipEsiLedEnergyCounterHighTariff": _MigrationConfig(
+        "esi_led_energy_high", channel=1
+    ),
+    "HomematicipSoilMoistureSensor": _MigrationConfig("soil_moisture", channel=1),
+    "HomematicipSoilTemperatureSensor": _MigrationConfig("soil_temperature", channel=1),
+    # light
+    "HomematicipLight": _MigrationConfig("light", channel=1),
+    "HomematicipLightHS": _MigrationConfig("light"),
+    "HomematicipLightMeasuring": _MigrationConfig("light", channel=1),
+    "HomematicipMultiDimmer": _MigrationConfig("dimmer"),
+    "HomematicipDimmer": _MigrationConfig("dimmer", channel=1),
+    "HomematicipNotificationLight": _MigrationConfig("notification_light"),
+    "HomematicipNotificationLightV2": _MigrationConfig("notification_light"),
+    "HomematicipColorLight": _MigrationConfig("color_light", channel=1),
+    "HomematicipOpticalSignalLight": _MigrationConfig(
+        "optical_signal_light", channel=1
+    ),
+    "HomematicipCombinationSignallingLight": _MigrationConfig(
+        "combination_signalling_light", channel=1
+    ),
+    # switch
+    "HomematicipMultiSwitch": _MigrationConfig("switch"),
+    "HomematicipSwitch": _MigrationConfig("switch", channel=1),
+    "HomematicipGroupSwitch": _MigrationConfig("switch", is_group=True),
+    "HomematicipSwitchMeasuring": _MigrationConfig("switch", channel=1),
+    # cover
+    "HomematicipBlindModule": _MigrationConfig("blind", channel=1),
+    "HomematicipMultiCoverShutter": _MigrationConfig("shutter"),
+    "HomematicipCoverShutter": _MigrationConfig("shutter", channel=1),
+    "HomematicipMultiCoverSlats": _MigrationConfig("slats"),
+    "HomematicipCoverSlats": _MigrationConfig("slats", channel=1),
+    "HomematicipGarageDoorModule": _MigrationConfig("garage_door", channel=1),
+    "HomematicipCoverShutterGroup": _MigrationConfig("shutter", is_group=True),
+    # climate
+    "HomematicipHeatingGroup": _MigrationConfig("climate", is_group=True),
+    # weather
+    "HomematicipWeatherSensor": _MigrationConfig("weather", channel=1),
+    "HomematicipWeatherSensorPro": _MigrationConfig("weather", channel=1),
+    "HomematicipHomeWeather": _MigrationConfig("home_weather", is_group=True),
+    # valve
+    "HomematicipWateringValve": _MigrationConfig("watering"),
+    # lock
+    "HomematicipDoorLockDrive": _MigrationConfig("lock", channel=1),
+    # button
+    "HomematicipGarageDoorControllerButton": _MigrationConfig(
+        "garage_button", channel=1
+    ),
+    "HomematicipFullFlushLockControllerButton": _MigrationConfig(
+        "lock_opener_button", channel=1
+    ),
+    # event
+    "HomematicipDoorBellEvent": _MigrationConfig("doorbell", channel=1),
+    # alarm_control_panel
+    "HomematicipAlarmControlPanelEntity": _MigrationConfig("alarm", is_group=True),
+    # siren
+    "HomematicipMP3Siren": _MigrationConfig("siren", channel=1),
+}
+
+# Sorted by length descending so longer class names match before shorter ones
+# (e.g., "HomematicipSwitchMeasuring" before "HomematicipSwitch")
+_SORTED_CLASS_NAMES = sorted(UNIQUE_ID_MIGRATION_MAP, key=len, reverse=True)
+
+_CHANNEL_RE = re.compile(r"^Channel(\d+)_(.+)$")
+_NOTIFICATION_LIGHT_RE = re.compile(r"^(Top|Bottom)_(.+)$")
+
+_NOTIFICATION_LIGHT_CHANNEL_MAP = {"Top": 2, "Bottom": 3}
+
+
+def _migrate_unique_id(old_unique_id: str) -> str | None:
+    """Convert an old-format unique_id to the new format.
+
+    Old formats:
+      {ClassName}_{device_id}
+      {ClassName}_Channel{N}_{device_id}
+      {ClassName}_{Top|Bottom}_{device_id}  (NotificationLight only)
+
+    New format:
+      {device_id}_{channel}_{feature_id}    (device entities)
+      {device_id}_{feature_id}              (group/home entities)
+    """
+    # Find the matching class name (longest first)
+    matched_class: str | None = None
+    for class_name in _SORTED_CLASS_NAMES:
+        prefix = class_name + "_"
+        if old_unique_id.startswith(prefix):
+            matched_class = class_name
+            break
+
+    if matched_class is None:
+        return None
+
+    config = UNIQUE_ID_MIGRATION_MAP[matched_class]
+    remainder = old_unique_id[len(matched_class) + 1 :]
+
+    # Parse remainder to extract channel and device_id
+    channel: int | None = None
+    device_id: str
+
+    # Check for Channel{N}_{rest} pattern
+    channel_match = _CHANNEL_RE.match(remainder)
+    if channel_match:
+        channel = int(channel_match.group(1))
+        device_id = channel_match.group(2)
+    elif matched_class in (
+        "HomematicipNotificationLight",
+        "HomematicipNotificationLightV2",
+    ):
+        # Check for Top/Bottom pattern
+        notif_match = _NOTIFICATION_LIGHT_RE.match(remainder)
+        if notif_match:
+            channel = _NOTIFICATION_LIGHT_CHANNEL_MAP[notif_match.group(1)]
+            device_id = notif_match.group(2)
+        else:
+            device_id = remainder
+            channel = config.channel
+    else:
+        device_id = remainder
+        channel = config.channel
+
+    # Build new unique_id
+    if config.is_group:
+        return f"{device_id}_{config.feature_id}"
+
+    if channel is not None:
+        return f"{device_id}_{channel}_{config.feature_id}"
+
+    _LOGGER.warning(
+        "Cannot determine channel for unique_id: %s",
+        old_unique_id,
+    )
+    return None
+
+
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional(DOMAIN, default=[]): vol.All(
@@ -40,6 +273,86 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+) -> bool:
+    """Migrate the config entry from version 1 to version 2."""
+    if config_entry.version > 2:
+        return False
+
+    if config_entry.version == 1:
+        _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")
+
+        # Remove obsolete entities before the bulk unique_id rewrite.
+        # After rewrite, old-format patterns would no longer be matchable.
+        # HomematicipAccesspointStatus* entities are always obsolete (removed
+        # in firmware 2.2.12+). HomematicipBatterySensor_{hapid} entities for
+        # access points are also obsolete. Those legacy access point battery
+        # entities do not belong to a device registry device, unlike real
+        # device battery sensors, so we can safely remove them before rewrite.
+        entity_registry = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        for entry in entries:
+            if entry.unique_id.startswith("HomematicipAccesspointStatus"):
+                _LOGGER.debug(
+                    "Removing obsolete access point status entity: %s",
+                    entry.entity_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+                continue
+
+            if (
+                entry.unique_id.startswith("HomematicipBatterySensor_")
+                and entry.device_id is None
+            ):
+                _LOGGER.debug(
+                    "Removing obsolete access point battery entity: %s",
+                    entry.entity_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+
+        @callback
+        def _update_unique_id(
+            entity_entry: er.RegistryEntry,
+        ) -> dict[str, str] | None:
+            new_unique_id = _migrate_unique_id(entity_entry.unique_id)
+            if new_unique_id is None:
+                # Some entities (e.g. HmipSmokeDetectorSensor) already use
+                # stable non-class-name unique_ids and don't need migration.
+                # Only warn if the ID looks like an old class-name format.
+                if any(
+                    entity_entry.unique_id.startswith(cls + "_")
+                    for cls in _SORTED_CLASS_NAMES
+                ):
+                    _LOGGER.warning(
+                        "Could not migrate unique_id for %s: %s",
+                        entity_entry.entity_id,
+                        entity_entry.unique_id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Skipping unique_id %s (already stable format)",
+                        entity_entry.unique_id,
+                    )
+                return None
+            _LOGGER.debug(
+                "Migrating %s: %s -> %s",
+                entity_entry.entity_id,
+                entity_entry.unique_id,
+                new_unique_id,
+            )
+            return {"new_unique_id": new_unique_id}
+
+        await er.async_migrate_entries(hass, config_entry.entry_id, _update_unique_id)
+
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        _LOGGER.info("Migration to version 2 successful")
+
+    return True
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -135,6 +448,9 @@ def _async_remove_obsolete_entities(
             entity_registry.async_remove(er_entry.entity_id)
             continue
 
+        # For v2+ config entries, battery sensor cleanup already happened
+        # during migration in async_migrate_entry. This is a safety net for
+        # any edge case where the migration didn't run.
         for hapid in hap.home.accessPointUpdateStates:
             if er_entry.unique_id == f"HomematicipBatterySensor_{hapid}":
                 entity_registry.async_remove(er_entry.entity_id)

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     HMIPC_NAME,
 )
 from .hap import HomematicIPConfigEntry, HomematicipHAP
-from .migration import _SORTED_CLASS_NAMES, _migrate_unique_id
+from .migration import _migrate_unique_id
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -163,23 +163,10 @@ async def async_migrate_entry(
         ) -> dict[str, str] | None:
             new_unique_id = _migrate_unique_id(entity_entry.unique_id)
             if new_unique_id is None:
-                # Some entities (e.g. HmipSmokeDetectorSensor) already use
-                # stable non-class-name unique_ids and don't need migration.
-                # Only warn if the ID looks like an old class-name format.
-                if any(
-                    entity_entry.unique_id.startswith(cls + "_")
-                    for cls in _SORTED_CLASS_NAMES
-                ):
-                    _LOGGER.warning(
-                        "Could not migrate unique_id for %s: %s",
-                        entity_entry.entity_id,
-                        entity_entry.unique_id,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Skipping unique_id %s (already stable format)",
-                        entity_entry.unique_id,
-                    )
+                _LOGGER.debug(
+                    "Skipping unique_id %s (already stable format)",
+                    entity_entry.unique_id,
+                )
                 return None
             _LOGGER.debug(
                 "Migrating %s: %s -> %s",

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -42,11 +42,11 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
         | AlarmControlPanelEntityFeature.ARM_AWAY
     )
     _attr_code_arm_required = False
+    _feature_id = "alarm"
 
     def __init__(self, hap: HomematicipHAP) -> None:
         """Initialize the alarm control panel."""
         self._home: AsyncHome = hap.home
-        self._feature_id = "alarm"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -46,6 +46,7 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
     def __init__(self, hap: HomematicipHAP) -> None:
         """Initialize the alarm control panel."""
         self._home: AsyncHome = hap.home
+        self._feature_id = "alarm"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -127,4 +128,4 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return f"{self.__class__.__name__}_{self._home.id}"
+        return f"{self._home.id}_{self._feature_id}"

--- a/homeassistant/components/homematicip_cloud/binary_sensor.py
+++ b/homeassistant/components/homematicip_cloud/binary_sensor.py
@@ -179,7 +179,7 @@ class HomematicipCloudConnectionSensor(HomematicipGenericEntity, BinarySensorEnt
 
     def __init__(self, hap: HomematicipHAP) -> None:
         """Initialize the cloud connection sensor."""
-        super().__init__(hap, hap.home)
+        super().__init__(hap, hap.home, feature_id="cloud_connection")
 
     @property
     def name(self) -> str:
@@ -245,9 +245,17 @@ class HomematicipBaseActionSensor(HomematicipGenericEntity, BinarySensorEntity):
 class HomematicipAccelerationSensor(HomematicipBaseActionSensor):
     """Representation of the HomematicIP acceleration sensor."""
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the acceleration sensor."""
+        super().__init__(hap, device, feature_id="acceleration")
+
 
 class HomematicipTiltVibrationSensor(HomematicipBaseActionSensor):
     """Representation of the HomematicIP tilt vibration sensor."""
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the tilt vibration sensor."""
+        super().__init__(hap, device, feature_id="tilt_vibration")
 
 
 class HomematicipMultiContactInterface(HomematicipGenericEntity, BinarySensorEntity):
@@ -262,6 +270,7 @@ class HomematicipMultiContactInterface(HomematicipGenericEntity, BinarySensorEnt
         channel=1,
         is_multi_channel=True,
         channel_real_index=None,
+        feature_id: str = "contact",
     ) -> None:
         """Initialize the multi contact entity."""
         super().__init__(
@@ -270,6 +279,7 @@ class HomematicipMultiContactInterface(HomematicipGenericEntity, BinarySensorEnt
             channel=channel,
             is_multi_channel=is_multi_channel,
             channel_real_index=channel_real_index,
+            feature_id=feature_id,
         )
 
     @property
@@ -286,7 +296,7 @@ class HomematicipContactInterface(HomematicipMultiContactInterface, BinarySensor
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the multi contact entity."""
-        super().__init__(hap, device, is_multi_channel=False)
+        super().__init__(hap, device, is_multi_channel=False, feature_id="contact")
 
 
 class HomematicipShutterContact(HomematicipMultiContactInterface, BinarySensorEntity):
@@ -298,7 +308,9 @@ class HomematicipShutterContact(HomematicipMultiContactInterface, BinarySensorEn
         self, hap: HomematicipHAP, device, has_additional_state: bool = False
     ) -> None:
         """Initialize the shutter contact."""
-        super().__init__(hap, device, is_multi_channel=False)
+        super().__init__(
+            hap, device, is_multi_channel=False, feature_id="shutter_contact"
+        )
         self.has_additional_state = has_additional_state
 
     @property
@@ -319,6 +331,10 @@ class HomematicipMotionDetector(HomematicipGenericEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.MOTION
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the motion detector."""
+        super().__init__(hap, device, feature_id="motion")
+
     @property
     def is_on(self) -> bool:
         """Return true if motion is detected."""
@@ -334,7 +350,7 @@ class HomematicipFullFlushLockControllerLocked(
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the full flush lock controller lock sensor."""
-        super().__init__(hap, device, post="Locked")
+        super().__init__(hap, device, post="Locked", feature_id="lock_locked")
 
     @property
     def is_on(self) -> bool:
@@ -359,7 +375,7 @@ class HomematicipFullFlushLockControllerGlassBreak(
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the full flush lock controller glass break sensor."""
-        super().__init__(hap, device, post="Glass break")
+        super().__init__(hap, device, post="Glass break", feature_id="glass_break")
 
     @property
     def is_on(self) -> bool:
@@ -379,6 +395,10 @@ class HomematicipPresenceDetector(HomematicipGenericEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.PRESENCE
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the presence detector."""
+        super().__init__(hap, device, feature_id="presence")
+
     @property
     def is_on(self) -> bool:
         """Return true if presence is detected."""
@@ -389,6 +409,10 @@ class HomematicipSmokeDetector(HomematicipGenericEntity, BinarySensorEntity):
     """Representation of the HomematicIP smoke detector."""
 
     _attr_device_class = BinarySensorDeviceClass.SMOKE
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the smoke detector."""
+        super().__init__(hap, device, feature_id="smoke")
 
     @property
     def is_on(self) -> bool:
@@ -410,7 +434,9 @@ class HomematicipSmokeDetectorChamberDegraded(
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize smoke detector chamber health sensor."""
-        super().__init__(hap, device, post="Chamber Degraded")
+        super().__init__(
+            hap, device, post="Chamber Degraded", feature_id="chamber_degraded"
+        )
 
     @property
     def is_on(self) -> bool:
@@ -423,6 +449,10 @@ class HomematicipWaterDetector(HomematicipGenericEntity, BinarySensorEntity):
 
     _attr_device_class = BinarySensorDeviceClass.MOISTURE
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the water detector."""
+        super().__init__(hap, device, feature_id="water")
+
     @property
     def is_on(self) -> bool:
         """Return true, if moisture or waterlevel is detected."""
@@ -434,7 +464,7 @@ class HomematicipStormSensor(HomematicipGenericEntity, BinarySensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize storm sensor."""
-        super().__init__(hap, device, "Storm")
+        super().__init__(hap, device, "Storm", feature_id="storm")
 
     @property
     def icon(self) -> str:
@@ -454,7 +484,7 @@ class HomematicipRainSensor(HomematicipGenericEntity, BinarySensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize rain sensor."""
-        super().__init__(hap, device, "Raining")
+        super().__init__(hap, device, "Raining", feature_id="rain")
 
     @property
     def is_on(self) -> bool:
@@ -469,7 +499,7 @@ class HomematicipSunshineSensor(HomematicipGenericEntity, BinarySensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize sunshine sensor."""
-        super().__init__(hap, device, post="Sunshine")
+        super().__init__(hap, device, post="Sunshine", feature_id="sunshine")
 
     @property
     def is_on(self) -> bool:
@@ -495,7 +525,7 @@ class HomematicipBatterySensor(HomematicipGenericEntity, BinarySensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize battery sensor."""
-        super().__init__(hap, device, post="Battery")
+        super().__init__(hap, device, post="Battery", channel=0, feature_id="battery")
 
     @property
     def is_on(self) -> bool:
@@ -512,7 +542,7 @@ class HomematicipPluggableMainsFailureSurveillanceSensor(
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize pluggable mains failure surveillance sensor."""
-        super().__init__(hap, device)
+        super().__init__(hap, device, feature_id="mains_failure")
 
     @property
     def is_on(self) -> bool:
@@ -525,10 +555,16 @@ class HomematicipSecurityZoneSensorGroup(HomematicipGenericEntity, BinarySensorE
 
     _attr_device_class = BinarySensorDeviceClass.SAFETY
 
-    def __init__(self, hap: HomematicipHAP, device, post: str = "SecurityZone") -> None:
+    def __init__(
+        self,
+        hap: HomematicipHAP,
+        device,
+        post: str = "SecurityZone",
+        feature_id: str = "security_zone",
+    ) -> None:
         """Initialize security zone group."""
         device.modelType = f"HmIP-{post}"
-        super().__init__(hap, device, post=post)
+        super().__init__(hap, device, post=post, feature_id=feature_id)
 
     @property
     def available(self) -> bool:
@@ -578,7 +614,7 @@ class HomematicipSecuritySensorGroup(
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize security group."""
-        super().__init__(hap, device, post="Sensors")
+        super().__init__(hap, device, post="Sensors", feature_id="security")
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/homematicip_cloud/button.py
+++ b/homeassistant/components/homematicip_cloud/button.py
@@ -45,7 +45,7 @@ class HomematicipGarageDoorControllerButton(HomematicipGenericEntity, ButtonEnti
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize a wall mounted garage door controller."""
-        super().__init__(hap, device)
+        super().__init__(hap, device, feature_id="garage_button")
         self._attr_icon = "mdi:arrow-up-down"
 
     async def async_press(self) -> None:
@@ -58,7 +58,9 @@ class HomematicipFullFlushLockControllerButton(HomematicipGenericEntity, ButtonE
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the full flush lock controller opener button."""
-        super().__init__(hap, device, post="Door opener")
+        super().__init__(
+            hap, device, post="Door opener", feature_id="lock_opener_button"
+        )
         self._attr_icon = "mdi:door-open"
 
     async def async_press(self) -> None:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -83,7 +83,7 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     def __init__(self, hap: HomematicipHAP, device: HeatingGroup) -> None:
         """Initialize heating group."""
         device.modelType = "HmIP-Heating-Group"
-        super().__init__(hap, device)
+        super().__init__(hap, device, feature_id="climate")
         self._simple_heating = None
         if device.actualTemperature is None:
             self._simple_heating = self._first_radiator_thermostat

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -16,7 +16,7 @@ from .hap import HomematicipAuth
 class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for the HomematicIP Cloud component."""
 
-    VERSION = 1
+    VERSION = 2
 
     auth: HomematicipAuth
 

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -69,6 +69,10 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.BLIND
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the blind module entity."""
+        super().__init__(hap, device, feature_id="blind")
+
     @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
@@ -153,10 +157,15 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
         device,
         channel=1,
         is_multi_channel=True,
+        feature_id="shutter",
     ) -> None:
         """Initialize the multi cover entity."""
         super().__init__(
-            hap, device, channel=channel, is_multi_channel=is_multi_channel
+            hap,
+            device,
+            channel=channel,
+            is_multi_channel=is_multi_channel,
+            feature_id=feature_id,
         )
 
     @property
@@ -218,7 +227,11 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
     ) -> None:
         """Initialize the multi slats entity."""
         super().__init__(
-            hap, device, channel=channel, is_multi_channel=is_multi_channel
+            hap,
+            device,
+            channel=channel,
+            is_multi_channel=is_multi_channel,
+            feature_id="slats",
         )
 
     @property
@@ -269,6 +282,10 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
 
     _attr_device_class = CoverDeviceClass.GARAGE
 
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the garage door module entity."""
+        super().__init__(hap, device, feature_id="garage_door")
+
     @property
     def current_cover_position(self) -> int | None:
         """Return current position of cover."""
@@ -310,7 +327,9 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
     def __init__(self, hap: HomematicipHAP, device, post: str = "ShutterGroup") -> None:
         """Initialize switching group."""
         device.modelType = f"HmIP-{post}"
-        super().__init__(hap, device, post, is_multi_channel=False)
+        super().__init__(
+            hap, device, post, is_multi_channel=False, feature_id="shutter"
+        )
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -86,7 +86,8 @@ class HomematicipGenericEntity(Entity):
         channel: int | None = None,
         is_multi_channel: bool | None = False,
         channel_real_index: int | None = None,
-        feature_id: str | None = None,
+        *,
+        feature_id: str,
     ) -> None:
         """Initialize the generic entity."""
         self._hap = hap
@@ -239,17 +240,10 @@ class HomematicipGenericEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        if self._feature_id is not None:
-            if not isinstance(self._device, Device):
-                return f"{self._device.id}_{self._feature_id}"
-            channel_index = self.get_channel_index()
-            return f"{self._device.id}_{channel_index}_{self._feature_id}"
-
-        # Legacy fallback
-        unique_id = f"{self.__class__.__name__}_{self._device.id}"
-        if self._is_multi_channel:
-            unique_id = f"{self.__class__.__name__}_Channel{self.get_channel_index()}_{self._device.id}"
-        return unique_id
+        if not isinstance(self._device, Device):
+            return f"{self._device.id}_{self._feature_id}"
+        channel_index = self.get_channel_index()
+        return f"{self._device.id}_{channel_index}_{self._feature_id}"
 
     @property
     def icon(self) -> str | None:

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -86,6 +86,7 @@ class HomematicipGenericEntity(Entity):
         channel: int | None = None,
         is_multi_channel: bool | None = False,
         channel_real_index: int | None = None,
+        feature_id: str | None = None,
     ) -> None:
         """Initialize the generic entity."""
         self._hap = hap
@@ -101,6 +102,7 @@ class HomematicipGenericEntity(Entity):
         # Using channel_real_index ensures you reference the correct channel.
         self._channel_real_index: int | None = channel_real_index
 
+        self._feature_id = feature_id
         self._is_multi_channel = is_multi_channel
         self.functional_channel = None
         with contextlib.suppress(ValueError):
@@ -237,10 +239,16 @@ class HomematicipGenericEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
+        if self._feature_id is not None:
+            if not isinstance(self._device, Device):
+                return f"{self._device.id}_{self._feature_id}"
+            channel_index = self.get_channel_index()
+            return f"{self._device.id}_{channel_index}_{self._feature_id}"
+
+        # Legacy fallback
         unique_id = f"{self.__class__.__name__}_{self._device.id}"
         if self._is_multi_channel:
             unique_id = f"{self.__class__.__name__}_Channel{self.get_channel_index()}_{self._device.id}"
-
         return unique_id
 
     @property

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -103,6 +103,10 @@ class HomematicipGenericEntity(Entity):
         # Using channel_real_index ensures you reference the correct channel.
         self._channel_real_index: int | None = channel_real_index
 
+        if not feature_id:
+            raise ValueError(
+                f"feature_id must be a non-empty string, got {feature_id!r}"
+            )
         self._feature_id = feature_id
         self._is_multi_channel = is_multi_channel
         self.functional_channel = None

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -103,10 +103,6 @@ class HomematicipGenericEntity(Entity):
         # Using channel_real_index ensures you reference the correct channel.
         self._channel_real_index: int | None = channel_real_index
 
-        if not feature_id:
-            raise ValueError(
-                f"feature_id must be a non-empty string, got {feature_id!r}"
-            )
         self._feature_id = feature_id
         self._is_multi_channel = is_multi_channel
         self.functional_channel = None

--- a/homeassistant/components/homematicip_cloud/event.py
+++ b/homeassistant/components/homematicip_cloud/event.py
@@ -85,6 +85,7 @@ class HomematicipDoorBellEvent(HomematicipGenericEntity, EventEntity):
             post=description.key,
             channel=channel,
             is_multi_channel=False,
+            feature_id="doorbell",
         )
 
         self.entity_description = description

--- a/homeassistant/components/homematicip_cloud/light.py
+++ b/homeassistant/components/homematicip_cloud/light.py
@@ -126,7 +126,7 @@ class HomematicipLight(HomematicipGenericEntity, LightEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the light entity."""
-        super().__init__(hap, device)
+        super().__init__(hap, device, feature_id="light")
 
     @property
     def is_on(self) -> bool:
@@ -147,7 +147,13 @@ class HomematicipColorLight(HomematicipGenericEntity, LightEntity):
 
     def __init__(self, hap: HomematicipHAP, device: Device, channel_index: int) -> None:
         """Initialize the light entity."""
-        super().__init__(hap, device, channel=channel_index, is_multi_channel=True)
+        super().__init__(
+            hap,
+            device,
+            channel=channel_index,
+            is_multi_channel=True,
+            feature_id="color_light",
+        )
 
     def _supports_color(self) -> bool:
         """Return true if device supports hue/saturation color control."""
@@ -243,7 +249,11 @@ class HomematicipMultiDimmer(HomematicipGenericEntity, LightEntity):
     ) -> None:
         """Initialize the dimmer light entity."""
         super().__init__(
-            hap, device, channel=channel, is_multi_channel=is_multi_channel
+            hap,
+            device,
+            channel=channel,
+            is_multi_channel=is_multi_channel,
+            feature_id="dimmer",
         )
 
     @property
@@ -290,7 +300,14 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
 
     def __init__(self, hap: HomematicipHAP, device, channel: int, post: str) -> None:
         """Initialize the notification light entity."""
-        super().__init__(hap, device, post=post, channel=channel, is_multi_channel=True)
+        super().__init__(
+            hap,
+            device,
+            post=post,
+            channel=channel,
+            is_multi_channel=True,
+            feature_id="notification_light",
+        )
 
         self._color_switcher: dict[str, tuple[float, float]] = {
             RGBColorState.WHITE: (0.0, 0.0),
@@ -334,11 +351,6 @@ class HomematicipNotificationLight(HomematicipGenericEntity, LightEntity):
             state_attr[ATTR_COLOR_NAME] = self._func_channel.simpleRGBColorState
 
         return state_attr
-
-    @property
-    def unique_id(self) -> str:
-        """Return a unique ID."""
-        return f"{self.__class__.__name__}_{self._post}_{self._device.id}"
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on."""
@@ -513,6 +525,7 @@ class HomematicipOpticalSignalLight(HomematicipGenericEntity, LightEntity):
             channel=channel_index,
             is_multi_channel=True,
             channel_real_index=channel_index,
+            feature_id="optical_signal_light",
         )
 
     @property
@@ -614,7 +627,13 @@ class HomematicipCombinationSignallingLight(HomematicipGenericEntity, LightEntit
         self, hap: HomematicipHAP, device: CombinationSignallingDevice
     ) -> None:
         """Initialize the combination signalling light entity."""
-        super().__init__(hap, device, channel=1, is_multi_channel=False)
+        super().__init__(
+            hap,
+            device,
+            channel=1,
+            is_multi_channel=False,
+            feature_id="combination_signalling_light",
+        )
 
     @property
     def _func_channel(self) -> NotificationMp3SoundChannel:

--- a/homeassistant/components/homematicip_cloud/lock.py
+++ b/homeassistant/components/homematicip_cloud/lock.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import HomematicipGenericEntity
-from .hap import HomematicIPConfigEntry
+from .hap import HomematicIPConfigEntry, HomematicipHAP
 from .helpers import handle_errors
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,6 +52,10 @@ class HomematicipDoorLockDrive(HomematicipGenericEntity, LockEntity):
     """Representation of the HomematicIP DoorLockDrive."""
 
     _attr_supported_features = LockEntityFeature.OPEN
+
+    def __init__(self, hap: HomematicipHAP, device: DoorLockDrive) -> None:
+        """Initialize the door lock drive."""
+        super().__init__(hap, device, feature_id="lock")
 
     @property
     def is_locked(self) -> bool | None:

--- a/homeassistant/components/homematicip_cloud/migration.py
+++ b/homeassistant/components/homematicip_cloud/migration.py
@@ -6,10 +6,6 @@ from dataclasses import dataclass
 import logging
 import re
 
-from homeassistant import config_entries
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -235,83 +231,3 @@ def _migrate_unique_id(old_unique_id: str) -> str | None:
         old_unique_id,
     )
     return None
-
-
-async def async_migrate_entry(
-    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
-) -> bool:
-    """Migrate the config entry from version 1 to version 2."""
-    if config_entry.version > 2:
-        return False
-
-    if config_entry.version == 1:
-        _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")
-
-        # Remove obsolete entities before the bulk unique_id rewrite.
-        # After rewrite, old-format patterns would no longer be matchable.
-        # HomematicipAccesspointStatus* entities are always obsolete (removed
-        # in firmware 2.2.12+). HomematicipBatterySensor_{hapid} entities for
-        # access points are also obsolete. Those legacy access point battery
-        # entities do not belong to a device registry device, unlike real
-        # device battery sensors, so we can safely remove them before rewrite.
-        entity_registry = er.async_get(hass)
-        entries = er.async_entries_for_config_entry(
-            entity_registry, config_entry.entry_id
-        )
-        for entry in entries:
-            if entry.unique_id.startswith("HomematicipAccesspointStatus"):
-                _LOGGER.debug(
-                    "Removing obsolete access point status entity: %s",
-                    entry.entity_id,
-                )
-                entity_registry.async_remove(entry.entity_id)
-                continue
-
-            if (
-                entry.unique_id.startswith("HomematicipBatterySensor_")
-                and entry.device_id is None
-            ):
-                _LOGGER.debug(
-                    "Removing obsolete access point battery entity: %s",
-                    entry.entity_id,
-                )
-                entity_registry.async_remove(entry.entity_id)
-
-        @callback
-        def _update_unique_id(
-            entity_entry: er.RegistryEntry,
-        ) -> dict[str, str] | None:
-            new_unique_id = _migrate_unique_id(entity_entry.unique_id)
-            if new_unique_id is None:
-                # Some entities (e.g. HmipSmokeDetectorSensor) already use
-                # stable non-class-name unique_ids and don't need migration.
-                # Only warn if the ID looks like an old class-name format.
-                if any(
-                    entity_entry.unique_id.startswith(cls + "_")
-                    for cls in _SORTED_CLASS_NAMES
-                ):
-                    _LOGGER.warning(
-                        "Could not migrate unique_id for %s: %s",
-                        entity_entry.entity_id,
-                        entity_entry.unique_id,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Skipping unique_id %s (already stable format)",
-                        entity_entry.unique_id,
-                    )
-                return None
-            _LOGGER.debug(
-                "Migrating %s: %s -> %s",
-                entity_entry.entity_id,
-                entity_entry.unique_id,
-                new_unique_id,
-            )
-            return {"new_unique_id": new_unique_id}
-
-        await er.async_migrate_entries(hass, config_entry.entry_id, _update_unique_id)
-
-        hass.config_entries.async_update_entry(config_entry, version=2)
-        _LOGGER.info("Migration to version 2 successful")
-
-    return True

--- a/homeassistant/components/homematicip_cloud/migration.py
+++ b/homeassistant/components/homematicip_cloud/migration.py
@@ -1,0 +1,317 @@
+"""Unique ID migration for HomematicIP Cloud entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _MigrationConfig:
+    """Configuration for migrating a single entity class to the new unique_id format."""
+
+    feature_id: str
+    channel: int | None = None
+    is_group: bool = False
+
+
+UNIQUE_ID_MIGRATION_MAP: dict[str, _MigrationConfig] = {
+    # binary_sensor
+    "HomematicipCloudConnectionSensor": _MigrationConfig(
+        "cloud_connection", is_group=True
+    ),
+    "HomematicipAccelerationSensor": _MigrationConfig("acceleration", channel=1),
+    "HomematicipTiltVibrationSensor": _MigrationConfig("tilt_vibration", channel=1),
+    "HomematicipMultiContactInterface": _MigrationConfig("contact"),
+    "HomematicipContactInterface": _MigrationConfig("contact", channel=1),
+    "HomematicipShutterContact": _MigrationConfig("shutter_contact", channel=1),
+    "HomematicipMotionDetector": _MigrationConfig("motion", channel=1),
+    "HomematicipPresenceDetector": _MigrationConfig("presence", channel=1),
+    "HomematicipSmokeDetector": _MigrationConfig("smoke", channel=1),
+    "HomematicipWaterDetector": _MigrationConfig("water", channel=1),
+    "HomematicipStormSensor": _MigrationConfig("storm", channel=1),
+    "HomematicipRainSensor": _MigrationConfig("rain", channel=1),
+    "HomematicipSunshineSensor": _MigrationConfig("sunshine", channel=1),
+    "HomematicipBatterySensor": _MigrationConfig("battery", channel=0),
+    "HomematicipPluggableMainsFailureSurveillanceSensor": _MigrationConfig(
+        "mains_failure", channel=1
+    ),
+    "HomematicipSecurityZoneSensorGroup": _MigrationConfig(
+        "security_zone", is_group=True
+    ),
+    "HomematicipSecuritySensorGroup": _MigrationConfig("security", is_group=True),
+    "HomematicipFullFlushLockControllerLocked": _MigrationConfig(
+        "lock_locked", channel=1
+    ),
+    "HomematicipFullFlushLockControllerGlassBreak": _MigrationConfig(
+        "glass_break", channel=1
+    ),
+    "HomematicipSmokeDetectorChamberDegraded": _MigrationConfig(
+        "chamber_degraded", channel=1
+    ),
+    # sensor
+    "HomematicipAccesspointDutyCycle": _MigrationConfig("duty_cycle", channel=0),
+    "HomematicipHeatingThermostat": _MigrationConfig("valve_position", channel=1),
+    "HomematicipHumiditySensor": _MigrationConfig("humidity", channel=1),
+    "HomematicipTemperatureSensor": _MigrationConfig("temperature", channel=1),
+    "HomematicipAbsoluteHumiditySensor": _MigrationConfig(
+        "absolute_humidity", channel=1
+    ),
+    "HomematicipIlluminanceSensor": _MigrationConfig("illuminance", channel=1),
+    "HomematicipPowerSensor": _MigrationConfig("power", channel=1),
+    "HomematicipEnergySensor": _MigrationConfig("energy", channel=1),
+    "HomematicipWindspeedSensor": _MigrationConfig("wind_speed", channel=1),
+    "HomematicipTodayRainSensor": _MigrationConfig("today_rain", channel=1),
+    "HomematicipPassageDetectorDeltaCounter": _MigrationConfig(
+        "passage_counter", channel=1
+    ),
+    "HomematicipWaterFlowSensor": _MigrationConfig("water_flow"),
+    "HomematicipWaterVolumeSensor": _MigrationConfig("water_volume"),
+    "HomematicipWaterVolumeSinceOpenSensor": _MigrationConfig(
+        "water_volume_since_open"
+    ),
+    "HomematicipTiltAngleSensor": _MigrationConfig("tilt_angle", channel=1),
+    "HomematicipTiltStateSensor": _MigrationConfig("tilt_state", channel=1),
+    "HomematicipFloorTerminalBlockMechanicChannelValve": _MigrationConfig(
+        "ftb_valve_position"
+    ),
+    "HomematicpTemperatureExternalSensorCh1": _MigrationConfig(
+        "temperature_external_ch1", channel=1
+    ),
+    "HomematicpTemperatureExternalSensorCh2": _MigrationConfig(
+        "temperature_external_ch2", channel=1
+    ),
+    "HomematicpTemperatureExternalSensorDelta": _MigrationConfig(
+        "temperature_external_delta", channel=1
+    ),
+    "HmipEsiIecPowerConsumption": _MigrationConfig("esi_iec_power", channel=1),
+    "HmipEsiIecEnergyCounterHighTariff": _MigrationConfig(
+        "esi_iec_energy_high", channel=1
+    ),
+    "HmipEsiIecEnergyCounterLowTariff": _MigrationConfig(
+        "esi_iec_energy_low", channel=1
+    ),
+    "HmipEsiIecEnergyCounterInputSingleTariff": _MigrationConfig(
+        "esi_iec_energy_input", channel=1
+    ),
+    "HmipEsiGasCurrentGasFlow": _MigrationConfig("esi_gas_flow", channel=1),
+    "HmipEsiGasGasVolume": _MigrationConfig("esi_gas_volume", channel=1),
+    "HmipEsiLedCurrentPowerConsumption": _MigrationConfig("esi_led_power", channel=1),
+    "HmipEsiLedEnergyCounterHighTariff": _MigrationConfig(
+        "esi_led_energy_high", channel=1
+    ),
+    "HomematicipSoilMoistureSensor": _MigrationConfig("soil_moisture", channel=1),
+    "HomematicipSoilTemperatureSensor": _MigrationConfig("soil_temperature", channel=1),
+    # light
+    "HomematicipLight": _MigrationConfig("light", channel=1),
+    "HomematicipLightHS": _MigrationConfig("light"),
+    "HomematicipLightMeasuring": _MigrationConfig("light", channel=1),
+    "HomematicipMultiDimmer": _MigrationConfig("dimmer"),
+    "HomematicipDimmer": _MigrationConfig("dimmer", channel=1),
+    "HomematicipNotificationLight": _MigrationConfig("notification_light"),
+    "HomematicipNotificationLightV2": _MigrationConfig("notification_light"),
+    "HomematicipColorLight": _MigrationConfig("color_light", channel=1),
+    "HomematicipOpticalSignalLight": _MigrationConfig(
+        "optical_signal_light", channel=1
+    ),
+    "HomematicipCombinationSignallingLight": _MigrationConfig(
+        "combination_signalling_light", channel=1
+    ),
+    # switch
+    "HomematicipMultiSwitch": _MigrationConfig("switch"),
+    "HomematicipSwitch": _MigrationConfig("switch", channel=1),
+    "HomematicipGroupSwitch": _MigrationConfig("switch", is_group=True),
+    "HomematicipSwitchMeasuring": _MigrationConfig("switch", channel=1),
+    # cover
+    "HomematicipBlindModule": _MigrationConfig("blind", channel=1),
+    "HomematicipMultiCoverShutter": _MigrationConfig("shutter"),
+    "HomematicipCoverShutter": _MigrationConfig("shutter", channel=1),
+    "HomematicipMultiCoverSlats": _MigrationConfig("slats"),
+    "HomematicipCoverSlats": _MigrationConfig("slats", channel=1),
+    "HomematicipGarageDoorModule": _MigrationConfig("garage_door", channel=1),
+    "HomematicipCoverShutterGroup": _MigrationConfig("shutter", is_group=True),
+    # climate
+    "HomematicipHeatingGroup": _MigrationConfig("climate", is_group=True),
+    # weather
+    "HomematicipWeatherSensor": _MigrationConfig("weather", channel=1),
+    "HomematicipWeatherSensorPro": _MigrationConfig("weather", channel=1),
+    "HomematicipHomeWeather": _MigrationConfig("home_weather", is_group=True),
+    # valve
+    "HomematicipWateringValve": _MigrationConfig("watering"),
+    # lock
+    "HomematicipDoorLockDrive": _MigrationConfig("lock", channel=1),
+    # button
+    "HomematicipGarageDoorControllerButton": _MigrationConfig(
+        "garage_button", channel=1
+    ),
+    "HomematicipFullFlushLockControllerButton": _MigrationConfig(
+        "lock_opener_button", channel=1
+    ),
+    # event
+    "HomematicipDoorBellEvent": _MigrationConfig("doorbell", channel=1),
+    # alarm_control_panel
+    "HomematicipAlarmControlPanelEntity": _MigrationConfig("alarm", is_group=True),
+    # siren
+    "HomematicipMP3Siren": _MigrationConfig("siren", channel=1),
+}
+
+# Sorted by length descending so longer class names match before shorter ones
+# (e.g., "HomematicipSwitchMeasuring" before "HomematicipSwitch")
+_SORTED_CLASS_NAMES = sorted(UNIQUE_ID_MIGRATION_MAP, key=len, reverse=True)
+
+_CHANNEL_RE = re.compile(r"^Channel(\d+)_(.+)$")
+_NOTIFICATION_LIGHT_RE = re.compile(r"^(Top|Bottom)_(.+)$")
+
+_NOTIFICATION_LIGHT_CHANNEL_MAP = {"Top": 2, "Bottom": 3}
+
+
+def _migrate_unique_id(old_unique_id: str) -> str | None:
+    """Convert an old-format unique_id to the new format.
+
+    Old formats:
+      {ClassName}_{device_id}
+      {ClassName}_Channel{N}_{device_id}
+      {ClassName}_{Top|Bottom}_{device_id}  (NotificationLight only)
+
+    New format:
+      {device_id}_{channel}_{feature_id}    (device entities)
+      {device_id}_{feature_id}              (group/home entities)
+    """
+    # Find the matching class name (longest first)
+    matched_class: str | None = None
+    for class_name in _SORTED_CLASS_NAMES:
+        prefix = class_name + "_"
+        if old_unique_id.startswith(prefix):
+            matched_class = class_name
+            break
+
+    if matched_class is None:
+        return None
+
+    config = UNIQUE_ID_MIGRATION_MAP[matched_class]
+    remainder = old_unique_id[len(matched_class) + 1 :]
+
+    # Parse remainder to extract channel and device_id
+    channel: int | None = None
+    device_id: str
+
+    # Check for Channel{N}_{rest} pattern
+    channel_match = _CHANNEL_RE.match(remainder)
+    if channel_match:
+        channel = int(channel_match.group(1))
+        device_id = channel_match.group(2)
+    elif matched_class in (
+        "HomematicipNotificationLight",
+        "HomematicipNotificationLightV2",
+    ):
+        # Check for Top/Bottom pattern
+        notif_match = _NOTIFICATION_LIGHT_RE.match(remainder)
+        if notif_match:
+            channel = _NOTIFICATION_LIGHT_CHANNEL_MAP[notif_match.group(1)]
+            device_id = notif_match.group(2)
+        else:
+            device_id = remainder
+            channel = config.channel
+    else:
+        device_id = remainder
+        channel = config.channel
+
+    # Build new unique_id
+    if config.is_group:
+        return f"{device_id}_{config.feature_id}"
+
+    if channel is not None:
+        return f"{device_id}_{channel}_{config.feature_id}"
+
+    _LOGGER.warning(
+        "Cannot determine channel for unique_id: %s",
+        old_unique_id,
+    )
+    return None
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
+) -> bool:
+    """Migrate the config entry from version 1 to version 2."""
+    if config_entry.version > 2:
+        return False
+
+    if config_entry.version == 1:
+        _LOGGER.debug("Migrating HomematicIP Cloud config entry to version 2")
+
+        # Remove obsolete entities before the bulk unique_id rewrite.
+        # After rewrite, old-format patterns would no longer be matchable.
+        # HomematicipAccesspointStatus* entities are always obsolete (removed
+        # in firmware 2.2.12+). HomematicipBatterySensor_{hapid} entities for
+        # access points are also obsolete. Those legacy access point battery
+        # entities do not belong to a device registry device, unlike real
+        # device battery sensors, so we can safely remove them before rewrite.
+        entity_registry = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(
+            entity_registry, config_entry.entry_id
+        )
+        for entry in entries:
+            if entry.unique_id.startswith("HomematicipAccesspointStatus"):
+                _LOGGER.debug(
+                    "Removing obsolete access point status entity: %s",
+                    entry.entity_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+                continue
+
+            if (
+                entry.unique_id.startswith("HomematicipBatterySensor_")
+                and entry.device_id is None
+            ):
+                _LOGGER.debug(
+                    "Removing obsolete access point battery entity: %s",
+                    entry.entity_id,
+                )
+                entity_registry.async_remove(entry.entity_id)
+
+        @callback
+        def _update_unique_id(
+            entity_entry: er.RegistryEntry,
+        ) -> dict[str, str] | None:
+            new_unique_id = _migrate_unique_id(entity_entry.unique_id)
+            if new_unique_id is None:
+                # Some entities (e.g. HmipSmokeDetectorSensor) already use
+                # stable non-class-name unique_ids and don't need migration.
+                # Only warn if the ID looks like an old class-name format.
+                if any(
+                    entity_entry.unique_id.startswith(cls + "_")
+                    for cls in _SORTED_CLASS_NAMES
+                ):
+                    _LOGGER.warning(
+                        "Could not migrate unique_id for %s: %s",
+                        entity_entry.entity_id,
+                        entity_entry.unique_id,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Skipping unique_id %s (already stable format)",
+                        entity_entry.unique_id,
+                    )
+                return None
+            _LOGGER.debug(
+                "Migrating %s: %s -> %s",
+                entity_entry.entity_id,
+                entity_entry.unique_id,
+                new_unique_id,
+            )
+            return {"new_unique_id": new_unique_id}
+
+        await er.async_migrate_entries(hass, config_entry.entry_id, _update_unique_id)
+
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        _LOGGER.info("Migration to version 2 successful")
+
+    return True

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -383,7 +383,14 @@ class HomematicipWaterFlowSensor(HomematicipGenericEntity, SensorEntity):
         self, hap: HomematicipHAP, device: Device, channel: int, post: str
     ) -> None:
         """Initialize the watering flow sensor device."""
-        super().__init__(hap, device, post=post, channel=channel, is_multi_channel=True)
+        super().__init__(
+            hap,
+            device,
+            post=post,
+            channel=channel,
+            is_multi_channel=True,
+            feature_id="water_flow",
+        )
 
     @property
     def native_value(self) -> float | None:
@@ -405,9 +412,17 @@ class HomematicipWaterVolumeSensor(HomematicipGenericEntity, SensorEntity):
         channel: int,
         post: str,
         attribute: str,
+        feature_id: str = "water_volume",
     ) -> None:
         """Initialize the watering volume sensor device."""
-        super().__init__(hap, device, post=post, channel=channel, is_multi_channel=True)
+        super().__init__(
+            hap,
+            device,
+            post=post,
+            channel=channel,
+            is_multi_channel=True,
+            feature_id=feature_id,
+        )
         self._attribute_name = attribute
 
     @property
@@ -430,6 +445,7 @@ class HomematicipWaterVolumeSinceOpenSensor(HomematicipWaterVolumeSensor):
             channel=channel,
             post="waterVolumeSinceOpen",
             attribute="waterVolumeSinceOpen",
+            feature_id="water_volume_since_open",
         )
 
 
@@ -441,7 +457,7 @@ class HomematicipTiltAngleSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the tilt angle sensor device."""
-        super().__init__(hap, device, post="Tilt Angle")
+        super().__init__(hap, device, post="Tilt Angle", feature_id="tilt_angle")
 
     @property
     def native_value(self) -> int | None:
@@ -458,7 +474,7 @@ class HomematicipTiltStateSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the tilt sensor device."""
-        super().__init__(hap, device, post="Tilt State")
+        super().__init__(hap, device, post="Tilt State", feature_id="tilt_state")
 
     @property
     def native_value(self) -> str | None:
@@ -502,6 +518,7 @@ class HomematicipFloorTerminalBlockMechanicChannelValve(
             channel=channel,
             is_multi_channel=is_multi_channel,
             post="Valve Position",
+            feature_id="ftb_valve_position",
         )
 
     @property
@@ -540,7 +557,9 @@ class HomematicipAccesspointDutyCycle(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize access point status entity."""
-        super().__init__(hap, device, post="Duty Cycle")
+        super().__init__(
+            hap, device, post="Duty Cycle", channel=0, feature_id="duty_cycle"
+        )
 
     @property
     def native_value(self) -> float:
@@ -555,7 +574,7 @@ class HomematicipHeatingThermostat(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize heating thermostat device."""
-        super().__init__(hap, device, post="Heating")
+        super().__init__(hap, device, post="Heating", feature_id="valve_position")
 
     @property
     def icon(self) -> str | None:
@@ -583,7 +602,7 @@ class HomematicipHumiditySensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the thermometer device."""
-        super().__init__(hap, device, post="Humidity")
+        super().__init__(hap, device, post="Humidity", feature_id="humidity")
 
     @property
     def native_value(self) -> int:
@@ -600,7 +619,7 @@ class HomematicipTemperatureSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the thermometer device."""
-        super().__init__(hap, device, post="Temperature")
+        super().__init__(hap, device, post="Temperature", feature_id="temperature")
 
     @property
     def native_value(self) -> float:
@@ -633,7 +652,9 @@ class HomematicipAbsoluteHumiditySensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the thermometer device."""
-        super().__init__(hap, device, post="Absolute Humidity")
+        super().__init__(
+            hap, device, post="Absolute Humidity", feature_id="absolute_humidity"
+        )
 
     @property
     def native_value(self) -> float | None:
@@ -654,7 +675,7 @@ class HomematicipIlluminanceSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Illuminance")
+        super().__init__(hap, device, post="Illuminance", feature_id="illuminance")
 
     @property
     def native_value(self) -> float:
@@ -685,7 +706,7 @@ class HomematicipPowerSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Power")
+        super().__init__(hap, device, post="Power", feature_id="power")
 
     @property
     def native_value(self) -> float:
@@ -702,7 +723,7 @@ class HomematicipEnergySensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the device."""
-        super().__init__(hap, device, post="Energy")
+        super().__init__(hap, device, post="Energy", feature_id="energy")
 
     @property
     def native_value(self) -> float:
@@ -719,7 +740,7 @@ class HomematicipWindspeedSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the windspeed sensor."""
-        super().__init__(hap, device, post="Windspeed")
+        super().__init__(hap, device, post="Windspeed", feature_id="wind_speed")
 
     @property
     def native_value(self) -> float:
@@ -751,7 +772,7 @@ class HomematicipTodayRainSensor(HomematicipGenericEntity, SensorEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Today Rain")
+        super().__init__(hap, device, post="Today Rain", feature_id="today_rain")
 
     @property
     def native_value(self) -> float:
@@ -768,7 +789,12 @@ class HomematicpTemperatureExternalSensorCh1(HomematicipGenericEntity, SensorEnt
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Channel 1 Temperature")
+        super().__init__(
+            hap,
+            device,
+            post="Channel 1 Temperature",
+            feature_id="temperature_external_ch1",
+        )
 
     @property
     def native_value(self) -> float:
@@ -785,7 +811,12 @@ class HomematicpTemperatureExternalSensorCh2(HomematicipGenericEntity, SensorEnt
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Channel 2 Temperature")
+        super().__init__(
+            hap,
+            device,
+            post="Channel 2 Temperature",
+            feature_id="temperature_external_ch2",
+        )
 
     @property
     def native_value(self) -> float:
@@ -802,7 +833,12 @@ class HomematicpTemperatureExternalSensorDelta(HomematicipGenericEntity, SensorE
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the  device."""
-        super().__init__(hap, device, post="Delta Temperature")
+        super().__init__(
+            hap,
+            device,
+            post="Delta Temperature",
+            feature_id="temperature_external_delta",
+        )
 
     @property
     def native_value(self) -> float:
@@ -820,6 +856,7 @@ class HmipEsiSensorEntity(HomematicipGenericEntity, SensorEntity):
         key: str,
         value_fn: Callable[[FunctionalChannel], StateType],
         type_fn: Callable[[FunctionalChannel], str],
+        feature_id: str | None = None,
     ) -> None:
         """Initialize Sensor Entity."""
         super().__init__(
@@ -828,6 +865,7 @@ class HmipEsiSensorEntity(HomematicipGenericEntity, SensorEntity):
             channel=1,
             post=key,
             is_multi_channel=False,
+            feature_id=feature_id,
         )
 
         self._value_fn = value_fn
@@ -862,6 +900,7 @@ class HmipEsiIecPowerConsumption(HmipEsiSensorEntity):
             key="CurrentPowerConsumption",
             value_fn=lambda channel: channel.currentPowerConsumption,
             type_fn=lambda channel: "CurrentPowerConsumption",
+            feature_id="esi_iec_power",
         )
 
 
@@ -880,6 +919,7 @@ class HmipEsiIecEnergyCounterHighTariff(HmipEsiSensorEntity):
             key=ESI_TYPE_ENERGY_COUNTER_USAGE_HIGH_TARIFF,
             value_fn=lambda channel: channel.energyCounterOne,
             type_fn=lambda channel: channel.energyCounterOneType,
+            feature_id="esi_iec_energy_high",
         )
 
 
@@ -898,6 +938,7 @@ class HmipEsiIecEnergyCounterLowTariff(HmipEsiSensorEntity):
             key=ESI_TYPE_ENERGY_COUNTER_USAGE_LOW_TARIFF,
             value_fn=lambda channel: channel.energyCounterTwo,
             type_fn=lambda channel: channel.energyCounterTwoType,
+            feature_id="esi_iec_energy_low",
         )
 
 
@@ -916,6 +957,7 @@ class HmipEsiIecEnergyCounterInputSingleTariff(HmipEsiSensorEntity):
             key=ESI_TYPE_ENERGY_COUNTER_INPUT_SINGLE_TARIFF,
             value_fn=lambda channel: channel.energyCounterThree,
             type_fn=lambda channel: channel.energyCounterThreeType,
+            feature_id="esi_iec_energy_input",
         )
 
 
@@ -934,6 +976,7 @@ class HmipEsiGasCurrentGasFlow(HmipEsiSensorEntity):
             key="CurrentGasFlow",
             value_fn=lambda channel: channel.currentGasFlow,
             type_fn=lambda channel: "CurrentGasFlow",
+            feature_id="esi_gas_flow",
         )
 
 
@@ -952,6 +995,7 @@ class HmipEsiGasGasVolume(HmipEsiSensorEntity):
             key="GasVolume",
             value_fn=lambda channel: channel.gasVolume,
             type_fn=lambda channel: "GasVolume",
+            feature_id="esi_gas_volume",
         )
 
 
@@ -970,6 +1014,7 @@ class HmipEsiLedCurrentPowerConsumption(HmipEsiSensorEntity):
             key="CurrentPowerConsumption",
             value_fn=lambda channel: channel.currentPowerConsumption,
             type_fn=lambda channel: "CurrentPowerConsumption",
+            feature_id="esi_led_power",
         )
 
 
@@ -988,11 +1033,16 @@ class HmipEsiLedEnergyCounterHighTariff(HmipEsiSensorEntity):
             key=ESI_TYPE_ENERGY_COUNTER_USAGE_HIGH_TARIFF,
             value_fn=lambda channel: channel.energyCounterOne,
             type_fn=lambda channel: ESI_TYPE_ENERGY_COUNTER_USAGE_HIGH_TARIFF,
+            feature_id="esi_led_energy_high",
         )
 
 
 class HomematicipPassageDetectorDeltaCounter(HomematicipGenericEntity, SensorEntity):
     """Representation of the HomematicIP passage detector delta counter."""
+
+    def __init__(self, hap: HomematicipHAP, device) -> None:
+        """Initialize the passage detector delta counter."""
+        super().__init__(hap, device, feature_id="passage_counter")
 
     @property
     def native_value(self) -> int:
@@ -1022,7 +1072,9 @@ class HmipSmokeDetectorSensor(HomematicipGenericEntity, SensorEntity):
         description: HmipSmokeDetectorSensorDescription,
     ) -> None:
         """Initialize the smoke detector sensor."""
-        super().__init__(hap, device, post=description.key)
+        super().__init__(
+            hap, device, post=description.key, feature_id="smoke_detector_sensor"
+        )
         self.entity_description = description
         self._sensor_unique_id = f"{device.id}_{description.key}"
 
@@ -1047,7 +1099,12 @@ class HomematicipSoilMoistureSensor(HomematicipGenericEntity, SensorEntity):
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the soil moisture sensor device."""
         super().__init__(
-            hap, device, post="Soil Moisture", channel=1, is_multi_channel=True
+            hap,
+            device,
+            post="Soil Moisture",
+            channel=1,
+            is_multi_channel=True,
+            feature_id="soil_moisture",
         )
 
     @property
@@ -1068,7 +1125,12 @@ class HomematicipSoilTemperatureSensor(HomematicipGenericEntity, SensorEntity):
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the soil temperature sensor device."""
         super().__init__(
-            hap, device, post="Soil Temperature", channel=1, is_multi_channel=True
+            hap,
+            device,
+            post="Soil Temperature",
+            channel=1,
+            is_multi_channel=True,
+            feature_id="soil_temperature",
         )
 
     @property

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -856,7 +856,7 @@ class HmipEsiSensorEntity(HomematicipGenericEntity, SensorEntity):
         key: str,
         value_fn: Callable[[FunctionalChannel], StateType],
         type_fn: Callable[[FunctionalChannel], str],
-        feature_id: str | None = None,
+        feature_id: str,
     ) -> None:
         """Initialize Sensor Entity."""
         super().__init__(

--- a/homeassistant/components/homematicip_cloud/siren.py
+++ b/homeassistant/components/homematicip_cloud/siren.py
@@ -60,7 +60,14 @@ class HomematicipMP3Siren(HomematicipGenericEntity, SirenEntity):
         self, hap: HomematicipHAP, device: CombinationSignallingDevice
     ) -> None:
         """Initialize the siren entity."""
-        super().__init__(hap, device, post="Siren", channel=1, is_multi_channel=False)
+        super().__init__(
+            hap,
+            device,
+            post="Siren",
+            channel=1,
+            is_multi_channel=False,
+            feature_id="siren",
+        )
 
     @property
     def _func_channel(self) -> NotificationMp3SoundChannel:

--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -109,7 +109,11 @@ class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
     ) -> None:
         """Initialize the multi switch device."""
         super().__init__(
-            hap, device, channel=channel, is_multi_channel=is_multi_channel
+            hap,
+            device,
+            channel=channel,
+            is_multi_channel=is_multi_channel,
+            feature_id="switch",
         )
 
     @property
@@ -143,7 +147,7 @@ class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
     def __init__(self, hap: HomematicipHAP, device, post: str = "Group") -> None:
         """Initialize switching group."""
         device.modelType = f"HmIP-{post}"
-        super().__init__(hap, device, post)
+        super().__init__(hap, device, post, feature_id="switch")
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/homematicip_cloud/valve.py
+++ b/homeassistant/components/homematicip_cloud/valve.py
@@ -42,7 +42,12 @@ class HomematicipWateringValve(HomematicipGenericEntity, ValveEntity):
     def __init__(self, hap: HomematicipHAP, device: Device, channel: int) -> None:
         """Initialize the valve."""
         super().__init__(
-            hap, device=device, channel=channel, post="watering", is_multi_channel=True
+            hap,
+            device=device,
+            channel=channel,
+            post="watering",
+            is_multi_channel=True,
+            feature_id="watering",
         )
 
     async def async_open_valve(self) -> None:

--- a/homeassistant/components/homematicip_cloud/weather.py
+++ b/homeassistant/components/homematicip_cloud/weather.py
@@ -72,7 +72,7 @@ class HomematicipWeatherSensor(HomematicipGenericEntity, WeatherEntity):
 
     def __init__(self, hap: HomematicipHAP, device) -> None:
         """Initialize the weather sensor."""
-        super().__init__(hap, device)
+        super().__init__(hap, device, feature_id="weather")
 
     @property
     def name(self) -> str:
@@ -125,7 +125,7 @@ class HomematicipHomeWeather(HomematicipGenericEntity, WeatherEntity):
     def __init__(self, hap: HomematicipHAP) -> None:
         """Initialize the home weather."""
         hap.home.modelType = "HmIP-Home-Weather"
-        super().__init__(hap, hap.home)
+        super().__init__(hap, hap.home, feature_id="home_weather")
 
     @property
     def available(self) -> bool:

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -8,11 +8,6 @@ from unittest.mock import AsyncMock, Mock, patch
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 import pytest
 
-from homeassistant.components.homematicip_cloud import (
-    UNIQUE_ID_MIGRATION_MAP,
-    _migrate_unique_id,
-    async_migrate_entry,
-)
 from homeassistant.components.homematicip_cloud.const import (
     CONF_ACCESSPOINT,
     CONF_AUTHTOKEN,
@@ -22,6 +17,11 @@ from homeassistant.components.homematicip_cloud.const import (
     HMIPC_NAME,
 )
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
+from homeassistant.components.homematicip_cloud.migration import (
+    UNIQUE_ID_MIGRATION_MAP,
+    _migrate_unique_id,
+    async_migrate_entry,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -315,12 +315,12 @@ async def test_migrate_group_entity(
     )
 
 
-async def test_migrate_unknown_class_warns(
+async def test_migrate_stable_unique_id_skipped(
     hass: HomeAssistant,
     mock_config_entry_v1: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that an unknown class name warns and preserves the old unique_id."""
+    """Test that a non-class-name unique_id is silently skipped and preserved."""
     entity_registry = er.async_get(hass)
     entity_registry.async_get_or_create(
         "sensor",

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -3,11 +3,12 @@
 import ast
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 import pytest
 
+from homeassistant.components.homematicip_cloud import async_migrate_entry
 from homeassistant.components.homematicip_cloud.const import (
     CONF_ACCESSPOINT,
     CONF_AUTHTOKEN,
@@ -16,12 +17,10 @@ from homeassistant.components.homematicip_cloud.const import (
     HMIPC_HAPID,
     HMIPC_NAME,
 )
-from homeassistant.components.homematicip_cloud.entity import HomematicipGenericEntity
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.components.homematicip_cloud.migration import (
     UNIQUE_ID_MIGRATION_MAP,
     _migrate_unique_id,
-    async_migrate_entry,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
@@ -232,15 +231,41 @@ def mock_config_entry_v1(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-async def test_migrate_single_channel_entity(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+@pytest.mark.parametrize(
+    ("platform", "old_unique_id", "new_unique_id"),
+    [
+        (
+            "binary_sensor",
+            "HomematicipMotionDetector_3014F711ABCD",
+            "3014F711ABCD_1_motion",
+        ),
+        (
+            "switch",
+            "HomematicipMultiSwitch_Channel3_3014F711ABCD",
+            "3014F711ABCD_3_switch",
+        ),
+        (
+            "light",
+            "HomematicipNotificationLight_Top_3014F711ABCD",
+            "3014F711ABCD_2_notification_light",
+        ),
+        ("climate", "HomematicipHeatingGroup_UUID-GROUP-123", "UUID-GROUP-123_climate"),
+    ],
+    ids=["single_channel", "multi_channel", "notification_light", "group"],
+)
+async def test_migrate_unique_id(
+    hass: HomeAssistant,
+    mock_config_entry_v1: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    platform: str,
+    old_unique_id: str,
+    new_unique_id: str,
 ) -> None:
-    """Test migration of a single-channel entity like MotionDetector."""
-    entity_registry = er.async_get(hass)
+    """Test unique_id migration for different entity types."""
     entity_registry.async_get_or_create(
-        "binary_sensor",
+        platform,
         DOMAIN,
-        "HomematicipMotionDetector_3014F711ABCD",
+        old_unique_id,
         config_entry=mock_config_entry_v1,
     )
 
@@ -248,81 +273,16 @@ async def test_migrate_single_channel_entity(
 
     assert result is True
     assert mock_config_entry_v1.version == 2
-    assert entity_registry.async_get_entity_id(
-        "binary_sensor", DOMAIN, "3014F711ABCD_1_motion"
-    )
-
-
-async def test_migrate_multi_channel_entity(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
-) -> None:
-    """Test migration of a multi-channel entity like MultiSwitch."""
-    entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
-        "switch",
-        DOMAIN,
-        "HomematicipMultiSwitch_Channel3_3014F711ABCD",
-        config_entry=mock_config_entry_v1,
-    )
-
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
-
-    assert result is True
-    assert mock_config_entry_v1.version == 2
-    assert entity_registry.async_get_entity_id(
-        "switch", DOMAIN, "3014F711ABCD_3_switch"
-    )
-
-
-async def test_migrate_notification_light(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
-) -> None:
-    """Test migration of NotificationLight with Top/Bottom suffix."""
-    entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
-        "light",
-        DOMAIN,
-        "HomematicipNotificationLight_Top_3014F711ABCD",
-        config_entry=mock_config_entry_v1,
-    )
-
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
-
-    assert result is True
-    assert mock_config_entry_v1.version == 2
-    assert entity_registry.async_get_entity_id(
-        "light", DOMAIN, "3014F711ABCD_2_notification_light"
-    )
-
-
-async def test_migrate_group_entity(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
-) -> None:
-    """Test migration of a group entity (no channel in new unique_id)."""
-    entity_registry = er.async_get(hass)
-    entity_registry.async_get_or_create(
-        "climate",
-        DOMAIN,
-        "HomematicipHeatingGroup_UUID-GROUP-123",
-        config_entry=mock_config_entry_v1,
-    )
-
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
-
-    assert result is True
-    assert mock_config_entry_v1.version == 2
-    assert entity_registry.async_get_entity_id(
-        "climate", DOMAIN, "UUID-GROUP-123_climate"
-    )
+    assert entity_registry.async_get_entity_id(platform, DOMAIN, new_unique_id)
 
 
 async def test_migrate_stable_unique_id_skipped(
     hass: HomeAssistant,
     mock_config_entry_v1: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that a non-class-name unique_id is silently skipped and preserved."""
-    entity_registry = er.async_get(hass)
     entity_registry.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -359,11 +319,12 @@ async def test_migrate_already_v2_is_noop(hass: HomeAssistant) -> None:
 
 
 async def test_migrate_battery_sensor(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+    hass: HomeAssistant,
+    mock_config_entry_v1: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test migration of battery sensor (channel 0)."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
     # Battery entity must be linked to a device, otherwise it's treated
     # as an obsolete access point battery entity and removed.
     device_entry = device_registry.async_get_or_create(
@@ -388,11 +349,12 @@ async def test_migrate_battery_sensor(
 
 
 async def test_migrate_removes_obsolete_access_point_battery_sensor(
-    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+    hass: HomeAssistant,
+    mock_config_entry_v1: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Remove obsolete access point battery entity but keep real device battery sensors."""
-    entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
 
     # Obsolete access point battery entity: legacy unique_id, no linked device.
     obsolete_entity_id = entity_registry.async_get_or_create(
@@ -572,24 +534,3 @@ async def test_unique_id_migration_round_trip(
     assert len(matched_classes) > 10, (
         f"Only matched {len(matched_classes)} classes: {sorted(matched_classes)}"
     )
-
-
-def test_entity_raises_on_empty_feature_id() -> None:
-    """Test that HomematicipGenericEntity raises ValueError for empty feature_id.
-
-    This verifies that feature_id is always explicitly set and cannot be
-    accidentally left empty, which would generate malformed unique IDs.
-    """
-    mock_hap = MagicMock()
-    mock_device = MagicMock()
-
-    with pytest.raises(ValueError, match="feature_id must be a non-empty string"):
-        HomematicipGenericEntity(
-            hap=mock_hap,
-            device=mock_device,
-            post="",
-            channel=1,
-            channel_real_index=1,
-            is_multi_channel=False,
-            feature_id="",
-        )

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -476,7 +476,7 @@ def test_migration_map_completeness() -> None:
     for filename in platform_files:
         filepath = integration_path / filename
         assert filepath.exists(), f"Platform file not found: {filepath}"
-        source = filepath.read_text()
+        source = filepath.read_text(encoding="utf-8")
         tree = ast.parse(source)
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef) and node.name not in excluded_classes:

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,9 +1,18 @@
 """Test HomematicIP Cloud setup process."""
 
+import ast
+from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
+import pytest
 
+from homeassistant.components.homematicip_cloud import (
+    UNIQUE_ID_MIGRATION_MAP,
+    _migrate_unique_id,
+    async_migrate_entry,
+)
 from homeassistant.components.homematicip_cloud.const import (
     CONF_ACCESSPOINT,
     CONF_AUTHTOKEN,
@@ -16,7 +25,10 @@ from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
+
+from .helper import HomeFactory
 
 from tests.common import MockConfigEntry
 
@@ -202,3 +214,360 @@ async def test_setup_services(hass: HomeAssistant) -> None:
     assert len(config_entries) == 1
 
     await hass.config_entries.async_unload(config_entries[0].entry_id)
+
+
+# --- Unique ID migration tests ---
+
+
+@pytest.fixture
+def mock_config_entry_v1(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a v1 config entry for migration testing."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "token", HMIPC_NAME: ""},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_migrate_single_channel_entity(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Test migration of a single-channel entity like MotionDetector."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "HomematicipMotionDetector_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "3014F711ABCD_1_motion"
+    )
+
+
+async def test_migrate_multi_channel_entity(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Test migration of a multi-channel entity like MultiSwitch."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "switch",
+        DOMAIN,
+        "HomematicipMultiSwitch_Channel3_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get_entity_id(
+        "switch", DOMAIN, "3014F711ABCD_3_switch"
+    )
+
+
+async def test_migrate_notification_light(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Test migration of NotificationLight with Top/Bottom suffix."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "light",
+        DOMAIN,
+        "HomematicipNotificationLight_Top_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get_entity_id(
+        "light", DOMAIN, "3014F711ABCD_2_notification_light"
+    )
+
+
+async def test_migrate_group_entity(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Test migration of a group entity (no channel in new unique_id)."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        "HomematicipHeatingGroup_UUID-GROUP-123",
+        config_entry=mock_config_entry_v1,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get_entity_id(
+        "climate", DOMAIN, "UUID-GROUP-123_climate"
+    )
+
+
+async def test_migrate_unknown_class_warns(
+    hass: HomeAssistant,
+    mock_config_entry_v1: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that an unknown class name warns and preserves the old unique_id."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "HomematicipFutureEntity_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    # Unknown prefix is not a known class name, so it's treated as already
+    # stable and skipped silently (no warning, just debug).
+    assert "already stable format" in caplog.text
+    # Old unique_id is preserved (not migrated)
+    assert entity_registry.async_get_entity_id(
+        "sensor", DOMAIN, "HomematicipFutureEntity_3014F711ABCD"
+    )
+
+
+async def test_migrate_already_v2_is_noop(hass: HomeAssistant) -> None:
+    """Test that a v2 config entry is a no-op."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "token", HMIPC_NAME: ""},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    result = await async_migrate_entry(hass, entry)
+
+    assert result is True
+    assert entry.version == 2
+
+
+async def test_migrate_battery_sensor(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Test migration of battery sensor (channel 0)."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    # Battery entity must be linked to a device, otherwise it's treated
+    # as an obsolete access point battery entity and removed.
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry_v1.entry_id,
+        identifiers={(DOMAIN, "3014F711ABCD")},
+    )
+    entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "HomematicipBatterySensor_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+        device_id=device_entry.id,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "3014F711ABCD_0_battery"
+    )
+
+
+async def test_migrate_removes_obsolete_access_point_battery_sensor(
+    hass: HomeAssistant, mock_config_entry_v1: MockConfigEntry
+) -> None:
+    """Remove obsolete access point battery entity but keep real device battery sensors."""
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    # Obsolete access point battery entity: legacy unique_id, no linked device.
+    obsolete_entity_id = entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "HomematicipBatterySensor_ABC123",
+        config_entry=mock_config_entry_v1,
+    ).entity_id
+
+    # Real device battery entity: same legacy class prefix, but attached to a device.
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry_v1.entry_id,
+        identifiers={(DOMAIN, "3014F711ABCD")},
+    )
+    entity_registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "HomematicipBatterySensor_3014F711ABCD",
+        config_entry=mock_config_entry_v1,
+        device_id=device_entry.id,
+    )
+
+    result = await async_migrate_entry(hass, mock_config_entry_v1)
+
+    assert result is True
+    assert mock_config_entry_v1.version == 2
+    assert entity_registry.async_get(obsolete_entity_id) is None
+    assert entity_registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "3014F711ABCD_0_battery"
+    )
+
+
+async def test_migrate_unique_id_collision_detection() -> None:
+    """Test that different classes produce distinct unique_ids for the same device."""
+    device_id = "3014F711ABCD"
+    temp_uid = _migrate_unique_id(f"HomematicipTemperatureSensor_{device_id}")
+    humidity_uid = _migrate_unique_id(f"HomematicipHumiditySensor_{device_id}")
+
+    assert temp_uid is not None
+    assert humidity_uid is not None
+    assert temp_uid != humidity_uid
+    assert temp_uid == f"{device_id}_1_temperature"
+    assert humidity_uid == f"{device_id}_1_humidity"
+
+
+def test_migration_map_completeness() -> None:
+    """Verify every entity class has a migration map entry."""
+    integration_path = Path(__file__).parents[3] / (
+        "homeassistant/components/homematicip_cloud"
+    )
+    assert integration_path.is_dir(), f"Integration path not found: {integration_path}"
+    platform_files = [
+        "binary_sensor.py",
+        "sensor.py",
+        "light.py",
+        "switch.py",
+        "cover.py",
+        "climate.py",
+        "weather.py",
+        "valve.py",
+        "lock.py",
+        "button.py",
+        "event.py",
+        "alarm_control_panel.py",
+        "siren.py",
+    ]
+    # Classes excluded from the migration map:
+    # - Abstract bases that never produce entities directly
+    # - Dataclass descriptors (not entity classes)
+    # - HmipSmokeDetectorSensor uses a custom unique_id format
+    #   ({device_id}_{description_key}) that is already stable
+    excluded_classes = {
+        "HomematicipGenericEntity",
+        "HomematicipBaseActionSensor",
+        "HmipEsiSensorEntity",
+        "HmipSmokeDetectorSensorDescription",
+        "HmipEventEntityDescription",
+        "HmipSmokeDetectorSensor",
+    }
+
+    entity_classes: set[str] = set()
+    for filename in platform_files:
+        filepath = integration_path / filename
+        assert filepath.exists(), f"Platform file not found: {filepath}"
+        source = filepath.read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name not in excluded_classes:
+                entity_classes.add(node.name)
+
+    missing = entity_classes - set(UNIQUE_ID_MIGRATION_MAP.keys())
+    assert not missing, (
+        f"Entity classes missing from UNIQUE_ID_MIGRATION_MAP: {missing}"
+    )
+
+
+async def test_unique_id_migration_round_trip(
+    hass: HomeAssistant,
+    default_mock_hap_factory: HomeFactory,
+    full_flush_lock_controller_device_data: dict[str, Any],
+) -> None:
+    """Verify that migrating old-format unique_ids produces the runtime unique_ids.
+
+    This catches mismatches between the migration map (channel/feature_id) and
+    the actual entity __init__ parameters. For example, if the migration map
+    says channel=1 for BatterySensor but the entity uses channel=0, this test
+    will fail.
+    """
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        extra_devices=[full_flush_lock_controller_device_data],
+    )
+
+    entity_registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_hap.config_entry.entry_id
+    )
+
+    # Collect all runtime unique_ids
+    runtime_unique_ids = {entry.unique_id for entry in entries}
+    assert runtime_unique_ids, "No entities found after setup"
+
+    # Build a reverse index: for each migration map class, record what old-format
+    # unique_ids would look like and what they migrate to.
+    # Then check that every migrated result matches a runtime unique_id.
+    matched_classes: set[str] = set()
+    mismatches: list[str] = []
+
+    for class_name, config in UNIQUE_ID_MIGRATION_MAP.items():
+        # For each runtime unique_id, check if this class could produce it
+        for runtime_uid in runtime_unique_ids:
+            if config.is_group:
+                # Group format: {device_id}_{feature_id}
+                # device_id may contain underscores, feature_id may contain underscores
+                if not runtime_uid.endswith(f"_{config.feature_id}"):
+                    continue
+                device_id = runtime_uid[: -(len(config.feature_id) + 1)]
+                # Construct old-format: {ClassName}_{device_id}
+                old_uid = f"{class_name}_{device_id}"
+            else:
+                # Device format: {device_id}_{channel}_{feature_id}
+                if not runtime_uid.endswith(f"_{config.feature_id}"):
+                    continue
+                if config.channel is not None:
+                    # Single-channel: known fixed channel
+                    suffix = f"_{config.channel}_{config.feature_id}"
+                    if not runtime_uid.endswith(suffix):
+                        continue
+                    device_id = runtime_uid[: -len(suffix)]
+                    old_uid = f"{class_name}_{device_id}"
+                else:
+                    # Multi-channel: parse channel from runtime unique_id
+                    # Runtime: {device_id}_{channel}_{feature_id}
+                    # Old: {ClassName}_Channel{N}_{device_id}
+                    prefix = runtime_uid[: -(len(config.feature_id) + 1)]
+                    # prefix is now {device_id}_{channel}
+                    last_underscore = prefix.rfind("_")
+                    if last_underscore == -1:
+                        continue
+                    channel_str = prefix[last_underscore + 1 :]
+                    if not channel_str.isdigit():
+                        continue
+                    device_id = prefix[:last_underscore]
+                    old_uid = f"{class_name}_Channel{channel_str}_{device_id}"
+
+            # Migrate and verify
+            migrated = _migrate_unique_id(old_uid)
+            if migrated == runtime_uid:
+                matched_classes.add(class_name)
+            else:
+                mismatches.append(
+                    f"{class_name}: old='{old_uid}' -> migrated='{migrated}'"
+                    f" != runtime='{runtime_uid}'"
+                )
+
+    assert not mismatches, "Migration round-trip mismatches:\n" + "\n".join(mismatches)
+    # Ensure we actually tested a meaningful number of classes
+    assert len(matched_classes) > 10, (
+        f"Only matched {len(matched_classes)} classes: {sorted(matched_classes)}"
+    )

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -3,7 +3,7 @@
 import ast
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 import pytest
@@ -16,6 +16,7 @@ from homeassistant.components.homematicip_cloud.const import (
     HMIPC_HAPID,
     HMIPC_NAME,
 )
+from homeassistant.components.homematicip_cloud.entity import HomematicipGenericEntity
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.components.homematicip_cloud.migration import (
     UNIQUE_ID_MIGRATION_MAP,
@@ -571,3 +572,24 @@ async def test_unique_id_migration_round_trip(
     assert len(matched_classes) > 10, (
         f"Only matched {len(matched_classes)} classes: {sorted(matched_classes)}"
     )
+
+
+def test_entity_raises_on_empty_feature_id() -> None:
+    """Test that HomematicipGenericEntity raises ValueError for empty feature_id.
+
+    This verifies that feature_id is always explicitly set and cannot be
+    accidentally left empty, which would generate malformed unique IDs.
+    """
+    mock_hap = MagicMock()
+    mock_device = MagicMock()
+
+    with pytest.raises(ValueError, match="feature_id must be a non-empty string"):
+        HomematicipGenericEntity(
+            hap=mock_hap,
+            device=mock_device,
+            post="",
+            channel=1,
+            channel_real_index=1,
+            is_multi_channel=False,
+            feature_id="",
+        )

--- a/tests/components/homematicip_cloud/test_init.py
+++ b/tests/components/homematicip_cloud/test_init.py
@@ -1,14 +1,10 @@
 """Test HomematicIP Cloud setup process."""
 
-import ast
-from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 from homematicip.exceptions.connection_exceptions import HmipConnectionError
 import pytest
 
-from homeassistant.components.homematicip_cloud import async_migrate_entry
 from homeassistant.components.homematicip_cloud.const import (
     CONF_ACCESSPOINT,
     CONF_AUTHTOKEN,
@@ -18,17 +14,11 @@ from homeassistant.components.homematicip_cloud.const import (
     HMIPC_NAME,
 )
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
-from homeassistant.components.homematicip_cloud.migration import (
-    UNIQUE_ID_MIGRATION_MAP,
-    _migrate_unique_id,
-)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
-
-from .helper import HomeFactory
 
 from tests.common import MockConfigEntry
 
@@ -269,9 +259,19 @@ async def test_migrate_unique_id(
         config_entry=mock_config_entry_v1,
     )
 
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
+    with patch("homeassistant.components.homematicip_cloud.HomematicipHAP") as mock_hap:
+        instance = mock_hap.return_value
+        instance.async_setup = AsyncMock(return_value=True)
+        instance.home.id = "1"
+        instance.home.modelType = "mock-type"
+        instance.home.name = "mock-name"
+        instance.home.label = "mock-label"
+        instance.home.currentAPVersion = "mock-ap-version"
+        instance.async_reset = AsyncMock(return_value=True)
 
-    assert result is True
+        await hass.config_entries.async_setup(mock_config_entry_v1.entry_id)
+        await hass.async_block_till_done()
+
     assert mock_config_entry_v1.version == 2
     assert entity_registry.async_get_entity_id(platform, DOMAIN, new_unique_id)
 
@@ -290,9 +290,19 @@ async def test_migrate_stable_unique_id_skipped(
         config_entry=mock_config_entry_v1,
     )
 
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
+    with patch("homeassistant.components.homematicip_cloud.HomematicipHAP") as mock_hap:
+        instance = mock_hap.return_value
+        instance.async_setup = AsyncMock(return_value=True)
+        instance.home.id = "1"
+        instance.home.modelType = "mock-type"
+        instance.home.name = "mock-name"
+        instance.home.label = "mock-label"
+        instance.home.currentAPVersion = "mock-ap-version"
+        instance.async_reset = AsyncMock(return_value=True)
 
-    assert result is True
+        await hass.config_entries.async_setup(mock_config_entry_v1.entry_id)
+        await hass.async_block_till_done()
+
     assert mock_config_entry_v1.version == 2
     # Unknown prefix is not a known class name, so it's treated as already
     # stable and skipped silently (no warning, just debug).
@@ -303,58 +313,13 @@ async def test_migrate_stable_unique_id_skipped(
     )
 
 
-async def test_migrate_already_v2_is_noop(hass: HomeAssistant) -> None:
-    """Test that a v2 config entry is a no-op."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "token", HMIPC_NAME: ""},
-        version=2,
-    )
-    entry.add_to_hass(hass)
-
-    result = await async_migrate_entry(hass, entry)
-
-    assert result is True
-    assert entry.version == 2
-
-
-async def test_migrate_battery_sensor(
+async def test_migrate_battery_and_obsolete_access_point(
     hass: HomeAssistant,
     mock_config_entry_v1: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test migration of battery sensor (channel 0)."""
-    # Battery entity must be linked to a device, otherwise it's treated
-    # as an obsolete access point battery entity and removed.
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=mock_config_entry_v1.entry_id,
-        identifiers={(DOMAIN, "3014F711ABCD")},
-    )
-    entity_registry.async_get_or_create(
-        "binary_sensor",
-        DOMAIN,
-        "HomematicipBatterySensor_3014F711ABCD",
-        config_entry=mock_config_entry_v1,
-        device_id=device_entry.id,
-    )
-
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
-
-    assert result is True
-    assert mock_config_entry_v1.version == 2
-    assert entity_registry.async_get_entity_id(
-        "binary_sensor", DOMAIN, "3014F711ABCD_0_battery"
-    )
-
-
-async def test_migrate_removes_obsolete_access_point_battery_sensor(
-    hass: HomeAssistant,
-    mock_config_entry_v1: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Remove obsolete access point battery entity but keep real device battery sensors."""
+    """Test battery migration and obsolete access point entity removal."""
 
     # Obsolete access point battery entity: legacy unique_id, no linked device.
     obsolete_entity_id = entity_registry.async_get_or_create(
@@ -377,160 +342,23 @@ async def test_migrate_removes_obsolete_access_point_battery_sensor(
         device_id=device_entry.id,
     )
 
-    result = await async_migrate_entry(hass, mock_config_entry_v1)
+    with patch("homeassistant.components.homematicip_cloud.HomematicipHAP") as mock_hap:
+        instance = mock_hap.return_value
+        instance.async_setup = AsyncMock(return_value=True)
+        instance.home.id = "1"
+        instance.home.modelType = "mock-type"
+        instance.home.name = "mock-name"
+        instance.home.label = "mock-label"
+        instance.home.currentAPVersion = "mock-ap-version"
+        instance.async_reset = AsyncMock(return_value=True)
 
-    assert result is True
+        await hass.config_entries.async_setup(mock_config_entry_v1.entry_id)
+        await hass.async_block_till_done()
+
     assert mock_config_entry_v1.version == 2
+    # Obsolete access point battery entity removed
     assert entity_registry.async_get(obsolete_entity_id) is None
+    # Real device battery entity migrated
     assert entity_registry.async_get_entity_id(
         "binary_sensor", DOMAIN, "3014F711ABCD_0_battery"
-    )
-
-
-async def test_migrate_unique_id_collision_detection() -> None:
-    """Test that different classes produce distinct unique_ids for the same device."""
-    device_id = "3014F711ABCD"
-    temp_uid = _migrate_unique_id(f"HomematicipTemperatureSensor_{device_id}")
-    humidity_uid = _migrate_unique_id(f"HomematicipHumiditySensor_{device_id}")
-
-    assert temp_uid is not None
-    assert humidity_uid is not None
-    assert temp_uid != humidity_uid
-    assert temp_uid == f"{device_id}_1_temperature"
-    assert humidity_uid == f"{device_id}_1_humidity"
-
-
-def test_migration_map_completeness() -> None:
-    """Verify every entity class has a migration map entry."""
-    integration_path = Path(__file__).parents[3] / (
-        "homeassistant/components/homematicip_cloud"
-    )
-    assert integration_path.is_dir(), f"Integration path not found: {integration_path}"
-    platform_files = [
-        "binary_sensor.py",
-        "sensor.py",
-        "light.py",
-        "switch.py",
-        "cover.py",
-        "climate.py",
-        "weather.py",
-        "valve.py",
-        "lock.py",
-        "button.py",
-        "event.py",
-        "alarm_control_panel.py",
-        "siren.py",
-    ]
-    # Classes excluded from the migration map:
-    # - Abstract bases that never produce entities directly
-    # - Dataclass descriptors (not entity classes)
-    # - HmipSmokeDetectorSensor uses a custom unique_id format
-    #   ({device_id}_{description_key}) that is already stable
-    excluded_classes = {
-        "HomematicipGenericEntity",
-        "HomematicipBaseActionSensor",
-        "HmipEsiSensorEntity",
-        "HmipSmokeDetectorSensorDescription",
-        "HmipEventEntityDescription",
-        "HmipSmokeDetectorSensor",
-    }
-
-    entity_classes: set[str] = set()
-    for filename in platform_files:
-        filepath = integration_path / filename
-        assert filepath.exists(), f"Platform file not found: {filepath}"
-        source = filepath.read_text(encoding="utf-8")
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef) and node.name not in excluded_classes:
-                entity_classes.add(node.name)
-
-    missing = entity_classes - set(UNIQUE_ID_MIGRATION_MAP.keys())
-    assert not missing, (
-        f"Entity classes missing from UNIQUE_ID_MIGRATION_MAP: {missing}"
-    )
-
-
-async def test_unique_id_migration_round_trip(
-    hass: HomeAssistant,
-    default_mock_hap_factory: HomeFactory,
-    full_flush_lock_controller_device_data: dict[str, Any],
-) -> None:
-    """Verify that migrating old-format unique_ids produces the runtime unique_ids.
-
-    This catches mismatches between the migration map (channel/feature_id) and
-    the actual entity __init__ parameters. For example, if the migration map
-    says channel=1 for BatterySensor but the entity uses channel=0, this test
-    will fail.
-    """
-    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
-        extra_devices=[full_flush_lock_controller_device_data],
-    )
-
-    entity_registry = er.async_get(hass)
-    entries = er.async_entries_for_config_entry(
-        entity_registry, mock_hap.config_entry.entry_id
-    )
-
-    # Collect all runtime unique_ids
-    runtime_unique_ids = {entry.unique_id for entry in entries}
-    assert runtime_unique_ids, "No entities found after setup"
-
-    # Build a reverse index: for each migration map class, record what old-format
-    # unique_ids would look like and what they migrate to.
-    # Then check that every migrated result matches a runtime unique_id.
-    matched_classes: set[str] = set()
-    mismatches: list[str] = []
-
-    for class_name, config in UNIQUE_ID_MIGRATION_MAP.items():
-        # For each runtime unique_id, check if this class could produce it
-        for runtime_uid in runtime_unique_ids:
-            if config.is_group:
-                # Group format: {device_id}_{feature_id}
-                # device_id may contain underscores, feature_id may contain underscores
-                if not runtime_uid.endswith(f"_{config.feature_id}"):
-                    continue
-                device_id = runtime_uid[: -(len(config.feature_id) + 1)]
-                # Construct old-format: {ClassName}_{device_id}
-                old_uid = f"{class_name}_{device_id}"
-            else:
-                # Device format: {device_id}_{channel}_{feature_id}
-                if not runtime_uid.endswith(f"_{config.feature_id}"):
-                    continue
-                if config.channel is not None:
-                    # Single-channel: known fixed channel
-                    suffix = f"_{config.channel}_{config.feature_id}"
-                    if not runtime_uid.endswith(suffix):
-                        continue
-                    device_id = runtime_uid[: -len(suffix)]
-                    old_uid = f"{class_name}_{device_id}"
-                else:
-                    # Multi-channel: parse channel from runtime unique_id
-                    # Runtime: {device_id}_{channel}_{feature_id}
-                    # Old: {ClassName}_Channel{N}_{device_id}
-                    prefix = runtime_uid[: -(len(config.feature_id) + 1)]
-                    # prefix is now {device_id}_{channel}
-                    last_underscore = prefix.rfind("_")
-                    if last_underscore == -1:
-                        continue
-                    channel_str = prefix[last_underscore + 1 :]
-                    if not channel_str.isdigit():
-                        continue
-                    device_id = prefix[:last_underscore]
-                    old_uid = f"{class_name}_Channel{channel_str}_{device_id}"
-
-            # Migrate and verify
-            migrated = _migrate_unique_id(old_uid)
-            if migrated == runtime_uid:
-                matched_classes.add(class_name)
-            else:
-                mismatches.append(
-                    f"{class_name}: old='{old_uid}' -> migrated='{migrated}'"
-                    f" != runtime='{runtime_uid}'"
-                )
-
-    assert not mismatches, "Migration round-trip mismatches:\n" + "\n".join(mismatches)
-    # Ensure we actually tested a meaningful number of classes
-    assert len(matched_classes) > 10, (
-        f"Only matched {len(matched_classes)} classes: {sorted(matched_classes)}"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate all entity unique IDs in the `homematicip_cloud` integration from a class-name-based format to a stable, implementation-independent format, allowing future code improvements like EntityDescriptions and channel-centric entity creation without breaking existing installations.

**Old format:** `HomematicipMotionDetector_3014F711ABCD`
**New format:** `3014F711ABCD_1_motion`

### Why

The current unique IDs embed Python class names. This means any refactoring that renames, merges, or removes entity classes (e.g., migrating to EntityDescriptions, adopting a channel-centric architecture) would break unique IDs — causing lost history, broken automations, and duplicate entities for users.

This PR decouples unique IDs from class names, making them stable across future code changes. It is a prerequisite for the entity description migration discussed in #166052.

### Design

The new format is `{device_id}_{channel}_{feature_id}` for device entities and `{id}_{feature_id}` for group/home-level entities:

| Entity type | Format | Example |
|---|---|---|
| Device (single-channel) | `{device_id}_{channel}_{feature_id}` | `3014F711ABCD_1_motion` |
| Device (multi-channel) | `{device_id}_{channel}_{feature_id}` | `3014F711ABCD_3_switch` |
| Group | `{group_id}_{feature_id}` | `UUID123_climate` |
| Home-level | `{home_id}_{feature_id}` | `00000000AAAA_cloud_connection` |

A new `_feature_id` field on `HomematicipGenericEntity` drives unique ID generation at runtime. This is deliberately separate from the existing `_post` field (which is used for display names) to avoid coupling display and identity concerns. The `_feature_id` values will likely become `translation_key` values in the future entity descriptions migration.

### Migration

The config entry version bumps from 1 to 2. `async_migrate_entry` uses the standard `er.async_migrate_entries()` callback pattern (the same approach used by e.g. the AirOS integration). An explicit `UNIQUE_ID_MIGRATION_MAP` maps every old class name to its new `(channel, feature_id)` pair. The map covers all 79 entity classes across 15 platform files.

Old unique IDs are parsed by matching the longest known class name prefix, then extracting the channel (from `Channel{N}_` patterns) or using the fixed channel from the migration config. The `HomematicipNotificationLight` special case (`Top`/`Bottom` suffixes instead of channel numbers) is handled explicitly.

A test verifies that every entity class in the codebase has a corresponding migration map entry, so future additions cannot be accidentally missed.

### Relation to @hahn-th's `unique-id` branch

This PR was inspired by @hahn-th's proof-of-concept on the [`unique-id` branch](https://github.com/hahn-th/core/tree/unique-id), which demonstrated the migration approach with 3 example entity classes. This PR takes the same architectural direction but was implemented from scratch on a clean `dev` base with:
- Complete coverage of all 79 entity classes (vs. 3 in the PoC)
- A separate `_feature_id` field instead of repurposing `_post`
- A completeness test that ensures no entity class is missing from the migration map
- Longest-prefix matching for class name parsing (handles ambiguous prefixes like `HomematicipSwitch` vs `HomematicipSwitchMeasuring`)

Users will not notice any difference — entity IDs, history, automations, and customizations are all preserved through the migration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #166052
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr