### PR TITLE
Bump ttn_client from 1.2.3 to 1.3.0

### DIFF
--- a/homeassistant/components/thethingsnetwork/manifest.json
+++ b/homeassistant/components/thethingsnetwork/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/thethingsnetwork",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["ttn_client==1.2.3"]
+  "requirements": ["ttn_client==1.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3157,7 +3157,7 @@ trmnl==0.1.1
 ttls==1.8.3
 
 # homeassistant.components.thethingsnetwork
-ttn_client==1.2.3
+ttn_client==1.3.0
 
 # homeassistant.components.tuya
 tuya-device-handlers==0.0.15

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2666,7 +2666,7 @@ trmnl==0.1.1
 ttls==1.8.3
 
 # homeassistant.components.thethingsnetwork
-ttn_client==1.2.3
+ttn_client==1.3.0
 
 # homeassistant.components.tuya
 tuya-device-handlers==0.0.15


### PR DESCRIPTION
## Proposed change

Bump `ttn_client` from 1.2.3 to 1.3.0.

This dependency upgrade is required for `TTNSensorAttribute` support, which is used in #166565.

Changelog: https://github.com/angelnu/thethingsnetwork_python_client/releases/tag/v1.3.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue: #166565
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
