### PR TITLE
Add native WebRTC streaming support for Abode Cam 2

### DIFF
--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -154,7 +154,12 @@ class AbodeCamera(AbodeDevice, Camera):
             LOGGER.warning("Failed to refresh camera snapshot image: %s", err)
             return False
 
-        snapshot_data_url = self._device.snapshot_data_url(get_snapshot=False)
+        try:
+            snapshot_data_url = self._device.snapshot_data_url(get_snapshot=False)
+        except AbodeException as err:
+            LOGGER.warning("Failed to fetch camera snapshot data URL: %s", err)
+            return False
+
         _, separator, encoded_snapshot = snapshot_data_url.partition(",")
         if not separator:
             LOGGER.warning(
@@ -163,7 +168,7 @@ class AbodeCamera(AbodeDevice, Camera):
             return False
 
         try:
-            self._snapshot_image = base64.b64decode(encoded_snapshot)
+            self._snapshot_image = base64.b64decode(encoded_snapshot, validate=True)
         except (binascii.Error, ValueError) as err:
             LOGGER.warning("Failed to decode camera snapshot: %s", err)
             return False
@@ -201,7 +206,19 @@ class AbodeCamera(AbodeDevice, Camera):
             LOGGER.warning("Failed to get camera stream URL: %s", err)
             return None
 
-        playback_url = response.json().get("playbackUrl")
+        try:
+            playback_data = response.json()
+        except ValueError as err:
+            LOGGER.warning("Failed to decode camera stream response JSON: %s", err)
+            return None
+
+        if not isinstance(playback_data, dict):
+            LOGGER.warning(
+                "Failed to get camera stream URL: unexpected response format"
+            )
+            return None
+
+        playback_url = playback_data.get("playbackUrl")
         if not playback_url:
             LOGGER.warning("Failed to get camera stream URL: missing playbackUrl")
             return None

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -2,18 +2,39 @@
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import binascii
+from contextlib import suppress
+from dataclasses import dataclass
 from datetime import timedelta
+import json
+import time
 from typing import Any, cast
 
+from aiohttp import ClientError, ClientWebSocketResponse, WSMessage, WSMsgType
 from jaraco.abode.devices.base import Device
 from jaraco.abode.devices.camera import Camera as AbodeCam
+from jaraco.abode.exceptions import Exception as AbodeException
 from jaraco.abode.helpers import timeline
 import requests
 from requests.models import Response
+from webrtc_models import RTCConfiguration, RTCIceServer
 
-from homeassistant.components.camera import Camera
+from homeassistant.components.camera import (
+    Camera,
+    CameraEntityFeature,
+    RTCIceCandidateInit,
+    WebRTCAnswer,
+    WebRTCCandidate,
+    WebRTCClientConfiguration,
+    WebRTCError,
+    WebRTCSendMessage,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import Throttle
@@ -23,6 +44,24 @@ from .const import DOMAIN_DATA, LOGGER
 from .entity import AbodeDevice
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=90)
+SNAPSHOT_CAMERA_TYPE_TAGS: set[str] = {
+    "device_type.mini_cam",
+    "device_type.doorbell",
+    "device_type.abode_cam_3",
+}
+MEDIA_PLAYBACK_URL = "/integrations/v1/media/getPlaybackUrl"
+KVS_STREAM_URL = "/integrations/v1/camera/{camera_id}/kvs/stream"
+KVS_SIGNALING_ACTION_SDP_OFFER = "SDP_OFFER"
+KVS_SIGNALING_ACTION_ICE_CANDIDATE = "ICE_CANDIDATE"
+KVS_SIGNALING_CACHE_SECONDS = 240
+
+
+@dataclass(slots=True)
+class _AbodeWebRTCSession:
+    """Track an active Abode WebRTC signaling session."""
+
+    ws: ClientWebSocketResponse
+    listener_task: asyncio.Task[None] | None = None
 
 
 async def async_setup_entry(
@@ -51,6 +90,17 @@ class AbodeCamera(AbodeDevice, Camera):
         Camera.__init__(self)
         self._event = event
         self._response: Response | None = None
+        type_tag = str(getattr(device, "type_tag", "")).lower()
+        self._supports_snapshot = bool(getattr(device, "is_new_camera", False)) or (
+            type_tag in SNAPSHOT_CAMERA_TYPE_TAGS
+        )
+        self._snapshot_image: bytes | None = None
+        self._webrtc_ice_servers: list[RTCIceServer] = []
+        self._kvs_channel_endpoint: str | None = None
+        self._kvs_signaling_last_refresh_monotonic = 0.0
+        self._webrtc_sessions: dict[str, _AbodeWebRTCSession] = {}
+        if self._supports_snapshot:
+            self._attr_supported_features |= CameraEntityFeature.STREAM
 
     async def async_added_to_hass(self) -> None:
         """Subscribe Abode events."""
@@ -64,6 +114,19 @@ class AbodeCamera(AbodeDevice, Camera):
 
         signal = f"abode_camera_capture_{self.entity_id}"
         self.async_on_remove(async_dispatcher_connect(self.hass, signal, self.capture))
+        if self._supports_snapshot:
+            self.hass.async_create_task(self._async_refresh_kvs_signaling_info())
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cleanup active WebRTC sessions."""
+        await super().async_will_remove_from_hass()
+        await asyncio.gather(
+            *(
+                self._async_close_webrtc_session(session_id)
+                for session_id in list(self._webrtc_sessions)
+            ),
+            return_exceptions=True,
+        )
 
     def capture(self) -> bool:
         """Request a new image capture."""
@@ -72,8 +135,40 @@ class AbodeCamera(AbodeDevice, Camera):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def refresh_image(self) -> None:
         """Find a new image on the timeline."""
-        if self._device.refresh_image():
-            self.get_image()
+        if self._supports_snapshot and self._refresh_snapshot_image():
+            return
+
+        try:
+            if self._device.refresh_image():
+                self.get_image()
+        except AbodeException as err:
+            LOGGER.warning("Failed to refresh camera image: %s", err)
+
+    def _refresh_snapshot_image(self) -> bool:
+        """Attempt to refresh image using Abode snapshot endpoint."""
+        try:
+            if not self._device.snapshot():
+                LOGGER.debug("Camera snapshot request did not return image data")
+                return False
+        except AbodeException as err:
+            LOGGER.warning("Failed to refresh camera snapshot image: %s", err)
+            return False
+
+        snapshot_data_url = self._device.snapshot_data_url(get_snapshot=False)
+        _, separator, encoded_snapshot = snapshot_data_url.partition(",")
+        if not separator:
+            LOGGER.warning(
+                "Failed to decode camera snapshot: unexpected snapshot format"
+            )
+            return False
+
+        try:
+            self._snapshot_image = base64.b64decode(encoded_snapshot)
+        except (binascii.Error, ValueError) as err:
+            LOGGER.warning("Failed to decode camera snapshot: %s", err)
+            return False
+
+        return True
 
     def get_image(self) -> None:
         """Attempt to download the most recent capture."""
@@ -90,11 +185,320 @@ class AbodeCamera(AbodeDevice, Camera):
         else:
             self._response = None
 
+    def _get_stream_source(self) -> str | None:
+        """Get an HLS stream source URL for cameras supporting KVS playback."""
+        stream_request_payload = {
+            "cameraId": self._device.id,
+            "startTime": int(time.time()) - 30,
+            "format": "hls",
+            "playbackMode": "LIVE_REPLAY",
+        }
+        try:
+            response = self._data.abode.send_request(
+                "post", MEDIA_PLAYBACK_URL, data=stream_request_payload
+            )
+        except AbodeException as err:
+            LOGGER.warning("Failed to get camera stream URL: %s", err)
+            return None
+
+        playback_url = response.json().get("playbackUrl")
+        if not playback_url:
+            LOGGER.warning("Failed to get camera stream URL: missing playbackUrl")
+            return None
+
+        LOGGER.debug("Fetched camera stream URL for camera %s", self._device.id)
+        return str(playback_url)
+
+    async def stream_source(self) -> str | None:
+        """Get the source of the stream."""
+        if not self._supports_snapshot:
+            return None
+
+        return await self.hass.async_add_executor_job(self._get_stream_source)
+
+    def _get_kvs_signaling_info(self) -> dict[str, Any]:
+        """Get KVS signaling metadata for the camera."""
+        response = self._data.abode.send_request(
+            "post", KVS_STREAM_URL.format(camera_id=self._device.id)
+        )
+        raw_signaling_info = response.json()
+        if not isinstance(raw_signaling_info, dict):
+            raise HomeAssistantError("Invalid KVS signaling response")
+        signaling_info = raw_signaling_info
+        channel_endpoint = signaling_info.get("channelEndpoint")
+        if not isinstance(channel_endpoint, str) or not channel_endpoint:
+            raise HomeAssistantError("Missing KVS channel endpoint")
+
+        self._kvs_channel_endpoint = channel_endpoint
+        self._webrtc_ice_servers = self._parse_ice_servers(
+            signaling_info.get("iceServers", [])
+        )
+        self._kvs_signaling_last_refresh_monotonic = time.monotonic()
+        return signaling_info
+
+    def _kvs_signaling_is_fresh(self) -> bool:
+        """Return whether cached KVS signaling metadata is still fresh."""
+        if not self._kvs_channel_endpoint:
+            return False
+        return (
+            time.monotonic() - self._kvs_signaling_last_refresh_monotonic
+        ) < KVS_SIGNALING_CACHE_SECONDS
+
+    async def _async_refresh_kvs_signaling_info(
+        self, *, force: bool = False
+    ) -> dict[str, Any] | None:
+        """Refresh cached KVS signaling metadata."""
+        if not force and self._kvs_signaling_is_fresh():
+            return {
+                "channelEndpoint": self._kvs_channel_endpoint,
+                "iceServers": [server.to_dict() for server in self._webrtc_ice_servers],
+            }
+        try:
+            return await self.hass.async_add_executor_job(self._get_kvs_signaling_info)
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Failed to refresh Abode KVS signaling info: %s", err)
+            return None
+
+    @staticmethod
+    def _parse_ice_servers(raw_ice_servers: Any) -> list[RTCIceServer]:
+        """Parse Abode KVS ICE servers into WebRTC model objects."""
+        if not isinstance(raw_ice_servers, list):
+            return []
+
+        ice_servers: list[RTCIceServer] = []
+        for raw_server in raw_ice_servers:
+            if not isinstance(raw_server, dict):
+                continue
+            urls = raw_server.get("urls")
+            if not isinstance(urls, (str, list)):
+                continue
+            username = raw_server.get("username")
+            credential = raw_server.get("credential")
+            ice_servers.append(
+                RTCIceServer(
+                    urls=urls,
+                    username=username if isinstance(username, str) else None,
+                    credential=credential if isinstance(credential, str) else None,
+                )
+            )
+
+        return ice_servers
+
+    @staticmethod
+    def _build_signaling_message(action: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Build a KVS signaling message."""
+        encoded_payload = base64.b64encode(json.dumps(payload).encode()).decode()
+        return {
+            "action": action,
+            "messagePayload": encoded_payload,
+        }
+
+    @staticmethod
+    def _decode_signaling_message(msg: WSMessage) -> tuple[str, dict[str, Any]] | None:
+        """Decode a signaling message from KVS."""
+        try:
+            message_data = json.loads(msg.data)
+        except (TypeError, json.JSONDecodeError):
+            return None
+
+        message_type = message_data.get("messageType")
+        encoded_payload = message_data.get("messagePayload")
+        if not isinstance(message_type, str) or not isinstance(encoded_payload, str):
+            return None
+
+        try:
+            payload = json.loads(base64.b64decode(encoded_payload))
+        except (TypeError, ValueError, binascii.Error, json.JSONDecodeError):
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        return message_type, payload
+
+    @staticmethod
+    def _parse_remote_ice_candidate(payload: dict[str, Any]) -> RTCIceCandidateInit | None:
+        """Parse a remote ICE candidate payload."""
+        try:
+            return RTCIceCandidateInit.from_dict(payload)
+        except (TypeError, ValueError):
+            candidate = payload.get("candidate")
+            if not isinstance(candidate, str):
+                return None
+            sdp_mid = payload.get("sdpMid")
+            sdp_m_line_index = payload.get("sdpMLineIndex")
+            return RTCIceCandidateInit(
+                candidate,
+                sdp_mid=sdp_mid if isinstance(sdp_mid, str) else None,
+                sdp_m_line_index=(
+                    sdp_m_line_index if isinstance(sdp_m_line_index, int) else None
+                ),
+            )
+
+    async def _async_listen_webrtc_messages(
+        self,
+        session_id: str,
+        ws: ClientWebSocketResponse,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Listen for KVS signaling messages for a session."""
+        try:
+            while True:
+                msg = await ws.receive()
+                if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
+                    break
+                if msg.type is WSMsgType.ERROR:
+                    error = ws.exception()
+                    send_message(
+                        WebRTCError(
+                            "webrtc_signaling_error",
+                            str(error) if error else "Unknown signaling error",
+                        )
+                    )
+                    break
+                if msg.type is not WSMsgType.TEXT:
+                    continue
+
+                if not (decoded := self._decode_signaling_message(msg)):
+                    continue
+
+                message_type, payload = decoded
+                if message_type == "SDP_ANSWER":
+                    sdp = payload.get("sdp")
+                    if isinstance(sdp, str):
+                        LOGGER.debug(
+                            "Received WebRTC SDP answer for camera %s session %s",
+                            self._device.id,
+                            session_id,
+                        )
+                        send_message(WebRTCAnswer(sdp))
+                elif message_type == "ICE_CANDIDATE":
+                    if candidate := self._parse_remote_ice_candidate(payload):
+                        LOGGER.debug(
+                            "Received remote WebRTC ICE candidate for camera %s session %s",
+                            self._device.id,
+                            session_id,
+                        )
+                        send_message(WebRTCCandidate(candidate))
+        finally:
+            await self._async_close_webrtc_session(session_id, cancel_listener=False)
+
+    async def _async_close_webrtc_session(
+        self, session_id: str, *, cancel_listener: bool = True
+    ) -> None:
+        """Close and cleanup a WebRTC session."""
+        if not (session := self._webrtc_sessions.pop(session_id, None)):
+            return
+
+        if (
+            cancel_listener
+            and session.listener_task
+            and not session.listener_task.done()
+        ):
+            session.listener_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await session.listener_task
+
+        if not session.ws.closed:
+            await session.ws.close()
+
+    def _async_get_webrtc_client_configuration(self) -> WebRTCClientConfiguration:
+        """Return WebRTC client configuration for Abode cameras."""
+        return WebRTCClientConfiguration(
+            configuration=RTCConfiguration(ice_servers=self._webrtc_ice_servers.copy())
+        )
+
+    async def async_handle_async_webrtc_offer(
+        self,
+        offer_sdp: str,
+        session_id: str,
+        send_message: WebRTCSendMessage,
+    ) -> None:
+        """Handle an incoming WebRTC offer from the frontend."""
+        if not self._supports_snapshot:
+            raise HomeAssistantError("Camera does not support WebRTC")
+
+        if not self._kvs_signaling_is_fresh() and (
+            await self._async_refresh_kvs_signaling_info()
+        ) is None and not self._kvs_channel_endpoint:
+            raise HomeAssistantError("Failed to refresh Abode WebRTC signaling info")
+
+        if not self._kvs_channel_endpoint:
+            raise HomeAssistantError("Missing Abode WebRTC channel endpoint")
+
+        client_session = async_get_clientsession(self.hass)
+        LOGGER.debug(
+            "Opening Abode WebRTC signaling websocket for camera %s",
+            self._device.id,
+        )
+        try:
+            ws = await client_session.ws_connect(self._kvs_channel_endpoint)
+        except ClientError as err:
+            raise HomeAssistantError(
+                "Failed to connect to Abode WebRTC signaling endpoint"
+            ) from err
+
+        webrtc_session = _AbodeWebRTCSession(ws=ws)
+        self._webrtc_sessions[session_id] = webrtc_session
+        webrtc_session.listener_task = self.hass.async_create_task(
+            self._async_listen_webrtc_messages(session_id, ws, send_message)
+        )
+
+        try:
+            await ws.send_json(
+                self._build_signaling_message(
+                    KVS_SIGNALING_ACTION_SDP_OFFER,
+                    {"type": "offer", "sdp": offer_sdp},
+                )
+            )
+            LOGGER.debug(
+                "Sent WebRTC SDP offer for camera %s session %s",
+                self._device.id,
+                session_id,
+            )
+        except ClientError as err:
+            await self._async_close_webrtc_session(session_id)
+            raise HomeAssistantError("Failed to send WebRTC offer") from err
+
+    async def async_on_webrtc_candidate(
+        self, session_id: str, candidate: RTCIceCandidateInit
+    ) -> None:
+        """Handle a local WebRTC candidate from the frontend."""
+        if not (session := self._webrtc_sessions.get(session_id)):
+            LOGGER.debug(
+                "Ignoring local WebRTC ICE candidate for unknown session %s camera %s",
+                session_id,
+                self._device.id,
+            )
+            return
+
+        try:
+            await session.ws.send_json(
+                self._build_signaling_message(
+                    KVS_SIGNALING_ACTION_ICE_CANDIDATE, candidate.to_dict()
+                )
+            )
+            LOGGER.debug(
+                "Sent local WebRTC ICE candidate for camera %s session %s",
+                self._device.id,
+                session_id,
+            )
+        except ClientError as err:
+            raise HomeAssistantError("Failed to send WebRTC candidate") from err
+
+    @callback
+    def close_webrtc_session(self, session_id: str) -> None:
+        """Close a WebRTC session."""
+        self.hass.async_create_task(self._async_close_webrtc_session(session_id))
+
     def camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Get a camera image."""
         self.refresh_image()
+
+        if self._snapshot_image:
+            return self._snapshot_image
 
         if self._response:
             return self._response.content

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -303,6 +303,9 @@ class AbodeCamera(AbodeDevice, Camera):
         except TypeError, json.JSONDecodeError:
             return None
 
+        if not isinstance(message_data, dict):
+            return None
+
         message_type = message_data.get("messageType")
         encoded_payload = message_data.get("messagePayload")
         if not isinstance(message_type, str) or not isinstance(encoded_payload, str):
@@ -331,12 +334,20 @@ class AbodeCamera(AbodeDevice, Camera):
                 return None
             sdp_mid = payload.get("sdpMid")
             sdp_m_line_index = payload.get("sdpMLineIndex")
+            sdp_m_line_index_int: int | None
+            if isinstance(sdp_m_line_index, int):
+                sdp_m_line_index_int = sdp_m_line_index
+            elif isinstance(sdp_m_line_index, str):
+                try:
+                    sdp_m_line_index_int = int(sdp_m_line_index)
+                except TypeError, ValueError:
+                    sdp_m_line_index_int = None
+            else:
+                sdp_m_line_index_int = None
             return RTCIceCandidateInit(
                 candidate,
                 sdp_mid=sdp_mid if isinstance(sdp_mid, str) else None,
-                sdp_m_line_index=(
-                    sdp_m_line_index if isinstance(sdp_m_line_index, int) else None
-                ),
+                sdp_m_line_index=sdp_m_line_index_int,
             )
 
     async def _async_listen_webrtc_messages(

--- a/homeassistant/components/abode/camera.py
+++ b/homeassistant/components/abode/camera.py
@@ -285,7 +285,9 @@ class AbodeCamera(AbodeDevice, Camera):
         return ice_servers
 
     @staticmethod
-    def _build_signaling_message(action: str, payload: dict[str, Any]) -> dict[str, Any]:
+    def _build_signaling_message(
+        action: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
         """Build a KVS signaling message."""
         encoded_payload = base64.b64encode(json.dumps(payload).encode()).decode()
         return {
@@ -298,7 +300,7 @@ class AbodeCamera(AbodeDevice, Camera):
         """Decode a signaling message from KVS."""
         try:
             message_data = json.loads(msg.data)
-        except (TypeError, json.JSONDecodeError):
+        except TypeError, json.JSONDecodeError:
             return None
 
         message_type = message_data.get("messageType")
@@ -308,7 +310,7 @@ class AbodeCamera(AbodeDevice, Camera):
 
         try:
             payload = json.loads(base64.b64decode(encoded_payload))
-        except (TypeError, ValueError, binascii.Error, json.JSONDecodeError):
+        except TypeError, ValueError, binascii.Error, json.JSONDecodeError:
             return None
 
         if not isinstance(payload, dict):
@@ -317,11 +319,13 @@ class AbodeCamera(AbodeDevice, Camera):
         return message_type, payload
 
     @staticmethod
-    def _parse_remote_ice_candidate(payload: dict[str, Any]) -> RTCIceCandidateInit | None:
+    def _parse_remote_ice_candidate(
+        payload: dict[str, Any],
+    ) -> RTCIceCandidateInit | None:
         """Parse a remote ICE candidate payload."""
         try:
             return RTCIceCandidateInit.from_dict(payload)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             candidate = payload.get("candidate")
             if not isinstance(candidate, str):
                 return None
@@ -418,9 +422,11 @@ class AbodeCamera(AbodeDevice, Camera):
         if not self._supports_snapshot:
             raise HomeAssistantError("Camera does not support WebRTC")
 
-        if not self._kvs_signaling_is_fresh() and (
-            await self._async_refresh_kvs_signaling_info()
-        ) is None and not self._kvs_channel_endpoint:
+        if (
+            not self._kvs_signaling_is_fresh()
+            and (await self._async_refresh_kvs_signaling_info()) is None
+            and not self._kvs_channel_endpoint
+        ):
             raise HomeAssistantError("Failed to refresh Abode WebRTC signaling info")
 
         if not self._kvs_channel_endpoint:

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -470,6 +470,23 @@ async def test_camera_snapshot_refresh_invalid_snapshot_format(
         assert camera._refresh_snapshot_image() is False
 
 
+async def test_camera_snapshot_refresh_snapshot_data_url_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test snapshot refresh handles snapshot data URL fetch errors."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with (
+        patch("jaraco.abode.devices.camera.Camera.snapshot", return_value=True),
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot_data_url",
+            side_effect=AbodeException((403, "forbidden")),
+        ),
+    ):
+        assert camera._refresh_snapshot_image() is False
+
+
 async def test_camera_snapshot_refresh_invalid_base64(hass: HomeAssistant) -> None:
     """Test snapshot refresh handles invalid base64 payloads."""
     await setup_platform(hass, CAMERA_DOMAIN)
@@ -479,7 +496,7 @@ async def test_camera_snapshot_refresh_invalid_base64(hass: HomeAssistant) -> No
         patch("jaraco.abode.devices.camera.Camera.snapshot", return_value=True),
         patch(
             "jaraco.abode.devices.camera.Camera.snapshot_data_url",
-            return_value="data:image/jpeg;base64,a",
+            return_value="data:image/jpeg;base64,!!!",
         ),
     ):
         assert camera._refresh_snapshot_image() is False
@@ -532,6 +549,32 @@ async def test_camera_stream_source_handles_request_error(hass: HomeAssistant) -
         "jaraco.abode.client.Client.send_request",
         side_effect=AbodeException((500, "error")),
     ):
+        stream_source = await async_get_stream_source(hass, "camera.test_cam")
+
+    assert stream_source is None
+
+
+async def test_camera_stream_source_handles_invalid_json(hass: HomeAssistant) -> None:
+    """Test stream source returns None when playback response JSON is invalid."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    response = Mock()
+    response.json.side_effect = ValueError("invalid json")
+
+    with patch("jaraco.abode.client.Client.send_request", return_value=response):
+        stream_source = await async_get_stream_source(hass, "camera.test_cam")
+
+    assert stream_source is None
+
+
+async def test_camera_stream_source_handles_non_dict_json(hass: HomeAssistant) -> None:
+    """Test stream source returns None when playback response JSON is not an object."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    response = Mock()
+    response.json.return_value = ["not", "a", "dict"]
+
+    with patch("jaraco.abode.client.Client.send_request", return_value=response):
         stream_source = await async_get_stream_source(hass, "camera.test_cam")
 
     assert stream_source is None
@@ -755,7 +798,7 @@ async def test_camera_webrtc_offer_requires_supported_camera(
 
     with pytest.raises(HomeAssistantError, match="does not support WebRTC"):
         await camera.async_handle_async_webrtc_offer(
-            "offer-sdp", "session-1", list.append
+            "offer-sdp", "session-1", lambda *_: None
         )
 
 
@@ -774,7 +817,7 @@ async def test_camera_webrtc_offer_fails_when_refresh_fails_and_no_endpoint(
         ),
     ):
         await camera.async_handle_async_webrtc_offer(
-            "offer-sdp", "session-1", list.append
+            "offer-sdp", "session-1", lambda *_: None
         )
 
 
@@ -793,7 +836,7 @@ async def test_camera_webrtc_offer_fails_without_channel_endpoint(
         ),
     ):
         await camera.async_handle_async_webrtc_offer(
-            "offer-sdp", "session-1", list.append
+            "offer-sdp", "session-1", lambda *_: None
         )
 
 
@@ -819,7 +862,7 @@ async def test_camera_webrtc_offer_fails_when_ws_connect_fails(
         ),
     ):
         await camera.async_handle_async_webrtc_offer(
-            "offer-sdp", "session-1", list.append
+            "offer-sdp", "session-1", lambda *_: None
         )
 
 
@@ -847,7 +890,7 @@ async def test_camera_webrtc_offer_fails_when_offer_send_fails(
         pytest.raises(HomeAssistantError, match="Failed to send WebRTC offer"),
     ):
         await camera.async_handle_async_webrtc_offer(
-            "offer-sdp", "session-send-fail", list.append
+            "offer-sdp", "session-send-fail", lambda *_: None
         )
 
     assert "session-send-fail" not in camera._webrtc_sessions

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -30,8 +30,8 @@ from homeassistant.components.camera import (
     WebRTCCandidate,
     async_get_image,
     async_get_stream_source,
+    get_camera_from_entity_id,
 )
-from homeassistant.components.camera.helper import get_camera_from_entity_id
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -339,7 +339,9 @@ async def test_camera_webrtc_offer_sends_offer_and_receives_events(
     }
     ws = _FakeWebSocket(
         [
-            _kvs_signaling_message("SDP_ANSWER", {"type": "answer", "sdp": "answer-sdp"}),
+            _kvs_signaling_message(
+                "SDP_ANSWER", {"type": "answer", "sdp": "answer-sdp"}
+            ),
             _kvs_signaling_message(
                 "ICE_CANDIDATE",
                 {
@@ -437,7 +439,9 @@ async def test_camera_refresh_image_handles_auth_error(hass: HomeAssistant) -> N
     assert image is None
 
 
-async def test_camera_snapshot_refresh_handles_snapshot_error(hass: HomeAssistant) -> None:
+async def test_camera_snapshot_refresh_handles_snapshot_error(
+    hass: HomeAssistant,
+) -> None:
     """Test snapshot refresh returns False when snapshot request raises."""
     await setup_platform(hass, CAMERA_DOMAIN)
     camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
@@ -634,13 +638,18 @@ def test_decode_signaling_message_invalid_payloads() -> None:
         )
         is None
     )
-    encoded_list_payload = base64.b64encode(json.dumps(["not", "dict"]).encode()).decode()
+    encoded_list_payload = base64.b64encode(
+        json.dumps(["not", "dict"]).encode()
+    ).decode()
     assert (
         AbodeCamera._decode_signaling_message(
             SimpleNamespace(
                 type=WSMsgType.TEXT,
                 data=json.dumps(
-                    {"messageType": "SDP_ANSWER", "messagePayload": encoded_list_payload}
+                    {
+                        "messageType": "SDP_ANSWER",
+                        "messagePayload": encoded_list_payload,
+                    }
                 ),
             )
         )
@@ -739,7 +748,9 @@ async def test_camera_webrtc_offer_requires_supported_camera(
     camera._supports_snapshot = False
 
     with pytest.raises(HomeAssistantError, match="does not support WebRTC"):
-        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp", "session-1", list.append
+        )
 
 
 async def test_camera_webrtc_offer_fails_when_refresh_fails_and_no_endpoint(
@@ -756,7 +767,9 @@ async def test_camera_webrtc_offer_fails_when_refresh_fails_and_no_endpoint(
             HomeAssistantError, match="Failed to refresh Abode WebRTC signaling info"
         ),
     ):
-        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp", "session-1", list.append
+        )
 
 
 async def test_camera_webrtc_offer_fails_without_channel_endpoint(
@@ -769,9 +782,13 @@ async def test_camera_webrtc_offer_fails_without_channel_endpoint(
 
     with (
         patch.object(camera, "_kvs_signaling_is_fresh", return_value=True),
-        pytest.raises(HomeAssistantError, match="Missing Abode WebRTC channel endpoint"),
+        pytest.raises(
+            HomeAssistantError, match="Missing Abode WebRTC channel endpoint"
+        ),
     ):
-        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp", "session-1", list.append
+        )
 
 
 async def test_camera_webrtc_offer_fails_when_ws_connect_fails(
@@ -791,10 +808,13 @@ async def test_camera_webrtc_offer_fails_when_ws_connect_fails(
             return_value=session,
         ),
         pytest.raises(
-            HomeAssistantError, match="Failed to connect to Abode WebRTC signaling endpoint"
+            HomeAssistantError,
+            match="Failed to connect to Abode WebRTC signaling endpoint",
         ),
     ):
-        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp", "session-1", list.append
+        )
 
 
 async def test_camera_webrtc_offer_fails_when_offer_send_fails(
@@ -820,7 +840,9 @@ async def test_camera_webrtc_offer_fails_when_offer_send_fails(
         ),
         pytest.raises(HomeAssistantError, match="Failed to send WebRTC offer"),
     ):
-        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-send-fail", list.append)
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp", "session-send-fail", list.append
+        )
 
     assert "session-send-fail" not in camera._webrtc_sessions
 
@@ -854,7 +876,9 @@ async def test_camera_capture_callback_updates_state(hass: HomeAssistant) -> Non
     camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
 
     with (
-        patch.object(camera._device, "update_image_location") as mock_update_image_location,
+        patch.object(
+            camera._device, "update_image_location"
+        ) as mock_update_image_location,
         patch.object(camera, "get_image") as mock_get_image,
         patch.object(camera, "schedule_update_ha_state") as mock_schedule_update,
     ):

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -1,14 +1,98 @@
 """Tests for the Abode camera device."""
 
-from unittest.mock import patch
+import asyncio
+import base64
+import json
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock, PropertyMock, patch
 
+from aiohttp import ClientError, WSMsgType
+from jaraco.abode.exceptions import Exception as AbodeException
+import pytest
+from requests.exceptions import HTTPError
+from webrtc_models import RTCIceServer
+
+from homeassistant.components.abode.camera import (
+    KVS_SIGNALING_ACTION_ICE_CANDIDATE,
+    KVS_SIGNALING_ACTION_SDP_OFFER,
+    MEDIA_PLAYBACK_URL,
+    AbodeCamera,
+    _AbodeWebRTCSession,
+)
 from homeassistant.components.abode.const import DOMAIN
-from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, CameraState
+from homeassistant.components.camera import (
+    DOMAIN as CAMERA_DOMAIN,
+    CameraState,
+    RTCIceCandidateInit,
+    WebRTCAnswer,
+    WebRTCCandidate,
+    async_get_image,
+    async_get_stream_source,
+)
+from homeassistant.components.camera.helper import get_camera_from_entity_id
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
+
+
+def _kvs_signaling_message(message_type: str, payload: dict[str, str | int]) -> Any:
+    """Create a fake KVS signaling websocket text message."""
+    encoded_payload = base64.b64encode(json.dumps(payload).encode()).decode()
+    return SimpleNamespace(
+        type=WSMsgType.TEXT,
+        data=json.dumps(
+            {"messageType": message_type, "messagePayload": encoded_payload}
+        ),
+    )
+
+
+class _FakeWebSocket:
+    """Simple websocket stub for Abode WebRTC tests."""
+
+    def __init__(self, messages: list[Any] | None = None) -> None:
+        self._messages = messages or []
+        self._index = 0
+        self.sent_json: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        """Capture sent websocket JSON payloads."""
+        self.sent_json.append(payload)
+
+    async def receive(self) -> Any:
+        """Return queued websocket messages."""
+        await asyncio.sleep(0)
+        if self._index < len(self._messages):
+            msg = self._messages[self._index]
+            self._index += 1
+            return msg
+        return SimpleNamespace(type=WSMsgType.CLOSED, data=None)
+
+    async def close(self) -> None:
+        """Mark websocket closed."""
+        self.closed = True
+
+    def exception(self) -> None:
+        """Return websocket exception state."""
+        return None  # noqa: RET501
+
+
+class _FakeClientSession:
+    """Simple aiohttp client session stub for ws_connect."""
+
+    def __init__(self, ws: _FakeWebSocket) -> None:
+        self.ws = ws
+        self.connected_url: str | None = None
+
+    async def ws_connect(self, url: str) -> _FakeWebSocket:
+        """Return the fake websocket."""
+        self.connected_url = url
+        return self.ws
 
 
 async def test_entity_registry(
@@ -72,3 +156,723 @@ async def test_camera_off(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
         mock_capture.assert_called_once_with(True)
+
+
+async def test_camera_image_uses_snapshot_for_new_camera(hass: HomeAssistant) -> None:
+    """Test new Abode camera images are fetched via snapshot endpoint."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    image_bytes = b"snapshot-bytes"
+    snapshot_data_url = (
+        f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+    )
+
+    with (
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot",
+            return_value=True,
+        ) as mock_snapshot,
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot_data_url",
+            return_value=snapshot_data_url,
+        ) as mock_snapshot_data_url,
+        patch("jaraco.abode.devices.camera.Camera.refresh_image") as mock_refresh_image,
+        patch(
+            "homeassistant.components.abode.camera.requests.get"
+        ) as mock_requests_get,
+    ):
+        image = await async_get_image(hass, "camera.test_cam")
+
+    assert image.content == image_bytes
+    mock_snapshot.assert_called_once()
+    mock_snapshot_data_url.assert_called_once_with(get_snapshot=False)
+    mock_refresh_image.assert_not_called()
+    mock_requests_get.assert_not_called()
+
+
+async def test_camera_image_snapshot_fallback_to_timeline(hass: HomeAssistant) -> None:
+    """Test new camera falls back to timeline image flow if snapshot fails."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    response = Mock()
+    response.content = b"timeline-image"
+    response.raise_for_status.return_value = None
+
+    with (
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot",
+            return_value=False,
+        ) as mock_snapshot,
+        patch(
+            "jaraco.abode.devices.camera.Camera.refresh_image",
+            return_value=True,
+        ) as mock_refresh_image,
+        patch(
+            "jaraco.abode.devices.camera.Camera.image_url",
+            new_callable=PropertyMock,
+            return_value="https://example.com/image.jpg",
+        ),
+        patch(
+            "homeassistant.components.abode.camera.requests.get",
+            return_value=response,
+        ) as mock_requests_get,
+    ):
+        image = await async_get_image(hass, "camera.test_cam")
+
+    assert image.content == b"timeline-image"
+    mock_snapshot.assert_called_once()
+    mock_refresh_image.assert_called_once()
+    mock_requests_get.assert_called_once()
+
+
+async def test_snapshot_failure_keeps_last_snapshot_image(hass: HomeAssistant) -> None:
+    """Test snapshot failures keep last good snapshot image."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    image_bytes = b"snapshot-bytes"
+    snapshot_data_url = (
+        f"data:image/jpeg;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+    )
+
+    with (
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot",
+            side_effect=[True, False],
+        ) as mock_snapshot,
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot_data_url",
+            return_value=snapshot_data_url,
+        ),
+    ):
+        assert camera._refresh_snapshot_image() is True
+        assert camera._snapshot_image == image_bytes
+        assert camera._refresh_snapshot_image() is False
+
+    assert camera._snapshot_image == image_bytes
+    assert mock_snapshot.call_count == 2
+
+
+async def test_camera_stream_source_uses_hls_playback_url(hass: HomeAssistant) -> None:
+    """Test stream source is fetched from Abode playback URL endpoint."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    response = Mock()
+    response.json.return_value = {"playbackUrl": "https://example.com/live.m3u8"}
+
+    with (
+        patch("homeassistant.components.abode.camera.time.time", return_value=12345),
+        patch(
+            "jaraco.abode.client.Client.send_request", return_value=response
+        ) as mock_send,
+    ):
+        stream_source = await async_get_stream_source(hass, "camera.test_cam")
+
+    assert stream_source == "https://example.com/live.m3u8"
+    mock_send.assert_called_once_with(
+        "post",
+        MEDIA_PLAYBACK_URL,
+        data={
+            "cameraId": "XF:b0c5ba27592a",
+            "startTime": 12315,
+            "format": "hls",
+            "playbackMode": "LIVE_REPLAY",
+        },
+    )
+
+
+async def test_camera_stream_source_returns_none_without_playback_url(
+    hass: HomeAssistant,
+) -> None:
+    """Test stream source falls back to none when playback URL is not returned."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    response = Mock()
+    response.json.return_value = {}
+
+    with patch("jaraco.abode.client.Client.send_request", return_value=response):
+        stream_source = await async_get_stream_source(hass, "camera.test_cam")
+
+    assert stream_source is None
+
+
+async def test_camera_webrtc_client_config_uses_kvs_ice_servers(
+    hass: HomeAssistant,
+) -> None:
+    """Test WebRTC client configuration uses Abode-provided ICE servers."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    response = Mock()
+    response.json.return_value = {
+        "channelEndpoint": "wss://example.com/signaling",
+        "iceServers": [
+            {
+                "urls": ["stun:stun.kinesisvideo.us-east-1.amazonaws.com:443"],
+                "username": "user",
+                "credential": "pass",
+            }
+        ],
+    }
+
+    with patch("jaraco.abode.client.Client.send_request", return_value=response):
+        assert await camera._async_refresh_kvs_signaling_info() is not None
+
+    config = camera.async_get_webrtc_client_configuration().to_frontend_dict()
+    assert config["configuration"]["iceServers"][0] == {
+        "urls": ["stun:stun.kinesisvideo.us-east-1.amazonaws.com:443"],
+        "username": "user",
+        "credential": "pass",
+    }
+
+
+async def test_camera_webrtc_offer_sends_offer_and_receives_events(
+    hass: HomeAssistant,
+) -> None:
+    """Test WebRTC offer sends signaling offer and emits answer/candidate."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    response = Mock()
+    response.json.return_value = {
+        "channelEndpoint": "wss://example.com/signaling",
+        "iceServers": [],
+    }
+    ws = _FakeWebSocket(
+        [
+            _kvs_signaling_message("SDP_ANSWER", {"type": "answer", "sdp": "answer-sdp"}),
+            _kvs_signaling_message(
+                "ICE_CANDIDATE",
+                {
+                    "candidate": "candidate:0 1 UDP 2122252543 192.0.2.1 5000 typ host",
+                    "sdpMid": "0",
+                    "sdpMLineIndex": 0,
+                },
+            ),
+            SimpleNamespace(type=WSMsgType.CLOSED, data=None),
+        ]
+    )
+    session = _FakeClientSession(ws)
+    events: list[Any] = []
+
+    with (
+        patch("jaraco.abode.client.Client.send_request", return_value=response),
+        patch(
+            "homeassistant.components.abode.camera.async_get_clientsession",
+            return_value=session,
+        ),
+    ):
+        await camera.async_handle_async_webrtc_offer(
+            "offer-sdp",
+            "session-1",
+            events.append,
+        )
+        await hass.async_block_till_done()
+
+    assert session.connected_url == "wss://example.com/signaling"
+    assert ws.sent_json
+    assert ws.sent_json[0]["action"] == KVS_SIGNALING_ACTION_SDP_OFFER
+    sent_offer = json.loads(base64.b64decode(ws.sent_json[0]["messagePayload"]))
+    assert sent_offer == {"type": "offer", "sdp": "offer-sdp"}
+    assert any(isinstance(event, WebRTCAnswer) for event in events)
+    assert any(isinstance(event, WebRTCCandidate) for event in events)
+    assert "session-1" not in camera._webrtc_sessions
+
+
+async def test_camera_webrtc_candidate_sends_signaling_message(
+    hass: HomeAssistant,
+) -> None:
+    """Test WebRTC candidates are forwarded to KVS signaling websocket."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    ws = _FakeWebSocket()
+    camera._webrtc_sessions["session-candidate"] = _AbodeWebRTCSession(ws=ws)
+
+    await camera.async_on_webrtc_candidate(
+        "session-candidate",
+        RTCIceCandidateInit(
+            "candidate:0 1 UDP 2122252543 192.0.2.1 5000 typ host",
+            sdp_mid="0",
+            sdp_m_line_index=0,
+        ),
+    )
+
+    assert ws.sent_json
+    assert ws.sent_json[0]["action"] == KVS_SIGNALING_ACTION_ICE_CANDIDATE
+
+
+async def test_camera_webrtc_candidate_ignores_unknown_session(
+    hass: HomeAssistant,
+) -> None:
+    """Test unknown WebRTC candidate sessions are ignored."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    await camera.async_on_webrtc_candidate(
+        "unknown-session",
+        RTCIceCandidateInit(
+            "candidate:0 1 UDP 2122252543 192.0.2.1 5000 typ host",
+            sdp_mid="0",
+            sdp_m_line_index=0,
+        ),
+    )
+
+
+async def test_camera_refresh_image_handles_auth_error(hass: HomeAssistant) -> None:
+    """Test camera image refresh handles Abode auth errors without raising."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with (
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot",
+            return_value=False,
+        ),
+        patch(
+            "jaraco.abode.devices.camera.Camera.refresh_image",
+            side_effect=AbodeException((403, "forbidden")),
+        ),
+    ):
+        image = await hass.async_add_executor_job(camera.camera_image)
+
+    assert image is None
+
+
+async def test_camera_snapshot_refresh_handles_snapshot_error(hass: HomeAssistant) -> None:
+    """Test snapshot refresh returns False when snapshot request raises."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with patch(
+        "jaraco.abode.devices.camera.Camera.snapshot",
+        side_effect=AbodeException((403, "forbidden")),
+    ):
+        assert camera._refresh_snapshot_image() is False
+
+
+async def test_camera_snapshot_refresh_invalid_snapshot_format(
+    hass: HomeAssistant,
+) -> None:
+    """Test snapshot refresh handles malformed snapshot data url."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with (
+        patch("jaraco.abode.devices.camera.Camera.snapshot", return_value=True),
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot_data_url",
+            return_value="invalid-format",
+        ),
+    ):
+        assert camera._refresh_snapshot_image() is False
+
+
+async def test_camera_snapshot_refresh_invalid_base64(hass: HomeAssistant) -> None:
+    """Test snapshot refresh handles invalid base64 payloads."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with (
+        patch("jaraco.abode.devices.camera.Camera.snapshot", return_value=True),
+        patch(
+            "jaraco.abode.devices.camera.Camera.snapshot_data_url",
+            return_value="data:image/jpeg;base64,a",
+        ),
+    ):
+        assert camera._refresh_snapshot_image() is False
+
+
+async def test_camera_get_image_handles_http_error(hass: HomeAssistant) -> None:
+    """Test timeline image fetch handles HTTP errors."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    response = Mock()
+    response.raise_for_status.side_effect = HTTPError("boom")
+
+    with (
+        patch(
+            "jaraco.abode.devices.camera.Camera.image_url",
+            new_callable=PropertyMock,
+            return_value="https://example.com/image.jpg",
+        ),
+        patch(
+            "homeassistant.components.abode.camera.requests.get",
+            return_value=response,
+        ),
+    ):
+        camera.get_image()
+
+    assert camera._response is None
+
+
+async def test_camera_get_image_without_image_url(hass: HomeAssistant) -> None:
+    """Test timeline image fetch clears response when URL is missing."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._response = Mock()
+
+    with patch(
+        "jaraco.abode.devices.camera.Camera.image_url",
+        new_callable=PropertyMock,
+        return_value=None,
+    ):
+        camera.get_image()
+
+    assert camera._response is None
+
+
+async def test_camera_stream_source_handles_request_error(hass: HomeAssistant) -> None:
+    """Test stream source returns None when Abode request fails."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+
+    with patch(
+        "jaraco.abode.client.Client.send_request",
+        side_effect=AbodeException((500, "error")),
+    ):
+        stream_source = await async_get_stream_source(hass, "camera.test_cam")
+
+    assert stream_source is None
+
+
+async def test_camera_stream_source_returns_none_when_snapshot_not_supported(
+    hass: HomeAssistant,
+) -> None:
+    """Test stream_source returns None for non-snapshot cameras."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._supports_snapshot = False
+    assert await camera.stream_source() is None
+
+
+async def test_camera_refresh_kvs_signaling_info_uses_cache(
+    hass: HomeAssistant,
+) -> None:
+    """Test KVS signaling refresh uses cached endpoint/ICE servers."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._kvs_channel_endpoint = "wss://example.com/signaling"
+    camera._webrtc_ice_servers = [RTCIceServer(urls=["stun:example"])]
+    camera._kvs_signaling_last_refresh_monotonic = time.monotonic()
+
+    with patch.object(camera, "_get_kvs_signaling_info") as mock_refresh:
+        cached = await camera._async_refresh_kvs_signaling_info()
+
+    assert cached is not None
+    assert cached["channelEndpoint"] == "wss://example.com/signaling"
+    assert mock_refresh.call_count == 0
+
+
+async def test_camera_get_kvs_signaling_info_requires_channel_endpoint(
+    hass: HomeAssistant,
+) -> None:
+    """Test KVS signaling metadata requires a channel endpoint."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    response = Mock()
+    response.json.return_value = {}
+
+    with (
+        patch("jaraco.abode.client.Client.send_request", return_value=response),
+        pytest.raises(HomeAssistantError, match="Missing KVS channel endpoint"),
+    ):
+        camera._get_kvs_signaling_info()
+
+
+async def test_camera_get_kvs_signaling_info_requires_dict_response(
+    hass: HomeAssistant,
+) -> None:
+    """Test KVS signaling metadata requires JSON object response."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    response = Mock()
+    response.json.return_value = []
+
+    with (
+        patch("jaraco.abode.client.Client.send_request", return_value=response),
+        pytest.raises(HomeAssistantError, match="Invalid KVS signaling response"),
+    ):
+        camera._get_kvs_signaling_info()
+
+
+async def test_camera_async_refresh_kvs_signaling_info_handles_exception(
+    hass: HomeAssistant,
+) -> None:
+    """Test KVS signaling async refresh handles unexpected exceptions."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with patch.object(
+        camera,
+        "_get_kvs_signaling_info",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert await camera._async_refresh_kvs_signaling_info(force=True) is None
+
+
+def test_parse_ice_servers_handles_invalid_entries() -> None:
+    """Test ICE server parser skips invalid entries."""
+    assert AbodeCamera._parse_ice_servers("invalid") == []
+    parsed = AbodeCamera._parse_ice_servers(
+        [
+            1,
+            {"urls": 1},
+            {"urls": "stun:example"},
+            {"urls": ["turn:example"], "username": 1, "credential": 2},
+        ]
+    )
+    assert len(parsed) == 2
+    assert parsed[0].urls == "stun:example"
+    assert parsed[1].urls == ["turn:example"]
+    assert parsed[1].username is None
+    assert parsed[1].credential is None
+
+
+def test_decode_signaling_message_invalid_payloads() -> None:
+    """Test signaling decode returns None for malformed payloads."""
+    assert (
+        AbodeCamera._decode_signaling_message(
+            SimpleNamespace(type=WSMsgType.TEXT, data="not-json")
+        )
+        is None
+    )
+    encoded_list_payload = base64.b64encode(json.dumps(["not", "dict"]).encode()).decode()
+    assert (
+        AbodeCamera._decode_signaling_message(
+            SimpleNamespace(
+                type=WSMsgType.TEXT,
+                data=json.dumps(
+                    {"messageType": "SDP_ANSWER", "messagePayload": encoded_list_payload}
+                ),
+            )
+        )
+        is None
+    )
+
+
+def test_parse_remote_ice_candidate_fallback_and_invalid() -> None:
+    """Test remote ICE candidate parser fallback behavior."""
+    with patch(
+        "homeassistant.components.abode.camera.RTCIceCandidateInit.from_dict",
+        side_effect=ValueError("invalid"),
+    ):
+        candidate = AbodeCamera._parse_remote_ice_candidate(
+            {"candidate": "candidate-line", "sdpMid": 1, "sdpMLineIndex": "0"}
+        )
+
+    assert candidate is not None
+    assert candidate.candidate == "candidate-line"
+    assert candidate.sdp_mid is None
+    assert candidate.sdp_m_line_index == 0
+
+    with patch(
+        "homeassistant.components.abode.camera.RTCIceCandidateInit.from_dict",
+        side_effect=ValueError("invalid"),
+    ):
+        assert (
+            AbodeCamera._parse_remote_ice_candidate({"candidate": 1, "sdpMid": "0"})
+            is None
+        )
+
+
+async def test_listen_webrtc_messages_sends_error_event(hass: HomeAssistant) -> None:
+    """Test websocket error messages emit WebRTCError and cleanup session."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    ws = _FakeWebSocket([SimpleNamespace(type=WSMsgType.ERROR, data=None)])
+    camera._webrtc_sessions["session-error"] = _AbodeWebRTCSession(ws=ws)
+    events: list[Any] = []
+
+    await camera._async_listen_webrtc_messages("session-error", ws, events.append)
+
+    assert events
+    assert events[0].code == "webrtc_signaling_error"
+    assert "session-error" not in camera._webrtc_sessions
+
+
+async def test_listen_webrtc_messages_ignores_non_text(hass: HomeAssistant) -> None:
+    """Test websocket non-text signaling messages are ignored."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    ws = _FakeWebSocket(
+        [
+            SimpleNamespace(type=WSMsgType.BINARY, data=b"1"),
+            SimpleNamespace(type=WSMsgType.CLOSED, data=None),
+        ]
+    )
+    camera._webrtc_sessions["session-binary"] = _AbodeWebRTCSession(ws=ws)
+    events: list[Any] = []
+
+    await camera._async_listen_webrtc_messages("session-binary", ws, events.append)
+
+    assert events == []
+    assert "session-binary" not in camera._webrtc_sessions
+
+
+async def test_close_webrtc_session_without_active_session(hass: HomeAssistant) -> None:
+    """Test closing unknown WebRTC session is a no-op."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    await camera._async_close_webrtc_session("missing-session")
+
+
+async def test_close_webrtc_session_cancels_listener_task(hass: HomeAssistant) -> None:
+    """Test closing WebRTC session cancels listener task."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    ws = _FakeWebSocket()
+    listener_task = hass.async_create_task(asyncio.sleep(10))
+    camera._webrtc_sessions["session-cancel"] = _AbodeWebRTCSession(
+        ws=ws, listener_task=listener_task
+    )
+
+    await camera._async_close_webrtc_session("session-cancel")
+
+    assert listener_task.cancelled()
+    assert ws.closed
+
+
+async def test_camera_webrtc_offer_requires_supported_camera(
+    hass: HomeAssistant,
+) -> None:
+    """Test unsupported cameras reject WebRTC offers."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._supports_snapshot = False
+
+    with pytest.raises(HomeAssistantError, match="does not support WebRTC"):
+        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+
+
+async def test_camera_webrtc_offer_fails_when_refresh_fails_and_no_endpoint(
+    hass: HomeAssistant,
+) -> None:
+    """Test offer fails when signaling refresh fails without cached endpoint."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._kvs_channel_endpoint = None
+
+    with (
+        patch.object(camera, "_async_refresh_kvs_signaling_info", return_value=None),
+        pytest.raises(
+            HomeAssistantError, match="Failed to refresh Abode WebRTC signaling info"
+        ),
+    ):
+        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+
+
+async def test_camera_webrtc_offer_fails_without_channel_endpoint(
+    hass: HomeAssistant,
+) -> None:
+    """Test offer fails when no channel endpoint is available."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._kvs_channel_endpoint = None
+
+    with (
+        patch.object(camera, "_kvs_signaling_is_fresh", return_value=True),
+        pytest.raises(HomeAssistantError, match="Missing Abode WebRTC channel endpoint"),
+    ):
+        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+
+
+async def test_camera_webrtc_offer_fails_when_ws_connect_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test offer fails when signaling websocket cannot be opened."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._kvs_channel_endpoint = "wss://example.com/signaling"
+    session = Mock()
+    session.ws_connect.side_effect = ClientError("connect-failed")
+
+    with (
+        patch.object(camera, "_kvs_signaling_is_fresh", return_value=True),
+        patch(
+            "homeassistant.components.abode.camera.async_get_clientsession",
+            return_value=session,
+        ),
+        pytest.raises(
+            HomeAssistantError, match="Failed to connect to Abode WebRTC signaling endpoint"
+        ),
+    ):
+        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-1", list.append)
+
+
+async def test_camera_webrtc_offer_fails_when_offer_send_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Test offer send failures cleanup the WebRTC session."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    camera._kvs_channel_endpoint = "wss://example.com/signaling"
+    ws = _FakeWebSocket()
+
+    async def _raise_send_json(payload: dict[str, Any]) -> None:
+        raise ClientError("send-failed")
+
+    ws.send_json = _raise_send_json  # type: ignore[method-assign]
+    session = _FakeClientSession(ws)
+
+    with (
+        patch.object(camera, "_kvs_signaling_is_fresh", return_value=True),
+        patch(
+            "homeassistant.components.abode.camera.async_get_clientsession",
+            return_value=session,
+        ),
+        pytest.raises(HomeAssistantError, match="Failed to send WebRTC offer"),
+    ):
+        await camera.async_handle_async_webrtc_offer("offer-sdp", "session-send-fail", list.append)
+
+    assert "session-send-fail" not in camera._webrtc_sessions
+
+
+async def test_camera_webrtc_candidate_send_failure_raises(hass: HomeAssistant) -> None:
+    """Test candidate send failures are surfaced."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+    ws = _FakeWebSocket()
+
+    async def _raise_send_json(payload: dict[str, Any]) -> None:
+        raise ClientError("send-failed")
+
+    ws.send_json = _raise_send_json  # type: ignore[method-assign]
+    camera._webrtc_sessions["session-candidate-fail"] = _AbodeWebRTCSession(ws=ws)
+
+    with pytest.raises(HomeAssistantError, match="Failed to send WebRTC candidate"):
+        await camera.async_on_webrtc_candidate(
+            "session-candidate-fail",
+            RTCIceCandidateInit(
+                "candidate:0 1 UDP 2122252543 192.0.2.1 5000 typ host",
+                sdp_mid="0",
+                sdp_m_line_index=0,
+            ),
+        )
+
+
+async def test_camera_capture_callback_updates_state(hass: HomeAssistant) -> None:
+    """Test capture callback updates image location and schedules state update."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with (
+        patch.object(camera._device, "update_image_location") as mock_update_image_location,
+        patch.object(camera, "get_image") as mock_get_image,
+        patch.object(camera, "schedule_update_ha_state") as mock_schedule_update,
+    ):
+        camera._capture_callback({"id": "capture-id"})
+
+    mock_update_image_location.assert_called_once_with({"id": "capture-id"})
+    mock_get_image.assert_called_once()
+    mock_schedule_update.assert_called_once()
+
+
+async def test_camera_is_on_property(hass: HomeAssistant) -> None:
+    """Test is_on property forwards device value."""
+    await setup_platform(hass, CAMERA_DOMAIN)
+    camera = cast(AbodeCamera, get_camera_from_entity_id(hass, "camera.test_cam"))
+
+    with patch(
+        "jaraco.abode.devices.camera.Camera.is_on",
+        new_callable=PropertyMock,
+        return_value=True,
+    ):
+        assert camera.is_on is True

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -638,6 +638,12 @@ def test_decode_signaling_message_invalid_payloads() -> None:
         )
         is None
     )
+    assert (
+        AbodeCamera._decode_signaling_message(
+            SimpleNamespace(type=WSMsgType.TEXT, data=json.dumps(["not", "dict"]))
+        )
+        is None
+    )
     encoded_list_payload = base64.b64encode(
         json.dumps(["not", "dict"]).encode()
     ).decode()
@@ -664,13 +670,13 @@ def test_parse_remote_ice_candidate_fallback_and_invalid() -> None:
         side_effect=ValueError("invalid"),
     ):
         candidate = AbodeCamera._parse_remote_ice_candidate(
-            {"candidate": "candidate-line", "sdpMid": 1, "sdpMLineIndex": "0"}
+            {"candidate": "candidate-line", "sdpMid": 1, "sdpMLineIndex": "3"}
         )
 
     assert candidate is not None
     assert candidate.candidate == "candidate-line"
     assert candidate.sdp_mid is None
-    assert candidate.sdp_m_line_index == 0
+    assert candidate.sdp_m_line_index == 3
 
     with patch(
         "homeassistant.components.abode.camera.RTCIceCandidateInit.from_dict",


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
This PR adds native WebRTC streaming support for Abode Cam 2 (AC2) and other KVS-capable Abode cameras in Home Assistant.

What is included:
- Add native WebRTC signaling in the Abode camera entity using Abode KVS signaling (`/integrations/v1/camera/{camera_id}/kvs/stream`).
- Keep existing stream source support (`/integrations/v1/media/getPlaybackUrl`) for HLS fallback.
- Improve runtime resilience for camera image refresh paths:
  - Catch Abode auth/API exceptions during snapshot and timeline refresh attempts.
  - Avoid user-facing unknown-session noise by safely ignoring out-of-order ICE candidates.
  - Cache KVS signaling metadata briefly to reduce repeated signaling metadata calls.
- Add comprehensive tests for:
  - WebRTC offer/candidate flow and websocket signaling behavior
  - ICE/signaling payload parsing edge cases
  - Signaling cache behavior
  - Failure paths (snapshot/timeline/WebRTC connect/send errors)

This contribution is submitted from the official Abode Systems account.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #98367
- This PR is related to issue: #69635
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

### Local validation
- `PATH=".venv/bin:$PATH" .venv/bin/python -m script.hassfest --action validate --integration-path homeassistant/components/abode`
- `.venv/bin/ruff check homeassistant/components/abode/camera.py tests/components/abode/test_camera.py`
- `.venv/bin/mypy homeassistant/components/abode`
- `.venv/bin/pytest tests/components/abode/test_camera.py --cov=homeassistant.components.abode.camera --cov-report=term-missing -q`
- `.venv/bin/pytest tests/components/abode -q --maxfail=1`
