### PR TITLE
Improve comelit type handling

### DIFF
--- a/homeassistant/components/comelit/climate.py
+++ b/homeassistant/components/comelit/climate.py
@@ -9,7 +9,6 @@ from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import CLIMATE
 
 from homeassistant.components.climate import (
-    DOMAIN as CLIMATE_DOMAIN,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -92,7 +91,7 @@ async def async_setup_entry(
 
     entities: list[ClimateEntity] = []
     for device in coordinator.data[CLIMATE].values():
-        values = load_api_data(device, CLIMATE_DOMAIN)
+        values = load_api_data(device, "climate")
         if values[0] == 0 and values[4] == 0:
             # No climate data, device is only a humidifier/dehumidifier
 
@@ -140,7 +139,7 @@ class ComelitClimateEntity(ComelitBridgeBaseEntity, ClimateEntity):
     def _update_attributes(self) -> None:
         """Update class attributes."""
         device = self.coordinator.data[CLIMATE][self._device.index]
-        values = load_api_data(device, CLIMATE_DOMAIN)
+        values = load_api_data(device, "climate")
 
         _active = values[1]
         _mode = values[2]  # Values from API: "O", "L", "U"

--- a/homeassistant/components/comelit/humidifier.py
+++ b/homeassistant/components/comelit/humidifier.py
@@ -9,7 +9,6 @@ from aiocomelit import ComelitSerialBridgeObject
 from aiocomelit.const import CLIMATE
 
 from homeassistant.components.humidifier import (
-    DOMAIN as HUMIDIFIER_DOMAIN,
     MODE_AUTO,
     MODE_NORMAL,
     HumidifierAction,
@@ -68,7 +67,7 @@ async def async_setup_entry(
 
     entities: list[ComelitHumidifierEntity] = []
     for device in coordinator.data[CLIMATE].values():
-        values = load_api_data(device, HUMIDIFIER_DOMAIN)
+        values = load_api_data(device, "humidifier")
         if values[0] == 0 and values[4] == 0:
             # No humidity data, device is only a climate
 
@@ -142,7 +141,7 @@ class ComelitHumidifierEntity(ComelitBridgeBaseEntity, HumidifierEntity):
     def _update_attributes(self) -> None:
         """Update class attributes."""
         device = self.coordinator.data[CLIMATE][self._device.index]
-        values = load_api_data(device, HUMIDIFIER_DOMAIN)
+        values = load_api_data(device, "humidifier")
 
         _active = values[1]
         _mode = values[2]  # Values from API: "O", "L", "U"

--- a/homeassistant/components/comelit/strings.json
+++ b/homeassistant/components/comelit/strings.json
@@ -113,9 +113,6 @@
     "humidity_while_off": {
       "message": "Cannot change humidity while off"
     },
-    "invalid_clima_data": {
-      "message": "Invalid 'clima' data"
-    },
     "update_failed": {
       "message": "Failed to update data: {error}"
     }

--- a/homeassistant/components/comelit/utils.py
+++ b/homeassistant/components/comelit/utils.py
@@ -2,13 +2,12 @@
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Concatenate
+from typing import TYPE_CHECKING, Any, Concatenate, Literal
 
 from aiocomelit.api import ComelitSerialBridgeObject
 from aiocomelit.exceptions import CannotAuthenticate, CannotConnect, CannotRetrieveData
 from aiohttp import ClientSession, CookieJar
 
-from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -30,17 +29,19 @@ async def async_client_session(hass: HomeAssistant) -> ClientSession:
     )
 
 
-def load_api_data(device: ComelitSerialBridgeObject, domain: str) -> list[Any]:
+def load_api_data(
+    device: ComelitSerialBridgeObject,
+    domain: Literal["climate", "humidifier"],
+) -> list[Any]:
     """Load data from the API."""
-    # This function is called when the data is loaded from the API
-    if not isinstance(device.val, list):
-        raise HomeAssistantError(
-            translation_domain=domain, translation_key="invalid_clima_data"
-        )
+    # This function is called when the data is loaded from the API.
+    # For climate and humidifier device.val is always a list.
+    if TYPE_CHECKING:
+        assert isinstance(device.val, list)
     # CLIMATE has a 2 item tuple:
     # - first  for Clima
     # - second for Humidifier
-    return device.val[0] if domain == CLIMATE_DOMAIN else device.val[1]
+    return device.val[0] if domain == "climate" else device.val[1]
 
 
 async def cleanup_stale_entity(

--- a/tests/components/comelit/test_climate.py
+++ b/tests/components/comelit/test_climate.py
@@ -126,43 +126,6 @@ async def test_climate_data_update(
     assert state.attributes[ATTR_TEMPERATURE] == temp
 
 
-async def test_climate_data_update_bad_data(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_serial_bridge: AsyncMock,
-    mock_serial_bridge_config_entry: MockConfigEntry,
-) -> None:
-    """Test climate data update."""
-    await setup_integration(hass, mock_serial_bridge_config_entry)
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == HVACMode.HEAT
-    assert state.attributes[ATTR_TEMPERATURE] == 5.0
-
-    mock_serial_bridge.get_all_devices.return_value[CLIMATE] = {
-        0: ComelitSerialBridgeObject(
-            index=0,
-            name="Climate0",
-            status=0,
-            human_status="off",
-            type="climate",
-            val="bad_data",  # type: ignore[arg-type]
-            protected=0,
-            zone="Living room",
-            power=0.0,
-            power_unit=WATT,
-        ),
-    }
-
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == HVACMode.HEAT
-    assert state.attributes[ATTR_TEMPERATURE] == 5.0
-
-
 async def test_climate_set_temperature(
     hass: HomeAssistant,
     mock_serial_bridge: AsyncMock,

--- a/tests/components/comelit/test_humidifier.py
+++ b/tests/components/comelit/test_humidifier.py
@@ -126,43 +126,6 @@ async def test_humidifier_data_update(
     assert state.attributes[ATTR_HUMIDITY] == humidity
 
 
-async def test_humidifier_data_update_bad_data(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_serial_bridge: AsyncMock,
-    mock_serial_bridge_config_entry: MockConfigEntry,
-) -> None:
-    """Test humidifier data update."""
-    await setup_integration(hass, mock_serial_bridge_config_entry)
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_HUMIDITY] == 50.0
-
-    mock_serial_bridge.get_all_devices.return_value[CLIMATE] = {
-        0: ComelitSerialBridgeObject(
-            index=0,
-            name="Climate0",
-            status=0,
-            human_status="off",
-            type="climate",
-            val="bad_data",  # type: ignore[arg-type]
-            protected=0,
-            zone="Living room",
-            power=0.0,
-            power_unit=WATT,
-        ),
-    }
-
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    assert (state := hass.states.get(ENTITY_ID))
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_HUMIDITY] == 50.0
-
-
 async def test_humidifier_set_humidity(
     hass: HomeAssistant,
     mock_serial_bridge: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The removed exception can not happen in production, according to this comment: https://github.com/home-assistant/core/pull/139455#discussion_r1977625344. It was a way to handle a type annotation inconsistency.
- The problem grew when tests were added to cover a case that can't really happen. These tests fail when bumping Python to 3.14.3.
- It's not appropriate to raise an exception in this part of the code as it's after the data fetching either when creating the entity or when updating the entity state. So if this bad data could actually occur it should have been handled during the coordinator fetching of data and not afterwards.
- Remove the exception and just assert the data type for now since we know what it will be. A better longer term solution is to improve the type annotation of the library to avoid the union at this level of the data structure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
