### PR TITLE
Fix hydrawise crashes when controllers/zones are added

### DIFF
--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -111,6 +111,15 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             # the test_connect_retry test in test_init.py fails.
             return  # type: ignore[unreachable]
 
+        # Sync zone and controller data to the water_use coordinator so that
+        # new entities created in callbacks below can access their data.
+        if hasattr(self.config_entry, "runtime_data"):
+            water_use = self.config_entry.runtime_data.water_use
+            if water_use.data is not None:
+                water_use.data.zones = self.data.zones
+                water_use.data.controllers = self.data.controllers
+                water_use.data.sensors = self.data.sensors
+
         device_registry = dr.async_get(self.hass)
         devices = dr.async_entries_for_config_entry(
             device_registry, self.config_entry.entry_id

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -111,15 +111,6 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
             # the test_connect_retry test in test_init.py fails.
             return  # type: ignore[unreachable]
 
-        # Sync zone and controller data to the water_use coordinator so that
-        # new entities created in callbacks below can access their data.
-        if hasattr(self.config_entry, "runtime_data"):
-            water_use = self.config_entry.runtime_data.water_use
-            if water_use.data is not None:
-                water_use.data.zones = self.data.zones
-                water_use.data.controllers = self.data.controllers
-                water_use.data.sensors = self.data.sensors
-
         device_registry = dr.async_get(self.hass)
         devices = dr.async_entries_for_config_entry(
             device_registry, self.config_entry.entry_id

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -69,6 +69,8 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the state."""
+        if self.controller.id not in self.coordinator.data.controllers:
+            return
         self.controller = self.coordinator.data.controllers[self.controller.id]
         self._update_attrs()
         super()._handle_coordinator_update()

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -69,6 +69,8 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the state."""
+        # Guard against updates arriving after the controller has been removed
+        # but before the entity has been unsubscribed from the coordinator.
         if self.controller.id not in self.coordinator.data.controllers:
             return
         self.controller = self.coordinator.data.controllers[self.controller.id]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Python 3.14.3 changes how tasks are scheduled which led to a few integrations now having flaky tests, hydrawise being one of them. While looking over the tests, I found that the tests are correct, but the integration has two bugs:
1.   Adding zones/controllers: When the 'main' coordinator (5-min interval) discovers new zones, `_add_remove_zones` creates entities bound to the 'water use' coordinator (60-min interval). The entity constructor looks up the zone name from its coordinator's data, but the 'water use' coordinator hasn't refreshed yet and doesn't have the new zones. Fixed in #164862
2. When a device (and all entities) is cleaned up after a zone dissapeared from the API, there is still the `_handle_coordinator_update` callback is still registered for one more update cycle. This results in a key error.

Test fixed with this PR:
- `tests/components/hydrawise/test_init.py::test_auto_remove_devices`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
