### PR TITLE
Load lovelace resource collection eagerly during setup

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -182,6 +182,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         resource_collection = resources.ResourceStorageCollection(hass, default_config)
 
+        await resource_collection.async_load()
+        resource_collection.loaded = True
+
         resources.ResourceStorageCollectionWebsocket(
             resource_collection,
             "lovelace/resources",

--- a/tests/components/lovelace/test_resources.py
+++ b/tests/components/lovelace/test_resources.py
@@ -8,6 +8,7 @@ import uuid
 import pytest
 
 from homeassistant.components.lovelace import dashboard, resources
+from homeassistant.components.lovelace.const import LOVELACE_DATA
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -276,6 +277,31 @@ async def test_storage_resources_import_invalid(
         "resources"
         in hass_storage[dashboard.CONFIG_STORAGE_KEY_DEFAULT]["data"]["config"]
     )
+
+
+async def test_storage_resources_loaded_on_setup(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test resources are loaded eagerly during setup.
+
+    Custom integrations may call async_items() or async_create_item()
+    before the frontend triggers a resource listing. Without eager loading,
+    async_items() returns empty and async_create_item() overwrites existing
+    resources on disk.
+    """
+    resource_config = [{**item, "id": uuid.uuid4().hex} for item in RESOURCE_EXAMPLES]
+    hass_storage[resources.RESOURCE_STORAGE_KEY] = {
+        "key": resources.RESOURCE_STORAGE_KEY,
+        "version": 1,
+        "data": {"items": resource_config},
+    }
+    assert await async_setup_component(hass, "lovelace", {})
+
+    # Resources should be available immediately without any websocket call
+    resource_collection = hass.data[LOVELACE_DATA].resources
+    assert resource_collection.loaded is True
+    assert resource_collection.async_items() == resource_config
 
 
 @pytest.mark.parametrize("list_cmd", ["lovelace/resources", "lovelace/resources/list"])


### PR DESCRIPTION
Rebase of #165773 to newest dev, as it's reported stale. 

## Proposed change

`ResourceStorageCollection` is created during `lovelace.async_setup()` but never loaded from disk at that point. Loading is deferred (lazy) and the guard only exists in `async_get_info()`, `_update_data()`, and `websocket_lovelace_resources_impl()`.

The inherited `async_items()` and `async_create_item()` have no lazy-load guard, so any code calling them before the frontend triggers a resource listing gets an empty collection. A subsequent `async_create_item()` then saves only the newly created item, **overwriting `.storage/lovelace_resources` and destroying all existing Lovelace resources**.

This change adds eager loading of the resource collection during setup, matching the existing pattern for the dashboards collection (which is already loaded eagerly via `await dashboards_collection.async_load()`).

The existing lazy-load guards in `async_get_info()`, `_update_data()`, and `websocket_lovelace_resources_impl()` become harmless no-ops since the `loaded` flag is already `True`.

Fixes #165767

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- Custom integrations that register Lovelace resources via `hass.data["lovelace"].resources.async_create_item()` during startup (before the frontend triggers a resource listing) would silently destroy all existing resources
- This was reported by multiple users at https://github.com/kvanbiesen/bmw-cardata-ha/discussions/316

## Checklist

- [x] The code change is tested and works locally
- [x] There is no commented out code in this PR
- [x] Tests have been added to verify that the new code works