### PR TITLE
Bump pooldose 0.9.0

### DIFF
--- a/homeassistant/components/pooldose/manifest.json
+++ b/homeassistant/components/pooldose/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "platinum",
-  "requirements": ["python-pooldose==0.8.6"]
+  "requirements": ["python-pooldose==0.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2651,7 +2651,7 @@ python-overseerr==0.9.0
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.8.6
+python-pooldose==0.9.0
 
 # homeassistant.components.hr_energy_qube
 python-qube-heatpump==1.7.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2253,7 +2253,7 @@ python-overseerr==0.9.0
 python-picnic-api2==1.3.1
 
 # homeassistant.components.pooldose
-python-pooldose==0.8.6
+python-pooldose==0.9.0
 
 # homeassistant.components.hr_energy_qube
 python-qube-heatpump==1.7.0


### PR DESCRIPTION
## Proposed change

Bump `python-pooldose` from 0.8.6 to 0.9.0.

## Library diff

**Diff between versions:** https://github.com/lmaertin/python-pooldose/compare/0.8.6...0.9.0

Key changes in 0.9.0:
- **Session consistency fix**: `_get_core_params()` now uses the shared session from Home Assistant instead of creating a standalone one ([#35](https://github.com/lmaertin/python-pooldose/pull/35))
- **Exception handling**: Added broad exception fallback in `_get_core_params()` to catch unexpected errors like `UnicodeDecodeError` ([#36](https://github.com/lmaertin/python-pooldose/pull/36))
- **Async host check**: `check_host_reachable()` is now properly async ([#31](https://github.com/lmaertin/python-pooldose/pull/31))
- **JSON parse errors**: Fixed `JSONDecodeError` handling in `RequestHandler` methods ([#29](https://github.com/lmaertin/python-pooldose/pull/29))
- **Test coverage**: 16 new tests added (160 total, all passing) ([#30](https://github.com/lmaertin/python-pooldose/pull/30))
- **Code quality**: PEP 8 improvements, pylint 10.00/10, mypy clean ([#32](https://github.com/lmaertin/python-pooldose/pull/32), [#33](https://github.com/lmaertin/python-pooldose/pull/33))

Full changelog: https://github.com/lmaertin/python-pooldose/blob/main/CHANGELOG.md#090---2026-03-26

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.