### PR TITLE
Discover MQTT Vacuum segments via state instead of discovery

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -187,6 +187,7 @@ ABBREVIATIONS = {
     "rgbww_cmd_t": "rgbww_command_topic",
     "rgbww_stat_t": "rgbww_state_topic",
     "rgbww_val_tpl": "rgbww_value_template",
+    "segmnts": "segments",
     "send_cmd_t": "send_command_topic",
     "send_if_off": "send_if_off",
     "set_fan_spd_t": "set_fan_speed_topic",

--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -187,7 +187,6 @@ ABBREVIATIONS = {
     "rgbww_cmd_t": "rgbww_command_topic",
     "rgbww_stat_t": "rgbww_state_topic",
     "rgbww_val_tpl": "rgbww_value_template",
-    "segmnts": "segments",
     "send_cmd_t": "send_command_topic",
     "send_if_off": "send_if_off",
     "set_fan_spd_t": "set_fan_speed_topic",

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -54,6 +54,7 @@ POSSIBLE_STATES: dict[str, VacuumActivity] = {
     STATE_CLEANING: VacuumActivity.CLEANING,
 }
 
+CONF_SEGMENTS = "segments"
 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC = "clean_segments_command_topic"
 CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE = "clean_segments_command_template"
 CONF_SUPPORTED_FEATURES = ATTR_SUPPORTED_FEATURES
@@ -142,17 +143,35 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 
 def validate_clean_area_config(config: ConfigType) -> ConfigType:
-    """Validate clean area config requires unique_id."""
+    """Check for a valid configuration and check segments."""
+    if config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC not in config:
+        raise vol.Invalid(
+            f"Options `{CONF_SEGMENTS}` and "
+            f"`{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` must be defined together"
+        )
     if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config and not config.get(CONF_UNIQUE_ID):
         raise vol.Invalid(
             f"Option `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` requires"
             f" `{CONF_UNIQUE_ID}` to be configured"
         )
+    segments: list[str]
+    if segments := config[CONF_SEGMENTS]:
+        unique_segments: set[str] = set()
+        for segment in segments:
+            segment_id, _, _ = segment.partition(".")
+            if not segment_id or segment_id in unique_segments:
+                raise vol.Invalid(
+                    f"The `{CONF_SEGMENTS}` option contains an invalid or non-"
+                    f"unique segment ID '{segment_id}'. Got {segments}"
+                )
+            unique_segments.add(segment_id)
+
     return config
 
 
 _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
+        vol.Optional(CONF_SEGMENTS, default=[]): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
@@ -253,6 +272,14 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         )
         if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
+            if config[CONF_SEGMENTS]:
+                segments: list[str] = config[CONF_SEGMENTS]
+                self._segments = [
+                    Segment(id=segment_id, name=name or segment_id)
+                    for segment_id, _, name in [
+                        segment.partition(".") for segment in segments
+                    ]
+                ]
             self._clean_segments_command_topic = config[
                 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC
             ]

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -16,7 +16,7 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME, CONF_UNIQUE_ID
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -34,6 +34,7 @@ from .util import valid_publish_topic
 
 PARALLEL_UPDATES = 0
 
+SEGMENTS = "segments"
 FAN_SPEED = "fan_speed"
 STATE = "state"
 
@@ -53,7 +54,6 @@ POSSIBLE_STATES: dict[str, VacuumActivity] = {
     STATE_CLEANING: VacuumActivity.CLEANING,
 }
 
-CONF_SEGMENTS = "segments"
 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC = "clean_segments_command_topic"
 CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE = "clean_segments_command_template"
 CONF_SUPPORTED_FEATURES = ATTR_SUPPORTED_FEATURES
@@ -141,37 +141,8 @@ MQTT_VACUUM_ATTRIBUTES_BLOCKED = frozenset(
 MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 
-def validate_clean_area_config(config: ConfigType) -> ConfigType:
-    """Check for a valid configuration and check segments."""
-    if (config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC not in config) or (
-        not config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config
-    ):
-        raise vol.Invalid(
-            f"Options `{CONF_SEGMENTS}` and "
-            f"`{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` must be defined together"
-        )
-    segments: list[str]
-    if segments := config[CONF_SEGMENTS]:
-        if not config.get(CONF_UNIQUE_ID):
-            raise vol.Invalid(
-                f"Option `{CONF_SEGMENTS}` requires `{CONF_UNIQUE_ID}` to be configured"
-            )
-        unique_segments: set[str] = set()
-        for segment in segments:
-            segment_id, _, _ = segment.partition(".")
-            if not segment_id or segment_id in unique_segments:
-                raise vol.Invalid(
-                    f"The `{CONF_SEGMENTS}` option contains an invalid or non-"
-                    f"unique segment ID '{segment_id}'. Got {segments}"
-                )
-            unique_segments.add(segment_id)
-
-    return config
-
-
 _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
-        vol.Optional(CONF_SEGMENTS, default=[]): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TOPIC): valid_publish_topic,
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_FAN_SPEED_LIST, default=[]): vol.All(
@@ -199,10 +170,8 @@ _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
-PLATFORM_SCHEMA_MODERN = vol.All(_BASE_SCHEMA, validate_clean_area_config)
-DISCOVERY_SCHEMA = vol.All(
-    _BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA), validate_clean_area_config
-)
+PLATFORM_SCHEMA_MODERN = vol.All(_BASE_SCHEMA)
+DISCOVERY_SCHEMA = vol.All(_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA))
 
 
 async def async_setup_entry(
@@ -229,7 +198,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     _entity_id_format = ENTITY_ID_FORMAT
     _attributes_extra_blocked = MQTT_VACUUM_ATTRIBUTES_BLOCKED
 
-    _segments: list[Segment]
+    _segments: list[Segment] | None
     _command_topic: str | None
     _set_fan_speed_topic: str | None
     _send_command_topic: str | None
@@ -245,6 +214,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     ) -> None:
         """Initialize the vacuum."""
         self._state_attrs: dict[str, Any] = {}
+        self._segments = None
 
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
@@ -269,15 +239,8 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         self._attr_supported_features = _strings_to_services(
             supported_feature_strings, STRING_TO_SERVICE
         )
-        if config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
+        if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
-            segments: list[str] = config[CONF_SEGMENTS]
-            self._segments = [
-                Segment(id=segment_id, name=name or segment_id)
-                for segment_id, _, name in [
-                    segment.partition(".") for segment in segments
-                ]
-            ]
             self._clean_segments_command_topic = config[
                 CONF_CLEAN_SEGMENTS_COMMAND_TOPIC
             ]
@@ -309,6 +272,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         if (
             self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA
             and (last_seen := self.last_seen_segments) is not None
+            and self._segments is not None
             and {s.id: s for s in last_seen} != {s.id: s for s in self._segments}
         ):
             self.async_create_segments_issue()
@@ -333,6 +297,13 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                 POSSIBLE_STATES[cast(str, state)] if payload[STATE] else None
             )
             del payload[STATE]
+        if SEGMENTS in payload:
+            segments = cast(dict[str, str], payload[SEGMENTS])
+            self._segments = [
+                Segment(id=segment_id, name=str(name or segment_id))
+                for segment_id, name in segments.items()
+            ]
+            self._process_entity_update()
         self._update_state_attributes(payload)
 
     @callback
@@ -359,7 +330,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
 
     async def async_get_segments(self) -> list[Segment]:
         """Return the available segments."""
-        return self._segments
+        return self._segments if self._segments is not None else []
 
     async def _async_publish_command(self, feature: VacuumEntityFeature) -> None:
         """Publish a command."""

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -338,7 +338,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
             del payload[STATE]
         if SEGMENTS in payload and (segments := payload[SEGMENTS]):
             if not isinstance(segments, dict) or not all(
-                isinstance(k, str) and isinstance(v, (str, type(None)))
+                isinstance(k, str) and isinstance(v, (str, type(None))) and k
                 for k, v in segments.items()
             ):
                 _LOGGER.debug(
@@ -351,6 +351,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                     for segment_id, name in segments.items()
                 ]
                 self._process_entity_update()
+            del payload[SEGMENTS]
         self._update_state_attributes(payload)
 
     @callback

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -16,7 +16,7 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME
+from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -141,6 +141,16 @@ MQTT_VACUUM_ATTRIBUTES_BLOCKED = frozenset(
 MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 
+def validate_clean_area_config(config: ConfigType) -> ConfigType:
+    """Validate clean area config requires unique_id."""
+    if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config and not config.get(CONF_UNIQUE_ID):
+        raise vol.Invalid(
+            f"Option `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` requires"
+            f" `{CONF_UNIQUE_ID}` to be configured"
+        )
+    return config
+
+
 _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     {
         vol.Optional(CONF_CLEAN_SEGMENTS_COMMAND_TOPIC): valid_publish_topic,
@@ -170,8 +180,10 @@ _BASE_SCHEMA = MQTT_BASE_SCHEMA.extend(
     }
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
-PLATFORM_SCHEMA_MODERN = vol.All(_BASE_SCHEMA)
-DISCOVERY_SCHEMA = vol.All(_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA))
+PLATFORM_SCHEMA_MODERN = vol.All(_BASE_SCHEMA, validate_clean_area_config)
+DISCOVERY_SCHEMA = vol.All(
+    _BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA), validate_clean_area_config
+)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -309,13 +309,21 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
                 POSSIBLE_STATES[cast(str, state)] if payload[STATE] else None
             )
             del payload[STATE]
-        if SEGMENTS in payload:
-            segments = cast(dict[str, str], payload[SEGMENTS])
-            self._segments = [
-                Segment(id=segment_id, name=str(name or segment_id))
-                for segment_id, name in segments.items()
-            ]
-            self._process_entity_update()
+        if SEGMENTS in payload and (segments := payload[SEGMENTS]):
+            if not isinstance(segments, dict) or not all(
+                isinstance(k, str) and isinstance(v, (str, type(None)))
+                for k, v in segments.items()
+            ):
+                _LOGGER.debug(
+                    "Ignoring invalid `segments` value in state payload: %s",
+                    segments,
+                )
+            else:
+                self._segments = [
+                    Segment(id=segment_id, name=str(name or segment_id))
+                    for segment_id, name in segments.items()
+                ]
+                self._process_entity_update()
         self._update_state_attributes(payload)
 
     @callback

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -482,6 +482,31 @@ async def test_clean_segments_command_update(
     ]
 
 
+@pytest.mark.usefixtures("hass")
+@pytest.mark.parametrize(
+    ("hass_config", "error_message"),
+    [
+        (
+            help_custom_config(
+                vacuum.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"clean_segments_command_topic": "test-topic"},),
+            ),
+            "Option `clean_segments_command_topic` requires"
+            " `unique_id` to be configured",
+        ),
+    ],
+)
+async def test_clean_segments_config_validation(
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    error_message: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test status clean segment config validation."""
+    await mqtt_mock_entry()
+    assert error_message in caplog.text
+
+
 @pytest.mark.parametrize(
     "hass_config",
     [

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -98,6 +98,30 @@ CONFIG_CLEAN_SEGMENTS = {
     }
 }
 
+CONFIG_CLEAN_SEGMENTS_1 = {
+    mqtt.DOMAIN: {
+        vacuum.DOMAIN: {
+            "name": "test",
+            "unique_id": "veryunique",
+            "state_topic": "vacuum/state",
+            "segments": ["Livingroom", "Kitchen"],
+            "clean_segments_command_topic": "vacuum/clean_segment",
+        }
+    }
+}
+
+CONFIG_CLEAN_SEGMENTS_2 = {
+    mqtt.DOMAIN: {
+        vacuum.DOMAIN: {
+            "name": "test",
+            "unique_id": "veryunique",
+            "state_topic": "vacuum/state",
+            "segments": ["1.Livingroom", "2.Kitchen"],
+            "clean_segments_command_topic": "vacuum/clean_segment",
+        }
+    }
+}
+
 DEFAULT_CONFIG_2 = {mqtt.DOMAIN: {vacuum.DOMAIN: {"name": "test"}}}
 
 CONFIG_ALL_SERVICES = help_custom_config(
@@ -482,6 +506,64 @@ async def test_clean_segments_command_update(
     ]
 
 
+@pytest.mark.parametrize(
+    "hass_config",
+    [
+        {
+            mqtt.DOMAIN: {
+                vacuum.DOMAIN: {
+                    "name": "test",
+                    "unique_id": "veryunique",
+                    "segments": ["Livingroom", "Kitchen", "Kitchen"],
+                    "clean_segments_command_topic": "vacuum/clean_segment",
+                }
+            }
+        },
+        {
+            mqtt.DOMAIN: {
+                vacuum.DOMAIN: {
+                    "name": "test",
+                    "unique_id": "veryunique",
+                    "segments": ["Livingroom", "Kitchen", ""],
+                    "clean_segments_command_topic": "vacuum/clean_segment",
+                }
+            }
+        },
+        {
+            mqtt.DOMAIN: {
+                vacuum.DOMAIN: {
+                    "name": "test",
+                    "unique_id": "veryunique",
+                    "segments": ["1.Livingroom", "1.Kitchen"],
+                    "clean_segments_command_topic": "vacuum/clean_segment",
+                }
+            }
+        },
+        {
+            mqtt.DOMAIN: {
+                vacuum.DOMAIN: {
+                    "name": "test",
+                    "unique_id": "veryunique",
+                    "segments": ["1.Livingroom", "1.Kitchen", ".Diningroom"],
+                    "clean_segments_command_topic": "vacuum/clean_segment",
+                }
+            }
+        },
+    ],
+)
+async def test_non_unique_segments(
+    hass: HomeAssistant,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test with non-unique list of cleanable segments with valid segment IDs."""
+    await mqtt_mock_entry()
+    assert (
+        "The `segments` option contains an invalid or non-unique segment ID"
+        in caplog.text
+    )
+
+
 @pytest.mark.usefixtures("hass")
 @pytest.mark.parametrize(
     ("hass_config", "error_message"),
@@ -491,6 +573,29 @@ async def test_clean_segments_command_update(
                 vacuum.DOMAIN,
                 DEFAULT_CONFIG,
                 ({"clean_segments_command_topic": "test-topic"},),
+            ),
+            "Option `clean_segments_command_topic` requires"
+            " `unique_id` to be configured",
+        ),
+        (
+            help_custom_config(
+                vacuum.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"segments": ["Livingroom"]},),
+            ),
+            "Options `segments` and "
+            "`clean_segments_command_topic` must be defined together",
+        ),
+        (
+            help_custom_config(
+                vacuum.DOMAIN,
+                DEFAULT_CONFIG,
+                (
+                    {
+                        "segments": ["Livingroom"],
+                        "clean_segments_command_topic": "test-topic",
+                    },
+                ),
             ),
             "Option `clean_segments_command_topic` requires"
             " `unique_id` to be configured",
@@ -574,6 +679,76 @@ async def test_clean_segments_command_with_command_template(
         {"id": "1", "name": "Livingroom", "group": None},
         {"id": "2", "name": "Kitchen", "group": None},
     ]
+
+
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_2])
+async def test_clean_segments_config_overridden_by_state_topic(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test segments from config are overridden by state topic segments."""
+    mqtt_mock = await mqtt_mock_entry()
+    entity_registry.async_update_entity_options(
+        "vacuum.test",
+        vacuum.DOMAIN,
+        {
+            "area_mapping": {"Livingroom": ["1"], "Kitchen": ["2"]},
+            "last_seen_segments": [
+                {"id": "1", "name": "Livingroom"},
+                {"id": "2", "name": "Kitchen"},
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    # Verify initial segments from config
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+    ]
+
+    issue_registry = ir.async_get(hass)
+    assert len(issue_registry.issues) == 0
+
+    # Send updated segments via state topic — adds a new segment
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps(
+            {"segments": {"1": "Livingroom", "2": "Kitchen", "3": "Diningroom"}}
+        ),
+    )
+    await hass.async_block_till_done()
+
+    # Segments should be overridden by state topic
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+        {"id": "3", "name": "Diningroom", "group": None},
+    ]
+
+    # A repair flow should start because segments changed vs last_seen
+    assert len(issue_registry.issues) == 1
+
+    # Clean area should use the new segments
+    await common.async_clean_area(hass, ["Kitchen"], entity_id="vacuum.test")
+    assert (
+        call("vacuum/clean_segment", '["2"]', 0, False)
+        in mqtt_mock.async_publish.mock_calls
+    )
 
 
 @pytest.mark.parametrize("hass_config", [CONFIG_ALL_SERVICES])

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -377,14 +377,110 @@ async def test_clean_segments_initial_setup_without_repair_issue(
     assert len(issue_registry.issues) == 0
 
 
-@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
-async def test_clean_segments_command(
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_1])
+async def test_clean_segments_command_without_id(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test cleanable segments with explicit segment IDs."""
+    """Test cleanable segments without ID."""
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    entity_registry.async_get_or_create(
+        vacuum.DOMAIN,
+        mqtt.DOMAIN,
+        "veryunique",
+        config_entry=config_entry,
+        suggested_object_id="test",
+    )
+    entity_registry.async_update_entity_options(
+        "vacuum.test",
+        vacuum.DOMAIN,
+        {
+            "area_mapping": {"Nabu Casa": ["Kitchen", "Livingroom"]},
+            "last_seen_segments": [
+                {"id": "Livingroom", "name": "Livingroom"},
+                {"id": "Kitchen", "name": "Kitchen"},
+            ],
+        },
+    )
+    mqtt_mock = await mqtt_mock_entry()
+    await hass.async_block_till_done()
+    issue_registry = ir.async_get(hass)
+    # We do not expect a repair flow
+    assert len(issue_registry.issues) == 0
+
+    state = hass.states.get("vacuum.test")
+    assert state.state == STATE_UNKNOWN
+    await common.async_clean_area(hass, ["Nabu Casa"], entity_id="vacuum.test")
+    assert (
+        call("vacuum/clean_segment", '["Kitchen","Livingroom"]', 0, False)
+        in mqtt_mock.async_publish.mock_calls
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "Livingroom", "name": "Livingroom", "group": None},
+        {"id": "Kitchen", "name": "Kitchen", "group": None},
+    ]
+
+
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_2])
+async def test_clean_segments_command_with_id(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test cleanable segments with ID."""
+    mqtt_mock = await mqtt_mock_entry()
+    # Set the area mapping
+    entity_registry.async_update_entity_options(
+        "vacuum.test",
+        vacuum.DOMAIN,
+        {
+            "area_mapping": {"Livingroom": ["1"], "Kitchen": ["2"]},
+            "last_seen_segments": [
+                {"id": "1", "name": "Livingroom"},
+                {"id": "2", "name": "Kitchen"},
+            ],
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("vacuum.test")
+    assert state.state == STATE_UNKNOWN
+    await common.async_clean_area(hass, ["Kitchen"], entity_id="vacuum.test")
+    assert (
+        call("vacuum/clean_segment", '["2"]', 0, False)
+        in mqtt_mock.async_publish.mock_calls
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+    ]
+
+
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
+async def test_clean_segments_command_from_state_topic(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+) -> None:
+    """Test cleanable segments from state topic."""
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     entity_registry.async_get_or_create(
         vacuum.DOMAIN,

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -87,22 +87,12 @@ DEFAULT_CONFIG = {
     }
 }
 
-CONFIG_CLEAN_SEGMENTS_1 = {
+CONFIG_CLEAN_SEGMENTS = {
     mqtt.DOMAIN: {
         vacuum.DOMAIN: {
             "name": "test",
             "unique_id": "veryunique",
-            "segments": ["Livingroom", "Kitchen"],
-            "clean_segments_command_topic": "vacuum/clean_segment",
-        }
-    }
-}
-CONFIG_CLEAN_SEGMENTS_2 = {
-    mqtt.DOMAIN: {
-        vacuum.DOMAIN: {
-            "name": "test",
-            "unique_id": "veryunique",
-            "segments": ["1.Livingroom", "2.Kitchen"],
+            "state_topic": "vacuum/state",
             "clean_segments_command_topic": "vacuum/clean_segment",
         }
     }
@@ -320,25 +310,13 @@ async def test_command_without_command_topic(
     mqtt_mock.async_publish.reset_mock()
 
 
-@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_1])
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
 async def test_clean_segments_initial_setup_without_repair_issue(
     hass: HomeAssistant,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
-) -> None:
-    """Test cleanable segments initial setup does not fire repair flow."""
-    await mqtt_mock_entry()
-    issue_registry = ir.async_get(hass)
-    assert len(issue_registry.issues) == 0
-
-
-@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_1])
-async def test_clean_segments_command_without_id(
-    hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test cleanable segments without ID."""
+    """Test cleanable segments initial setup does not fire repair flow."""
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     entity_registry.async_get_or_create(
         vacuum.DOMAIN,
@@ -351,49 +329,46 @@ async def test_clean_segments_command_without_id(
         "vacuum.test",
         vacuum.DOMAIN,
         {
-            "area_mapping": {"Nabu Casa": ["Kitchen", "Livingroom"]},
+            "area_mapping": {"Livingroom": ["1"], "Kitchen": ["2"]},
             "last_seen_segments": [
-                {"id": "Livingroom", "name": "Livingroom"},
-                {"id": "Kitchen", "name": "Kitchen"},
+                {"id": "1", "name": "Livingroom"},
+                {"id": "2", "name": "Kitchen"},
             ],
         },
     )
-    mqtt_mock = await mqtt_mock_entry()
+    await mqtt_mock_entry()
     await hass.async_block_till_done()
+
     issue_registry = ir.async_get(hass)
-    # We do not expect a repair flow
+    # No issue before segments are received
     assert len(issue_registry.issues) == 0
 
-    state = hass.states.get("vacuum.test")
-    assert state.state == STATE_UNKNOWN
-    await common.async_clean_area(hass, ["Nabu Casa"], entity_id="vacuum.test")
-    assert (
-        call("vacuum/clean_segment", '["Kitchen","Livingroom"]', 0, False)
-        in mqtt_mock.async_publish.mock_calls
+    # Send segments matching last_seen_segments — still no issue
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps({"segments": {"1": "Livingroom", "2": "Kitchen"}}),
     )
-
-    client = await hass_ws_client(hass)
-    await client.send_json_auto_id(
-        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
-    )
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert msg["result"]["segments"] == [
-        {"id": "Livingroom", "name": "Livingroom", "group": None},
-        {"id": "Kitchen", "name": "Kitchen", "group": None},
-    ]
+    await hass.async_block_till_done()
+    assert len(issue_registry.issues) == 0
 
 
-@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_2])
-async def test_clean_segments_command_with_id(
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
+async def test_clean_segments_command(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test cleanable segments with ID."""
-    mqtt_mock = await mqtt_mock_entry()
-    # Set the area mapping
+    """Test cleanable segments with explicit segment IDs."""
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    entity_registry.async_get_or_create(
+        vacuum.DOMAIN,
+        mqtt.DOMAIN,
+        "veryunique",
+        config_entry=config_entry,
+        suggested_object_id="test",
+    )
     entity_registry.async_update_entity_options(
         "vacuum.test",
         vacuum.DOMAIN,
@@ -404,6 +379,15 @@ async def test_clean_segments_command_with_id(
                 {"id": "2", "name": "Kitchen"},
             ],
         },
+    )
+    mqtt_mock = await mqtt_mock_entry()
+    await hass.async_block_till_done()
+
+    # Send segments via state topic
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps({"segments": {"1": "Livingroom", "2": "Kitchen"}}),
     )
     await hass.async_block_till_done()
 
@@ -427,14 +411,14 @@ async def test_clean_segments_command_with_id(
     ]
 
 
+@pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS])
 async def test_clean_segments_command_update(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test cleanable segments update via discovery."""
+    """Test cleanable segments update via state topic raises repair."""
     # Prepare original entity config entry
     config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
     entity_registry.async_get_or_create(
@@ -456,11 +440,14 @@ async def test_clean_segments_command_update(
         },
     )
     await mqtt_mock_entry()
-    # Do initial discovery
-    config1 = CONFIG_CLEAN_SEGMENTS_2[mqtt.DOMAIN][vacuum.DOMAIN]
-    payload1 = json.dumps(config1)
-    config_topic = "homeassistant/vacuum/bla/config"
-    async_fire_mqtt_message(hass, config_topic, payload1)
+    await hass.async_block_till_done()
+
+    # Send initial segments matching last_seen_segments
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps({"segments": {"1": "Livingroom", "2": "Kitchen"}}),
+    )
     await hass.async_block_till_done()
     state = hass.states.get("vacuum.test")
     assert state.state == STATE_UNKNOWN
@@ -469,11 +456,14 @@ async def test_clean_segments_command_update(
     # We do not expect a repair flow
     assert len(issue_registry.issues) == 0
 
-    # Update the segments
-    config2 = config1.copy()
-    config2["segments"] = ["1.Livingroom", "2.Kitchen", "3.Diningroom"]
-    payload2 = json.dumps(config2)
-    async_fire_mqtt_message(hass, config_topic, payload2)
+    # Update the segments with a new segment added
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps(
+            {"segments": {"1": "Livingroom", "2": "Kitchen", "3": "Diningroom"}}
+        ),
+    )
     await hass.async_block_till_done()
 
     # A repair flow should start
@@ -491,141 +481,32 @@ async def test_clean_segments_command_update(
         {"id": "3", "name": "Diningroom", "group": None},
     ]
 
-    # Test update with a non-unique segment list fails
-    config3 = config1.copy()
-    config3["segments"] = ["1.Livingroom", "2.Kitchen", "2.Diningroom"]
-    payload3 = json.dumps(config3)
-    async_fire_mqtt_message(hass, config_topic, payload3)
-    await hass.async_block_till_done()
-    assert (
-        "Error 'The `segments` option contains an invalid or non-unique segment ID '2'"
-        in caplog.text
-    )
-
-
-@pytest.mark.parametrize(
-    "hass_config",
-    [
-        {
-            mqtt.DOMAIN: {
-                vacuum.DOMAIN: {
-                    "name": "test",
-                    "unique_id": "veryunique",
-                    "segments": ["Livingroom", "Kitchen", "Kitchen"],
-                    "clean_segments_command_topic": "vacuum/clean_segment",
-                }
-            }
-        },
-        {
-            mqtt.DOMAIN: {
-                vacuum.DOMAIN: {
-                    "name": "test",
-                    "unique_id": "veryunique",
-                    "segments": ["Livingroom", "Kitchen", ""],
-                    "clean_segments_command_topic": "vacuum/clean_segment",
-                }
-            }
-        },
-        {
-            mqtt.DOMAIN: {
-                vacuum.DOMAIN: {
-                    "name": "test",
-                    "unique_id": "veryunique",
-                    "segments": ["1.Livingroom", "1.Kitchen"],
-                    "clean_segments_command_topic": "vacuum/clean_segment",
-                }
-            }
-        },
-        {
-            mqtt.DOMAIN: {
-                vacuum.DOMAIN: {
-                    "name": "test",
-                    "unique_id": "veryunique",
-                    "segments": ["1.Livingroom", "1.Kitchen", ".Diningroom"],
-                    "clean_segments_command_topic": "vacuum/clean_segment",
-                }
-            }
-        },
-    ],
-)
-async def test_non_unique_segments(
-    hass: HomeAssistant,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test with non-unique list of cleanable segments with valid segment IDs."""
-    await mqtt_mock_entry()
-    assert (
-        "The `segments` option contains an invalid or non-unique segment ID"
-        in caplog.text
-    )
-
-
-@pytest.mark.usefixtures("hass")
-@pytest.mark.parametrize(
-    ("hass_config", "error_message"),
-    [
-        (
-            help_custom_config(
-                vacuum.DOMAIN,
-                DEFAULT_CONFIG,
-                ({"clean_segments_command_topic": "test-topic"},),
-            ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
-        ),
-        (
-            help_custom_config(
-                vacuum.DOMAIN,
-                DEFAULT_CONFIG,
-                ({"segments": ["Livingroom"]},),
-            ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
-        ),
-        (
-            help_custom_config(
-                vacuum.DOMAIN,
-                DEFAULT_CONFIG,
-                (
-                    {
-                        "segments": ["Livingroom"],
-                        "clean_segments_command_topic": "test-topic",
-                    },
-                ),
-            ),
-            "Option `segments` requires `unique_id` to be configured",
-        ),
-    ],
-)
-async def test_clean_segments_config_validation(
-    mqtt_mock_entry: MqttMockHAClientGenerator,
-    error_message: str,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test status clean segment config validation."""
-    await mqtt_mock_entry()
-    assert error_message in caplog.text
-
 
 @pytest.mark.parametrize(
     "hass_config",
     [
         help_custom_config(
             vacuum.DOMAIN,
-            CONFIG_CLEAN_SEGMENTS_2,
+            CONFIG_CLEAN_SEGMENTS,
             ({"clean_segments_command_template": "{{ ';'.join(value) }}"},),
         )
     ],
 )
-async def test_clean_segments_command_with_id_and_command_template(
+async def test_clean_segments_command_with_command_template(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
     """Test clean segments with command template."""
-    mqtt_mock = await mqtt_mock_entry()
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    entity_registry.async_get_or_create(
+        vacuum.DOMAIN,
+        mqtt.DOMAIN,
+        "veryunique",
+        config_entry=config_entry,
+        suggested_object_id="test",
+    )
     entity_registry.async_update_entity_options(
         "vacuum.test",
         vacuum.DOMAIN,
@@ -636,6 +517,15 @@ async def test_clean_segments_command_with_id_and_command_template(
                 {"id": "2", "name": "Kitchen"},
             ],
         },
+    )
+    mqtt_mock = await mqtt_mock_entry()
+    await hass.async_block_till_done()
+
+    # Send segments via state topic
+    async_fire_mqtt_message(
+        hass,
+        "vacuum/state",
+        json.dumps({"segments": {"1": "Livingroom", "2": "Kitchen"}}),
     )
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This moves the segments out of the discovery payload and into the state payload, as they can change during the lifetime of the device.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As discussed in #166687 and https://github.com/Hypfer/Valetudo/discussions/2486 , I propose to move the available segments into the vacuum robots state instead of the discovery payload, as those can change during the runtime of the device due to (automatic) remapping etc.

I also chose to implement it as a dict instead of the list of strings with ids separated with a dot, as that seems more idiomatic to me, and inherently solves the required unique-id validation. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]
Will follow as soon as the direction is approved.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
