### PR TITLE
Improve energyid config flow tests

### DIFF
--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -40,6 +40,15 @@ def mock_polling_interval_fixture() -> Generator[int]:
         yield polling_interval
 
 
+@pytest.fixture(autouse=True)
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.energyid.async_setup_entry", return_value=True
+    ) as mock_setup:
+        yield mock_setup
+
+
 async def test_config_flow_user_step_success_claimed(hass: HomeAssistant) -> None:
     """Test user step where device is already claimed."""
     mock_client = MagicMock()
@@ -105,7 +114,7 @@ async def test_config_flow_auth_and_claim_step_success(hass: HomeAssistant) -> N
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -552,7 +561,7 @@ async def test_config_flow_reauth_needs_claim(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             return_value=mock_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -613,7 +622,7 @@ async def test_polling_stops_on_invalid_auth_error(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -661,7 +670,7 @@ async def test_polling_stops_on_cannot_connect_error(hass: HomeAssistant) -> Non
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -713,7 +722,7 @@ async def test_auth_and_claim_subsequent_auth_error(hass: HomeAssistant) -> None
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -821,7 +830,7 @@ async def test_polling_cancellation_on_auth_failure(hass: HomeAssistant) -> None
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -894,7 +903,7 @@ async def test_polling_cancellation_on_success(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.asyncio.sleep"),
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -918,24 +927,16 @@ async def test_polling_cancellation_on_success(hass: HomeAssistant) -> None:
 
         # Verify polling made authentication attempt
         # auth_call_count should be 1 (polling detected device is claimed)
-        assert auth_call_count >= 1
-        claimed_auth_count = auth_call_count
+        assert auth_call_count == 2  # One for polling, one for the final check
 
         # User continues - device is already claimed, polling should be cancelled
         result_done = await hass.config_entries.flow.async_configure(
             result_external["flow_id"]
         )
-        assert result_done["type"] is FlowResultType.EXTERNAL_STEP_DONE
+        assert result_done["type"] is FlowResultType.CREATE_ENTRY
 
-        # Verify polling was cancelled - the auth count should only increase by 1
-        # (for the manual check when user continues, not from polling)
-        assert auth_call_count == claimed_auth_count + 1
-
-        # Final call to create entry
-        final_result = await hass.config_entries.flow.async_configure(
-            result_external["flow_id"]
-        )
-        assert final_result["type"] is FlowResultType.CREATE_ENTRY
+        # Verify polling was cancelled - the auth count should not increase
+        assert auth_call_count == 2
 
         # Wait a bit and verify no further authentication attempts from polling
         await hass.async_block_till_done()

--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -918,7 +918,6 @@ async def test_polling_cancellation_on_success(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # Verify polling made authentication attempt
-        # auth_call_count should be 1 (polling detected device is claimed)
         assert auth_call_count == 2  # One for polling, one for the final check
 
         # User continues - device is already claimed, polling should be cancelled

--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -114,7 +114,6 @@ async def test_config_flow_auth_and_claim_step_success(hass: HomeAssistant) -> N
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -155,7 +154,6 @@ async def test_config_flow_claim_timeout(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             return_value=mock_unclaimed_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -561,7 +559,6 @@ async def test_config_flow_reauth_needs_claim(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             return_value=mock_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -622,7 +619,6 @@ async def test_polling_stops_on_invalid_auth_error(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -670,7 +666,6 @@ async def test_polling_stops_on_cannot_connect_error(hass: HomeAssistant) -> Non
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -722,7 +717,6 @@ async def test_auth_and_claim_subsequent_auth_error(hass: HomeAssistant) -> None
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -830,7 +824,6 @@ async def test_polling_cancellation_on_auth_failure(hass: HomeAssistant) -> None
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -903,7 +896,6 @@ async def test_polling_cancellation_on_success(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             side_effect=mock_webhook_client,
         ),
-        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/energyid/test_config_flow.py
+++ b/tests/components/energyid/test_config_flow.py
@@ -146,13 +146,14 @@ async def test_config_flow_claim_timeout(hass: HomeAssistant) -> None:
             "homeassistant.components.energyid.config_flow.WebhookClient",
             return_value=mock_unclaimed_client,
         ),
-        patch(
-            "homeassistant.components.energyid.config_flow.asyncio.sleep",
-        ) as mock_sleep,
+        patch("homeassistant.components.energyid.config_flow.POLLING_INTERVAL", new=0),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+
+        assert mock_unclaimed_client.authenticate.call_count == 0
+
         result_external = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -160,7 +161,16 @@ async def test_config_flow_claim_timeout(hass: HomeAssistant) -> None:
                 CONF_PROVISIONING_SECRET: TEST_PROVISIONING_SECRET,
             },
         )
+
         assert result_external["type"] is FlowResultType.EXTERNAL_STEP
+
+        # Wait for the polling to time out.
+        await hass.async_block_till_done()
+
+        # Verify polling actually ran the expected number of times
+        # +1 for the initial attempt before polling starts
+        assert mock_unclaimed_client.authenticate.call_count == MAX_POLLING_ATTEMPTS + 1
+        mock_unclaimed_client.authenticate.reset_mock()
 
         # Simulate polling timeout, then user continuing the flow
         result_after_timeout = await hass.config_entries.flow.async_configure(
@@ -169,13 +179,9 @@ async def test_config_flow_claim_timeout(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # After timeout, polling stops and user continues - should see external step again
+        assert mock_unclaimed_client.authenticate.call_count == 1
         assert result_after_timeout["type"] is FlowResultType.EXTERNAL_STEP
         assert result_after_timeout["step_id"] == "auth_and_claim"
-
-        # Verify polling actually ran the expected number of times
-        # Sleep happens at beginning of polling loop, so MAX_POLLING_ATTEMPTS + 1 sleeps
-        # but only MAX_POLLING_ATTEMPTS authentication attempts
-        assert mock_sleep.call_count == MAX_POLLING_ATTEMPTS + 1
 
 
 async def test_duplicate_unique_id_prevented(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Avoid patching `asyncio.sleep`. It can be used by other parts of Home Assistant during the test, so it's not robust to patch it.
- Patch `async_setup_entry` to avoid setting up the integration on CREATE_ENTRY result.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Spotted in https://github.com/home-assistant/core/pull/162263
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
