### PR TITLE
Migrate wifi switch unique_id for Fritz

### DIFF
--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -80,6 +80,5 @@ FRITZ_EXCEPTIONS = (
 
 FRITZ_AUTH_EXCEPTIONS = (FritzAuthorizationError, FritzSecurityError)
 
-WIFI_STANDARD = {1: "2.4Ghz", 2: "5Ghz", 3: "5Ghz", 4: "Guest"}
 
 CONNECTION_TYPE_LAN = "LAN"

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -169,6 +169,18 @@
     "switch": {
       "internet_access": {
         "name": "Internet access"
+      },
+      "wi_fi_guest": {
+        "name": "Guest"
+      },
+      "wi_fi_main_2_4ghz": {
+        "name": "Main 2.4 GHz"
+      },
+      "wi_fi_main_5ghz": {
+        "name": "Main 5 GHz"
+      },
+      "wi_fi_main_5ghz_high_6ghz": {
+        "name": "Main 5 GHz High / 6 GHz"
       }
     }
   },

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -121,18 +121,14 @@ async def _migrate_to_new_unique_id(
         )
 
         if entity_id is not None:
-            new_entity_id = entity_id.replace(
-                old_unique_id_suffix, new_unique_id_suffix
-            )
             entity_registry.async_update_entity(
                 entity_id,
-                new_entity_id=new_entity_id,
                 new_unique_id=f"{avm_wrapper.unique_id}-{new_unique_id_suffix}",
             )
             _LOGGER.debug(
-                "Migrating Wi-FI switch [%s] unique_id and entity_id [%s]",
+                "Migrating Wi-FI switch unique_id from [%s] to [%s]",
                 f"{avm_wrapper.unique_id}-{old_unique_id_suffix}",
-                entity_id,
+                f"{avm_wrapper.unique_id}-{new_unique_id_suffix}",
             )
 
     _LOGGER.debug("Migration completed")

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -9,6 +9,7 @@ from homeassistant.components.network import async_get_source_ip
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -22,8 +23,8 @@ from .const import (
     SWITCH_TYPE_PORTFORWARD,
     SWITCH_TYPE_PROFILE,
     SWITCH_TYPE_WIFINETWORK,
-    WIFI_STANDARD,
     MeshRoles,
+    Platform,
 )
 from .coordinator import FRITZ_DATA_KEY, AvmWrapper, FritzConfigEntry, FritzData
 from .entity import FritzBoxBaseEntity
@@ -34,6 +35,107 @@ _LOGGER = logging.getLogger(__name__)
 
 # Set a sane value to avoid too many updates
 PARALLEL_UPDATES = 5
+
+WIFI_STANDARD = {1: "2.4Ghz", 2: "5Ghz", 3: "5Ghz", 4: "Guest"}
+
+WIFI_SCHEMA = {
+    0: {"band": "2.4Ghz", "type": "Main"},
+    1: {"band": "5Ghz", "type": "Main"},
+    3: {"band": "5Ghz High / 6Ghz", "type": "Main"},
+}
+
+
+def _wifi_naming(
+    network_info: dict[str, Any], wifi_index: int, wifi_count: int
+) -> str | None:
+    """Return a friendly name for a Wi-Fi network."""
+
+    if wifi_index == 2 and wifi_count == 4:
+        # In case of 4 Wi-Fi networks, the 2nd one is used for internal communication
+        # between mesh devices and should not be named like the others to avoid confusion
+        return None
+
+    if (wifi_index + 1) == wifi_count:
+        # Last Wi-Fi network in the guest network, both bands available
+        return "Guest"
+
+    # Cast to correct type for type checker
+    result = WIFI_SCHEMA.get(wifi_index)
+    if result is not None:
+        return result["type"] + (f" {result['band']}" if result["band"] else "")
+
+    return None
+
+
+async def _get_wifi_networks_list(avm_wrapper: AvmWrapper) -> dict[int, dict[str, Any]]:
+    """Get a list of wifi networks with friendly names."""
+    wifi_count = len(
+        [
+            s
+            for s in avm_wrapper.connection.services
+            if s.startswith("WLANConfiguration")
+        ]
+    )
+    _LOGGER.debug("WiFi networks count: %s", wifi_count)
+    networks: dict[int, dict[str, Any]] = {}
+    for i in range(1, wifi_count + 1):
+        network_info = await avm_wrapper.async_get_wlan_configuration(i)
+        if (switch_name := _wifi_naming(network_info, i - 1, wifi_count)) is None:
+            continue
+        networks[i] = network_info
+        networks[i]["switch_name"] = switch_name
+
+    _LOGGER.debug("WiFi networks list: %s", networks)
+    return networks
+
+
+async def _migrate_to_new_unique_id(
+    hass: HomeAssistant, avm_wrapper: AvmWrapper
+) -> None:
+    """Migrate old unique ids to new unique ids."""
+
+    _LOGGER.debug("Migrating Wi-Fi switches")
+    entity_registry = er.async_get(hass)
+
+    networks = await _get_wifi_networks_list(avm_wrapper)
+    for index, network in networks.items():
+        old_unique_id_suffix = f"wi_fi_{network['NewSSID'].lower()}"
+        if (
+            len(
+                [
+                    j
+                    for j, n in networks.items()
+                    if slugify(n["NewSSID"]) == slugify(network["NewSSID"])
+                ]
+            )
+            > 1
+        ):
+            old_unique_id_suffix += f" ({WIFI_STANDARD[index]})"
+
+        new_unique_id_suffix = (
+            f"wi_fi_{slugify(_wifi_naming(network, index - 1, len(networks)))}"
+        )
+
+        entity_id = entity_registry.async_get_entity_id(
+            Platform.SWITCH, DOMAIN, f"{avm_wrapper.unique_id}-{old_unique_id_suffix}"
+        )
+
+        if entity_id is not None:
+            new_entity_id = entity_id.replace(
+                old_unique_id_suffix, new_unique_id_suffix
+            )
+            entity_registry.async_update_entity(
+                entity_id,
+                new_entity_id=new_entity_id,
+                new_unique_id=f"{avm_wrapper.unique_id}-{new_unique_id_suffix}",
+            )
+            _LOGGER.debug(
+                "Migrating Wi-FI switch [%s] unique_id and entity_id [%s]",
+                f"{avm_wrapper.unique_id}-{old_unique_id_suffix}",
+                entity_id,
+            )
+
+    _LOGGER.debug("Migration completed")
 
 
 async def _async_deflection_entities_list(
@@ -125,35 +227,7 @@ async def _async_wifi_entities_list(
     #
     # https://avm.de/fileadmin/user_upload/Global/Service/Schnittstellen/wlanconfigSCPD.pdf
     #
-    wifi_count = len(
-        [
-            s
-            for s in avm_wrapper.connection.services
-            if s.startswith("WLANConfiguration")
-        ]
-    )
-    _LOGGER.debug("WiFi networks count: %s", wifi_count)
-    networks: dict[int, dict[str, Any]] = {}
-    for i in range(1, wifi_count + 1):
-        network_info = await avm_wrapper.async_get_wlan_configuration(i)
-        # Devices with 4 WLAN services, use the 2nd for internal communications
-        if not (wifi_count == 4 and i == 2):
-            networks[i] = network_info
-    for i, network in networks.copy().items():
-        networks[i]["switch_name"] = network["NewSSID"]
-        if (
-            len(
-                [
-                    j
-                    for j, n in networks.items()
-                    if slugify(n["NewSSID"]) == slugify(network["NewSSID"])
-                ]
-            )
-            > 1
-        ):
-            networks[i]["switch_name"] += f" ({WIFI_STANDARD[i]})"
-
-    _LOGGER.debug("WiFi networks list: %s", networks)
+    networks = await _get_wifi_networks_list(avm_wrapper)
     return [
         FritzBoxWifiSwitch(avm_wrapper, device_friendly_name, index, data)
         for index, data in networks.items()
@@ -224,6 +298,8 @@ async def async_setup_entry(
     _LOGGER.debug("Fritzbox services: %s", avm_wrapper.connection.services)
 
     local_ip = await async_get_source_ip(avm_wrapper.hass, target_ip=avm_wrapper.host)
+
+    await _migrate_to_new_unique_id(hass, avm_wrapper)
 
     entities_list = await async_all_entities_list(
         avm_wrapper,
@@ -554,8 +630,12 @@ class FritzBoxWifiSwitch(FritzBoxBaseSwitch):
         )
         self._network_num = network_num
 
+        description = f"Wi-Fi {network_data['switch_name']}"
+        self._attr_translation_key = slugify(description)
+
+        _LOGGER.error("Switch: %s", description)
         switch_info = SwitchInfo(
-            description=f"Wi-Fi {network_data['switch_name']}",
+            description=description,
             friendly_name=device_friendly_name,
             icon="mdi:wifi",
             type=SWITCH_TYPE_WIFINETWORK,

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -38,10 +38,10 @@ PARALLEL_UPDATES = 5
 
 WIFI_STANDARD = {1: "2.4Ghz", 2: "5Ghz", 3: "5Ghz", 4: "Guest"}
 
-WIFI_SCHEMA = {
-    0: {"band": "2.4Ghz", "type": "Main"},
-    1: {"band": "5Ghz", "type": "Main"},
-    3: {"band": "5Ghz High / 6Ghz", "type": "Main"},
+WIFI_BAND = {
+    0: {"band": "2.4Ghz"},
+    1: {"band": "5Ghz"},
+    3: {"band": "5Ghz High / 6Ghz"},
 }
 
 
@@ -60,9 +60,8 @@ def _wifi_naming(
         return "Guest"
 
     # Cast to correct type for type checker
-    result = WIFI_SCHEMA.get(wifi_index)
-    if result is not None:
-        return result["type"] + (f" {result['band']}" if result["band"] else "")
+    if (result := WIFI_BAND.get(wifi_index)) is not None:
+        return f"Main {result['band']}"
 
     return None
 
@@ -99,7 +98,9 @@ async def _migrate_to_new_unique_id(
 
     networks = await _get_wifi_networks_list(avm_wrapper)
     for index, network in networks.items():
-        old_unique_id_suffix = f"wi_fi_{network['NewSSID'].lower()}"
+        old_unique_id_suffix = (
+            f"{avm_wrapper.unique_id}-wi_fi_{network['NewSSID'].lower()}"
+        )
         if (
             len(
                 [
@@ -112,23 +113,21 @@ async def _migrate_to_new_unique_id(
         ):
             old_unique_id_suffix += f" ({WIFI_STANDARD[index]})"
 
-        new_unique_id_suffix = (
-            f"wi_fi_{slugify(_wifi_naming(network, index - 1, len(networks)))}"
-        )
+        new_unique_id_suffix = f"{avm_wrapper.unique_id}-wi_fi_{slugify(_wifi_naming(network, index - 1, len(networks)))}"
 
         entity_id = entity_registry.async_get_entity_id(
-            Platform.SWITCH, DOMAIN, f"{avm_wrapper.unique_id}-{old_unique_id_suffix}"
+            Platform.SWITCH, DOMAIN, old_unique_id_suffix
         )
 
         if entity_id is not None:
             entity_registry.async_update_entity(
                 entity_id,
-                new_unique_id=f"{avm_wrapper.unique_id}-{new_unique_id_suffix}",
+                new_unique_id=new_unique_id_suffix,
             )
             _LOGGER.debug(
                 "Migrating Wi-FI switch unique_id from [%s] to [%s]",
-                f"{avm_wrapper.unique_id}-{old_unique_id_suffix}",
-                f"{avm_wrapper.unique_id}-{new_unique_id_suffix}",
+                old_unique_id_suffix,
+                new_unique_id_suffix,
             )
 
     _LOGGER.debug("Migration completed")
@@ -629,7 +628,6 @@ class FritzBoxWifiSwitch(FritzBoxBaseSwitch):
         description = f"Wi-Fi {network_data['switch_name']}"
         self._attr_translation_key = slugify(description)
 
-        _LOGGER.error("Switch: %s", description)
         switch_info = SwitchInfo(
             description=description,
             friendly_name=device_friendly_name,

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -98,9 +98,7 @@ async def _migrate_to_new_unique_id(
 
     networks = await _get_wifi_networks_list(avm_wrapper)
     for index, network in networks.items():
-        old_unique_id_suffix = (
-            f"{avm_wrapper.unique_id}-wi_fi_{network['NewSSID'].lower()}"
-        )
+        description = f"Wi-Fi {network['NewSSID']}"
         if (
             len(
                 [
@@ -111,23 +109,24 @@ async def _migrate_to_new_unique_id(
             )
             > 1
         ):
-            old_unique_id_suffix += f" ({WIFI_STANDARD[index]})"
+            description += f" ({WIFI_STANDARD[index]})"
 
-        new_unique_id_suffix = f"{avm_wrapper.unique_id}-wi_fi_{slugify(_wifi_naming(network, index - 1, len(networks)))}"
+        old_unique_id = f"{avm_wrapper.unique_id}-{slugify(description)}"
+        new_unique_id = f"{avm_wrapper.unique_id}-wi_fi_{slugify(_wifi_naming(network, index - 1, len(networks)))}"
 
         entity_id = entity_registry.async_get_entity_id(
-            Platform.SWITCH, DOMAIN, old_unique_id_suffix
+            Platform.SWITCH, DOMAIN, old_unique_id
         )
 
         if entity_id is not None:
             entity_registry.async_update_entity(
                 entity_id,
-                new_unique_id=new_unique_id_suffix,
+                new_unique_id=new_unique_id,
             )
             _LOGGER.debug(
                 "Migrating Wi-FI switch unique_id from [%s] to [%s]",
-                old_unique_id_suffix,
-                new_unique_id_suffix,
+                old_unique_id,
+                new_unique_id,
             )
 
     _LOGGER.debug("Migration completed")

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -106,6 +106,15 @@ class FritzConnectionMock:
         return action_data
 
 
+def wifi_services_with_ssids(ssid_1: str, ssid_2: str) -> dict[str, dict[str, Any]]:
+    """Return Fritz services with overridden Wi-Fi SSIDs."""
+    services = deepcopy(MOCK_FB_SERVICES)
+    for index, ssid in enumerate((ssid_1, ssid_2), start=1):
+        services[f"WLANConfiguration{index}"]["GetInfo"]["NewSSID"] = ssid
+        services[f"WLANConfiguration{index}"]["GetSSID"]["NewSSID"] = ssid
+    return services
+
+
 @pytest.fixture(name="fc_data")
 def fc_data_mock() -> dict[str, dict[str, Any]]:
     """Fixture for default fc_data."""

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -920,62 +920,7 @@
     'state': 'on',
   })
 # ---
-<<<<<<< HEAD
-# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guestwifi-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_guestwifi',
-    'has_entity_name': False,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Mock Title Wi-Fi GuestWifi',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi GuestWifi',
-    'platform': 'fritz',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_guestwifi',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guestwifi-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi GuestWifi',
-      'icon': 'mdi:wifi',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_guestwifi',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-entry]
-=======
 # name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guest-entry]
->>>>>>> 35c4ee71982 (Migrate wifi switch unique_id for Fritz)
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1020,6 +965,57 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.mock_title_wi_fi_guest',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_main_2_4ghz-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Mock Title Wi-Fi Main 2.4Ghz',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:wifi',
+    'original_name': 'Mock Title Wi-Fi Main 2.4Ghz',
+    'platform': 'fritz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wi_fi_main_2_4ghz',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_main_2_4ghz',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_main_2_4ghz-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Mock Title Wi-Fi Main 2.4Ghz',
+      'icon': 'mdi:wifi',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/fritz/snapshots/test_switch.ambr
+++ b/tests/components/fritz/snapshots/test_switch.ambr
@@ -101,7 +101,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_guest-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -115,7 +115,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -123,36 +123,36 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'object_id_base': 'Mock Title Wi-Fi Guest',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'original_name': 'Mock Title Wi-Fi Guest',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_2_4ghz',
+    'translation_key': 'wi_fi_guest',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_guest',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_guest-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+      'friendly_name': 'Mock Title Wi-Fi Guest',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_5ghz-entry]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_main_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -166,7 +166,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -174,29 +174,29 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi (5Ghz)',
+    'object_id_base': 'Mock Title Wi-Fi Main 2.4Ghz',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi (5Ghz)',
+    'original_name': 'Mock Title Wi-Fi Main 2.4Ghz',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_5ghz',
+    'translation_key': 'wi_fi_main_2_4ghz',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_main_2_4ghz',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_wifi_5ghz-state]
+# name: test_switch_setup[fc_data0][switch.mock_title_wi_fi_main_2_4ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi (5Ghz)',
+      'friendly_name': 'Mock Title Wi-Fi Main 2.4Ghz',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -355,7 +355,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi-entry]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_guest-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -369,7 +369,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -377,36 +377,36 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi',
+    'object_id_base': 'Mock Title Wi-Fi Guest',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi',
+    'original_name': 'Mock Title Wi-Fi Guest',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi',
+    'translation_key': 'wi_fi_guest',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_guest',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi-state]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_guest-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi',
+      'friendly_name': 'Mock Title Wi-Fi Guest',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi2-entry]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_main_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -420,7 +420,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi2',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -428,29 +428,29 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi2',
+    'object_id_base': 'Mock Title Wi-Fi Main 2.4Ghz',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi2',
+    'original_name': 'Mock Title Wi-Fi Main 2.4Ghz',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi2',
+    'translation_key': 'wi_fi_main_2_4ghz',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_main_2_4ghz',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_wifi2-state]
+# name: test_switch_setup[fc_data1][switch.mock_title_wi_fi_main_2_4ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi2',
+      'friendly_name': 'Mock Title Wi-Fi Main 2.4Ghz',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi2',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -609,7 +609,7 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_2_4ghz-entry]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_guest-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -623,7 +623,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -631,36 +631,36 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'object_id_base': 'Mock Title Wi-Fi Guest',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+    'original_name': 'Mock Title Wi-Fi Guest',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_2_4ghz',
+    'translation_key': 'wi_fi_guest',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_guest',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_2_4ghz-state]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_guest-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi (2.4Ghz)',
+      'friendly_name': 'Mock Title Wi-Fi Guest',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_2_4ghz',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
   })
 # ---
-# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_5ghz-entry]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_main_2_4ghz-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -674,7 +674,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -682,29 +682,29 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
+    'object_id_base': 'Mock Title Wi-Fi Main 2.4Ghz',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
+    'original_name': 'Mock Title Wi-Fi Main 2.4Ghz',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_wifi_5ghz',
+    'translation_key': 'wi_fi_main_2_4ghz',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_main_2_4ghz',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_wifi_5ghz-state]
+# name: test_switch_setup[fc_data2][switch.mock_title_wi_fi_main_2_4ghz-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi WiFi+ (5Ghz)',
+      'friendly_name': 'Mock Title Wi-Fi Main 2.4Ghz',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_wifi_5ghz',
+    'entity_id': 'switch.mock_title_wi_fi_main_2_4ghz',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -920,6 +920,7 @@
     'state': 'on',
   })
 # ---
+<<<<<<< HEAD
 # name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guestwifi-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -972,6 +973,9 @@
   })
 # ---
 # name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-entry]
+=======
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guest-entry]
+>>>>>>> 35c4ee71982 (Migrate wifi switch unique_id for Fritz)
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -985,7 +989,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.mock_title_wi_fi_mywifi',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'has_entity_name': False,
     'hidden_by': None,
     'icon': None,
@@ -993,29 +997,29 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Mock Title Wi-Fi MyWifi',
+    'object_id_base': 'Mock Title Wi-Fi Guest',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': 'mdi:wifi',
-    'original_name': 'Mock Title Wi-Fi MyWifi',
+    'original_name': 'Mock Title Wi-Fi Guest',
     'platform': 'fritz',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '1C:ED:6F:12:34:11-wi_fi_mywifi',
+    'translation_key': 'wi_fi_guest',
+    'unique_id': '1C:ED:6F:12:34:11-wi_fi_guest',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_mywifi-state]
+# name: test_switch_setup[fc_data3][switch.mock_title_wi_fi_guest-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Mock Title Wi-Fi MyWifi',
+      'friendly_name': 'Mock Title Wi-Fi Guest',
       'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.mock_title_wi_fi_mywifi',
+    'entity_id': 'switch.mock_title_wi_fi_guest',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fritzconnection.core.exceptions import FritzActionError
 from fritzconnection.lib.fritzstatus import DefaultConnectionService
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.fritz import switch as fritz_switch
 from homeassistant.components.fritz.const import DOMAIN
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
@@ -25,13 +26,15 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .conftest import FritzConnectionMock
 from .const import (
     MOCK_CALL_DEFLECTION_DATA,
     MOCK_FB_SERVICES,
     MOCK_HOST_ATTRIBUTES_DATA,
+    MOCK_MESH_MASTER_MAC,
     MOCK_USER_DATA,
 )
 
@@ -397,7 +400,7 @@ async def test_switch_device_no_ip_address(
             STATE_ON,
         ),
         (
-            "switch.mock_title_wi_fi_mywifi",
+            "switch.mock_title_wi_fi_guest",
             "async_set_wlan_configuration",
             STATE_ON,
         ),
@@ -455,3 +458,80 @@ async def test_switch_turn_on_off(
 
     assert (state := hass.states.get(entity_id))
     assert state.state == state_value
+
+
+async def test_migrate_to_new_unique_id(
+    hass: HomeAssistant,
+    fc_class_mock,
+    fh_class_mock,
+    fs_class_mock,
+    entity_registry: EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test migrate from old unique ids to new unique ids."""
+
+    MOCK_UNIQUE_ID = "1234567890"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_USER_DATA, unique_id=MOCK_UNIQUE_ID
+    )
+    entry.add_to_hass(hass)
+
+    old_unique_id = f"{MOCK_MESH_MASTER_MAC}-wi_fi_mywifi"
+    new_unique_id = f"{MOCK_MESH_MASTER_MAC}-wi_fi_guest"
+
+    entity_registry.async_get_or_create(
+        suggested_object_id="mock_title_wi_fi_mywifi",
+        disabled_by=None,
+        domain=SWITCH_DOMAIN,
+        platform=DOMAIN,
+        unique_id=old_unique_id,
+        config_entry=entry,
+    )
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, MOCK_UNIQUE_ID)},
+        connections={
+            (dr.CONNECTION_NETWORK_MAC, MOCK_MESH_MASTER_MAC),
+        },
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_mywifi")
+    assert entity_entry
+    assert entity_entry.unique_id == old_unique_id
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_guest")
+    assert entity_entry
+    assert entity_entry.unique_id == new_unique_id
+
+
+async def test_wifi_naming_internal_comm_and_skipped() -> None:
+    """Test skip internal Wi-Fi network."""
+    # Prepare AvmWrapper mock with 4 Wi-Fi networks
+    avm_wrapper = MagicMock()
+    avm_wrapper.connection.services = [
+        "WLANConfiguration1",
+        "WLANConfiguration2",
+        "WLANConfiguration3",
+        "WLANConfiguration4",
+    ]
+    # The 3rd network (index 2) should be skipped
+    wifi_configs = [
+        {"NewSSID": "wifi1"},
+        {"NewSSID": "wifi2"},
+        {"NewSSID": "wifi3"},
+        {"NewSSID": "wifi4"},
+    ]
+    avm_wrapper.async_get_wlan_configuration = AsyncMock(side_effect=wifi_configs)
+
+    networks = await fritz_switch._get_wifi_networks_list(avm_wrapper)
+    # The 3rd network (index 2) should be skipped
+    assert 3 not in networks  # 1-based index, so 3 is the 3rd
+    # The rest should be present
+    assert set(networks.keys()) == {1, 2, 4}

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -506,7 +506,7 @@ async def test_migrate_to_new_unique_id(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_guest")
+    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_mywifi")
     assert entity_entry
     assert entity_entry.unique_id == new_unique_id
 

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -28,8 +28,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.util import slugify
 
-from .conftest import FritzConnectionMock
+from .conftest import FritzConnectionMock, wifi_services_with_ssids
 from .const import (
     MOCK_CALL_DEFLECTION_DATA,
     MOCK_FB_SERVICES,
@@ -460,6 +461,29 @@ async def test_switch_turn_on_off(
     assert state.state == state_value
 
 
+@pytest.mark.parametrize(
+    ("ssid_1", "ssid_2", "old_descriptions", "new_identifiers"),
+    [
+        (
+            "Main WiFi / +",
+            "Guest WiFi / +",
+            [
+                "Wi-Fi Main WiFi / +",
+                "Wi-Fi Guest WiFi / +",
+            ],
+            ["main_2_4ghz", "guest"],
+        ),
+        (
+            "My WiFi / +",
+            "My WiFi / +",
+            [
+                "Wi-Fi My WiFi / + (2.4Ghz)",
+                "Wi-Fi My WiFi / + (5Ghz)",
+            ],
+            ["main_2_4ghz", "guest"],
+        ),
+    ],
+)
 async def test_migrate_to_new_unique_id(
     hass: HomeAssistant,
     fc_class_mock,
@@ -467,28 +491,43 @@ async def test_migrate_to_new_unique_id(
     fs_class_mock,
     entity_registry: EntityRegistry,
     device_registry: dr.DeviceRegistry,
-    caplog: pytest.LogCaptureFixture,
+    ssid_1: str,
+    ssid_2: str,
+    old_descriptions: list[str],
+    new_identifiers: list[str],
 ) -> None:
     """Test migrate from old unique ids to new unique ids."""
 
     MOCK_UNIQUE_ID = "1234567890"
+
+    fc_class_mock.return_value.override_services(
+        wifi_services_with_ssids(ssid_1, ssid_2)
+    )
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_USER_DATA, unique_id=MOCK_UNIQUE_ID
     )
     entry.add_to_hass(hass)
 
-    old_unique_id = f"{MOCK_MESH_MASTER_MAC}-wi_fi_mywifi"
-    new_unique_id = f"{MOCK_MESH_MASTER_MAC}-wi_fi_guest"
+    entity_ids: list[str] = []
+    old_unique_ids: list[str] = []
+    new_unique_ids: list[str] = []
+    for old_description, new_identifier in zip(
+        old_descriptions, new_identifiers, strict=True
+    ):
+        old_unique_id = f"{MOCK_MESH_MASTER_MAC}-{slugify(old_description)}"
+        new_unique_id = f"{MOCK_MESH_MASTER_MAC}-wi_fi_{new_identifier}"
+        old_unique_ids.append(old_unique_id)
+        new_unique_ids.append(new_unique_id)
+        entity_ids.append(f"switch.fritz_{slugify(old_unique_id)}")
 
-    entity_registry.async_get_or_create(
-        suggested_object_id="mock_title_wi_fi_mywifi",
-        disabled_by=None,
-        domain=SWITCH_DOMAIN,
-        platform=DOMAIN,
-        unique_id=old_unique_id,
-        config_entry=entry,
-    )
+        entity_registry.async_get_or_create(
+            disabled_by=None,
+            domain=SWITCH_DOMAIN,
+            platform=DOMAIN,
+            unique_id=old_unique_id,
+            config_entry=entry,
+        )
 
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -499,16 +538,18 @@ async def test_migrate_to_new_unique_id(
     )
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_mywifi")
-    assert entity_entry
-    assert entity_entry.unique_id == old_unique_id
+    for entity_id, old_unique_id in zip(entity_ids, old_unique_ids, strict=True):
+        entity_entry = entity_registry.async_get(entity_id)
+        assert entity_entry
+        assert entity_entry.unique_id == old_unique_id
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    entity_entry = entity_registry.async_get("switch.mock_title_wi_fi_mywifi")
-    assert entity_entry
-    assert entity_entry.unique_id == new_unique_id
+    for entity_id, new_unique_id in zip(entity_ids, new_unique_ids, strict=True):
+        entity_entry = entity_registry.async_get(entity_id)
+        assert entity_entry
+        assert entity_entry.unique_id == new_unique_id
 
 
 async def test_wifi_naming_internal_comm_and_skipped() -> None:
@@ -535,3 +576,20 @@ async def test_wifi_naming_internal_comm_and_skipped() -> None:
     assert 3 not in networks  # 1-based index, so 3 is the 3rd
     # The rest should be present
     assert set(networks.keys()) == {1, 2, 4}
+
+
+@pytest.mark.parametrize(
+    ("wifi_index", "wifi_count", "expected_name"),
+    [
+        (0, 2, "Main 2.4Ghz"),
+        (1, 3, "Main 5Ghz"),
+        (1, 2, "Guest"),
+        (2, 4, None),
+        (2, 5, None),
+    ],
+)
+def test_wifi_naming_helper(
+    wifi_index: int, wifi_count: int, expected_name: str | None
+) -> None:
+    """Test Wi-Fi naming helper covers supported and fallback branches."""
+    assert fritz_switch._wifi_naming({}, wifi_index, wifi_count) == expected_name


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate Wi-Fi switches from using SSID in unique_id to a functional naming ( Guest, Main ).

~~Migrating not only unique_id but also entity_id will allow a consistency in naming and description of the switches:~~

~~Before: ~~

~~- entity_id: switch.router_name_wi_fi_primary_ssid~~
~~- unique_id: serial_number-wi_fi_primary_ssid~~
~~- friendly_name: "Router Wi-Fi PrimarySSID"~~

~~After:~~

~~- entity_id: switch.router_name_wi_fi_main_5ghz~~
~~- unique_id: serial_number-wi_fi_main_5ghz~~
~~- friendly_name: "Router Main 5 GHz"~~

~~Note: There are scenarios with different main SSID but once "slugified" they become identical (see linked issue).~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #163330
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
