### PR TITLE
Add Remote platform to SMLIGHT Integration

### DIFF
--- a/homeassistant/components/smlight/__init__.py
+++ b/homeassistant/components/smlight/__init__.py
@@ -19,6 +19,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.LIGHT,
+    Platform.REMOTE,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.UPDATE,

--- a/homeassistant/components/smlight/remote.py
+++ b/homeassistant/components/smlight/remote.py
@@ -27,10 +27,10 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.data
 
     if coordinator.data.info.has_peripherals:
-        async_add_entities([SmlightRemoteEntity(coordinator)])
+        async_add_entities([SmRemoteEntity(coordinator)])
 
 
-class SmlightRemoteEntity(SmEntity, RemoteEntity):
+class SmRemoteEntity(SmEntity, RemoteEntity):
     """Representation of a SLZB-Ultima remote."""
 
     _attr_translation_key = "remote"
@@ -41,21 +41,8 @@ class SmlightRemoteEntity(SmEntity, RemoteEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.unique_id}-remote"
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the remote on."""
-        self._attr_is_on = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the remote off."""
-        self._attr_is_on = False
-        self.async_write_ha_state()
-
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a sequence of commands to a device."""
-        if not self.is_on:
-            return
-
         for cmd in command:
             try:
                 await self.coordinator.async_execute_command(

--- a/homeassistant/components/smlight/remote.py
+++ b/homeassistant/components/smlight/remote.py
@@ -1,12 +1,19 @@
 """Remote platform for SLZB-Ultima."""
 
+import asyncio
 from collections.abc import Iterable
 from typing import Any
 
 from pysmlight.exceptions import SmlightError
 from pysmlight.models import IRPayload
 
-from homeassistant.components.remote import RemoteEntity
+from homeassistant.components.remote import (
+    ATTR_DELAY_SECS,
+    ATTR_NUM_REPEATS,
+    DEFAULT_DELAY_SECS,
+    DEFAULT_NUM_REPEATS,
+    RemoteEntity,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -43,14 +50,21 @@ class SmRemoteEntity(SmEntity, RemoteEntity):
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a sequence of commands to a device."""
-        for cmd in command:
-            try:
-                await self.coordinator.async_execute_command(
-                    self.coordinator.client.actions.send_ir_code, IRPayload(code=cmd)
-                )
-            except SmlightError as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="send_ir_code_failed",
-                    translation_placeholders={"error": str(err)},
-                ) from err
+        num_repeats = kwargs.get(ATTR_NUM_REPEATS, DEFAULT_NUM_REPEATS)
+        delay_secs = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
+
+        for _ in range(num_repeats):
+            for cmd in command:
+                try:
+                    await self.coordinator.async_execute_command(
+                        self.coordinator.client.actions.send_ir_code,
+                        IRPayload(code=cmd),
+                    )
+                except SmlightError as err:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="send_ir_code_failed",
+                        translation_placeholders={"error": str(err)},
+                    ) from err
+
+                await asyncio.sleep(delay_secs)

--- a/homeassistant/components/smlight/remote.py
+++ b/homeassistant/components/smlight/remote.py
@@ -1,0 +1,69 @@
+"""Remote platform for SLZB-Ultima."""
+
+from collections.abc import Iterable
+from typing import Any
+
+from pysmlight.exceptions import SmlightError
+from pysmlight.models import IRPayload
+
+from homeassistant.components.remote import RemoteEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
+from .entity import SmEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SmConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Initialize remote for SLZB-Ultima device."""
+    coordinator = entry.runtime_data.data
+
+    if coordinator.data.info.has_peripherals:
+        async_add_entities([SmlightRemoteEntity(coordinator)])
+
+
+class SmlightRemoteEntity(SmEntity, RemoteEntity):
+    """Representation of a SLZB-Ultima remote."""
+
+    _attr_translation_key = "remote"
+    _attr_is_on = True
+
+    def __init__(self, coordinator: SmDataUpdateCoordinator) -> None:
+        """Initialize the SLZB-Ultima remote."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.unique_id}-remote"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the remote on."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the remote off."""
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+    async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
+        """Send a sequence of commands to a device."""
+        if not self.is_on:
+            return
+
+        for cmd in command:
+            try:
+                await self.coordinator.async_execute_command(
+                    self.coordinator.client.actions.send_ir_code, IRPayload(code=cmd)
+                )
+            except SmlightError as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="send_ir_code_failed",
+                    translation_placeholders={"error": str(err)},
+                ) from err

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -84,6 +84,11 @@
         "name": "Ambilight"
       }
     },
+    "remote": {
+      "remote": {
+        "name": "IR Remote"
+      }
+    },
     "sensor": {
       "core_temperature": {
         "name": "Core chip temp"
@@ -159,6 +164,9 @@
     },
     "firmware_update_failed": {
       "message": "Firmware update failed for {device_name}."
+    },
+    "send_ir_code_failed": {
+      "message": "Failed to send IR code: {error}"
     }
   },
   "issues": {

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -166,7 +166,7 @@
       "message": "Firmware update failed for {device_name}."
     },
     "send_ir_code_failed": {
-      "message": "Failed to send IR code: {error}"
+      "message": "Failed to send IR code: {error}."
     }
   },
   "issues": {

--- a/tests/components/smlight/test_remote.py
+++ b/tests/components/smlight/test_remote.py
@@ -1,6 +1,6 @@
 """Tests for SLZB-Ultima remote entity."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from pysmlight import Info
 from pysmlight.exceptions import SmlightError
@@ -24,7 +24,7 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture
-def platforms() -> Platform | list[Platform]:
+def platforms() -> list[Platform]:
     """Platforms, which should be loaded during the test."""
     return [Platform.REMOTE]
 
@@ -83,7 +83,11 @@ async def test_remote_send_command(
     await hass.services.async_call(
         REMOTE_DOMAIN,
         SERVICE_SEND_COMMAND,
-        {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: ["my_code", "another_code"]},
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_COMMAND: ["my_code", "another_code"],
+            ATTR_DELAY_SECS: 0,
+        },
         blocking=True,
     )
 
@@ -120,7 +124,9 @@ async def test_remote_send_command_error(
     assert exc_info.value.translation_key == "send_ir_code_failed"
 
 
+@patch("homeassistant.components.smlight.remote.asyncio.sleep")
 async def test_remote_send_command_repeats(
+    mock_sleep: MagicMock,
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_smlight_client: MagicMock,
@@ -141,9 +147,11 @@ async def test_remote_send_command_repeats(
             ATTR_ENTITY_ID: entity_id,
             ATTR_COMMAND: ["my_code", "another_code"],
             ATTR_NUM_REPEATS: 2,
-            ATTR_DELAY_SECS: 0.1,
+            ATTR_DELAY_SECS: 0.5,
         },
         blocking=True,
     )
 
     assert mock_smlight_client.actions.send_ir_code.call_count == 4
+    assert mock_sleep.call_count == 5
+    mock_sleep.assert_called_with(0.5)

--- a/tests/components/smlight/test_remote.py
+++ b/tests/components/smlight/test_remote.py
@@ -9,6 +9,8 @@ import pytest
 
 from homeassistant.components.remote import (
     ATTR_COMMAND,
+    ATTR_DELAY_SECS,
+    ATTR_NUM_REPEATS,
     DOMAIN as REMOTE_DOMAIN,
     SERVICE_SEND_COMMAND,
 )
@@ -116,3 +118,32 @@ async def test_remote_send_command_error(
             blocking=True,
         )
     assert exc_info.value.translation_key == "send_ir_code_failed"
+
+
+async def test_remote_send_command_repeats(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test sending IR command with repeats and delay."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "remote.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_COMMAND: ["my_code", "another_code"],
+            ATTR_NUM_REPEATS: 2,
+            ATTR_DELAY_SECS: 0.1,
+        },
+        blocking=True,
+    )
+
+    assert mock_smlight_client.actions.send_ir_code.call_count == 4

--- a/tests/components/smlight/test_remote.py
+++ b/tests/components/smlight/test_remote.py
@@ -1,0 +1,118 @@
+"""Tests for SLZB-Ultima remote entity."""
+
+from unittest.mock import MagicMock
+
+from pysmlight import Info
+from pysmlight.exceptions import SmlightError
+from pysmlight.models import IRPayload
+import pytest
+
+from homeassistant.components.remote import (
+    ATTR_COMMAND,
+    DOMAIN as REMOTE_DOMAIN,
+    SERVICE_SEND_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def platforms() -> Platform | list[Platform]:
+    """Platforms, which should be loaded during the test."""
+    return [Platform.REMOTE]
+
+
+MOCK_ULTIMA = Info(
+    MAC="AA:BB:CC:DD:EE:FF",
+    model="SLZB-Ultima3",
+)
+
+
+async def test_remote_setup_ultima(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test remote entity is created for Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("remote.mock_title_ir_remote")
+    assert state is not None
+
+
+async def test_remote_not_created_non_ultima(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test remote entity is not created for non-Ultima devices."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info(
+        MAC="AA:BB:CC:DD:EE:FF",
+        model="SLZB-MR1",
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("remote.mock_title_ir_remote")
+    assert state is None
+
+
+async def test_remote_send_command(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test sending IR command."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "remote.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: ["my_code", "another_code"]},
+        blocking=True,
+    )
+
+    assert mock_smlight_client.actions.send_ir_code.call_count == 2
+    mock_smlight_client.actions.send_ir_code.assert_any_call(IRPayload(code="my_code"))
+    mock_smlight_client.actions.send_ir_code.assert_any_call(
+        IRPayload(code="another_code")
+    )
+
+
+async def test_remote_send_command_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test connection error handling."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = MOCK_ULTIMA
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "remote.mock_title_ir_remote"
+    state = hass.states.get(entity_id)
+    assert state is not None
+
+    mock_smlight_client.actions.send_ir_code.side_effect = SmlightError("Failed")
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: ["my_code"]},
+            blocking=True,
+        )
+    assert exc_info.value.translation_key == "send_ir_code_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SLZB_Ultima devices feature an IR transceiver that can be used to send and receive  raw IR codes for controlling devices that use IR remote.

This PR adds the remote platform for sending IR Codes. Raw IR codes can be captured from a physical remote using the IR receiver in the SLZB-OS web UI.

We will later add `LEARN_COMMAND` feature after implementing event platform to receive codes via SSE events.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44355
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X]  I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
