### PR TITLE
Add repair issue for expired API token in UniFi Access

### DIFF
--- a/homeassistant/components/unifi_access/__init__.py
+++ b/homeassistant/components/unifi_access/__init__.py
@@ -8,7 +8,13 @@ from homeassistant.const import CONF_API_TOKEN, CONF_HOST, CONF_VERIFY_SSL, Plat
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
 
+from .const import DOMAIN
 from .coordinator import UnifiAccessConfigEntry, UnifiAccessCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -36,6 +42,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnifiAccessConfigEntry) 
     try:
         await client.authenticate()
     except ApiAuthError as err:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "api_token_expired",
+            is_fixable=True,
+            is_persistent=True,
+            learn_more_url="https://www.home-assistant.io/integrations/unifi_access/",
+            severity=IssueSeverity.ERROR,
+            translation_key="api_token_expired",
+            translation_placeholders={"host": entry.data[CONF_HOST]},
+            data={"entry_id": entry.entry_id},
+        )
         raise ConfigEntryAuthFailed(
             f"Authentication failed for UniFi Access at {entry.data[CONF_HOST]}"
         ) from err
@@ -43,6 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: UnifiAccessConfigEntry) 
         raise ConfigEntryNotReady(
             f"Unable to connect to UniFi Access at {entry.data[CONF_HOST]}"
         ) from err
+
+    async_delete_issue(hass, DOMAIN, "api_token_expired")
 
     coordinator = UnifiAccessCoordinator(hass, entry, client)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/unifi_access/quality_scale.yaml
+++ b/homeassistant/components/unifi_access/quality_scale.yaml
@@ -59,7 +59,7 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
-  repair-issues: todo
+  repair-issues: done
   stale-devices: todo
 
   # Platinum

--- a/homeassistant/components/unifi_access/repairs.py
+++ b/homeassistant/components/unifi_access/repairs.py
@@ -1,0 +1,59 @@
+"""Repairs for the UniFi Access integration."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .coordinator import UnifiAccessConfigEntry
+
+
+class ApiTokenExpiredRepair(RepairsFlow):
+    """Handler for fixing an expired API token."""
+
+    _entry: UnifiAccessConfigEntry
+
+    def __init__(self, *, entry: UnifiAccessConfigEntry) -> None:
+        """Initialize the repair flow."""
+        self._entry = entry
+        super().__init__()
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of the fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of the fix flow."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm",
+                data_schema=vol.Schema({}),
+            )
+
+        self._entry.async_start_reauth(self.hass)
+        return self.async_create_entry(data={})
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if (
+        data is not None
+        and "entry_id" in data
+        and (entry := hass.config_entries.async_get_entry(cast(str, data["entry_id"])))
+    ):
+        if issue_id == "api_token_expired":
+            return ApiTokenExpiredRepair(entry=entry)
+    return ConfirmRepairFlow()

--- a/homeassistant/components/unifi_access/strings.json
+++ b/homeassistant/components/unifi_access/strings.json
@@ -116,5 +116,18 @@
     "unlock_failed": {
       "message": "Failed to unlock the door."
     }
+  },
+  "issues": {
+    "api_token_expired": {
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "description": "The API token for your UniFi Access controller at `{host}` is no longer valid.\n\nGenerate a new API token in the UniFi Access settings and confirm this repair to start the reauthentication flow.",
+            "title": "API token expired for UniFi Access"
+          }
+        }
+      },
+      "title": "API token expired for UniFi Access"
+    }
   }
 }

--- a/tests/components/unifi_access/test_repairs.py
+++ b/tests/components/unifi_access/test_repairs.py
@@ -1,0 +1,96 @@
+"""Tests for UniFi Access repairs."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from unifi_access_api import ApiAuthError
+
+from homeassistant.components.unifi_access.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
+from homeassistant.setup import async_setup_component
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.repairs import (
+    async_process_repairs_platforms,
+    process_repair_fix_flow,
+    start_repair_fix_flow,
+)
+from tests.typing import ClientSessionGenerator, WebSocketGenerator
+
+
+async def test_api_token_expired_creates_repair_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that an expired API token creates a repair issue."""
+    mock_client.authenticate.side_effect = ApiAuthError()
+    await setup_integration(hass, mock_config_entry)
+
+    assert await async_setup_component(hass, "repairs", {})
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    issue = next(
+        i for i in msg["result"]["issues"] if i["issue_id"] == "api_token_expired"
+    )
+    assert issue["is_fixable"] is True
+    assert issue["severity"] == "error"
+    assert issue["translation_key"] == "api_token_expired"
+
+
+async def test_api_token_expired_repair_flow_triggers_reauth(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that the repair flow triggers reauthentication."""
+    mock_client.authenticate.side_effect = ApiAuthError()
+    await setup_integration(hass, mock_config_entry)
+
+    assert await async_setup_component(hass, "repairs", {})
+    await async_process_repairs_platforms(hass)
+    client = await hass_client()
+
+    data = await start_repair_fix_flow(client, DOMAIN, "api_token_expired")
+    flow_id = data["flow_id"]
+    assert data["step_id"] == "confirm"
+
+    data = await process_repair_fix_flow(client, flow_id)
+    assert data["type"] == "create_entry"
+
+    await hass.async_block_till_done()
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+
+
+async def test_successful_setup_clears_repair_issue(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test that a successful setup clears the repair issue."""
+    # First, trigger the repair issue with an auth error
+    mock_client.authenticate.side_effect = ApiAuthError()
+    await setup_integration(hass, mock_config_entry)
+
+    issue_registry = async_get_issue_registry(hass)
+    assert issue_registry.async_get_issue(DOMAIN, "api_token_expired") is not None
+
+    # Now simulate successful reauth by clearing the error and reloading
+    mock_client.authenticate.side_effect = None
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, "api_token_expired") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Implement the `repair-issues` Gold quality scale rule for the UniFi Access integration.

When the API token has expired or is invalid, a fixable repair issue is now created in the Repairs panel. The repair flow explains the problem, links to the integration documentation, and triggers the existing reauthentication flow so the user can enter a new token. The issue is automatically cleared on successful setup after reauthentication.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
