### PR TITLE
Remove number entity support from battery triggers and conditions

### DIFF
--- a/homeassistant/components/battery/condition.py
+++ b/homeassistant/components/battery/condition.py
@@ -6,7 +6,6 @@ from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
 )
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberDeviceClass
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import PERCENTAGE, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -27,7 +26,6 @@ BATTERY_CHARGING_DOMAIN_SPECS = {
 }
 BATTERY_PERCENTAGE_DOMAIN_SPECS = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.BATTERY),
-    NUMBER_DOMAIN: DomainSpec(device_class=NumberDeviceClass.BATTERY),
 }
 
 CONDITIONS: dict[str, type[Condition]] = {

--- a/homeassistant/components/battery/conditions.yaml
+++ b/homeassistant/components/battery/conditions.yaml
@@ -19,8 +19,6 @@
     unit_of_measurement: "%"
   - domain: sensor
     device_class: battery
-  - domain: number
-    device_class: battery
 
 .battery_threshold_number: &battery_threshold_number
   min: 0
@@ -52,8 +50,6 @@ is_level:
   target:
     entity:
       - domain: sensor
-        device_class: battery
-      - domain: number
         device_class: battery
   fields:
     behavior: *condition_behavior

--- a/homeassistant/components/battery/trigger.py
+++ b/homeassistant/components/battery/trigger.py
@@ -6,7 +6,6 @@ from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
 )
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberDeviceClass
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -30,7 +29,6 @@ BATTERY_CHARGING_DOMAIN_SPECS: dict[str, DomainSpec] = {
 
 BATTERY_PERCENTAGE_DOMAIN_SPECS: dict[str, DomainSpec] = {
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.BATTERY),
-    NUMBER_DOMAIN: DomainSpec(device_class=NumberDeviceClass.BATTERY),
 }
 
 TRIGGERS: dict[str, type[Trigger]] = {

--- a/homeassistant/components/battery/triggers.yaml
+++ b/homeassistant/components/battery/triggers.yaml
@@ -13,8 +13,6 @@
 .battery_threshold_entity: &battery_threshold_entity
   - domain: input_number
     unit_of_measurement: "%"
-  - domain: number
-    device_class: battery
   - domain: sensor
     device_class: battery
 
@@ -37,8 +35,6 @@
 .trigger_target_percentage: &trigger_target_percentage
   entity:
     - domain: sensor
-      device_class: battery
-    - domain: number
       device_class: battery
 
 low:

--- a/tests/components/battery/test_condition.py
+++ b/tests/components/battery/test_condition.py
@@ -40,12 +40,6 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, "sensor")
 
 
-@pytest.fixture
-async def target_numbers(hass: HomeAssistant) -> dict[str, list[str]]:
-    """Create multiple number entities associated with different targets."""
-    return await target_entities(hass, "number")
-
-
 @pytest.mark.parametrize(
     "condition",
     [

--- a/tests/components/battery/test_trigger.py
+++ b/tests/components/battery/test_trigger.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -38,12 +37,6 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple sensor entities associated with different targets."""
     return await target_entities(hass, "sensor")
-
-
-@pytest.fixture
-async def target_numbers(hass: HomeAssistant) -> dict[str, list[str]]:
-    """Create multiple number entities associated with different targets."""
-    return await target_entities(hass, "number")
 
 
 @pytest.mark.parametrize(
@@ -357,125 +350,6 @@ async def test_battery_level_crossed_threshold_sensor_behavior_last(
     await assert_trigger_behavior_last(
         hass,
         target_entities=target_sensors,
-        trigger_target_config=trigger_target_config,
-        entity_id=entity_id,
-        entities_in_target=entities_in_target,
-        trigger=trigger,
-        trigger_options=trigger_options,
-        states=states,
-    )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("number"),
-)
-@pytest.mark.parametrize(
-    ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_numerical_state_value_changed_trigger_states(
-            "battery.level_changed",
-            device_class=NumberDeviceClass.BATTERY,
-            unit_attributes={ATTR_UNIT_OF_MEASUREMENT: "%"},
-        ),
-        *parametrize_numerical_state_value_crossed_threshold_trigger_states(
-            "battery.level_crossed_threshold",
-            device_class=NumberDeviceClass.BATTERY,
-            unit_attributes={ATTR_UNIT_OF_MEASUREMENT: "%"},
-        ),
-    ],
-)
-async def test_battery_number_trigger_behavior_any(
-    hass: HomeAssistant,
-    target_numbers: dict[str, list[str]],
-    trigger_target_config: dict,
-    entity_id: str,
-    entities_in_target: int,
-    trigger: str,
-    trigger_options: dict[str, Any],
-    states: list[TriggerStateDescription],
-) -> None:
-    """Test battery number triggers with 'any' behavior."""
-    await assert_trigger_behavior_any(
-        hass,
-        target_entities=target_numbers,
-        trigger_target_config=trigger_target_config,
-        entity_id=entity_id,
-        entities_in_target=entities_in_target,
-        trigger=trigger,
-        trigger_options=trigger_options,
-        states=states,
-    )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("number"),
-)
-@pytest.mark.parametrize(
-    ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_numerical_state_value_crossed_threshold_trigger_states(
-            "battery.level_crossed_threshold",
-            device_class=NumberDeviceClass.BATTERY,
-            unit_attributes={ATTR_UNIT_OF_MEASUREMENT: "%"},
-        ),
-    ],
-)
-async def test_battery_level_crossed_threshold_number_behavior_first(
-    hass: HomeAssistant,
-    target_numbers: dict[str, list[str]],
-    trigger_target_config: dict,
-    entity_id: str,
-    entities_in_target: int,
-    trigger: str,
-    trigger_options: dict[str, Any],
-    states: list[TriggerStateDescription],
-) -> None:
-    """Test battery level_crossed_threshold trigger fires on the first number state change."""
-    await assert_trigger_behavior_first(
-        hass,
-        target_entities=target_numbers,
-        trigger_target_config=trigger_target_config,
-        entity_id=entity_id,
-        entities_in_target=entities_in_target,
-        trigger=trigger,
-        trigger_options=trigger_options,
-        states=states,
-    )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("trigger_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("number"),
-)
-@pytest.mark.parametrize(
-    ("trigger", "trigger_options", "states"),
-    [
-        *parametrize_numerical_state_value_crossed_threshold_trigger_states(
-            "battery.level_crossed_threshold",
-            device_class=NumberDeviceClass.BATTERY,
-            unit_attributes={ATTR_UNIT_OF_MEASUREMENT: "%"},
-        ),
-    ],
-)
-async def test_battery_level_crossed_threshold_number_behavior_last(
-    hass: HomeAssistant,
-    target_numbers: dict[str, list[str]],
-    trigger_target_config: dict,
-    entity_id: str,
-    entities_in_target: int,
-    trigger: str,
-    trigger_options: dict[str, Any],
-    states: list[TriggerStateDescription],
-) -> None:
-    """Test battery level_crossed_threshold trigger fires when the last number changes state."""
-    await assert_trigger_behavior_last(
-        hass,
-        target_entities=target_numbers,
         trigger_target_config=trigger_target_config,
         entity_id=entity_id,
         entities_in_target=entities_in_target,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove number entity support from battery triggers and conditions

Background for the change is in https://github.com/home-assistant/core/issues/166582

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
