### PR TITLE
MQTT Vacuum: Get Segments from separate MQTT Topic

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -188,6 +188,7 @@ ABBREVIATIONS = {
     "rgbww_stat_t": "rgbww_state_topic",
     "rgbww_val_tpl": "rgbww_value_template",
     "segmnts": "segments",
+    "segmnts_t": "segments_topic",
     "send_cmd_t": "send_command_topic",
     "send_if_off": "send_if_off",
     "set_fan_spd_t": "set_fan_speed_topic",

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -238,6 +238,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     _attributes_extra_blocked = MQTT_VACUUM_ATTRIBUTES_BLOCKED
 
     _segments: list[Segment]
+    _segments_received_from_topic: bool = False
     _command_topic: str | None
     _set_fan_speed_topic: str | None
     _send_command_topic: str | None
@@ -282,8 +283,9 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
 
             if CONF_SEGMENTS_TOPIC in config:
-                self._segments = []
-            if CONF_SEGMENTS in config:
+                if not self._segments_received_from_topic:
+                    self._segments = []
+            elif CONF_SEGMENTS in config:
                 segments: list[str] = config[CONF_SEGMENTS]
                 self._segments = [
                     Segment(id=segment_id, name=name or segment_id)
@@ -291,6 +293,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                         segment.partition(".") for segment in segments
                     ]
                 ]
+                self._segments_received_from_topic = True
             self._clean_segments_command_topic = config[
                 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC
             ]
@@ -321,6 +324,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         """Check vacuum segments with registry entry."""
         if (
             self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA
+            and self._segments_received_from_topic
             and (last_seen := self.last_seen_segments) is not None
             and {s.id: s for s in last_seen} != {s.id: s for s in self._segments}
         ):
@@ -355,6 +359,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             Segment(id=segment_id, name=str(name or segment_id))
             for segment_id, name in payload.items()
         ]
+        self._segments_received_from_topic = True
         self._process_entity_update()
         self.async_write_ha_state()
 

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -54,6 +54,7 @@ POSSIBLE_STATES: dict[str, VacuumActivity] = {
 }
 
 CONF_SEGMENTS = "segments"
+CONF_SEGMENTS_TOPIC = "segments_topic"
 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC = "clean_segments_command_topic"
 CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE = "clean_segments_command_template"
 CONF_SUPPORTED_FEATURES = ATTR_SUPPORTED_FEATURES
@@ -143,13 +144,13 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 def validate_clean_area_config(config: ConfigType) -> ConfigType:
     """Check for a valid configuration and check segments."""
-    if (config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC not in config) or (
-        not config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config
-    ):
-        raise vol.Invalid(
-            f"Options `{CONF_SEGMENTS}` and "
-            f"`{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` must be defined together"
-        )
+    if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
+        if (CONF_SEGMENTS_TOPIC not in config) and (CONF_SEGMENTS not in config):
+            raise vol.Invalid(
+                f"Options `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` and "
+                f"`{CONF_SEGMENTS}` or `{CONF_SEGMENTS_TOPIC}` must be defined together"
+            )
+
     segments: list[str]
     if segments := config[CONF_SEGMENTS]:
         if not config.get(CONF_UNIQUE_ID):
@@ -166,12 +167,19 @@ def validate_clean_area_config(config: ConfigType) -> ConfigType:
                 )
             unique_segments.add(segment_id)
 
+    if CONF_SEGMENTS_TOPIC in config:
+        if not config.get(CONF_UNIQUE_ID):
+            raise vol.Invalid(
+                f"Option `{CONF_SEGMENTS_TOPIC}` requires `{CONF_UNIQUE_ID}` to be configured"
+            )
+
     return config
 
 
 _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Optional(CONF_SEGMENTS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_SEGMENTS_TOPIC): valid_publish_topic,
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
@@ -269,15 +277,20 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         self._attr_supported_features = _strings_to_services(
             supported_feature_strings, STRING_TO_SERVICE
         )
-        if config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
+
+        if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
-            segments: list[str] = config[CONF_SEGMENTS]
-            self._segments = [
-                Segment(id=segment_id, name=name or segment_id)
-                for segment_id, _, name in [
-                    segment.partition(".") for segment in segments
+
+            if CONF_SEGMENTS_TOPIC in config:
+                self._segments = []
+            if CONF_SEGMENTS in config:
+                segments: list[str] = config[CONF_SEGMENTS]
+                self._segments = [
+                    Segment(id=segment_id, name=name or segment_id)
+                    for segment_id, _, name in [
+                        segment.partition(".") for segment in segments
+                    ]
                 ]
-            ]
             self._clean_segments_command_topic = config[
                 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC
             ]
@@ -336,12 +349,27 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         self._update_state_attributes(payload)
 
     @callback
+    def _segment_message_received(self, msg: ReceiveMessage) -> None:
+        payload = json_loads_object(msg.payload)
+        self._segments = [
+            Segment(id=segment_id, name=str(name or segment_id))
+            for segment_id, name in payload.items()
+        ]
+        self._process_entity_update()
+        self.async_write_ha_state()
+
+    @callback
     def _prepare_subscribe_topics(self) -> None:
         """(Re)Subscribe to topics."""
         self.add_subscription(
             CONF_STATE_TOPIC,
             self._state_message_received,
             {"_attr_battery_level", "_attr_fan_speed", "_attr_activity"},
+        )
+        self.add_subscription(
+            CONF_SEGMENTS_TOPIC,
+            self._segment_message_received,
+            None,
         )
 
     async def _subscribe_topics(self) -> None:

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -148,10 +148,12 @@ def validate_clean_area_config(config: ConfigType) -> ConfigType:
     has_segments_topic = CONF_SEGMENTS_TOPIC in config
     has_command_topic = CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config
 
-    if has_command_topic != (has_segments or has_segments_topic):
+    if has_command_topic != (has_segments or has_segments_topic) or (
+        has_segments and has_segments_topic
+    ):
         raise vol.Invalid(
             f"Options `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` and "
-            f"`{CONF_SEGMENTS}` or `{CONF_SEGMENTS_TOPIC}` must be defined together"
+            f"either `{CONF_SEGMENTS}` or `{CONF_SEGMENTS_TOPIC}` must be defined together"
         )
 
     segments: list[str]
@@ -241,7 +243,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     _attributes_extra_blocked = MQTT_VACUUM_ATTRIBUTES_BLOCKED
 
     _segments: list[Segment]
-    _segments_received_from_topic: bool = False
+    _segments_loaded: bool = False
     _command_topic: str | None
     _set_fan_speed_topic: str | None
     _send_command_topic: str | None
@@ -286,7 +288,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
 
             if CONF_SEGMENTS_TOPIC in config:
-                if not self._segments_received_from_topic:
+                if not self._segments_loaded:
                     self._segments = []
             elif CONF_SEGMENTS in config:
                 segments: list[str] = config[CONF_SEGMENTS]
@@ -296,7 +298,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                         segment.partition(".") for segment in segments
                     ]
                 ]
-                self._segments_received_from_topic = True
+                self._segments_loaded = True
             self._clean_segments_command_topic = config[
                 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC
             ]
@@ -327,7 +329,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         """Check vacuum segments with registry entry."""
         if (
             self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA
-            and self._segments_received_from_topic
+            and self._segments_loaded
             and (last_seen := self.last_seen_segments) is not None
             and {s.id: s for s in last_seen} != {s.id: s for s in self._segments}
         ):
@@ -362,7 +364,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             Segment(id=segment_id, name=str(name or segment_id))
             for segment_id, name in payload.items()
         ]
-        self._segments_received_from_topic = True
+        self._segments_loaded = True
         self._process_entity_update()
         self.async_write_ha_state()
 

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -144,12 +144,15 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 def validate_clean_area_config(config: ConfigType) -> ConfigType:
     """Check for a valid configuration and check segments."""
-    if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
-        if (CONF_SEGMENTS_TOPIC not in config) and (CONF_SEGMENTS not in config):
-            raise vol.Invalid(
-                f"Options `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` and "
-                f"`{CONF_SEGMENTS}` or `{CONF_SEGMENTS_TOPIC}` must be defined together"
-            )
+    has_segments = bool(config[CONF_SEGMENTS])
+    has_segments_topic = CONF_SEGMENTS_TOPIC in config
+    has_command_topic = CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config
+
+    if has_command_topic != (has_segments or has_segments_topic):
+        raise vol.Invalid(
+            f"Options `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` and "
+            f"`{CONF_SEGMENTS}` or `{CONF_SEGMENTS_TOPIC}` must be defined together"
+        )
 
     segments: list[str]
     if segments := config[CONF_SEGMENTS]:

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -677,7 +677,7 @@ async def test_non_unique_segments(
                 ({"clean_segments_command_topic": "test-topic"},),
             ),
             "Options `clean_segments_command_topic` and "
-            "`segments` or `segments_topic` must be defined together",
+            "either `segments` or `segments_topic` must be defined together",
         ),
         (
             help_custom_config(
@@ -686,7 +686,7 @@ async def test_non_unique_segments(
                 ({"segments_topic": "test-topic"},),
             ),
             "Options `clean_segments_command_topic` and "
-            "`segments` or `segments_topic` must be defined together",
+            "either `segments` or `segments_topic` must be defined together",
         ),
         (
             help_custom_config(
@@ -695,7 +695,16 @@ async def test_non_unique_segments(
                 ({"segments": ["Livingroom"]},),
             ),
             "Options `clean_segments_command_topic` and "
-            "`segments` or `segments_topic` must be defined together",
+            "either `segments` or `segments_topic` must be defined together",
+        ),
+        (
+            help_custom_config(
+                vacuum.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"segments": ["Livingroom"], "segments_topic": "topic"},),
+            ),
+            "Options `clean_segments_command_topic` and "
+            "either `segments` or `segments_topic` must be defined together",
         ),
         (
             help_custom_config(

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -108,6 +108,17 @@ CONFIG_CLEAN_SEGMENTS_2 = {
     }
 }
 
+CONFIG_SEGMENTS_TOPIC = {
+    mqtt.DOMAIN: {
+        vacuum.DOMAIN: {
+            "name": "test",
+            "unique_id": "veryunique",
+            "segments_topic": "vacuum/segments",
+            "clean_segments_command_topic": "vacuum/clean_segment",
+        }
+    }
+}
+
 DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
 
 CONFIG_ALL_SERVICES = help_custom_config(
@@ -503,6 +514,100 @@ async def test_clean_segments_command_update(
     )
 
 
+@pytest.mark.parametrize("hass_config", [CONFIG_SEGMENTS_TOPIC])
+async def test_segments_topic_received(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test segments received from a segments_topic are returned by get_segments."""
+    await mqtt_mock_entry()
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/segments",
+        json.dumps({"1": "Livingroom", "2": "Kitchen"}),
+    )
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+    ]
+
+
+@pytest.mark.parametrize("hass_config", [CONFIG_SEGMENTS_TOPIC])
+async def test_segments_topic_change_triggers_repair(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test that a repair issue is created when segments_topic reports new segments."""
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    entity_registry.async_get_or_create(
+        vacuum.DOMAIN,
+        mqtt.DOMAIN,
+        "veryunique",
+        config_entry=config_entry,
+        suggested_object_id="test",
+    )
+    entity_registry.async_update_entity_options(
+        "vacuum.test",
+        vacuum.DOMAIN,
+        {
+            "area_mapping": {"Livingroom": ["1"], "Kitchen": ["2"]},
+            "last_seen_segments": [
+                {"id": "1", "name": "Livingroom", "group": None},
+                {"id": "2", "name": "Kitchen", "group": None},
+            ],
+        },
+    )
+    await mqtt_mock_entry()
+    await hass.async_block_till_done()
+
+    issue_registry = ir.async_get(hass)
+
+    # Publish segments matching last_seen_segments — no repair issue expected
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/segments",
+        json.dumps({"1": "Livingroom", "2": "Kitchen"}),
+    )
+    await hass.async_block_till_done()
+    assert len(issue_registry.issues) == 0
+
+    # Publish updated segments that differ from last_seen_segments
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/segments",
+        json.dumps({"1": "Livingroom", "2": "Kitchen", "3": "Diningroom"}),
+    )
+    await hass.async_block_till_done()
+
+    # A repair issue should be created
+    assert len(issue_registry.issues) == 1
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+        {"id": "3", "name": "Diningroom", "group": None},
+    ]
+
+
 @pytest.mark.parametrize(
     "hass_config",
     [
@@ -571,8 +676,17 @@ async def test_non_unique_segments(
                 DEFAULT_CONFIG,
                 ({"clean_segments_command_topic": "test-topic"},),
             ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
+            "Options `clean_segments_command_topic` and "
+            "`segments` or `segments_topic` must be defined together",
+        ),
+        (
+            help_custom_config(
+                vacuum.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"segments_topic": "test-topic"},),
+            ),
+            "Options `clean_segments_command_topic` and "
+            "`segments` or `segments_topic` must be defined together",
         ),
         (
             help_custom_config(
@@ -580,8 +694,8 @@ async def test_non_unique_segments(
                 DEFAULT_CONFIG,
                 ({"segments": ["Livingroom"]},),
             ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
+            "Options `clean_segments_command_topic` and "
+            "`segments` or `segments_topic` must be defined together",
         ),
         (
             help_custom_config(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Introduce a `segments_topic` option to the MQTT Vacuum, so that the segments can be served via a separate topic. As segments can change due to remapping or automatic map adjustment by a vacuum, they can change rather often, while the vacuum discovery message should stay the same during the whole lifetime.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

Will follow if the direction of this PR is approved.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
