### PR TITLE
Introduce a base entity for NINA

### DIFF
--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -8,11 +8,8 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_AFFECTED_AREAS,
@@ -28,9 +25,9 @@ from .const import (
     ATTR_WEB,
     CONF_MESSAGE_SLOTS,
     CONF_REGIONS,
-    DOMAIN,
 )
 from .coordinator import NinaConfigEntry, NINADataUpdateCoordinator
+from .entity import NinaEntity
 
 
 async def async_setup_entry(
@@ -46,7 +43,7 @@ async def async_setup_entry(
     message_slots: int = config_entry.data[CONF_MESSAGE_SLOTS]
 
     async_add_entities(
-        NINAMessage(coordinator, ent, regions[ent], i + 1, config_entry)
+        NINAMessage(coordinator, ent, regions[ent], i + 1)
         for ent in coordinator.data
         for i in range(message_slots)
     )
@@ -55,7 +52,7 @@ async def async_setup_entry(
 PARALLEL_UPDATES = 0
 
 
-class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEntity):
+class NINAMessage(NinaEntity, BinarySensorEntity):
     """Representation of an NINA warning."""
 
     _attr_device_class = BinarySensorDeviceClass.SAFETY
@@ -67,31 +64,21 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
         region: str,
         region_name: str,
         slot_id: int,
-        config_entry: ConfigEntry,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator)
-
-        self._region = region
-        self._warning_index = slot_id - 1
+        super().__init__(coordinator, region, slot_id)
 
         self._attr_name = f"Warning: {region_name} {slot_id}"
         self._attr_unique_id = f"{region}-{slot_id}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, config_entry.entry_id)},
-            manufacturer="NINA",
-            entry_type=DeviceEntryType.SERVICE,
-        )
+        self._attr_device_info = coordinator.device_info
 
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        if len(self.coordinator.data[self._region]) <= self._warning_index:
+        if self._active_warning_count <= self._warning_index:
             return False
 
-        data = self.coordinator.data[self._region][self._warning_index]
-
-        return data.is_valid
+        return self._get_warning_data().is_valid
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -99,7 +86,7 @@ class NINAMessage(CoordinatorEntity[NINADataUpdateCoordinator], BinarySensorEnti
         if not self.is_on:
             return {}
 
-        data = self.coordinator.data[self._region][self._warning_index]
+        data = self._get_warning_data()
 
         return {
             ATTR_HEADLINE: data.headline,

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -75,7 +75,7 @@ class NINAMessage(NinaEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the sensor."""
-        if self._active_warning_count <= self._warning_index:
+        if self._get_active_warnings_count() <= self._warning_index:
             return False
 
         return self._get_warning_data().is_valid

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -70,7 +70,6 @@ class NINAMessage(NinaEntity, BinarySensorEntity):
 
         self._attr_translation_key = "warning"
         self._attr_unique_id = f"{region}-{slot_id}"
-        self._attr_device_info = coordinator.device_info
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/nina/binary_sensor.py
+++ b/homeassistant/components/nina/binary_sensor.py
@@ -31,7 +31,7 @@ from .entity import NinaEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
+    _: HomeAssistant,
     config_entry: NinaConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
@@ -66,9 +66,9 @@ class NINAMessage(NinaEntity, BinarySensorEntity):
         slot_id: int,
     ) -> None:
         """Initialize."""
-        super().__init__(coordinator, region, slot_id)
+        super().__init__(coordinator, region, region_name, slot_id)
 
-        self._attr_name = f"Warning: {region_name} {slot_id}"
+        self._attr_translation_key = "warning"
         self._attr_unique_id = f"{region}-{slot_id}"
         self._attr_device_info = coordinator.device_info
 

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -12,6 +12,7 @@ from pynina import ApiError, Nina
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -74,6 +75,15 @@ class NINADataUpdateCoordinator(
             config_entry=config_entry,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for nina entries."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.config_entry.entry_id)},
+            manufacturer="NINA",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     async def _async_update_data(self) -> dict[str, list[NinaWarningData]]:

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -65,6 +65,12 @@ class NINADataUpdateCoordinator(
         ]
         self.area_filter: str = config_entry.data[CONF_FILTERS][CONF_AREA_FILTER]
 
+        self.device_info = DeviceInfo(
+            identifiers={(DOMAIN, config_entry.entry_id)},
+            manufacturer="NINA",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
         regions: dict[str, str] = config_entry.data[CONF_REGIONS]
         for region in regions:
             self._nina.add_region(region)
@@ -75,15 +81,6 @@ class NINADataUpdateCoordinator(
             config_entry=config_entry,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
-        )
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for nina entries."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self.config_entry.entry_id)},
-            manufacturer="NINA",
-            entry_type=DeviceEntryType.SERVICE,
         )
 
     async def _async_update_data(self) -> dict[str, list[NinaWarningData]]:

--- a/homeassistant/components/nina/entity.py
+++ b/homeassistant/components/nina/entity.py
@@ -9,7 +9,11 @@ class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
     """Base class for NINA entities."""
 
     def __init__(
-        self, coordinator: NINADataUpdateCoordinator, region: str, slot_id: int
+        self,
+        coordinator: NINADataUpdateCoordinator,
+        region: str,
+        region_name: str,
+        slot_id: int,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -18,6 +22,12 @@ class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
         self._warning_index: int = slot_id - 1
 
         self._active_warning_count: int = len(coordinator.data[self._region])
+
+        self._attr_translation_placeholders = {
+            "region_name": region_name,
+            "slot_id": str(slot_id),
+        }
+        self._attr_device_info = coordinator.device_info
 
     def _get_warning_data(self) -> NinaWarningData:
         """Return warning data."""

--- a/homeassistant/components/nina/entity.py
+++ b/homeassistant/components/nina/entity.py
@@ -1,0 +1,24 @@
+"""NINA common entity."""
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import NINADataUpdateCoordinator, NinaWarningData
+
+
+class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
+    """Base class for NINA entities."""
+
+    def __init__(
+        self, coordinator: NINADataUpdateCoordinator, region: str, slot_id: int
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator)
+
+        self._region: str = region
+        self._warning_index: int = slot_id - 1
+
+        self._active_warning_count: int = len(coordinator.data[self._region])
+
+    def _get_warning_data(self) -> NinaWarningData:
+        """Return warning data."""
+        return self.coordinator.data[self._region][self._warning_index]

--- a/homeassistant/components/nina/entity.py
+++ b/homeassistant/components/nina/entity.py
@@ -29,6 +29,10 @@ class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
         }
         self._attr_device_info = coordinator.device_info
 
+    def _get_active_warnings_count(self) -> int:
+        """Return the number of active warnings for the region."""
+        return len(self.coordinator.data[self._region])
+
     def _get_warning_data(self) -> NinaWarningData:
         """Return warning data."""
         return self.coordinator.data[self._region][self._warning_index]

--- a/homeassistant/components/nina/entity.py
+++ b/homeassistant/components/nina/entity.py
@@ -21,8 +21,6 @@ class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
         self._region = region
         self._warning_index = slot_id - 1
 
-        self._active_warning_count: int = len(coordinator.data[self._region])
-
         self._attr_translation_placeholders = {
             "region_name": region_name,
             "slot_id": str(slot_id),

--- a/homeassistant/components/nina/entity.py
+++ b/homeassistant/components/nina/entity.py
@@ -18,8 +18,8 @@ class NinaEntity(CoordinatorEntity[NINADataUpdateCoordinator]):
         """Initialize."""
         super().__init__(coordinator)
 
-        self._region: str = region
-        self._warning_index: int = slot_id - 1
+        self._region = region
+        self._warning_index = slot_id - 1
 
         self._active_warning_count: int = len(coordinator.data[self._region])
 

--- a/homeassistant/components/nina/strings.json
+++ b/homeassistant/components/nina/strings.json
@@ -45,6 +45,13 @@
       }
     }
   },
+  "entity": {
+    "binary_sensor": {
+      "warning": {
+        "name": "Warning: {region_name} {slot_id}"
+      }
+    }
+  },
   "options": {
     "abort": {
       "no_fetch": "[%key:component::nina::config::abort::no_fetch%]",

--- a/tests/components/nina/snapshots/test_binary_sensor.ambr
+++ b/tests/components/nina/snapshots/test_binary_sensor.ambr
@@ -31,7 +31,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'warning',
     'unique_id': '095760000000-1',
     'unit_of_measurement': None,
   })
@@ -93,7 +93,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'warning',
     'unique_id': '095760000000-2',
     'unit_of_measurement': None,
   })
@@ -144,7 +144,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'warning',
     'unique_id': '095760000000-3',
     'unit_of_measurement': None,
   })
@@ -195,7 +195,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'warning',
     'unique_id': '095760000000-4',
     'unit_of_measurement': None,
   })
@@ -246,7 +246,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'warning',
     'unique_id': '095760000000-5',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As a predecessor of #161882 this pr introduces a base entity for NINA warnings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
