### PR TITLE
Casper Glow: add dimming end time

### DIFF
--- a/homeassistant/components/casper_glow/quality_scale.yaml
+++ b/homeassistant/components/casper_glow/quality_scale.yaml
@@ -51,18 +51,24 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: todo
-  dynamic-devices: todo
+  dynamic-devices:
+    status: exempt
+    comment: Each config entry represents a single device.
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default: todo
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow:
+    status: exempt
+    comment: No user-configurable settings in the configuration flow.
   repair-issues:
     status: exempt
     comment: Integration does not register repair issues.
-  stale-devices: todo
+  stale-devices:
+    status: exempt
+    comment: Each config entry represents a single device.
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/casper_glow/sensor.py
+++ b/homeassistant/components/casper_glow/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 from pycasperglow import GlowState
 
 from homeassistant.components.sensor import (
@@ -13,6 +15,8 @@ from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.dt import utcnow
+from homeassistant.util.variance import ignore_variance
 
 from .coordinator import CasperGlowConfigEntry, CasperGlowCoordinator
 from .entity import CasperGlowEntity
@@ -26,7 +30,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the sensor platform for Casper Glow."""
-    async_add_entities([CasperGlowBatterySensor(entry.runtime_data)])
+    async_add_entities(
+        [
+            CasperGlowBatterySensor(entry.runtime_data),
+            CasperGlowDimmingEndTimeSensor(entry.runtime_data),
+        ]
+    )
 
 
 class CasperGlowBatterySensor(CasperGlowEntity, SensorEntity):
@@ -59,3 +68,67 @@ class CasperGlowBatterySensor(CasperGlowEntity, SensorEntity):
             if new_value != self._attr_native_value:
                 self._attr_native_value = new_value
                 self.async_write_ha_state()
+
+
+class CasperGlowDimmingEndTimeSensor(CasperGlowEntity, SensorEntity):
+    """Sensor entity for Casper Glow dimming end time."""
+
+    _attr_translation_key = "dimming_end_time"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: CasperGlowCoordinator) -> None:
+        """Initialize the dimming end time sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{format_mac(coordinator.device.address)}_dimming_end_time"
+        )
+        self._is_paused = False
+        self._projected_end_time = ignore_variance(
+            self._calculate_end_time,
+            timedelta(minutes=1, seconds=30),
+        )
+        self._update_from_state(coordinator.device.state)
+
+    @staticmethod
+    def _calculate_end_time(remaining_ms: int) -> datetime:
+        """Calculate projected dimming end time from remaining milliseconds."""
+        return utcnow() + timedelta(milliseconds=remaining_ms)
+
+    async def async_added_to_hass(self) -> None:
+        """Register state update callback when entity is added."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._device.register_callback(self._async_handle_state_update)
+        )
+
+    def _reset_projected_end_time(self) -> None:
+        """Clear the projected end time and reset the variance filter."""
+        self._attr_native_value = None
+        self._projected_end_time = ignore_variance(
+            self._calculate_end_time,
+            timedelta(minutes=1, seconds=30),
+        )
+
+    @callback
+    def _update_from_state(self, state: GlowState) -> None:
+        """Update entity attributes from device state."""
+        if state.is_paused is not None:
+            self._is_paused = state.is_paused
+
+        if self._is_paused:
+            self._reset_projected_end_time()
+            return
+
+        remaining_ms = state.dimming_time_remaining_ms
+        if not remaining_ms:
+            if remaining_ms == 0 or state.is_on is False:
+                self._reset_projected_end_time()
+            return
+        self._attr_native_value = self._projected_end_time(remaining_ms)
+
+    @callback
+    def _async_handle_state_update(self, state: GlowState) -> None:
+        """Handle a state update from the device."""
+        self._update_from_state(state)
+        self.async_write_ha_state()

--- a/homeassistant/components/casper_glow/strings.json
+++ b/homeassistant/components/casper_glow/strings.json
@@ -44,6 +44,11 @@
       "dimming_time": {
         "name": "Dimming time"
       }
+    },
+    "sensor": {
+      "dimming_end_time": {
+        "name": "Dimming end time"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/casper_glow/snapshots/test_sensor.ambr
+++ b/tests/components/casper_glow/snapshots/test_sensor.ambr
@@ -54,3 +54,54 @@
     'state': 'unknown',
   })
 # ---
+# name: test_entities[sensor.jar_dimming_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.jar_dimming_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Dimming end time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Dimming end time',
+    'platform': 'casper_glow',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dimming_end_time',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_dimming_end_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entities[sensor.jar_dimming_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Jar Dimming end time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jar_dimming_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/casper_glow/test_sensor.py
+++ b/tests/components/casper_glow/test_sensor.py
@@ -7,7 +7,8 @@ from pycasperglow import BatteryLevel, GlowState
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -16,8 +17,10 @@ from . import setup_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 BATTERY_ENTITY_ID = "sensor.jar_battery"
+DIMMING_END_TIME_ENTITY_ID = "sensor.jar_dimming_end_time"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_entities(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -70,3 +73,214 @@ async def test_battery_state_updated_via_callback(
     state = hass.states.get(BATTERY_ENTITY_ID)
     assert state is not None
     assert state.state == "50"
+
+
+async def test_dimming_end_time_disabled_by_default(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that dimming end time sensor is disabled by default."""
+    entry = entity_registry.async_get(DIMMING_END_TIME_ENTITY_ID)
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_when_enabled(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test dimming end time sensor reports a future timestamp when enabled."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=2_520_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+    assert state.attributes["device_class"] == SensorDeviceClass.TIMESTAMP
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_unknown_when_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test dimming end time sensor resets to unknown when device turns off."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+    # Device turns off — sensor should reset to unknown
+    await fire_callbacks(GlowState(is_on=False, dimming_time_remaining_ms=0))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_unknown_when_off_partial_callback(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test dimming end time resets to unknown on an off-only partial callback."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+    # Partial callback: only is_on=False, no remaining_ms
+    await fire_callbacks(GlowState(is_on=False))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_unknown_when_paused(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test dimming end time sensor resets to unknown when dimming is paused."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+    # Dimming paused — remaining_ms stays constant but end time is meaningless
+    await fire_callbacks(GlowState(is_paused=True, dimming_time_remaining_ms=900_000))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    # Dimming resumed — end time should be projected again
+    await fire_callbacks(GlowState(is_paused=False, dimming_time_remaining_ms=900_000))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_unknown_when_paused_partial_callback(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test dimming end time resets to unknown on a pause-only partial callback."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+
+    # Partial callback: only is_paused, no remaining_ms
+    await fire_callbacks(GlowState(is_paused=True))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_variance_reset_on_resume(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test that pause/resume resets the variance filter for a fresh timestamp."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    first_value = state.state
+
+    # Pause, then resume with 10 seconds less remaining. Without the
+    # variance reset, ignore_variance would return the cached pre-pause
+    # value since 10 seconds is within the 90-second deadband.
+    await fire_callbacks(GlowState(is_paused=True, dimming_time_remaining_ms=900_000))
+    await fire_callbacks(GlowState(is_paused=False, dimming_time_remaining_ms=890_000))
+
+    state = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNKNOWN
+    assert state.state != first_value
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_jitter_suppression(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test that small BLE jitter does not change the projected end time."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state1 = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state1 is not None
+    first_value = state1.state
+
+    # Simulate a small jitter — 10 seconds less (within 90-second deadband)
+    await fire_callbacks(GlowState(dimming_time_remaining_ms=890_000))
+
+    state2 = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state2 is not None
+    assert state2.state == first_value
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dimming_end_time_updates_on_significant_change(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_casper_glow: MagicMock,
+    fire_callbacks: Callable[[GlowState], Awaitable[None]],
+) -> None:
+    """Test that a large change in remaining time updates the projected end time."""
+    mock_casper_glow.state = GlowState(dimming_time_remaining_ms=900_000)
+    with patch("homeassistant.components.casper_glow.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state1 = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state1 is not None
+    first_value = state1.state
+
+    # Simulate a significant change — 10 minutes less (outside 90-second deadband)
+    await fire_callbacks(GlowState(dimming_time_remaining_ms=300_000))
+
+    state2 = hass.states.get(DIMMING_END_TIME_ENTITY_ID)
+    assert state2 is not None
+    assert state2.state != first_value


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add sensors for Casper Glow dimming end time.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/44367
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
