### PR TITLE
Fix OPNsense integration for 25.7+ and add config flow

### DIFF
--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 import aiohttp
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -61,9 +61,7 @@ class OPNsenseClient:
 
     async def get_arp(self) -> list[dict[str, Any]]:
         """Get the ARP table from OPNsense."""
-        result: list[dict[str, Any]] = await self._get(
-            "diagnostics/interface/get_arp"
-        )
+        result: list[dict[str, Any]] = await self._get("diagnostics/interface/get_arp")
         return result
 
     async def get_interfaces(self) -> dict[str, str]:
@@ -122,9 +120,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await client.get_arp()
     except (aiohttp.ClientError, TimeoutError) as err:
-        raise ConfigEntryNotReady(
-            "Failed to connect to OPNsense API endpoint"
-        ) from err
+        raise ConfigEntryNotReady("Failed to connect to OPNsense API endpoint") from err
 
     if tracker_interfaces:
         try:

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -58,11 +58,15 @@ class OPNsenseClient:
 
     async def get_arp(self) -> list[dict[str, Any]]:
         """Get the ARP table from OPNsense."""
-        return await self._get("diagnostics/interface/get_arp")
+        result: list[dict[str, Any]] = await self._get("diagnostics/interface/get_arp")
+        return result
 
     async def get_interfaces(self) -> dict[str, str]:
         """Get available network interfaces from OPNsense."""
-        return await self._get("diagnostics/networkinsight/get_interfaces")
+        result: dict[str, str] = await self._get(
+            "diagnostics/networkinsight/get_interfaces"
+        )
+        return result
 
     async def _get(self, endpoint: str) -> Any:
         """Make a GET request to the OPNsense API."""
@@ -115,9 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             interfaces_resp = await client.get_interfaces()
         except aiohttp.ClientError:
-            _LOGGER.exception(
-                "Failure while retrieving OPNsense network interfaces"
-            )
+            _LOGGER.exception("Failure while retrieving OPNsense network interfaces")
             return False
         interfaces = list(interfaces_resp.values())
         for interface in tracker_interfaces:

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -87,11 +87,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         interfaces = list(interfaces_resp.values())
         for interface in tracker_interfaces:
             if interface not in interfaces:
-                _LOGGER.error(
-                    "Specified OPNsense tracker interface %s is not found",
-                    interface,
+                raise ConfigEntryError(
+                    f"Specified OPNsense tracker interface {interface} is not found"
                 )
-                return False
 
     entry.runtime_data = {
         "client": client,

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -20,6 +21,8 @@ from .const import CONF_API_SECRET, CONF_TRACKER_INTERFACES, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.DEVICE_TRACKER]
+
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=20)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -58,7 +61,9 @@ class OPNsenseClient:
 
     async def get_arp(self) -> list[dict[str, Any]]:
         """Get the ARP table from OPNsense."""
-        result: list[dict[str, Any]] = await self._get("diagnostics/interface/get_arp")
+        result: list[dict[str, Any]] = await self._get(
+            "diagnostics/interface/get_arp"
+        )
         return result
 
     async def get_interfaces(self) -> dict[str, str]:
@@ -71,9 +76,14 @@ class OPNsenseClient:
     async def _get(self, endpoint: str) -> Any:
         """Make a GET request to the OPNsense API."""
         url = f"{self._url}/{endpoint}"
-        resp = await self._session.get(url, auth=self._auth, ssl=self._verify_ssl)
-        resp.raise_for_status()
-        return await resp.json()
+        async with self._session.get(
+            url,
+            auth=self._auth,
+            ssl=self._verify_ssl,
+            timeout=REQUEST_TIMEOUT,
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -111,16 +121,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.get_arp()
-    except aiohttp.ClientError:
-        _LOGGER.exception("Failure while connecting to OPNsense API endpoint")
-        return False
+    except (aiohttp.ClientError, TimeoutError) as err:
+        raise ConfigEntryNotReady(
+            "Failed to connect to OPNsense API endpoint"
+        ) from err
 
     if tracker_interfaces:
         try:
             interfaces_resp = await client.get_interfaces()
-        except aiohttp.ClientError:
-            _LOGGER.exception("Failure while retrieving OPNsense network interfaces")
-            return False
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise ConfigEntryNotReady(
+                "Failed to retrieve OPNsense network interfaces"
+            ) from err
         interfaces = list(interfaces_resp.values())
         for interface in tracker_interfaces:
             if interface not in interfaces:

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-import aiohttp
+from aioopnsense import OPNsenseApiError, OPNsenseClient
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -21,8 +20,6 @@ from .const import CONF_API_SECRET, CONF_TRACKER_INTERFACES, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.DEVICE_TRACKER]
-
-REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=20)
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -40,48 +37,6 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
-
-
-class OPNsenseClient:
-    """Client for the OPNsense API."""
-
-    def __init__(
-        self,
-        url: str,
-        api_key: str,
-        api_secret: str,
-        session: aiohttp.ClientSession,
-        verify_ssl: bool,
-    ) -> None:
-        """Initialize the OPNsense client."""
-        self._url = url.rstrip("/")
-        self._auth = aiohttp.BasicAuth(api_key, api_secret)
-        self._session = session
-        self._verify_ssl = verify_ssl
-
-    async def get_arp(self) -> list[dict[str, Any]]:
-        """Get the ARP table from OPNsense."""
-        result: list[dict[str, Any]] = await self._get("diagnostics/interface/get_arp")
-        return result
-
-    async def get_interfaces(self) -> dict[str, str]:
-        """Get available network interfaces from OPNsense."""
-        result: dict[str, str] = await self._get(
-            "diagnostics/networkinsight/get_interfaces"
-        )
-        return result
-
-    async def _get(self, endpoint: str) -> Any:
-        """Make a GET request to the OPNsense API."""
-        url = f"{self._url}/{endpoint}"
-        async with self._session.get(
-            url,
-            auth=self._auth,
-            ssl=self._verify_ssl,
-            timeout=REQUEST_TIMEOUT,
-        ) as resp:
-            resp.raise_for_status()
-            return await resp.json()
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -119,13 +74,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.get_arp()
-    except (aiohttp.ClientError, TimeoutError) as err:
+    except OPNsenseApiError as err:
         raise ConfigEntryNotReady("Failed to connect to OPNsense API endpoint") from err
 
     if tracker_interfaces:
         try:
             interfaces_resp = await client.get_interfaces()
-        except (aiohttp.ClientError, TimeoutError) as err:
+        except OPNsenseApiError as err:
             raise ConfigEntryNotReady(
                 "Failed to retrieve OPNsense network interfaces"
             ) from err

--- a/homeassistant/components/opnsense/__init__.py
+++ b/homeassistant/components/opnsense/__init__.py
@@ -1,26 +1,25 @@
 """Support for OPNsense Routers."""
 
-import logging
+from __future__ import annotations
 
-from pyopnsense import diagnostics
-from pyopnsense.exceptions import APIException
+import logging
+from typing import Any
+
+import aiohttp
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_API_SECRET,
-    CONF_INTERFACE_CLIENT,
-    CONF_TRACKER_INTERFACES,
-    DOMAIN,
-    OPNSENSE_DATA,
-)
+from .const import CONF_API_SECRET, CONF_TRACKER_INTERFACES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -40,42 +39,104 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the opnsense component."""
+class OPNsenseClient:
+    """Client for the OPNsense API."""
 
-    conf = config[DOMAIN]
-    url = conf[CONF_URL]
-    api_key = conf[CONF_API_KEY]
-    api_secret = conf[CONF_API_SECRET]
-    verify_ssl = conf[CONF_VERIFY_SSL]
-    tracker_interfaces = conf[CONF_TRACKER_INTERFACES]
+    def __init__(
+        self,
+        url: str,
+        api_key: str,
+        api_secret: str,
+        session: aiohttp.ClientSession,
+        verify_ssl: bool,
+    ) -> None:
+        """Initialize the OPNsense client."""
+        self._url = url.rstrip("/")
+        self._auth = aiohttp.BasicAuth(api_key, api_secret)
+        self._session = session
+        self._verify_ssl = verify_ssl
 
-    interfaces_client = diagnostics.InterfaceClient(
-        api_key, api_secret, url, verify_ssl, timeout=20
-    )
+    async def get_arp(self) -> list[dict[str, Any]]:
+        """Get the ARP table from OPNsense."""
+        return await self._get("diagnostics/interface/get_arp")
+
+    async def get_interfaces(self) -> dict[str, str]:
+        """Get available network interfaces from OPNsense."""
+        return await self._get("diagnostics/networkinsight/get_interfaces")
+
+    async def _get(self, endpoint: str) -> Any:
+        """Make a GET request to the OPNsense API."""
+        url = f"{self._url}/{endpoint}"
+        resp = await self._session.get(url, auth=self._auth, ssl=self._verify_ssl)
+        resp.raise_for_status()
+        return await resp.json()
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Import OPNsense configuration from YAML."""
+    if DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
+            )
+        )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up OPNsense from a config entry."""
+    data = entry.data
+    url = data[CONF_URL]
+    api_key = data[CONF_API_KEY]
+    api_secret = data[CONF_API_SECRET]
+    verify_ssl = data.get(CONF_VERIFY_SSL, False)
+    tracker_interfaces_raw = data.get(CONF_TRACKER_INTERFACES, "")
+
+    # Parse tracker interfaces from comma-separated string or list
+    if isinstance(tracker_interfaces_raw, list):
+        tracker_interfaces = tracker_interfaces_raw
+    elif tracker_interfaces_raw:
+        tracker_interfaces = [
+            i.strip() for i in tracker_interfaces_raw.split(",") if i.strip()
+        ]
+    else:
+        tracker_interfaces = []
+
+    session = async_get_clientsession(hass, verify_ssl=verify_ssl)
+    client = OPNsenseClient(url, api_key, api_secret, session, verify_ssl)
+
     try:
-        interfaces_client.get_arp()
-    except APIException:
+        await client.get_arp()
+    except aiohttp.ClientError:
         _LOGGER.exception("Failure while connecting to OPNsense API endpoint")
         return False
 
     if tracker_interfaces:
-        # Verify that specified tracker interfaces are valid
-        netinsight_client = diagnostics.NetworkInsightClient(
-            api_key, api_secret, url, verify_ssl, timeout=20
-        )
-        interfaces = list(netinsight_client.get_interfaces().values())
+        try:
+            interfaces_resp = await client.get_interfaces()
+        except aiohttp.ClientError:
+            _LOGGER.exception(
+                "Failure while retrieving OPNsense network interfaces"
+            )
+            return False
+        interfaces = list(interfaces_resp.values())
         for interface in tracker_interfaces:
             if interface not in interfaces:
                 _LOGGER.error(
-                    "Specified OPNsense tracker interface %s is not found", interface
+                    "Specified OPNsense tracker interface %s is not found",
+                    interface,
                 )
                 return False
 
-    hass.data[OPNSENSE_DATA] = {
-        CONF_INTERFACE_CLIENT: interfaces_client,
-        CONF_TRACKER_INTERFACES: tracker_interfaces,
+    entry.runtime_data = {
+        "client": client,
+        "tracker_interfaces": tracker_interfaces,
     }
 
-    load_platform(hass, Platform.DEVICE_TRACKER, DOMAIN, tracker_interfaces, config)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import aiohttp
+from aioopnsense import OPNsenseApiError, OPNsenseAuthError, OPNsenseClient
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -32,25 +32,19 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.hass,
                 verify_ssl=user_input.get(CONF_VERIFY_SSL, False),
             )
-            url = user_input[CONF_URL].rstrip("/")
-            auth = aiohttp.BasicAuth(
-                user_input[CONF_API_KEY], user_input[CONF_API_SECRET]
+            client = OPNsenseClient(
+                url=user_input[CONF_URL],
+                api_key=user_input[CONF_API_KEY],
+                api_secret=user_input[CONF_API_SECRET],
+                session=session,
+                verify_ssl=user_input.get(CONF_VERIFY_SSL, False),
             )
 
             try:
-                async with session.get(
-                    f"{url}/diagnostics/interface/get_arp",
-                    auth=auth,
-                    ssl=user_input.get(CONF_VERIFY_SSL, False),
-                    timeout=aiohttp.ClientTimeout(total=20),
-                ) as resp:
-                    resp.raise_for_status()
-            except aiohttp.ClientResponseError as err:
-                if err.status in (401, 403):
-                    errors["base"] = "invalid_auth"
-                else:
-                    errors["base"] = "cannot_connect"
-            except aiohttp.ClientError:
+                await client.get_arp()
+            except OPNsenseAuthError:
+                errors["base"] = "invalid_auth"
+            except OPNsenseApiError:
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_create_entry(

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -38,18 +38,19 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
             try:
-                resp = await session.get(
+                async with session.get(
                     f"{url}/diagnostics/interface/get_arp",
                     auth=auth,
                     ssl=user_input.get(CONF_VERIFY_SSL, False),
-                )
-                resp.raise_for_status()
+                    timeout=aiohttp.ClientTimeout(total=20),
+                ) as resp:
+                    resp.raise_for_status()
             except aiohttp.ClientResponseError as err:
                 if err.status in (401, 403):
                     errors["base"] = "invalid_auth"
                 else:
                     errors["base"] = "cannot_connect"
-            except aiohttp.ClientError:
+            except (aiohttp.ClientError, TimeoutError):
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_create_entry(

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -50,7 +50,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "invalid_auth"
                 else:
                     errors["base"] = "cannot_connect"
-            except (aiohttp.ClientError, TimeoutError):
+            except aiohttp.ClientError:
                 errors["base"] = "cannot_connect"
             else:
                 return self.async_create_entry(

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -26,6 +26,7 @@ class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            user_input[CONF_URL] = user_input[CONF_URL].rstrip("/")
             self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
 
             session = async_get_clientsession(

--- a/homeassistant/components/opnsense/config_flow.py
+++ b/homeassistant/components/opnsense/config_flow.py
@@ -1,0 +1,86 @@
+"""Config flow for OPNsense."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import CONF_API_SECRET, CONF_TRACKER_INTERFACES, DOMAIN
+
+
+class OPNsenseConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OPNsense."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
+
+            session = async_get_clientsession(
+                self.hass,
+                verify_ssl=user_input.get(CONF_VERIFY_SSL, False),
+            )
+            url = user_input[CONF_URL].rstrip("/")
+            auth = aiohttp.BasicAuth(
+                user_input[CONF_API_KEY], user_input[CONF_API_SECRET]
+            )
+
+            try:
+                resp = await session.get(
+                    f"{url}/diagnostics/interface/get_arp",
+                    auth=auth,
+                    ssl=user_input.get(CONF_VERIFY_SSL, False),
+                )
+                resp.raise_for_status()
+            except aiohttp.ClientResponseError as err:
+                if err.status in (401, 403):
+                    errors["base"] = "invalid_auth"
+                else:
+                    errors["base"] = "cannot_connect"
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=user_input[CONF_URL],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_URL): str,
+                    vol.Required(CONF_API_KEY): str,
+                    vol.Required(CONF_API_SECRET): str,
+                    vol.Optional(CONF_VERIFY_SSL, default=False): bool,
+                    vol.Optional(CONF_TRACKER_INTERFACES, default=""): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_import(
+        self, import_config: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Import OPNsense config from YAML."""
+        tracker_interfaces = import_config.get(CONF_TRACKER_INTERFACES, [])
+        import_config[CONF_TRACKER_INTERFACES] = ",".join(tracker_interfaces)
+
+        self._async_abort_entries_match({CONF_URL: import_config[CONF_URL]})
+
+        return self.async_create_entry(
+            title=import_config[CONF_URL],
+            data=import_config,
+        )

--- a/homeassistant/components/opnsense/const.py
+++ b/homeassistant/components/opnsense/const.py
@@ -1,8 +1,6 @@
 """Constants for OPNsense component."""
 
 DOMAIN = "opnsense"
-OPNSENSE_DATA = DOMAIN
 
 CONF_API_SECRET = "api_secret"
-CONF_INTERFACE_CLIENT = "interface_client"
 CONF_TRACKER_INTERFACES = "tracker_interfaces"

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -63,7 +63,7 @@ async def async_setup_entry(
                 if mac in tracked:
                     tracked[mac].update_from_arp(device)
                 else:
-                    entity = OPNsenseDevice(device)
+                    entity = OPNsenseDevice(device, config_entry.entry_id)
                     tracked[mac] = entity
                     new_entities.append(entity)
 
@@ -88,10 +88,12 @@ class OPNsenseDevice(ScannerEntity):
     """Representation of a device tracked via OPNsense."""
 
     _attr_source_type = SourceType.ROUTER
+    _attr_should_poll = False
 
-    def __init__(self, device: dict[str, Any]) -> None:
+    def __init__(self, device: dict[str, Any], entry_id: str) -> None:
         """Initialize the device."""
         self._mac: str = device["mac"]
+        self._entry_id = entry_id
         self._attr_hostname = device.get("hostname") or None
         self._attr_ip_address = device.get("ip")
         self._attr_mac_address = self._mac
@@ -105,7 +107,7 @@ class OPNsenseDevice(ScannerEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID for this device."""
-        return self._mac
+        return f"{self._entry_id}_{self._mac}"
 
     @property
     def is_connected(self) -> bool:

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-import aiohttp
+from aioopnsense import OPNsenseApiError
 
 from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -40,7 +40,7 @@ async def async_setup_entry(
         async with update_lock:
             try:
                 devices = await client.get_arp()
-            except aiohttp.ClientError:
+            except OPNsenseApiError:
                 _LOGGER.exception("Error fetching OPNsense ARP table")
                 return
 

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 from typing import Any
 
@@ -10,8 +11,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-
-from datetime import timedelta
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +40,10 @@ async def async_setup_entry(
         seen_macs: set[str] = set()
 
         for device in devices:
-            if tracker_interfaces and device.get("intf_description") not in tracker_interfaces:
+            if (
+                tracker_interfaces
+                and device.get("intf_description") not in tracker_interfaces
+            ):
                 continue
 
             mac = device.get("mac")
@@ -79,7 +81,7 @@ class OPNsenseDevice(ScannerEntity):
 
     def __init__(self, device: dict[str, Any]) -> None:
         """Initialize the device."""
-        self._mac = device["mac"]
+        self._mac: str = device["mac"]
         self._attr_hostname = device.get("hostname") or None
         self._attr_ip_address = device.get("ip")
         self._attr_mac_address = self._mac

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -1,73 +1,125 @@
 """Device tracker support for OPNsense routers."""
 
-from typing import Any, NewType
+from __future__ import annotations
 
-from pyopnsense import diagnostics
+import logging
+from typing import Any
 
-from homeassistant.components.device_tracker import DeviceScanner
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 
-from .const import CONF_INTERFACE_CLIENT, CONF_TRACKER_INTERFACES, OPNSENSE_DATA
+from datetime import timedelta
 
-DeviceDetails = NewType("DeviceDetails", dict[str, Any])
-DeviceDetailsByMAC = NewType("DeviceDetailsByMAC", dict[str, DeviceDetails])
+_LOGGER = logging.getLogger(__name__)
 
-
-async def async_get_scanner(
-    hass: HomeAssistant, config: ConfigType
-) -> DeviceScanner | None:
-    """Configure the OPNsense device_tracker."""
-    return OPNsenseDeviceScanner(
-        hass.data[OPNSENSE_DATA][CONF_INTERFACE_CLIENT],
-        hass.data[OPNSENSE_DATA][CONF_TRACKER_INTERFACES],
-    )
+SCAN_INTERVAL = timedelta(seconds=120)
 
 
-class OPNsenseDeviceScanner(DeviceScanner):
-    """This class queries a router running OPNsense."""
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up device tracker for OPNsense."""
+    client = config_entry.runtime_data["client"]
+    tracker_interfaces: list[str] = config_entry.runtime_data["tracker_interfaces"]
 
-    def __init__(
-        self, client: diagnostics.InterfaceClient, interfaces: list[str]
-    ) -> None:
-        """Initialize the scanner."""
-        self.last_results: dict[str, Any] = {}
-        self.client = client
-        self.interfaces = interfaces
+    tracked: dict[str, OPNsenseDevice] = {}
 
-    def _get_mac_addrs(self, devices: list[DeviceDetails]) -> DeviceDetailsByMAC | dict:
-        """Create dict with mac address keys from list of devices."""
-        out_devices = {}
+    async def _async_update_devices(_now: Any = None) -> None:
+        """Update devices from OPNsense ARP table."""
+        try:
+            devices = await client.get_arp()
+        except Exception:
+            _LOGGER.exception("Error fetching OPNsense ARP table")
+            return
+
+        new_entities: list[OPNsenseDevice] = []
+        seen_macs: set[str] = set()
+
         for device in devices:
-            if not self.interfaces or device["intf_description"] in self.interfaces:
-                out_devices[device["mac"]] = device
-        return out_devices
+            if tracker_interfaces and device.get("intf_description") not in tracker_interfaces:
+                continue
 
-    def scan_devices(self) -> list[str]:
-        """Scan for new devices and return a list with found device IDs."""
-        self.update_info()
-        return list(self.last_results)
+            mac = device.get("mac")
+            if not mac:
+                continue
 
-    def get_device_name(self, device: str) -> str | None:
-        """Return the name of the given device or None if we don't know."""
-        if device not in self.last_results:
-            return None
-        return self.last_results[device].get("hostname") or None
+            seen_macs.add(mac)
 
-    def update_info(self) -> bool:
-        """Ensure the information from the OPNsense router is up to date.
+            if mac in tracked:
+                tracked[mac].update_from_arp(device)
+            else:
+                entity = OPNsenseDevice(device)
+                tracked[mac] = entity
+                new_entities.append(entity)
 
-        Return boolean if scanning successful.
-        """
-        devices = self.client.get_arp()
-        self.last_results = self._get_mac_addrs(devices)
-        return True
+        # Mark devices not in ARP table as not connected
+        for mac, entity in tracked.items():
+            if mac not in seen_macs:
+                entity.mark_disconnected()
 
-    def get_extra_attributes(self, device: str) -> dict[Any, Any]:
-        """Return the extra attrs of the given device."""
-        if device not in self.last_results:
-            return {}
-        mfg = self.last_results[device].get("manufacturer")
-        if not mfg:
-            return {}
-        return {"manufacturer": mfg}
+        if new_entities:
+            async_add_entities(new_entities)
+
+    # Initial scan
+    await _async_update_devices()
+
+    # Schedule periodic scans
+    async_track_time_interval(hass, _async_update_devices, SCAN_INTERVAL)
+
+
+class OPNsenseDevice(ScannerEntity):
+    """Representation of a device tracked via OPNsense."""
+
+    _attr_source_type = SourceType.ROUTER
+
+    def __init__(self, device: dict[str, Any]) -> None:
+        """Initialize the device."""
+        self._mac = device["mac"]
+        self._attr_hostname = device.get("hostname") or None
+        self._attr_ip_address = device.get("ip")
+        self._attr_mac_address = self._mac
+        self._is_connected = True
+        self._manufacturer = device.get("manufacturer")
+
+        # Use hostname or MAC as display name
+        name = self._attr_hostname or self._mac.replace(":", "_")
+        self._attr_name = name
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID for this device."""
+        return self._mac
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is connected to the network."""
+        return self._is_connected
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        attrs: dict[str, Any] = {}
+        if self._manufacturer:
+            attrs["manufacturer"] = self._manufacturer
+        return attrs
+
+    @callback
+    def update_from_arp(self, device: dict[str, Any]) -> None:
+        """Update device data from ARP entry."""
+        self._is_connected = True
+        self._attr_hostname = device.get("hostname") or None
+        self._attr_ip_address = device.get("ip")
+        self._manufacturer = device.get("manufacturer")
+        self.async_write_ha_state()
+
+    @callback
+    def mark_disconnected(self) -> None:
+        """Mark device as not connected."""
+        if self._is_connected:
+            self._is_connected = False
+            self.async_write_ha_state()

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
                     entity.mark_disconnected()
 
             if new_entities:
-                async_add_entities(new_entities)
+                async_add_entities(new_entities, True)
 
     # Initial scan
     await _async_update_devices()

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
                     entity.mark_disconnected()
 
             if new_entities:
-                async_add_entities(new_entities, True)
+                async_add_entities(new_entities)
 
     # Initial scan
     await _async_update_devices()
@@ -87,8 +87,13 @@ async def async_setup_entry(
 class OPNsenseDevice(ScannerEntity):
     """Representation of a device tracked via OPNsense."""
 
-    _attr_source_type = SourceType.ROUTER
     _attr_should_poll = False
+    _attr_source_type = SourceType.ROUTER
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if entity is enabled by default."""
+        return True
 
     def __init__(self, device: dict[str, Any], entry_id: str) -> None:
         """Initialize the device."""

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import Any
+
+import aiohttp
 
 from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -27,51 +30,59 @@ async def async_setup_entry(
     tracker_interfaces: list[str] = config_entry.runtime_data["tracker_interfaces"]
 
     tracked: dict[str, OPNsenseDevice] = {}
+    update_lock = asyncio.Lock()
 
     async def _async_update_devices(_now: Any = None) -> None:
         """Update devices from OPNsense ARP table."""
-        try:
-            devices = await client.get_arp()
-        except Exception:
-            _LOGGER.exception("Error fetching OPNsense ARP table")
+        if update_lock.locked():
             return
 
-        new_entities: list[OPNsenseDevice] = []
-        seen_macs: set[str] = set()
+        async with update_lock:
+            try:
+                devices = await client.get_arp()
+            except (aiohttp.ClientError, TimeoutError):
+                _LOGGER.exception("Error fetching OPNsense ARP table")
+                return
 
-        for device in devices:
-            if (
-                tracker_interfaces
-                and device.get("intf_description") not in tracker_interfaces
-            ):
-                continue
+            new_entities: list[OPNsenseDevice] = []
+            seen_macs: set[str] = set()
 
-            mac = device.get("mac")
-            if not mac:
-                continue
+            for device in devices:
+                if (
+                    tracker_interfaces
+                    and device.get("intf_description")
+                    not in tracker_interfaces
+                ):
+                    continue
 
-            seen_macs.add(mac)
+                mac = device.get("mac")
+                if not mac:
+                    continue
 
-            if mac in tracked:
-                tracked[mac].update_from_arp(device)
-            else:
-                entity = OPNsenseDevice(device)
-                tracked[mac] = entity
-                new_entities.append(entity)
+                seen_macs.add(mac)
 
-        # Mark devices not in ARP table as not connected
-        for mac, entity in tracked.items():
-            if mac not in seen_macs:
-                entity.mark_disconnected()
+                if mac in tracked:
+                    tracked[mac].update_from_arp(device)
+                else:
+                    entity = OPNsenseDevice(device)
+                    tracked[mac] = entity
+                    new_entities.append(entity)
 
-        if new_entities:
-            async_add_entities(new_entities)
+            # Mark devices not in ARP table as not connected
+            for mac, entity in tracked.items():
+                if mac not in seen_macs:
+                    entity.mark_disconnected()
+
+            if new_entities:
+                async_add_entities(new_entities)
 
     # Initial scan
     await _async_update_devices()
 
-    # Schedule periodic scans
-    async_track_time_interval(hass, _async_update_devices, SCAN_INTERVAL)
+    # Schedule periodic scans and cancel on unload
+    config_entry.async_on_unload(
+        async_track_time_interval(hass, _async_update_devices, SCAN_INTERVAL)
+    )
 
 
 class OPNsenseDevice(ScannerEntity):

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -12,7 +12,7 @@ import aiohttp
 from homeassistant.components.device_tracker import ScannerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ SCAN_INTERVAL = timedelta(seconds=120)
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up device tracker for OPNsense."""
     client = config_entry.runtime_data["client"]

--- a/homeassistant/components/opnsense/device_tracker.py
+++ b/homeassistant/components/opnsense/device_tracker.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
         async with update_lock:
             try:
                 devices = await client.get_arp()
-            except (aiohttp.ClientError, TimeoutError):
+            except aiohttp.ClientError:
                 _LOGGER.exception("Error fetching OPNsense ARP table")
                 return
 
@@ -50,8 +50,7 @@ async def async_setup_entry(
             for device in devices:
                 if (
                     tracker_interfaces
-                    and device.get("intf_description")
-                    not in tracker_interfaces
+                    and device.get("intf_description") not in tracker_interfaces
                 ):
                     continue
 

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -6,6 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/opnsense",
   "integration_type": "hub",
   "iot_class": "local_polling",
+  "loggers": ["aioopnsense"],
   "quality_scale": "legacy",
-  "requirements": []
+  "requirements": ["aioopnsense==0.1.0"]
 }

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": ["@mtreinish"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/opnsense",
+  "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "legacy",
   "requirements": []

--- a/homeassistant/components/opnsense/manifest.json
+++ b/homeassistant/components/opnsense/manifest.json
@@ -2,9 +2,9 @@
   "domain": "opnsense",
   "name": "OPNsense",
   "codeowners": ["@mtreinish"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/opnsense",
   "iot_class": "local_polling",
-  "loggers": ["pbr", "pyopnsense"],
   "quality_scale": "legacy",
-  "requirements": ["pyopnsense==0.4.0"]
+  "requirements": []
 }

--- a/homeassistant/components/opnsense/strings.json
+++ b/homeassistant/components/opnsense/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to OPNsense",
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "api_secret": "API secret",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "tracker_interfaces": "Tracker interfaces (comma-separated, leave empty for all)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/opnsense/strings.json
+++ b/homeassistant/components/opnsense/strings.json
@@ -1,23 +1,23 @@
 {
   "config": {
-    "step": {
-      "user": {
-        "title": "Connect to OPNsense",
-        "data": {
-          "url": "[%key:common::config_flow::data::url%]",
-          "api_key": "[%key:common::config_flow::data::api_key%]",
-          "api_secret": "API secret",
-          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
-          "tracker_interfaces": "Tracker interfaces (comma-separated, leave empty for all)"
-        }
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    "step": {
+      "user": {
+        "data": {
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "api_secret": "API secret",
+          "tracker_interfaces": "Tracker interfaces (comma-separated, leave empty for all)",
+          "url": "[%key:common::config_flow::data::url%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "title": "Connect to OPNsense"
+      }
     }
   }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -522,6 +522,7 @@ FLOWS = {
         "opentherm_gw",
         "openuv",
         "openweathermap",
+        "opnsense",
         "opower",
         "oralb",
         "orvibo",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5010,7 +5010,7 @@
     "opnsense": {
       "name": "OPNsense",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "opower": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -347,11 +347,11 @@ aionut==4.3.4
 # homeassistant.components.onkyo
 aioonkyo==0.4.0
 
-# homeassistant.components.opnsense
-aioopnsense==0.1.0
-
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.6.8
+
+# homeassistant.components.opnsense
+aioopnsense==0.1.0
 
 # homeassistant.components.nmap_tracker
 aiooui==0.1.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -347,6 +347,9 @@ aionut==4.3.4
 # homeassistant.components.onkyo
 aioonkyo==0.4.0
 
+# homeassistant.components.opnsense
+aioopnsense==0.1.0
+
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.6.8
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2352,9 +2352,6 @@ pyopenuv==2023.02.0
 # homeassistant.components.openweathermap
 pyopenweathermap==0.2.2
 
-# homeassistant.components.opnsense
-pyopnsense==0.4.0
-
 # homeassistant.components.opple
 pyoppleio-legacy==1.0.8
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -332,11 +332,11 @@ aionut==4.3.4
 # homeassistant.components.onkyo
 aioonkyo==0.4.0
 
-# homeassistant.components.opnsense
-aioopnsense==0.1.0
-
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.6.8
+
+# homeassistant.components.opnsense
+aioopnsense==0.1.0
 
 # homeassistant.components.nmap_tracker
 aiooui==0.1.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2014,9 +2014,6 @@ pyopenuv==2023.02.0
 # homeassistant.components.openweathermap
 pyopenweathermap==0.2.2
 
-# homeassistant.components.opnsense
-pyopnsense==0.4.0
-
 # homeassistant.components.osoenergy
 pyosoenergyapi==1.2.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -332,6 +332,9 @@ aionut==4.3.4
 # homeassistant.components.onkyo
 aioonkyo==0.4.0
 
+# homeassistant.components.opnsense
+aioopnsense==0.1.0
+
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.6.8
 

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -189,11 +189,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "norway_air": {"pymetno": {"async-timeout"}},
     "opengarage": {"open-garage": {"async-timeout"}},
     "opensensemap": {"opensensemap-api": {"async-timeout"}},
-    "opnsense": {
-        # https://github.com/mtreinish/pyopnsense/issues/27
-        # pyopnsense > pbr > setuptools
-        "pbr": {"setuptools"}
-    },
     "pvpc_hourly_pricing": {"aiopvpc": {"async-timeout"}},
     "remote_rpi_gpio": {
         # https://github.com/waveform80/colorzero/issues/9
@@ -298,10 +293,6 @@ FORBIDDEN_PACKAGE_FILES_EXCEPTIONS = {
     },
     # https://github.com/ejpenney/pyobihai
     "obihai": {"homeassistant": {"pyobihai"}},
-    "opnsense": {
-        # Setuptools - distutils-precedence.pth
-        "pbr": {"setuptools"}
-    },
     # https://github.com/iamkubi/pydactyl
     "pterodactyl": {"homeassistant": {"py-dactyl"}},
     "remote_rpi_gpio": {

--- a/tests/components/opnsense/conftest.py
+++ b/tests/components/opnsense/conftest.py
@@ -1,0 +1,27 @@
+"""Fixtures for OPNsense tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_opnsense_client():
+    """Mock OPNsenseClient for all tests."""
+    client = AsyncMock()
+    client.get_arp = AsyncMock(return_value=[])
+    client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
+
+    with (
+        patch(
+            "homeassistant.components.opnsense.OPNsenseClient",
+            return_value=client,
+        ),
+        patch(
+            "homeassistant.components.opnsense.config_flow.OPNsenseClient",
+            return_value=client,
+        ),
+    ):
+        yield client

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -187,6 +187,32 @@ async def test_setup_entry_invalid_tracker_interface(
     assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
 
 
+async def test_setup_entry_interface_fetch_error(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test that interface fetch failure raises ConfigEntryNotReady."""
+    mock_opnsense_client.get_interfaces = AsyncMock(
+        side_effect=OPNsenseApiError("timeout")
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://opnsense.local/api",
+            CONF_API_KEY: "test_key",
+            CONF_API_SECRET: "test_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: "LAN",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+
+
 async def test_setup_entry_connection_error(
     hass: HomeAssistant, mock_opnsense_client: AsyncMock
 ) -> None:

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -3,7 +3,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
-import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.opnsense.const import (
@@ -159,9 +158,7 @@ async def test_import_flow(hass: HomeAssistant) -> None:
     ) as mock_client_cls:
         client = mock_client_cls.return_value
         client.get_arp = AsyncMock(return_value=[])
-        client.get_interfaces = AsyncMock(
-            return_value={"igb0": "WAN", "igb1": "LAN"}
-        )
+        client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
 
         result = await hass.config_entries.flow.async_init(
             DOMAIN,

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -1,0 +1,179 @@
+"""Tests for the OPNsense config flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.opnsense.const import (
+    CONF_API_SECRET,
+    CONF_TRACKER_INTERFACES,
+    DOMAIN,
+)
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+MOCK_USER_INPUT = {
+    CONF_URL: "https://opnsense.local/api",
+    CONF_API_KEY: "test_key",
+    CONF_API_SECRET: "test_secret",
+    CONF_VERIFY_SSL: False,
+    CONF_TRACKER_INTERFACES: "",
+}
+
+
+def _mock_session_success() -> MagicMock:
+    """Return a mock session that succeeds on get."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(return_value=mock_resp)
+    return mock_session
+
+
+async def test_user_form(hass: HomeAssistant) -> None:
+    """Test we get the user form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+async def test_user_form_success(hass: HomeAssistant) -> None:
+    """Test successful user config flow."""
+    mock_session = _mock_session_success()
+
+    with (
+        patch(
+            "homeassistant.components.opnsense.config_flow.async_get_clientsession",
+            return_value=mock_session,
+        ),
+        patch(
+            "homeassistant.components.opnsense.OPNsenseClient",
+            autospec=True,
+        ) as mock_client_cls,
+    ):
+        client = mock_client_cls.return_value
+        client.get_arp = AsyncMock(return_value=[])
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "https://opnsense.local/api"
+    assert result["data"][CONF_URL] == "https://opnsense.local/api"
+    assert result["data"][CONF_API_KEY] == "test_key"
+    assert result["data"][CONF_API_SECRET] == "test_secret"
+
+
+async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
+    """Test we handle invalid auth."""
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=MagicMock(), history=(), status=403, message="Forbidden"
+        )
+    )
+
+    with patch(
+        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle connection error."""
+    mock_session = MagicMock()
+    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError())
+
+    with patch(
+        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_form_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort if already configured."""
+    entry = config_entries.ConfigEntry(
+        data={
+            CONF_URL: "https://opnsense.local/api",
+            CONF_API_KEY: "test_key",
+            CONF_API_SECRET: "test_secret",
+            CONF_VERIFY_SSL: False,
+        },
+        discovery_keys={},
+        domain=DOMAIN,
+        minor_version=1,
+        options={},
+        source=config_entries.SOURCE_USER,
+        title="https://opnsense.local/api",
+        unique_id=None,
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    mock_session = _mock_session_success()
+
+    with patch(
+        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=MOCK_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow(hass: HomeAssistant) -> None:
+    """Test YAML import creates a config entry."""
+    with patch(
+        "homeassistant.components.opnsense.OPNsenseClient",
+        autospec=True,
+    ) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.get_arp = AsyncMock(return_value=[])
+        client.get_interfaces = AsyncMock(
+            return_value={"igb0": "WAN", "igb1": "LAN"}
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                CONF_URL: "https://opnsense.local/api",
+                CONF_API_KEY: "test_key",
+                CONF_API_SECRET: "test_secret",
+                CONF_VERIFY_SSL: False,
+                CONF_TRACKER_INTERFACES: ["LAN", "WAN"],
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_TRACKER_INTERFACES] == "LAN,WAN"

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -1,5 +1,7 @@
 """Tests for the OPNsense config flow."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -14,6 +16,8 @@ from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
+
 MOCK_USER_INPUT = {
     CONF_URL: "https://opnsense.local/api",
     CONF_API_KEY: "test_key",
@@ -24,11 +28,23 @@ MOCK_USER_INPUT = {
 
 
 def _mock_session_success() -> MagicMock:
-    """Return a mock session that succeeds on get."""
+    """Return a mock session where get() returns an async context manager."""
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
     mock_session = MagicMock()
-    mock_session.get = AsyncMock(return_value=mock_resp)
+    mock_session.get = MagicMock(return_value=mock_ctx)
+    return mock_session
+
+
+def _mock_session_error(error: Exception) -> MagicMock:
+    """Return a mock session where get() raises an error."""
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(side_effect=error)
     return mock_session
 
 
@@ -74,12 +90,19 @@ async def test_user_form_success(hass: HomeAssistant) -> None:
 
 async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
-    mock_session = MagicMock()
-    mock_session.get = AsyncMock(
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock(
         side_effect=aiohttp.ClientResponseError(
             request_info=MagicMock(), history=(), status=403, message="Forbidden"
         )
     )
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=mock_ctx)
 
     with patch(
         "homeassistant.components.opnsense.config_flow.async_get_clientsession",
@@ -97,8 +120,7 @@ async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
 
 async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle connection error."""
-    mock_session = MagicMock()
-    mock_session.get = AsyncMock(side_effect=aiohttp.ClientError())
+    mock_session = _mock_session_error(aiohttp.ClientError())
 
     with patch(
         "homeassistant.components.opnsense.config_flow.async_get_clientsession",
@@ -116,21 +138,14 @@ async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
 
 async def test_user_form_already_configured(hass: HomeAssistant) -> None:
     """Test we abort if already configured."""
-    entry = config_entries.ConfigEntry(
+    entry = MockConfigEntry(
+        domain=DOMAIN,
         data={
             CONF_URL: "https://opnsense.local/api",
             CONF_API_KEY: "test_key",
             CONF_API_SECRET: "test_secret",
             CONF_VERIFY_SSL: False,
         },
-        discovery_keys={},
-        domain=DOMAIN,
-        minor_version=1,
-        options={},
-        source=config_entries.SOURCE_USER,
-        title="https://opnsense.local/api",
-        unique_id=None,
-        version=1,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-import aiohttp
+from aioopnsense import OPNsenseApiError, OPNsenseAuthError
 
 from homeassistant import config_entries
 from homeassistant.components.opnsense.const import (
@@ -27,25 +27,11 @@ MOCK_USER_INPUT = {
 }
 
 
-def _mock_session_success() -> MagicMock:
-    """Return a mock session where get() returns an async context manager."""
-    mock_resp = MagicMock()
-    mock_resp.raise_for_status = MagicMock()
-
-    mock_ctx = AsyncMock()
-    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
-    mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
-    mock_session = MagicMock()
-    mock_session.get = MagicMock(return_value=mock_ctx)
-    return mock_session
-
-
-def _mock_session_error(error: Exception) -> MagicMock:
-    """Return a mock session where get() raises an error."""
-    mock_session = MagicMock()
-    mock_session.get = MagicMock(side_effect=error)
-    return mock_session
+def _mock_client(get_arp_result: list | None = None) -> AsyncMock:
+    """Create a mock OPNsenseClient."""
+    client = AsyncMock()
+    client.get_arp = AsyncMock(return_value=get_arp_result or [])
+    return client
 
 
 async def test_user_form(hass: HomeAssistant) -> None:
@@ -60,21 +46,16 @@ async def test_user_form(hass: HomeAssistant) -> None:
 
 async def test_user_form_success(hass: HomeAssistant) -> None:
     """Test successful user config flow."""
-    mock_session = _mock_session_success()
-
     with (
         patch(
-            "homeassistant.components.opnsense.config_flow.async_get_clientsession",
-            return_value=mock_session,
+            "homeassistant.components.opnsense.config_flow.OPNsenseClient",
+            return_value=_mock_client(),
         ),
         patch(
             "homeassistant.components.opnsense.OPNsenseClient",
-            autospec=True,
-        ) as mock_client_cls,
+            return_value=_mock_client(),
+        ),
     ):
-        client = mock_client_cls.return_value
-        client.get_arp = AsyncMock(return_value=[])
-
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
@@ -90,23 +71,12 @@ async def test_user_form_success(hass: HomeAssistant) -> None:
 
 async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
     """Test we handle invalid auth."""
-    mock_resp = MagicMock()
-    mock_resp.raise_for_status = MagicMock(
-        side_effect=aiohttp.ClientResponseError(
-            request_info=MagicMock(), history=(), status=403, message="Forbidden"
-        )
-    )
-
-    mock_ctx = AsyncMock()
-    mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
-    mock_ctx.__aexit__ = AsyncMock(return_value=False)
-
-    mock_session = MagicMock()
-    mock_session.get = MagicMock(return_value=mock_ctx)
+    mock_client = _mock_client()
+    mock_client.get_arp = AsyncMock(side_effect=OPNsenseAuthError("auth failed"))
 
     with patch(
-        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
-        return_value=mock_session,
+        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
+        return_value=mock_client,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -120,11 +90,12 @@ async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
 
 async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
     """Test we handle connection error."""
-    mock_session = _mock_session_error(aiohttp.ClientError())
+    mock_client = _mock_client()
+    mock_client.get_arp = AsyncMock(side_effect=OPNsenseApiError("connection failed"))
 
     with patch(
-        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
-        return_value=mock_session,
+        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
+        return_value=mock_client,
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -149,11 +120,9 @@ async def test_user_form_already_configured(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    mock_session = _mock_session_success()
-
     with patch(
-        "homeassistant.components.opnsense.config_flow.async_get_clientsession",
-        return_value=mock_session,
+        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
+        return_value=_mock_client(),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -167,14 +136,13 @@ async def test_user_form_already_configured(hass: HomeAssistant) -> None:
 
 async def test_import_flow(hass: HomeAssistant) -> None:
     """Test YAML import creates a config entry."""
+    mock_client = _mock_client()
+    mock_client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
+
     with patch(
         "homeassistant.components.opnsense.OPNsenseClient",
-        autospec=True,
-    ) as mock_client_cls:
-        client = mock_client_cls.return_value
-        client.get_arp = AsyncMock(return_value=[])
-        client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
-
+        return_value=mock_client,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": config_entries.SOURCE_IMPORT},

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from aioopnsense import OPNsenseApiError, OPNsenseAuthError
 
@@ -27,13 +27,6 @@ MOCK_USER_INPUT = {
 }
 
 
-def _mock_client(get_arp_result: list | None = None) -> AsyncMock:
-    """Create a mock OPNsenseClient."""
-    client = AsyncMock()
-    client.get_arp = AsyncMock(return_value=get_arp_result or [])
-    return client
-
-
 async def test_user_form(hass: HomeAssistant) -> None:
     """Test we get the user form."""
     result = await hass.config_entries.flow.async_init(
@@ -44,23 +37,16 @@ async def test_user_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
 
-async def test_user_form_success(hass: HomeAssistant) -> None:
+async def test_user_form_success(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test successful user config flow."""
-    with (
-        patch(
-            "homeassistant.components.opnsense.config_flow.OPNsenseClient",
-            return_value=_mock_client(),
-        ),
-        patch(
-            "homeassistant.components.opnsense.OPNsenseClient",
-            return_value=_mock_client(),
-        ),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=MOCK_USER_INPUT,
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "https://opnsense.local/api"
@@ -69,45 +55,45 @@ async def test_user_form_success(hass: HomeAssistant) -> None:
     assert result["data"][CONF_API_SECRET] == "test_secret"
 
 
-async def test_user_form_invalid_auth(hass: HomeAssistant) -> None:
+async def test_user_form_invalid_auth(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test we handle invalid auth."""
-    mock_client = _mock_client()
-    mock_client.get_arp = AsyncMock(side_effect=OPNsenseAuthError("auth failed"))
+    mock_opnsense_client.get_arp = AsyncMock(
+        side_effect=OPNsenseAuthError("auth failed")
+    )
 
-    with patch(
-        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
-        return_value=mock_client,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=MOCK_USER_INPUT,
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_user_form_cannot_connect(hass: HomeAssistant) -> None:
+async def test_user_form_cannot_connect(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test we handle connection error."""
-    mock_client = _mock_client()
-    mock_client.get_arp = AsyncMock(side_effect=OPNsenseApiError("connection failed"))
+    mock_opnsense_client.get_arp = AsyncMock(
+        side_effect=OPNsenseApiError("connection failed")
+    )
 
-    with patch(
-        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
-        return_value=mock_client,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=MOCK_USER_INPUT,
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_form_already_configured(hass: HomeAssistant) -> None:
+async def test_user_form_already_configured(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test we abort if already configured."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -120,40 +106,32 @@ async def test_user_form_already_configured(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.opnsense.config_flow.OPNsenseClient",
-        return_value=_mock_client(),
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_USER},
-            data=MOCK_USER_INPUT,
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=MOCK_USER_INPUT,
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_import_flow(hass: HomeAssistant) -> None:
+async def test_import_flow(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test YAML import creates a config entry."""
-    mock_client = _mock_client()
-    mock_client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
-
-    with patch(
-        "homeassistant.components.opnsense.OPNsenseClient",
-        return_value=mock_client,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_IMPORT},
-            data={
-                CONF_URL: "https://opnsense.local/api",
-                CONF_API_KEY: "test_key",
-                CONF_API_SECRET: "test_secret",
-                CONF_VERIFY_SSL: False,
-                CONF_TRACKER_INTERFACES: ["LAN", "WAN"],
-            },
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={
+            CONF_URL: "https://opnsense.local/api",
+            CONF_API_KEY: "test_key",
+            CONF_API_SECRET: "test_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: ["LAN", "WAN"],
+        },
+    )
+    await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TRACKER_INTERFACES] == "LAN,WAN"

--- a/tests/components/opnsense/test_config_flow.py
+++ b/tests/components/opnsense/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.opnsense.const import (
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -135,3 +136,78 @@ async def test_import_flow(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"][CONF_TRACKER_INTERFACES] == "LAN,WAN"
+
+
+async def test_yaml_import_triggers_config_flow(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test that YAML configuration triggers config flow import."""
+    await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                CONF_URL: "https://opnsense.local/api",
+                CONF_API_KEY: "test_key",
+                CONF_API_SECRET: "test_secret",
+                CONF_VERIFY_SSL: False,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_URL] == "https://opnsense.local/api"
+
+
+async def test_setup_entry_invalid_tracker_interface(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test that invalid tracker interfaces raise ConfigEntryError."""
+    mock_opnsense_client.get_interfaces = AsyncMock(
+        return_value={"igb0": "WAN", "igb1": "LAN"}
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://opnsense.local/api",
+            CONF_API_KEY: "test_key",
+            CONF_API_SECRET: "test_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: "NONEXISTENT",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_connection_error(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test that connection errors raise ConfigEntryNotReady."""
+    mock_opnsense_client.get_arp = AsyncMock(
+        side_effect=OPNsenseApiError("connection failed")
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://opnsense.local/api",
+            CONF_API_KEY: "test_key",
+            CONF_API_SECRET: "test_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: "",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -96,9 +96,7 @@ async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
     ) as mock_client_cls:
         client = mock_client_cls.return_value
         client.get_arp = AsyncMock(return_value=arp_mixed)
-        client.get_interfaces = AsyncMock(
-            return_value={"igb0": "WAN", "igb1": "LAN"}
-        )
+        client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
 
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -11,6 +11,7 @@ from homeassistant.components.opnsense.const import (
 )
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, STATE_HOME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -67,13 +68,19 @@ async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
         return_value=mock_client,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
-    states = hass.states.async_all("device_tracker")
-    assert len(states) == 2
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert len(entities) == 2
 
-    for state in states:
-        assert state.state == STATE_HOME
+    device_1 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
+    assert device_1 is not None
+    assert device_1.state == STATE_HOME
+
+    device_2 = hass.states.get("device_tracker.desktop")
+    assert device_2 is not None
+    assert device_2.state == STATE_HOME
 
 
 async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
@@ -108,9 +115,14 @@ async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
         return_value=mock_client,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
 
     # Only WAN device should be tracked
-    states = hass.states.async_all("device_tracker")
-    assert len(states) == 1
-    assert states[0].state == STATE_HOME
+    assert len(entities) == 1
+
+    device = hass.states.get("device_tracker.wandevice")
+    assert device is not None
+    assert device.state == STATE_HOME

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,5 +1,7 @@
 """The tests for the opnsense device tracker platform."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.opnsense.const import (
@@ -32,8 +34,19 @@ ARP_RESPONSE = [
 ]
 
 
+def _mock_client(arp_data: list, interfaces_data: dict | None = None) -> AsyncMock:
+    """Create a mock OPNsenseClient."""
+    client = AsyncMock()
+    client.get_arp = AsyncMock(return_value=arp_data)
+    if interfaces_data is not None:
+        client.get_interfaces = AsyncMock(return_value=interfaces_data)
+    return client
+
+
 async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
     """Test that setting up a config entry creates device tracker entities."""
+    mock_client = _mock_client(ARP_RESPONSE)
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -48,24 +61,33 @@ async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.opnsense.OPNsenseClient",
-        autospec=True,
-    ) as mock_client_cls:
-        client = mock_client_cls.return_value
-        client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
-
+        return_value=mock_client,
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
     states = hass.states.async_all("device_tracker")
     assert len(states) == 2
 
-    # Check that both devices are home
     for state in states:
         assert state.state == STATE_HOME
 
 
 async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
     """Test that tracker interfaces filter ARP results."""
+    arp_mixed = [
+        *ARP_RESPONSE,
+        {
+            "hostname": "WanDevice",
+            "intf": "igb0",
+            "intf_description": "WAN",
+            "ip": "10.0.0.1",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "manufacturer": "Test",
+        },
+    ]
+    mock_client = _mock_client(arp_mixed, {"igb0": "WAN", "igb1": "LAN"})
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -78,26 +100,10 @@ async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    arp_mixed = [
-        *ARP_RESPONSE,
-        {
-            "hostname": "WanDevice",
-            "intf": "igb0",
-            "intf_description": "WAN",
-            "ip": "10.0.0.1",
-            "mac": "aa:bb:cc:dd:ee:ff",
-            "manufacturer": "Test",
-        },
-    ]
-
     with patch(
         "homeassistant.components.opnsense.OPNsenseClient",
-        autospec=True,
-    ) as mock_client_cls:
-        client = mock_client_cls.return_value
-        client.get_arp = AsyncMock(return_value=arp_mixed)
-        client.get_interfaces = AsyncMock(return_value={"igb0": "WAN", "igb1": "LAN"})
-
+        return_value=mock_client,
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from homeassistant.components.opnsense.const import (
     CONF_API_SECRET,
@@ -35,21 +35,11 @@ ARP_RESPONSE = [
 ]
 
 
-def _mock_client(
-    arp_data: list | None = None,
-    interfaces_data: dict | None = None,
-) -> AsyncMock:
-    """Create a mock OPNsenseClient."""
-    client = AsyncMock()
-    client.get_arp = AsyncMock(return_value=arp_data or [])
-    if interfaces_data is not None:
-        client.get_interfaces = AsyncMock(return_value=interfaces_data)
-    return client
-
-
-async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
+async def test_setup_entry_creates_device_entities(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test that setting up a config entry creates device tracker entities."""
-    mock_client = _mock_client(ARP_RESPONSE)
+    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -63,12 +53,8 @@ async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.opnsense.OPNsenseClient",
-        return_value=mock_client,
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity_registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
@@ -83,7 +69,9 @@ async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
     assert device_2.state == STATE_HOME
 
 
-async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
+async def test_setup_entry_filters_by_interface(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
     """Test that tracker interfaces filter ARP results."""
     arp_mixed = [
         *ARP_RESPONSE,
@@ -96,7 +84,7 @@ async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
             "manufacturer": "Test",
         },
     ]
-    mock_client = _mock_client(arp_mixed, {"igb0": "WAN", "igb1": "LAN"})
+    mock_opnsense_client.get_arp = AsyncMock(return_value=arp_mixed)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -110,17 +98,11 @@ async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.opnsense.OPNsenseClient",
-        return_value=mock_client,
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity_registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-
-    # Only WAN device should be tracked
     assert len(entities) == 1
 
     device = hass.states.get("device_tracker.wandevice")

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -34,10 +34,13 @@ ARP_RESPONSE = [
 ]
 
 
-def _mock_client(arp_data: list, interfaces_data: dict | None = None) -> AsyncMock:
+def _mock_client(
+    arp_data: list | None = None,
+    interfaces_data: dict | None = None,
+) -> AsyncMock:
     """Create a mock OPNsenseClient."""
     client = AsyncMock()
-    client.get_arp = AsyncMock(return_value=arp_data)
+    client.get_arp = AsyncMock(return_value=arp_data or [])
     if interfaces_data is not None:
         client.get_interfaces = AsyncMock(return_value=interfaces_data)
     return client

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -1,68 +1,109 @@
 """The tests for the opnsense device tracker platform."""
 
-from unittest import mock
+from unittest.mock import AsyncMock, patch
 
-import pytest
-
-from homeassistant.components import opnsense
-from homeassistant.components.device_tracker import legacy
-from homeassistant.components.opnsense import CONF_API_SECRET, DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL
+from homeassistant.components.opnsense.const import (
+    CONF_API_SECRET,
+    CONF_TRACKER_INTERFACES,
+    DOMAIN,
+)
+from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, STATE_HOME
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+ARP_RESPONSE = [
+    {
+        "hostname": "",
+        "intf": "igb1",
+        "intf_description": "LAN",
+        "ip": "192.168.0.123",
+        "mac": "ff:ff:ff:ff:ff:ff",
+        "manufacturer": "",
+    },
+    {
+        "hostname": "Desktop",
+        "intf": "igb1",
+        "intf_description": "LAN",
+        "ip": "192.168.0.167",
+        "mac": "ff:ff:ff:ff:ff:fe",
+        "manufacturer": "OEM",
+    },
+]
 
 
-@pytest.fixture(name="mocked_opnsense")
-def mocked_opnsense():
-    """Mock for pyopnense.diagnostics."""
-    with mock.patch.object(opnsense, "diagnostics") as mocked_opn:
-        yield mocked_opn
-
-
-async def test_get_scanner(
-    hass: HomeAssistant, mocked_opnsense, mock_device_tracker_conf: list[legacy.Device]
-) -> None:
-    """Test creating an opnsense scanner."""
-    interface_client = mock.MagicMock()
-    mocked_opnsense.InterfaceClient.return_value = interface_client
-    interface_client.get_arp.return_value = [
-        {
-            "hostname": "",
-            "intf": "igb1",
-            "intf_description": "LAN",
-            "ip": "192.168.0.123",
-            "mac": "ff:ff:ff:ff:ff:ff",
-            "manufacturer": "",
-        },
-        {
-            "hostname": "Desktop",
-            "intf": "igb1",
-            "intf_description": "LAN",
-            "ip": "192.168.0.167",
-            "mac": "ff:ff:ff:ff:ff:fe",
-            "manufacturer": "OEM",
-        },
-    ]
-    network_insight_client = mock.MagicMock()
-    mocked_opnsense.NetworkInsightClient.return_value = network_insight_client
-    network_insight_client.get_interfaces.return_value = {"igb0": "WAN", "igb1": "LAN"}
-
-    result = await async_setup_component(
-        hass,
-        DOMAIN,
-        {
-            DOMAIN: {
-                CONF_URL: "https://fake_host_fun/api",
-                CONF_API_KEY: "fake_key",
-                CONF_API_SECRET: "fake_secret",
-                CONF_VERIFY_SSL: False,
-            }
+async def test_setup_entry_creates_device_entities(hass: HomeAssistant) -> None:
+    """Test that setting up a config entry creates device tracker entities."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://fake_host_fun/api",
+            CONF_API_KEY: "fake_key",
+            CONF_API_SECRET: "fake_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: "",
         },
     )
-    await hass.async_block_till_done()
-    assert result
-    device_1 = hass.states.get("device_tracker.desktop")
-    assert device_1 is not None
-    assert device_1.state == "home"
-    device_2 = hass.states.get("device_tracker.ff_ff_ff_ff_ff_ff")
-    assert device_2.state == "home"
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.opnsense.OPNsenseClient",
+        autospec=True,
+    ) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    states = hass.states.async_all("device_tracker")
+    assert len(states) == 2
+
+    # Check that both devices are home
+    for state in states:
+        assert state.state == STATE_HOME
+
+
+async def test_setup_entry_filters_by_interface(hass: HomeAssistant) -> None:
+    """Test that tracker interfaces filter ARP results."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_URL: "https://fake_host_fun/api",
+            CONF_API_KEY: "fake_key",
+            CONF_API_SECRET: "fake_secret",
+            CONF_VERIFY_SSL: False,
+            CONF_TRACKER_INTERFACES: "WAN",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    arp_mixed = [
+        *ARP_RESPONSE,
+        {
+            "hostname": "WanDevice",
+            "intf": "igb0",
+            "intf_description": "WAN",
+            "ip": "10.0.0.1",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "manufacturer": "Test",
+        },
+    ]
+
+    with patch(
+        "homeassistant.components.opnsense.OPNsenseClient",
+        autospec=True,
+    ) as mock_client_cls:
+        client = mock_client_cls.return_value
+        client.get_arp = AsyncMock(return_value=arp_mixed)
+        client.get_interfaces = AsyncMock(
+            return_value={"igb0": "WAN", "igb1": "LAN"}
+        )
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Only WAN device should be tracked
+    states = hass.states.async_all("device_tracker")
+    assert len(states) == 1
+    assert states[0].state == STATE_HOME

--- a/tests/components/opnsense/test_device_tracker.py
+++ b/tests/components/opnsense/test_device_tracker.py
@@ -2,18 +2,28 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import AsyncMock
+
+from aioopnsense import OPNsenseConnectionError
+from freezegun.api import FrozenDateTimeFactory
 
 from homeassistant.components.opnsense.const import (
     CONF_API_SECRET,
     CONF_TRACKER_INTERFACES,
     DOMAIN,
 )
-from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, STATE_HOME
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_URL,
+    CONF_VERIFY_SSL,
+    STATE_HOME,
+    STATE_NOT_HOME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 ARP_RESPONSE = [
     {
@@ -35,12 +45,8 @@ ARP_RESPONSE = [
 ]
 
 
-async def test_setup_entry_creates_device_entities(
-    hass: HomeAssistant, mock_opnsense_client: AsyncMock
-) -> None:
-    """Test that setting up a config entry creates device tracker entities."""
-    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
-
+def _make_entry(hass: HomeAssistant, tracker_interfaces: str = "") -> MockConfigEntry:
+    """Create and add a mock config entry."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -48,10 +54,19 @@ async def test_setup_entry_creates_device_entities(
             CONF_API_KEY: "fake_key",
             CONF_API_SECRET: "fake_secret",
             CONF_VERIFY_SSL: False,
-            CONF_TRACKER_INTERFACES: "",
+            CONF_TRACKER_INTERFACES: tracker_interfaces,
         },
     )
     entry.add_to_hass(hass)
+    return entry
+
+
+async def test_setup_entry_creates_device_entities(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test that setting up a config entry creates device tracker entities."""
+    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
+    entry = _make_entry(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
@@ -67,6 +82,7 @@ async def test_setup_entry_creates_device_entities(
     device_2 = hass.states.get("device_tracker.desktop")
     assert device_2 is not None
     assert device_2.state == STATE_HOME
+    assert device_2.attributes.get("manufacturer") == "OEM"
 
 
 async def test_setup_entry_filters_by_interface(
@@ -85,18 +101,7 @@ async def test_setup_entry_filters_by_interface(
         },
     ]
     mock_opnsense_client.get_arp = AsyncMock(return_value=arp_mixed)
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_URL: "https://fake_host_fun/api",
-            CONF_API_KEY: "fake_key",
-            CONF_API_SECRET: "fake_secret",
-            CONF_VERIFY_SSL: False,
-            CONF_TRACKER_INTERFACES: "WAN",
-        },
-    )
-    entry.add_to_hass(hass)
+    entry = _make_entry(hass, "WAN")
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
@@ -108,3 +113,69 @@ async def test_setup_entry_filters_by_interface(
     device = hass.states.get("device_tracker.wandevice")
     assert device is not None
     assert device.state == STATE_HOME
+
+
+async def test_device_goes_away(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a device is marked not_home when it disappears from ARP."""
+    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
+    entry = _make_entry(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    device = hass.states.get("device_tracker.desktop")
+    assert device is not None
+    assert device.state == STATE_HOME
+
+    # Device disappears from ARP table
+    mock_opnsense_client.get_arp = AsyncMock(return_value=[ARP_RESPONSE[0]])
+    freezer.tick(timedelta(seconds=121))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    device = hass.states.get("device_tracker.desktop")
+    assert device is not None
+    assert device.state == STATE_NOT_HOME
+
+
+async def test_update_handles_api_error(
+    hass: HomeAssistant,
+    mock_opnsense_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that API errors during update are handled gracefully."""
+    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
+    entry = _make_entry(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # API error on next poll - entities should keep existing state
+    mock_opnsense_client.get_arp = AsyncMock(
+        side_effect=OPNsenseConnectionError("timeout")
+    )
+    freezer.tick(timedelta(seconds=121))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    device = hass.states.get("device_tracker.desktop")
+    assert device is not None
+    assert device.state == STATE_HOME
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, mock_opnsense_client: AsyncMock
+) -> None:
+    """Test unloading a config entry."""
+    mock_opnsense_client.get_arp = AsyncMock(return_value=ARP_RESPONSE)
+    entry = _make_entry(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    result = await hass.config_entries.async_unload(entry.entry_id)
+    assert result is True


### PR DESCRIPTION
## Proposed change

OPNsense 25.7 changed all API endpoints from camelCase to snake_case (e.g. `diagnostics/interface/getArp` → `diagnostics/interface/get_arp`). The `pyopnsense` library is unmaintained and still uses the old endpoints, causing 403 errors for all OPNsense 25.7+ users.

This PR:
- Drops the `pyopnsense` dependency and replaces it with direct `aiohttp` API calls using the new snake_case endpoints
- Adds a UI config flow so users can set up OPNsense from the frontend
- Migrates the device tracker from legacy `DeviceScanner` to `ScannerEntity`
- Keeps YAML configuration support via import flow for backward compatibility

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Existing YAML config still works (auto-imported to config entry)
opnsense:
  url: https://opnsense.local/api
  api_key: YOUR_API_KEY
  api_secret: YOUR_API_SECRET
  verify_ssl: false
  tracker_interfaces:
    - LAN
```

## Additional information

- This PR fixes or closes issue: fixes #149414
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io