### PR TITLE
Allow MQTT vacuum segments list to be empty at initially

### DIFF
--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -143,28 +143,22 @@ MQTT_VACUUM_DOCS_URL = "https://www.home-assistant.io/integrations/vacuum.mqtt/"
 
 def validate_clean_area_config(config: ConfigType) -> ConfigType:
     """Check for a valid configuration and check segments."""
-    if (config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC not in config) or (
-        not config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config
-    ):
+    if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC not in config:
+        return config
+    if not config.get(CONF_UNIQUE_ID):
         raise vol.Invalid(
-            f"Options `{CONF_SEGMENTS}` and "
-            f"`{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` must be defined together"
+            f"Option `{CONF_CLEAN_SEGMENTS_COMMAND_TOPIC}` requires `{CONF_UNIQUE_ID}` to be configured"
         )
-    segments: list[str]
-    if segments := config[CONF_SEGMENTS]:
-        if not config.get(CONF_UNIQUE_ID):
+    segments: list[str] = config[CONF_SEGMENTS]
+    unique_segments: set[str] = set()
+    for segment in segments:
+        segment_id, _, _ = segment.partition(".")
+        if not segment_id or segment_id in unique_segments:
             raise vol.Invalid(
-                f"Option `{CONF_SEGMENTS}` requires `{CONF_UNIQUE_ID}` to be configured"
+                f"The `{CONF_SEGMENTS}` option contains an invalid or non-"
+                f"unique segment ID '{segment_id}'. Got {segments}"
             )
-        unique_segments: set[str] = set()
-        for segment in segments:
-            segment_id, _, _ = segment.partition(".")
-            if not segment_id or segment_id in unique_segments:
-                raise vol.Invalid(
-                    f"The `{CONF_SEGMENTS}` option contains an invalid or non-"
-                    f"unique segment ID '{segment_id}'. Got {segments}"
-                )
-            unique_segments.add(segment_id)
+        unique_segments.add(segment_id)
 
     return config
 
@@ -235,6 +229,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     _send_command_topic: str | None
     _clean_segments_command_topic: str
     _payloads: dict[str, str | None]
+    _initial_setup: bool = True
 
     def __init__(
         self,
@@ -269,7 +264,7 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         self._attr_supported_features = _strings_to_services(
             supported_feature_strings, STRING_TO_SERVICE
         )
-        if config[CONF_SEGMENTS] and CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
+        if CONF_CLEAN_SEGMENTS_COMMAND_TOPIC in config:
             self._attr_supported_features |= VacuumEntityFeature.CLEAN_AREA
             segments: list[str] = config[CONF_SEGMENTS]
             self._segments = [
@@ -308,14 +303,16 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
         """Check vacuum segments with registry entry."""
         if (
             self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA
-            and (last_seen := self.last_seen_segments) is not None
-            and {s.id: s for s in last_seen} != {s.id: s for s in self._segments}
+            and not self._initial_setup
+            and {s.id: s for s in self.last_seen_segments or []}
+            != {s.id: s for s in self._segments}
         ):
             self.async_create_segments_issue()
 
     async def mqtt_async_added_to_hass(self) -> None:
         """Check vacuum segments with registry entry."""
         self._process_entity_update()
+        self._initial_setup = False
 
     def _update_state_attributes(self, payload: dict[str, Any]) -> None:
         """Update the entity state attributes."""

--- a/homeassistant/components/mqtt/vacuum.py
+++ b/homeassistant/components/mqtt/vacuum.py
@@ -229,7 +229,6 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     _send_command_topic: str | None
     _clean_segments_command_topic: str
     _payloads: dict[str, str | None]
-    _initial_setup: bool = True
 
     def __init__(
         self,
@@ -301,18 +300,14 @@ class MqttStateVacuum(MqttEntity, StateVacuumEntity):
     @callback
     def _process_entity_update(self) -> None:
         """Check vacuum segments with registry entry."""
-        if (
-            self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA
-            and not self._initial_setup
-            and {s.id: s for s in self.last_seen_segments or []}
-            != {s.id: s for s in self._segments}
-        ):
+        if self._attr_supported_features & VacuumEntityFeature.CLEAN_AREA and {
+            s.id: s for s in self.last_seen_segments or []
+        } != {s.id: s for s in self._segments}:
             self.async_create_segments_issue()
 
     async def mqtt_async_added_to_hass(self) -> None:
         """Check vacuum segments with registry entry."""
         self._process_entity_update()
-        self._initial_setup = False
 
     def _update_state_attributes(self, payload: dict[str, Any]) -> None:
         """Update the entity state attributes."""

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -330,11 +330,11 @@ async def test_command_without_command_topic(
 
 
 @pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_1])
-async def test_clean_segments_initial_setup_without_repair_issue(
+async def test_clean_segments_initial_setup_repair_issue(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test cleanable segments initial setup does fire repair flow."""
+    """Test cleanable segments initial setup fires a repair flow."""
     await mqtt_mock_entry()
     issue_registry = ir.async_get(hass)
     assert len(issue_registry.issues) == 1

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -87,6 +87,15 @@ DEFAULT_CONFIG = {
     }
 }
 
+CONFIG_CLEAN_SEGMENTS_0 = {
+    mqtt.DOMAIN: {
+        vacuum.DOMAIN: {
+            "name": "test",
+            "unique_id": "veryunique",
+            "clean_segments_command_topic": "vacuum/clean_segment",
+        }
+    }
+}
 CONFIG_CLEAN_SEGMENTS_1 = {
     mqtt.DOMAIN: {
         vacuum.DOMAIN: {
@@ -503,6 +512,76 @@ async def test_clean_segments_command_update(
     )
 
 
+async def test_clean_segments_command_update_without_initial_segments(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    entity_registry: er.EntityRegistry,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test cleanable segments update via discovery without initial segments."""
+    # Prepare original entity config entry
+    config_entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
+    entity_registry.async_get_or_create(
+        vacuum.DOMAIN,
+        mqtt.DOMAIN,
+        "veryunique",
+        config_entry=config_entry,
+        suggested_object_id="test",
+    )
+    entity_registry.async_update_entity_options(
+        "vacuum.test",
+        vacuum.DOMAIN,
+        {},
+    )
+    await mqtt_mock_entry()
+    # Do initial discovery
+    config1 = CONFIG_CLEAN_SEGMENTS_0[mqtt.DOMAIN][vacuum.DOMAIN]
+    payload1 = json.dumps(config1)
+    config_topic = "homeassistant/vacuum/bla/config"
+    async_fire_mqtt_message(hass, config_topic, payload1)
+    await hass.async_block_till_done()
+    state = hass.states.get("vacuum.test")
+    assert state.state == STATE_UNKNOWN
+
+    issue_registry = ir.async_get(hass)
+    # We do not expect a repair flow
+    assert len(issue_registry.issues) == 0
+
+    # Update the segments
+    config2 = config1.copy()
+    config2["segments"] = ["1.Livingroom", "2.Kitchen", "3.Diningroom"]
+    payload2 = json.dumps(config2)
+    async_fire_mqtt_message(hass, config_topic, payload2)
+    await hass.async_block_till_done()
+
+    # A repair flow should start
+    assert len(issue_registry.issues) == 1
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "vacuum/get_segments", "entity_id": "vacuum.test"}
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"]["segments"] == [
+        {"id": "1", "name": "Livingroom", "group": None},
+        {"id": "2", "name": "Kitchen", "group": None},
+        {"id": "3", "name": "Diningroom", "group": None},
+    ]
+
+    # Test update with a non-unique segment list fails
+    config3 = config1.copy()
+    config3["segments"] = ["1.Livingroom", "2.Kitchen", "2.Diningroom"]
+    payload3 = json.dumps(config3)
+    async_fire_mqtt_message(hass, config_topic, payload3)
+    await hass.async_block_till_done()
+    assert (
+        "Error 'The `segments` option contains an invalid or non-unique segment ID '2'"
+        in caplog.text
+    )
+
+
 @pytest.mark.parametrize(
     "hass_config",
     [
@@ -569,24 +648,6 @@ async def test_non_unique_segments(
             help_custom_config(
                 vacuum.DOMAIN,
                 DEFAULT_CONFIG,
-                ({"clean_segments_command_topic": "test-topic"},),
-            ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
-        ),
-        (
-            help_custom_config(
-                vacuum.DOMAIN,
-                DEFAULT_CONFIG,
-                ({"segments": ["Livingroom"]},),
-            ),
-            "Options `segments` and "
-            "`clean_segments_command_topic` must be defined together",
-        ),
-        (
-            help_custom_config(
-                vacuum.DOMAIN,
-                DEFAULT_CONFIG,
                 (
                     {
                         "segments": ["Livingroom"],
@@ -594,7 +655,7 @@ async def test_non_unique_segments(
                     },
                 ),
             ),
-            "Option `segments` requires `unique_id` to be configured",
+            "Option `clean_segments_command_topic` requires `unique_id` to be configured",
         ),
     ],
 )

--- a/tests/components/mqtt/test_vacuum.py
+++ b/tests/components/mqtt/test_vacuum.py
@@ -334,10 +334,10 @@ async def test_clean_segments_initial_setup_without_repair_issue(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
 ) -> None:
-    """Test cleanable segments initial setup does not fire repair flow."""
+    """Test cleanable segments initial setup does fire repair flow."""
     await mqtt_mock_entry()
     issue_registry = ir.async_get(hass)
-    assert len(issue_registry.issues) == 0
+    assert len(issue_registry.issues) == 1
 
 
 @pytest.mark.parametrize("hass_config", [CONFIG_CLEAN_SEGMENTS_1])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is an alternative for: https://github.com/home-assistant/core/pull/166734

Allow MQTT vacuum segments list to be empty at initially when a vacuum dynamically discovers area segments. With this PR an initially empty segments list is allowed.

We do not suppress a repair flow on initial discovery as a vacuum needs an area segments mapping after being discovered. Also if a vacuum initially had no segments, a user should be notified after segments have been discovered.

In a follow-up PR allowing to update the segments via the state state topic will be added as a new feature.

This bugfix is done to prevent a breaking change later.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44363
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
