### PR TITLE
Add event entity to Transmission

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -40,7 +40,7 @@ from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.EVENT, Platform.SENSOR, Platform.SWITCH]
 
 MIGRATION_NAME_TO_KEY = {
     # Sensors

--- a/homeassistant/components/transmission/const.py
+++ b/homeassistant/components/transmission/const.py
@@ -55,6 +55,10 @@ EVENT_STARTED_TORRENT = "transmission_started_torrent"
 EVENT_REMOVED_TORRENT = "transmission_removed_torrent"
 EVENT_DOWNLOADED_TORRENT = "transmission_downloaded_torrent"
 
+EVENT_TYPE_STARTED = "started"
+EVENT_TYPE_REMOVED = "removed"
+EVENT_TYPE_DOWNLOADED = "downloaded"
+
 STATE_UP_DOWN = "up_down"
 STATE_SEEDING = "seeding"
 STATE_DOWNLOADING = "downloading"

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -105,7 +105,13 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""
-        return await self.hass.async_add_executor_job(self.update)
+        data = await self.hass.async_add_executor_job(self.update)
+
+        self.check_completed_torrent()
+        self.check_started_torrent()
+        self.check_removed_torrent()
+
+        return data
 
     def update(self) -> SessionStats:
         """Get the latest data from Transmission instance."""
@@ -116,10 +122,6 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
             self.port_forwarding = self.api.port_test()
         except transmission_rpc.TransmissionError as err:
             raise UpdateFailed("Unable to connect to Transmission client") from err
-
-        self.check_completed_torrent()
-        self.check_started_torrent()
-        self.check_removed_torrent()
 
         return data
 
@@ -159,9 +161,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self.hass.loop.call_soon_threadsafe(
-                    self._async_notify_event_listeners, event
-                )
+                self._async_notify_event_listeners(event)
 
         self._completed_torrents = current_completed_torrents
 
@@ -191,9 +191,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self.hass.loop.call_soon_threadsafe(
-                    self._async_notify_event_listeners, event
-                )
+                self._async_notify_event_listeners(event)
 
         self._started_torrents = current_started_torrents
 
@@ -219,9 +217,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     download_path=torrent.download_dir or "",
                     labels=torrent.labels,
                 )
-                self.hass.loop.call_soon_threadsafe(
-                    self._async_notify_event_listeners, event
-                )
+                self._async_notify_event_listeners(event)
 
         self._all_torrents = self.torrents.copy()
 

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -145,7 +145,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
-                self.hass.bus.fire(
+                self.hass.bus.async_fire(
                     EVENT_DOWNLOADED_TORRENT,
                     {
                         ATTR_NAME: torrent.name,
@@ -175,7 +175,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
-                self.hass.bus.fire(
+                self.hass.bus.async_fire(
                     EVENT_STARTED_TORRENT,
                     {
                         ATTR_NAME: torrent.name,
@@ -201,7 +201,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
-                self.hass.bus.fire(
+                self.hass.bus.async_fire(
                     EVENT_REMOVED_TORRENT,
                     {
                         ATTR_NAME: torrent.name,

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -101,7 +101,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     def _async_notify_event_listeners(self, event: TransmissionEventData) -> None:
         """Notify event listeners in the event loop."""
         for listener in self._event_listeners.values():
-            self.hass.add_job(listener, event)
+            listener(event)
 
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -28,6 +28,9 @@ from .const import (
     EVENT_DOWNLOADED_TORRENT,
     EVENT_REMOVED_TORRENT,
     EVENT_STARTED_TORRENT,
+    EVENT_TYPE_DOWNLOADED,
+    EVENT_TYPE_REMOVED,
+    EVENT_TYPE_STARTED,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -145,6 +148,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_completed_torrents:
             if torrent.id not in old_completed_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_DOWNLOADED_TORRENT,
                     {
@@ -155,7 +159,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     },
                 )
                 event = TransmissionEventData(
-                    event_type=EVENT_DOWNLOADED_TORRENT,
+                    event_type=EVENT_TYPE_DOWNLOADED,
                     name=torrent.name,
                     id=torrent.id,
                     download_path=torrent.download_dir or "",
@@ -175,6 +179,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in current_started_torrents:
             if torrent.id not in old_started_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_STARTED_TORRENT,
                     {
@@ -185,7 +190,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     },
                 )
                 event = TransmissionEventData(
-                    event_type=EVENT_STARTED_TORRENT,
+                    event_type=EVENT_TYPE_STARTED,
                     name=torrent.name,
                     id=torrent.id,
                     download_path=torrent.download_dir or "",
@@ -201,6 +206,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
 
         for torrent in self._all_torrents:
             if torrent.id not in current_torrents:
+                # Once event triggers are out of labs we can remove the bus event
                 self.hass.bus.async_fire(
                     EVENT_REMOVED_TORRENT,
                     {
@@ -211,7 +217,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                     },
                 )
                 event = TransmissionEventData(
-                    event_type=EVENT_REMOVED_TORRENT,
+                    event_type=EVENT_TYPE_REMOVED,
                     name=torrent.name,
                     id=torrent.id,
                     download_path=torrent.download_dir or "",

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -97,6 +97,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     def __async_remove_listener_internal(self, listener_id: str) -> None:
         del self._event_listeners[listener_id]
 
+    @callback
+    def _async_notify_event_listeners(self, event: TransmissionEventData) -> None:
+        """Notify event listeners in the event loop."""
+        for listener in self._event_listeners.values():
+            self.hass.add_job(listener, event)
+
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""
         return await self.hass.async_add_executor_job(self.update)
@@ -146,16 +152,16 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         ATTR_LABELS: torrent.labels,
                     },
                 )
-
-                for listener in self._event_listeners.values():
-                    event = TransmissionEventData(
-                        event_type=EVENT_DOWNLOADED_TORRENT,
-                        name=torrent.name,
-                        id=torrent.id,
-                        download_path=torrent.download_dir or "",
-                        labels=torrent.labels,
-                    )
-                    self.hass.add_job(listener, event)
+                event = TransmissionEventData(
+                    event_type=EVENT_DOWNLOADED_TORRENT,
+                    name=torrent.name,
+                    id=torrent.id,
+                    download_path=torrent.download_dir or "",
+                    labels=torrent.labels,
+                )
+                self.hass.loop.call_soon_threadsafe(
+                    self._async_notify_event_listeners, event
+                )
 
         self._completed_torrents = current_completed_torrents
 
@@ -178,16 +184,16 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         ATTR_LABELS: torrent.labels,
                     },
                 )
-
-                for listener in self._event_listeners.values():
-                    event = TransmissionEventData(
-                        event_type=EVENT_STARTED_TORRENT,
-                        name=torrent.name,
-                        id=torrent.id,
-                        download_path=torrent.download_dir or "",
-                        labels=torrent.labels,
-                    )
-                    self.hass.add_job(listener, event)
+                event = TransmissionEventData(
+                    event_type=EVENT_STARTED_TORRENT,
+                    name=torrent.name,
+                    id=torrent.id,
+                    download_path=torrent.download_dir or "",
+                    labels=torrent.labels,
+                )
+                self.hass.loop.call_soon_threadsafe(
+                    self._async_notify_event_listeners, event
+                )
 
         self._started_torrents = current_started_torrents
 
@@ -206,16 +212,16 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                         ATTR_LABELS: torrent.labels,
                     },
                 )
-
-                for listener in self._event_listeners.values():
-                    event = TransmissionEventData(
-                        event_type=EVENT_REMOVED_TORRENT,
-                        name=torrent.name,
-                        id=torrent.id,
-                        download_path=torrent.download_dir or "",
-                        labels=torrent.labels,
-                    )
-                    self.hass.add_job(listener, event)
+                event = TransmissionEventData(
+                    event_type=EVENT_REMOVED_TORRENT,
+                    name=torrent.name,
+                    id=torrent.id,
+                    download_path=torrent.download_dir or "",
+                    labels=torrent.labels,
+                )
+                self.hass.loop.call_soon_threadsafe(
+                    self._async_notify_event_listeners, event
+                )
 
         self._all_torrents = self.torrents.copy()
 

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -98,12 +98,12 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         return partial(self.__async_remove_listener_internal, target_event_id)
 
     def __async_remove_listener_internal(self, listener_id: str) -> None:
-        del self._event_listeners[listener_id]
+        self._event_listeners.pop(listener_id, None)
 
     @callback
     def _async_notify_event_listeners(self, event: TransmissionEventData) -> None:
         """Notify event listeners in the event loop."""
-        for listener in self._event_listeners.values():
+        for listener in list(self._event_listeners.values()):
             listener(event)
 
     async def _async_update_data(self) -> SessionStats:

--- a/homeassistant/components/transmission/coordinator.py
+++ b/homeassistant/components/transmission/coordinator.py
@@ -1,19 +1,24 @@
-"""Coordinator for transmssion integration."""
+"""Coordinator for transmission integration."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import timedelta
+from functools import partial
 import logging
 
 import transmission_rpc
 from transmission_rpc.session import SessionStats
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_ID, ATTR_NAME, CONF_HOST
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    ATTR_DOWNLOAD_PATH,
+    ATTR_LABELS,
     CONF_LIMIT,
     CONF_ORDER,
     DEFAULT_LIMIT,
@@ -27,7 +32,19 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+type EventCallback = Callable[[TransmissionEventData], None]
 type TransmissionConfigEntry = ConfigEntry[TransmissionDataUpdateCoordinator]
+
+
+@dataclass
+class TransmissionEventData:
+    """Data for a single event."""
+
+    event_type: str
+    name: str
+    id: int
+    download_path: str
+    labels: list[str]
 
 
 class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
@@ -49,6 +66,7 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
         self._all_torrents: list[transmission_rpc.Torrent] = []
         self._completed_torrents: list[transmission_rpc.Torrent] = []
         self._started_torrents: list[transmission_rpc.Torrent] = []
+        self._event_listeners: dict[str, EventCallback] = {}
         self.torrents: list[transmission_rpc.Torrent] = []
         super().__init__(
             hass,
@@ -67,6 +85,17 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
     def order(self) -> str:
         """Return order."""
         return self.config_entry.options.get(CONF_ORDER, DEFAULT_ORDER)  # type: ignore[no-any-return]
+
+    @callback
+    def async_add_event_listener(
+        self, update_callback: EventCallback, target_event_id: str
+    ) -> Callable[[], None]:
+        """Listen for updates."""
+        self._event_listeners[target_event_id] = update_callback
+        return partial(self.__async_remove_listener_internal, target_event_id)
+
+    def __async_remove_listener_internal(self, listener_id: str) -> None:
+        del self._event_listeners[listener_id]
 
     async def _async_update_data(self) -> SessionStats:
         """Update transmission data."""
@@ -111,12 +140,22 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                 self.hass.bus.fire(
                     EVENT_DOWNLOADED_TORRENT,
                     {
-                        "name": torrent.name,
-                        "id": torrent.id,
-                        "download_path": torrent.download_dir,
-                        "labels": torrent.labels,
+                        ATTR_NAME: torrent.name,
+                        ATTR_ID: torrent.id,
+                        ATTR_DOWNLOAD_PATH: torrent.download_dir,
+                        ATTR_LABELS: torrent.labels,
                     },
                 )
+
+                for listener in self._event_listeners.values():
+                    event = TransmissionEventData(
+                        event_type=EVENT_DOWNLOADED_TORRENT,
+                        name=torrent.name,
+                        id=torrent.id,
+                        download_path=torrent.download_dir or "",
+                        labels=torrent.labels,
+                    )
+                    self.hass.add_job(listener, event)
 
         self._completed_torrents = current_completed_torrents
 
@@ -133,12 +172,22 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                 self.hass.bus.fire(
                     EVENT_STARTED_TORRENT,
                     {
-                        "name": torrent.name,
-                        "id": torrent.id,
-                        "download_path": torrent.download_dir,
-                        "labels": torrent.labels,
+                        ATTR_NAME: torrent.name,
+                        ATTR_ID: torrent.id,
+                        ATTR_DOWNLOAD_PATH: torrent.download_dir,
+                        ATTR_LABELS: torrent.labels,
                     },
                 )
+
+                for listener in self._event_listeners.values():
+                    event = TransmissionEventData(
+                        event_type=EVENT_STARTED_TORRENT,
+                        name=torrent.name,
+                        id=torrent.id,
+                        download_path=torrent.download_dir or "",
+                        labels=torrent.labels,
+                    )
+                    self.hass.add_job(listener, event)
 
         self._started_torrents = current_started_torrents
 
@@ -151,12 +200,22 @@ class TransmissionDataUpdateCoordinator(DataUpdateCoordinator[SessionStats]):
                 self.hass.bus.fire(
                     EVENT_REMOVED_TORRENT,
                     {
-                        "name": torrent.name,
-                        "id": torrent.id,
-                        "download_path": torrent.download_dir,
-                        "labels": torrent.labels,
+                        ATTR_NAME: torrent.name,
+                        ATTR_ID: torrent.id,
+                        ATTR_DOWNLOAD_PATH: torrent.download_dir,
+                        ATTR_LABELS: torrent.labels,
                     },
                 )
+
+                for listener in self._event_listeners.values():
+                    event = TransmissionEventData(
+                        event_type=EVENT_REMOVED_TORRENT,
+                        name=torrent.name,
+                        id=torrent.id,
+                        download_path=torrent.download_dir or "",
+                        labels=torrent.labels,
+                    )
+                    self.hass.add_job(listener, event)
 
         self._all_torrents = self.torrents.copy()
 

--- a/homeassistant/components/transmission/event.py
+++ b/homeassistant/components/transmission/event.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from homeassistant.components.event import EventEntity, EventEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -17,7 +17,7 @@ from .const import (
     EVENT_REMOVED_TORRENT,
     EVENT_STARTED_TORRENT,
 )
-from .coordinator import TransmissionEventData
+from .coordinator import TransmissionConfigEntry, TransmissionEventData
 from .entity import TransmissionEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,7 +27,7 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TransmissionConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Transmission event platform."""
@@ -49,13 +49,12 @@ async def async_setup_entry(
 class TransmissionEvent(TransmissionEntity, EventEntity):
     """Representation of a Transmission event entity."""
 
-    _attr_should_poll = False
-
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await super().async_added_to_hass()
 
-        assert self._attr_unique_id
+        if TYPE_CHECKING:
+            assert self._attr_unique_id
 
         self.async_on_remove(
             self.coordinator.async_add_event_listener(

--- a/homeassistant/components/transmission/event.py
+++ b/homeassistant/components/transmission/event.py
@@ -1,0 +1,86 @@
+"""Define events for the Transmission integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ID, ATTR_NAME
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import (
+    ATTR_DOWNLOAD_PATH,
+    ATTR_LABELS,
+    EVENT_DOWNLOADED_TORRENT,
+    EVENT_REMOVED_TORRENT,
+    EVENT_STARTED_TORRENT,
+)
+from .coordinator import TransmissionEventData
+from .entity import TransmissionEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Transmission event platform."""
+    coordinator = config_entry.runtime_data
+
+    description = EventEntityDescription(
+        key="torrent",
+        translation_key="torrent",
+        event_types=[
+            EVENT_STARTED_TORRENT,
+            EVENT_DOWNLOADED_TORRENT,
+            EVENT_REMOVED_TORRENT,
+        ],
+    )
+
+    async_add_entities([TransmissionEvent(coordinator, description)])
+
+
+class TransmissionEvent(TransmissionEntity, EventEntity):
+    """Representation of a Transmission event entity."""
+
+    _attr_should_poll = False
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+
+        assert self._attr_unique_id
+
+        self.async_on_remove(
+            self.coordinator.async_add_event_listener(
+                self._handle_event, self._attr_unique_id
+            )
+        )
+
+    @callback
+    def _handle_event(self, event_data: TransmissionEventData) -> None:
+        """Handle the torrent events."""
+
+        event_type = event_data.event_type
+
+        if event_type not in self.event_types:
+            _LOGGER.warning("Event type %s is not known", event_type)
+            return
+
+        self._trigger_event(
+            event_type,
+            {
+                ATTR_NAME: event_data.name,
+                ATTR_ID: event_data.id,
+                ATTR_DOWNLOAD_PATH: event_data.download_path,
+                ATTR_LABELS: event_data.labels,
+            },
+        )
+
+        self.async_write_ha_state()

--- a/homeassistant/components/transmission/event.py
+++ b/homeassistant/components/transmission/event.py
@@ -13,9 +13,9 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .const import (
     ATTR_DOWNLOAD_PATH,
     ATTR_LABELS,
-    EVENT_DOWNLOADED_TORRENT,
-    EVENT_REMOVED_TORRENT,
-    EVENT_STARTED_TORRENT,
+    EVENT_TYPE_DOWNLOADED,
+    EVENT_TYPE_REMOVED,
+    EVENT_TYPE_STARTED,
 )
 from .coordinator import TransmissionConfigEntry, TransmissionEventData
 from .entity import TransmissionEntity
@@ -37,9 +37,9 @@ async def async_setup_entry(
         key="torrent",
         translation_key="torrent",
         event_types=[
-            EVENT_STARTED_TORRENT,
-            EVENT_DOWNLOADED_TORRENT,
-            EVENT_REMOVED_TORRENT,
+            EVENT_TYPE_STARTED,
+            EVENT_TYPE_DOWNLOADED,
+            EVENT_TYPE_REMOVED,
         ],
     )
 

--- a/homeassistant/components/transmission/icons.json
+++ b/homeassistant/components/transmission/icons.json
@@ -8,6 +8,11 @@
         }
       }
     },
+    "event": {
+      "torrent": {
+        "default": "mdi:folder-file-outline"
+      }
+    },
     "sensor": {
       "active_torrents": {
         "default": "mdi:counter"

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -56,9 +56,9 @@
         "state_attributes": {
           "event_type": {
             "state": {
-              "transmission_downloaded_torrent": "Downloaded",
-              "transmission_removed_torrent": "Removed",
-              "transmission_started_torrent": "Started"
+              "downloaded": "Downloaded",
+              "removed": "Removed",
+              "started": "Started"
             }
           }
         }

--- a/homeassistant/components/transmission/strings.json
+++ b/homeassistant/components/transmission/strings.json
@@ -50,6 +50,20 @@
         }
       }
     },
+    "event": {
+      "torrent": {
+        "name": "Torrent",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "transmission_downloaded_torrent": "Downloaded",
+              "transmission_removed_torrent": "Removed",
+              "transmission_started_torrent": "Started"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "active_torrents": {
         "name": "Active torrents",

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -1,14 +1,12 @@
 """Tests for the Transmission event platform."""
 
 from datetime import timedelta
-import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components import event as event_component
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.components.transmission.const import (
     DEFAULT_SCAN_INTERVAL,
@@ -102,50 +100,3 @@ async def test_event_updates_state(
     assert state.attributes["download_path"] == "/downloads"
     assert state.attributes["labels"] == []
     assert dt_util.parse_datetime(state.state) is not None
-
-
-async def test_unknown_event_ignored(
-    hass: HomeAssistant,
-    mock_transmission_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test an unknown event does not update the entity state and logs."""
-    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
-        await setup_integration(hass, mock_config_entry)
-
-    initial_state = hass.states.get("event.transmission_torrent")
-    assert initial_state is not None
-
-    coordinator = mock_config_entry.runtime_data
-    component = hass.data[event_component.DATA_COMPONENT]
-    entity = component.get_entity("event.transmission_torrent")
-    assert entity is not None
-    coordinator.async_add_event_listener(entity._handle_event, entity.unique_id)
-
-    caplog.set_level(logging.WARNING, "homeassistant.components.transmission.event")
-
-    client = mock_transmission_client.return_value
-    torrent = SimpleNamespace(
-        id=2,
-        name="Unknown",
-        status="downloading",
-        download_dir="/downloads",
-        labels=[],
-    )
-    client.get_torrents.side_effect = [[torrent]]
-
-    with patch(
-        "homeassistant.components.transmission.coordinator.EVENT_TYPE_STARTED",
-        "transmission_unknown_event",
-    ):
-        await coordinator.async_refresh()
-        await hass.async_block_till_done()
-
-    await hass.async_block_till_done()
-
-    state = hass.states.get("event.transmission_torrent")
-    assert state is not None
-    assert state.state == initial_state.state
-    assert state.attributes[ATTR_EVENT_TYPE] is None
-    assert "Event type transmission_unknown_event is not known" in caplog.text

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -1,0 +1,151 @@
+"""Tests for the Transmission event platform."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components import event as event_component
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
+from homeassistant.components.transmission.const import (
+    EVENT_DOWNLOADED_TORRENT,
+    EVENT_REMOVED_TORRENT,
+    EVENT_STARTED_TORRENT,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_event_entity_setup(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the event entity is created with expected capabilities."""
+    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
+        await setup_integration(hass, mock_config_entry)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("event.transmission_torrent")
+    assert state is not None
+    assert state.state == "unknown"
+    assert state.attributes[ATTR_EVENT_TYPE] is None
+    assert state.attributes[ATTR_EVENT_TYPES] == [
+        EVENT_STARTED_TORRENT,
+        EVENT_DOWNLOADED_TORRENT,
+        EVENT_REMOVED_TORRENT,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("hass_event", "expected_event_type"),
+    [
+        (EVENT_STARTED_TORRENT, EVENT_STARTED_TORRENT),
+        (EVENT_DOWNLOADED_TORRENT, EVENT_DOWNLOADED_TORRENT),
+        (EVENT_REMOVED_TORRENT, EVENT_REMOVED_TORRENT),
+    ],
+)
+async def test_event_updates_state(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_event: str,
+    expected_event_type: str,
+) -> None:
+    """Test Transmission events update the entity state and attributes."""
+    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
+        await setup_integration(hass, mock_config_entry)
+        await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    component = hass.data[event_component.DATA_COMPONENT]
+    entity = component.get_entity("event.transmission_torrent")
+    assert entity is not None
+
+    client = mock_transmission_client.return_value
+    torrent_status = {
+        EVENT_STARTED_TORRENT: "downloading",
+        EVENT_DOWNLOADED_TORRENT: "seeding",
+        EVENT_REMOVED_TORRENT: "stopped",
+    }[hass_event]
+    torrent = SimpleNamespace(
+        id=1,
+        name="Test",
+        status=torrent_status,
+        download_dir="/downloads",
+        labels=[],
+    )
+
+    torrents_sequence = {
+        EVENT_STARTED_TORRENT: [[torrent]],
+        EVENT_DOWNLOADED_TORRENT: [[torrent]],
+        EVENT_REMOVED_TORRENT: [[torrent], []],
+    }[hass_event]
+
+    client.get_torrents.side_effect = torrents_sequence
+
+    for _ in torrents_sequence:
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    state = hass.states.get("event.transmission_torrent")
+    assert state is not None
+    assert state.attributes[ATTR_EVENT_TYPE] == expected_event_type
+    assert state.attributes["id"] == 1
+    assert state.attributes["name"] == "Test"
+    assert state.attributes["download_path"] == "/downloads"
+    assert state.attributes["labels"] == []
+    assert dt_util.parse_datetime(state.state) is not None
+
+
+async def test_unknown_event_ignored(
+    hass: HomeAssistant,
+    mock_transmission_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an unknown event does not update the entity state and logs."""
+    with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
+        await setup_integration(hass, mock_config_entry)
+
+    initial_state = hass.states.get("event.transmission_torrent")
+    assert initial_state is not None
+
+    coordinator = mock_config_entry.runtime_data
+    component = hass.data[event_component.DATA_COMPONENT]
+    entity = component.get_entity("event.transmission_torrent")
+    assert entity is not None
+    coordinator.async_add_event_listener(entity._handle_event, entity.unique_id)
+
+    caplog.set_level(logging.WARNING, "homeassistant.components.transmission.event")
+
+    client = mock_transmission_client.return_value
+    torrent = SimpleNamespace(
+        id=2,
+        name="Unknown",
+        status="downloading",
+        download_dir="/downloads",
+        labels=[],
+    )
+    client.get_torrents.side_effect = [[torrent]]
+
+    with patch(
+        "homeassistant.components.transmission.coordinator.EVENT_STARTED_TORRENT",
+        "transmission_unknown_event",
+    ):
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("event.transmission_torrent")
+    assert state is not None
+    assert state.state == initial_state.state
+    assert state.attributes[ATTR_EVENT_TYPE] is None
+    assert "Event type transmission_unknown_event is not known" in caplog.text

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -1,14 +1,17 @@
 """Tests for the Transmission event platform."""
 
+from datetime import timedelta
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import event as event_component
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.components.transmission.const import (
+    DEFAULT_SCAN_INTERVAL,
     EVENT_DOWNLOADED_TORRENT,
     EVENT_REMOVED_TORRENT,
     EVENT_STARTED_TORRENT,
@@ -19,7 +22,7 @@ from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_event_entity_setup(
@@ -55,6 +58,7 @@ async def test_event_updates_state(
     hass: HomeAssistant,
     mock_transmission_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
     hass_event: str,
     expected_event_type: str,
 ) -> None:
@@ -62,11 +66,6 @@ async def test_event_updates_state(
     with patch("homeassistant.components.transmission.PLATFORMS", [Platform.EVENT]):
         await setup_integration(hass, mock_config_entry)
         await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    component = hass.data[event_component.DATA_COMPONENT]
-    entity = component.get_entity("event.transmission_torrent")
-    assert entity is not None
 
     client = mock_transmission_client.return_value
     torrent_status = {
@@ -91,8 +90,12 @@ async def test_event_updates_state(
     client.get_torrents.side_effect = torrents_sequence
 
     for _ in torrents_sequence:
-        await coordinator.async_refresh()
-        await hass.async_block_till_done()
+        freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1),
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("event.transmission_torrent")
     assert state is not None

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -91,10 +91,7 @@ async def test_event_updates_state(
 
     for _ in torrents_sequence:
         freezer.tick(timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1))
-        async_fire_time_changed(
-            hass,
-            dt_util.utcnow() + timedelta(seconds=DEFAULT_SCAN_INTERVAL + 1),
-        )
+        async_fire_time_changed(hass)
         await hass.async_block_till_done(wait_background_tasks=True)
 
     state = hass.states.get("event.transmission_torrent")

--- a/tests/components/transmission/test_event.py
+++ b/tests/components/transmission/test_event.py
@@ -12,9 +12,9 @@ from homeassistant.components import event as event_component
 from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
 from homeassistant.components.transmission.const import (
     DEFAULT_SCAN_INTERVAL,
-    EVENT_DOWNLOADED_TORRENT,
-    EVENT_REMOVED_TORRENT,
-    EVENT_STARTED_TORRENT,
+    EVENT_TYPE_DOWNLOADED,
+    EVENT_TYPE_REMOVED,
+    EVENT_TYPE_STARTED,
 )
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -40,18 +40,18 @@ async def test_event_entity_setup(
     assert state.state == "unknown"
     assert state.attributes[ATTR_EVENT_TYPE] is None
     assert state.attributes[ATTR_EVENT_TYPES] == [
-        EVENT_STARTED_TORRENT,
-        EVENT_DOWNLOADED_TORRENT,
-        EVENT_REMOVED_TORRENT,
+        EVENT_TYPE_STARTED,
+        EVENT_TYPE_DOWNLOADED,
+        EVENT_TYPE_REMOVED,
     ]
 
 
 @pytest.mark.parametrize(
     ("hass_event", "expected_event_type"),
     [
-        (EVENT_STARTED_TORRENT, EVENT_STARTED_TORRENT),
-        (EVENT_DOWNLOADED_TORRENT, EVENT_DOWNLOADED_TORRENT),
-        (EVENT_REMOVED_TORRENT, EVENT_REMOVED_TORRENT),
+        (EVENT_TYPE_STARTED, EVENT_TYPE_STARTED),
+        (EVENT_TYPE_DOWNLOADED, EVENT_TYPE_DOWNLOADED),
+        (EVENT_TYPE_REMOVED, EVENT_TYPE_REMOVED),
     ],
 )
 async def test_event_updates_state(
@@ -69,9 +69,9 @@ async def test_event_updates_state(
 
     client = mock_transmission_client.return_value
     torrent_status = {
-        EVENT_STARTED_TORRENT: "downloading",
-        EVENT_DOWNLOADED_TORRENT: "seeding",
-        EVENT_REMOVED_TORRENT: "stopped",
+        EVENT_TYPE_STARTED: "downloading",
+        EVENT_TYPE_DOWNLOADED: "seeding",
+        EVENT_TYPE_REMOVED: "stopped",
     }[hass_event]
     torrent = SimpleNamespace(
         id=1,
@@ -82,9 +82,9 @@ async def test_event_updates_state(
     )
 
     torrents_sequence = {
-        EVENT_STARTED_TORRENT: [[torrent]],
-        EVENT_DOWNLOADED_TORRENT: [[torrent]],
-        EVENT_REMOVED_TORRENT: [[torrent], []],
+        EVENT_TYPE_STARTED: [[torrent]],
+        EVENT_TYPE_DOWNLOADED: [[torrent]],
+        EVENT_TYPE_REMOVED: [[torrent], []],
     }[hass_event]
 
     client.get_torrents.side_effect = torrents_sequence
@@ -136,7 +136,7 @@ async def test_unknown_event_ignored(
     client.get_torrents.side_effect = [[torrent]]
 
     with patch(
-        "homeassistant.components.transmission.coordinator.EVENT_STARTED_TORRENT",
+        "homeassistant.components.transmission.coordinator.EVENT_TYPE_STARTED",
         "transmission_unknown_event",
     ):
         await coordinator.async_refresh()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a Torrent event entity to Transmission reflecting the last event to occur, this mirrors the existing bus events, allowing easier automation.

The event platform cannot listen to the bus events directly as they do not include the device, therefore implementing our own event listeners.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44345
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
