### PR TITLE
Skip unchanged connection check on reconfigure flow for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -165,7 +165,7 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
             if (
-                reconfigure_entry.state != ConfigEntryState.LOADED
+                reconfigure_entry.state is not ConfigEntryState.LOADED
                 or reconfigure_entry.data != user_input
             ):
                 if not await self.test_connection(

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     ConfigSubentryFlow,
@@ -161,12 +162,18 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
         reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
-            if reconfigure_entry.data == user_input:
-                return self.async_abort(reason="already_configured")
-
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
-            if await self.test_connection(user_input[CONF_HOST], user_input[CONF_PORT]):
+            if (
+                reconfigure_entry.state != ConfigEntryState.LOADED
+                or reconfigure_entry.data != user_input
+            ):
+                if not await self.test_connection(
+                    user_input[CONF_HOST], user_input[CONF_PORT]
+                ):
+                    errors["base"] = "cannot_connect"
+
+            if not errors:
                 return self.async_update_reload_and_abort(
                     reconfigure_entry,
                     data_updates={
@@ -174,10 +181,7 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_PORT: user_input[CONF_PORT],
                     },
                     title=user_input[CONF_HOST],
-                    reload_even_if_entry_is_unchanged=False,
                 )
-
-            errors["base"] = "cannot_connect"
 
         suggested_values: dict[str, Any] = {
             **reconfigure_entry.data,

--- a/homeassistant/components/satel_integra/config_flow.py
+++ b/homeassistant/components/satel_integra/config_flow.py
@@ -161,6 +161,9 @@ class SatelConfigFlow(ConfigFlow, domain=DOMAIN):
         reconfigure_entry = self._get_reconfigure_entry()
 
         if user_input is not None:
+            if reconfigure_entry.data == user_input:
+                return self.async_abort(reason="already_configured")
+
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
             if await self.test_connection(user_input[CONF_HOST], user_input[CONF_PORT]):

--- a/tests/components/satel_integra/test_config_flow.py
+++ b/tests/components/satel_integra/test_config_flow.py
@@ -363,6 +363,31 @@ async def test_reconfigure_flow_success(
     assert mock_setup_entry.call_count == 1
 
 
+async def test_reconfigure_flow_config_unchanged(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure aborts when the config is unchanged."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], dict(mock_config_entry.data)
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_config_entry.data == MOCK_CONFIG_DATA
+    assert mock_satel.connect.call_count == 0
+    assert mock_setup_entry.call_count == 0
+
+
 async def test_reconfigure_connection_failed(
     hass: HomeAssistant,
     mock_satel: AsyncMock,

--- a/tests/components/satel_integra/test_config_flow.py
+++ b/tests/components/satel_integra/test_config_flow.py
@@ -16,7 +16,12 @@ from homeassistant.components.satel_integra.const import (
     DEFAULT_PORT,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_RECONFIGURE, SOURCE_USER, ConfigSubentry
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+    ConfigEntryState,
+    ConfigSubentry,
+)
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -363,29 +368,58 @@ async def test_reconfigure_flow_success(
     assert mock_setup_entry.call_count == 1
 
 
-async def test_reconfigure_flow_config_unchanged(
+async def test_reconfigure_flow_config_unchanged_loaded(
     hass: HomeAssistant,
     mock_satel: AsyncMock,
     mock_setup_entry: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test reconfigure aborts when the config is unchanged."""
-    mock_config_entry.add_to_hass(hass)
+    """Test reconfigure skips connection testing if loaded config is unchanged."""
+    await setup_integration(hass, mock_config_entry)
 
     result = await mock_config_entry.start_reconfigure_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], dict(mock_config_entry.data)
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "reconfigure_successful"
     assert mock_config_entry.data == MOCK_CONFIG_DATA
     assert mock_satel.connect.call_count == 0
-    assert mock_setup_entry.call_count == 0
+
+    await hass.async_block_till_done()
+    assert mock_setup_entry.call_count == 1
+
+
+async def test_reconfigure_flow_config_unchanged_not_loaded(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure validates unchanged config if the entry is not loaded."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], dict(mock_config_entry.data)
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == MOCK_CONFIG_DATA
+    assert mock_satel.connect.call_count == 1
+    assert mock_setup_entry.call_count == 1
 
 
 async def test_reconfigure_connection_failed(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Reconfigure flow was recently added for Satel Integra. The alarm panels only allow 1 connection to be active at the same time, hence we can not check the connection if nothing changed.

The PR skips the connection check if the user_input is the same as the existing data. 

Target for 2026.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
