### PR TITLE
Remove number entity support from humidity triggers and conditions

### DIFF
--- a/homeassistant/components/humidity/condition.py
+++ b/homeassistant/components/humidity/condition.py
@@ -10,7 +10,6 @@ from homeassistant.components.humidifier import (
     ATTR_CURRENT_HUMIDITY as HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
     DOMAIN as HUMIDIFIER_DOMAIN,
 )
-from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, NumberDeviceClass
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
@@ -25,7 +24,6 @@ HUMIDITY_DOMAIN_SPECS = {
         value_source=HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
     ),
     SENSOR_DOMAIN: DomainSpec(device_class=SensorDeviceClass.HUMIDITY),
-    NUMBER_DOMAIN: DomainSpec(device_class=NumberDeviceClass.HUMIDITY),
 }
 
 CONDITIONS: dict[str, type[Condition]] = {

--- a/homeassistant/components/humidity/conditions.yaml
+++ b/homeassistant/components/humidity/conditions.yaml
@@ -3,6 +3,8 @@
     unit_of_measurement: "%"
   - domain: sensor
     device_class: humidity
+  - domain: number
+    device_class: humidity
 
 .humidity_threshold_number: &humidity_threshold_number
   min: 0

--- a/homeassistant/components/humidity/conditions.yaml
+++ b/homeassistant/components/humidity/conditions.yaml
@@ -3,8 +3,6 @@
     unit_of_measurement: "%"
   - domain: sensor
     device_class: humidity
-  - domain: number
-    device_class: humidity
 
 .humidity_threshold_number: &humidity_threshold_number
   min: 0
@@ -16,8 +14,6 @@ is_value:
   target:
     entity:
       - domain: sensor
-        device_class: humidity
-      - domain: number
         device_class: humidity
       - domain: climate
       - domain: humidifier

--- a/tests/components/humidity/test_condition.py
+++ b/tests/components/humidity/test_condition.py
@@ -37,12 +37,6 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 
 
 @pytest.fixture
-async def target_numbers(hass: HomeAssistant) -> dict[str, list[str]]:
-    """Create multiple number entities associated with different targets."""
-    return await target_entities(hass, "number")
-
-
-@pytest.fixture
 async def target_climates(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple climate entities associated with different targets."""
     return await target_entities(hass, "climate")
@@ -130,78 +124,6 @@ async def test_humidity_sensor_condition_behavior_all(
     await assert_condition_behavior_all(
         hass,
         target_entities=target_sensors,
-        condition_target_config=condition_target_config,
-        entity_id=entity_id,
-        entities_in_target=entities_in_target,
-        condition=condition,
-        condition_options=condition_options,
-        states=states,
-    )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("condition_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("number"),
-)
-@pytest.mark.parametrize(
-    ("condition", "condition_options", "states"),
-    parametrize_numerical_condition_above_below_any(
-        "humidity.is_value",
-        device_class="humidity",
-        unit_attributes=_HUMIDITY_UNIT_ATTRS,
-    ),
-)
-async def test_humidity_number_condition_behavior_any(
-    hass: HomeAssistant,
-    target_numbers: dict[str, list[str]],
-    condition_target_config: dict,
-    entity_id: str,
-    entities_in_target: int,
-    condition: str,
-    condition_options: dict[str, Any],
-    states: list[ConditionStateDescription],
-) -> None:
-    """Test the humidity number condition with 'any' behavior."""
-    await assert_condition_behavior_any(
-        hass,
-        target_entities=target_numbers,
-        condition_target_config=condition_target_config,
-        entity_id=entity_id,
-        entities_in_target=entities_in_target,
-        condition=condition,
-        condition_options=condition_options,
-        states=states,
-    )
-
-
-@pytest.mark.usefixtures("enable_labs_preview_features")
-@pytest.mark.parametrize(
-    ("condition_target_config", "entity_id", "entities_in_target"),
-    parametrize_target_entities("number"),
-)
-@pytest.mark.parametrize(
-    ("condition", "condition_options", "states"),
-    parametrize_numerical_condition_above_below_all(
-        "humidity.is_value",
-        device_class="humidity",
-        unit_attributes=_HUMIDITY_UNIT_ATTRS,
-    ),
-)
-async def test_humidity_number_condition_behavior_all(
-    hass: HomeAssistant,
-    target_numbers: dict[str, list[str]],
-    condition_target_config: dict,
-    entity_id: str,
-    entities_in_target: int,
-    condition: str,
-    condition_options: dict[str, Any],
-    states: list[ConditionStateDescription],
-) -> None:
-    """Test the humidity number condition with 'all' behavior."""
-    await assert_condition_behavior_all(
-        hass,
-        target_entities=target_numbers,
         condition_target_config=condition_target_config,
         entity_id=entity_id,
         entities_in_target=entities_in_target,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove number entity support from humidity conditions

Note: Number entity support is not present in humidity triggers, which means they don't need to be adjusted

Background for the change is in https://github.com/home-assistant/core/issues/166582

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
