### PR TITLE
Add start_charge action to renault

### DIFF
--- a/homeassistant/components/renault/icons.json
+++ b/homeassistant/components/renault/icons.json
@@ -88,6 +88,9 @@
     },
     "charge_set_schedules": {
       "service": "mdi:calendar-clock"
+    },
+    "charge_start": {
+      "service": "mdi:ev-station"
     }
   }
 }

--- a/homeassistant/components/renault/renault_vehicle.py
+++ b/homeassistant/components/renault/renault_vehicle.py
@@ -165,9 +165,11 @@ class RenaultVehicleProxy:
         return await self._vehicle.set_charge_mode(charge_mode)
 
     @with_error_wrapping
-    async def set_charge_start(self) -> models.KamereonVehicleChargingStartActionData:
+    async def set_charge_start(
+        self, when: datetime | None = None
+    ) -> models.KamereonVehicleChargingStartActionData:
         """Start vehicle charge."""
-        return await self._vehicle.set_charge_start()
+        return await self._vehicle.set_charge_start(when)
 
     @with_error_wrapping
     async def set_charge_stop(self) -> models.KamereonVehicleChargingStartActionData:

--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -36,6 +36,11 @@ SERVICE_AC_START_SCHEMA = SERVICE_VEHICLE_SCHEMA.extend(
         vol.Optional(ATTR_WHEN): cv.datetime,
     }
 )
+SERVICE_CHARGE_START_SCHEMA = SERVICE_VEHICLE_SCHEMA.extend(
+    {
+        vol.Optional(ATTR_WHEN): cv.datetime,
+    }
+)
 SERVICE_CHARGE_SET_SCHEDULE_DAY_SCHEMA = vol.Schema(
     {
         vol.Required("startTime"): cv.string,
@@ -111,6 +116,16 @@ async def ac_start(service_call: ServiceCall) -> None:
     LOGGER.debug("A/C start attempt: %s / %s", temperature, when)
     result = await proxy.set_ac_start(temperature, when)
     LOGGER.debug("A/C start result: %s", result.raw_data)
+
+
+async def charge_start(service_call: ServiceCall) -> None:
+    """Start Charging with optional delay."""
+    when: datetime | None = service_call.data.get(ATTR_WHEN)
+    proxy = get_vehicle_proxy(service_call)
+
+    LOGGER.debug("Charge start attempt, when: %s", when)
+    result = await proxy.set_charge_start(when)
+    LOGGER.debug("Charge start result: %s", result.raw_data)
 
 
 async def charge_set_schedules(service_call: ServiceCall) -> None:
@@ -195,6 +210,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         "ac_start",
         ac_start,
         schema=SERVICE_AC_START_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "charge_start",
+        charge_start,
+        schema=SERVICE_CHARGE_START_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/renault/services.yaml
+++ b/homeassistant/components/renault/services.yaml
@@ -64,7 +64,7 @@ charge_start:
     when:
       example: "2026-03-01T17:45:00"
       selector:
-        text:
+        datetime:
 
 charge_set_schedules:
   fields:

--- a/homeassistant/components/renault/services.yaml
+++ b/homeassistant/components/renault/services.yaml
@@ -54,6 +54,18 @@ ac_set_schedules:
       selector:
         object:
 
+charge_start:
+  fields:
+    vehicle:
+      required: true
+      selector:
+        device:
+          integration: renault
+    when:
+      example: "2026-03-01T17:45:00"
+      selector:
+        text:
+
 charge_set_schedules:
   fields:
     vehicle:

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -289,7 +289,7 @@
           "name": "When"
         }
       },
-      "name": "Start Charging"
+      "name": "Start charging"
     }
   }
 }

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -278,7 +278,7 @@
       "name": "Update charge schedule"
     },
     "charge_start": {
-      "description": "Starts Charging on vehicle.",
+      "description": "Starts charging on vehicle.",
       "fields": {
         "vehicle": {
           "description": "The vehicle to send the command to.",

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -276,6 +276,20 @@
         }
       },
       "name": "Update charge schedule"
+    },
+    "charge_start": {
+      "description": "Starts Charging on vehicle.",
+      "fields": {
+        "vehicle": {
+          "description": "The vehicle to send the command to.",
+          "name": "Vehicle"
+        },
+        "when": {
+          "description": "Timestamp for charging to start (optional - defaults to now).",
+          "name": "When"
+        }
+      },
+      "name": "Start Charging"
     }
   }
 }

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -281,7 +281,7 @@
       "description": "Starts charging on vehicle.",
       "fields": {
         "vehicle": {
-          "description": "The vehicle to send the command to.",
+          "description": "[%key:component::renault::services::ac_start::fields::vehicle::description%]",
           "name": "Vehicle"
         },
         "when": {

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -116,7 +116,7 @@ async def test_button_start_charge(
     with patch(
         "renault_api.renault_vehicle.RenaultVehicle.set_charge_start",
         return_value=(
-            schemas.KamereonVehicleHvacStartActionDataSchema.loads(
+            schemas.KamereonVehicleChargingStartActionDataSchema.loads(
                 await async_load_fixture(hass, "action.set_charge_start.json", DOMAIN)
             )
         ),
@@ -125,7 +125,7 @@ async def test_button_start_charge(
             BUTTON_DOMAIN, SERVICE_PRESS, service_data=data, blocking=True
         )
     assert len(mock_action.mock_calls) == 1
-    assert mock_action.mock_calls[0][1] == ()
+    assert mock_action.mock_calls[0][1] == (None,)
 
 
 @pytest.mark.usefixtures("fixtures_with_data")

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -132,7 +132,7 @@ async def test_service_set_ac_start_with_date(
     assert mock_action.mock_calls[0][1] == (temperature, when)
 
 
-async def test_service_start_charge_simple(
+async def test_service_charge_start_simple(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> None:
     """Test that service invokes renault_api with correct data."""

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -132,6 +132,59 @@ async def test_service_set_ac_start_with_date(
     assert mock_action.mock_calls[0][1] == (temperature, when)
 
 
+async def test_service_start_charge_simple(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Test that service invokes renault_api with correct data."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = {
+        ATTR_VEHICLE: get_device_id(hass),
+    }
+
+    with patch(
+        "renault_api.renault_vehicle.RenaultVehicle.set_charge_start",
+        return_value=(
+            schemas.KamereonVehicleChargingStartActionDataSchema.loads(
+                await async_load_fixture(hass, "action.set_charge_start.json", DOMAIN)
+            )
+        ),
+    ) as mock_action:
+        await hass.services.async_call(
+            DOMAIN, "charge_start", service_data=data, blocking=True
+        )
+    assert len(mock_action.mock_calls) == 1
+
+
+async def test_service_charge_start_with_date(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Test that service invokes renault_api with correct data."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    when = datetime(2025, 8, 23, 17, 12, 45)
+    data = {
+        ATTR_VEHICLE: get_device_id(hass),
+        ATTR_WHEN: when,
+    }
+
+    with patch(
+        "renault_api.renault_vehicle.RenaultVehicle.set_charge_start",
+        return_value=(
+            schemas.KamereonVehicleChargingStartActionDataSchema.loads(
+                await async_load_fixture(hass, "action.set_charge_start.json", DOMAIN)
+            )
+        ),
+    ) as mock_action:
+        await hass.services.async_call(
+            DOMAIN, "charge_start", service_data=data, blocking=True
+        )
+    assert len(mock_action.mock_calls) == 1
+    assert mock_action.mock_calls[0][1] == (when,)
+
+
 async def test_service_set_charge_schedule(
     hass: HomeAssistant, config_entry: ConfigEntry, snapshot: SnapshotAssertion
 ) -> None:

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -155,6 +155,7 @@ async def test_service_charge_start_simple(
             DOMAIN, "charge_start", service_data=data, blocking=True
         )
     assert len(mock_action.mock_calls) == 1
+    assert mock_action.mock_calls[0][1] == (None,)
 
 
 async def test_service_charge_start_with_date(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the action charge_start to initiate charging immediate or with a delay. This action can be used to switch between always, delayed or scheduled charging. Scheduled charging is set using the existing action charge_set_schedules

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
